### PR TITLE
Export final_draw_diagnostics from Scene3D and prefer it in UR5 adjacency smoke check

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -540,29 +540,66 @@ def _aabb_separation(a: dict[str, list[float]], b: dict[str, list[float]]) -> fl
     return math.sqrt(sq)
 
 
+def _final_draw_bbox_from_row(raw: dict[str, Any]) -> dict[str, list[float]] | None:
+    bbox = raw.get("final_draw_bbox")
+    if not isinstance(bbox, dict):
+        return None
+    bmin = _finite_float_list(bbox.get("min"), 3)
+    bmax = _finite_float_list(bbox.get("max"), 3)
+    if bmin is None or bmax is None:
+        return None
+    return {"min": bmin, "max": bmax}
+
+
 def _apply_ur5_rendered_mesh_adjacency(payload: dict[str, Any], *, repo_root: Path, scene_name: str | None, index_data: dict[str, Any]) -> None:
     if scene_name != "ur5_2f_test":
         payload.setdefault("rendered_mesh_adjacency_status", "SKIPPED")
         payload.setdefault("rendered_mesh_adjacency_errors", [])
         payload.setdefault("rendered_mesh_adjacency_checked_pairs", [])
         return
-    items = index_data.get("visual_items") or index_data.get("items") or []
-    if not isinstance(items, list):
-        items = []
+    final_draw_items = payload.get("final_draw_diagnostics")
+    if not isinstance(final_draw_items, list):
+        final_draw_items = []
     by_link: dict[str, dict[str, Any]] = {}
+    missing_final_bbox: list[str] = []
     for canonical, aliases in UR5_RENDERED_MESH_LINK_ALIASES.items():
-        for raw in items:
+        matched_final_item = False
+        for raw in final_draw_items:
             if not isinstance(raw, dict):
                 continue
             link = str(raw.get("link") or raw.get("link_name") or raw.get("name") or raw.get("id") or "")
-            if link in aliases and str(raw.get("geometry_type") or "").lower() == "mesh":
-                bounds = _world_bounds_for_visual(repo_root, raw)
+            if link in aliases:
+                matched_final_item = True
+                bounds = _final_draw_bbox_from_row(raw)
                 if bounds is not None:
-                    by_link[canonical] = {"link": link, "bounds": bounds}
+                    by_link[canonical] = {"link": link, "bounds": bounds, "source": "app_final_draw_diagnostics"}
                     break
+        if matched_final_item and canonical not in by_link:
+            missing_final_bbox.append(canonical)
+    payload["rendered_mesh_adjacency_source"] = "app_final_draw_diagnostics" if final_draw_items else "scene_visual_mesh_index_fallback"
+
+    # The static scene_visual_mesh_index.json is retained only as fallback context for
+    # older app smoke payloads that do not yet export final draw diagnostics.
+    if not final_draw_items:
+        items = index_data.get("visual_items") or index_data.get("items") or []
+        if not isinstance(items, list):
+            items = []
+        for canonical, aliases in UR5_RENDERED_MESH_LINK_ALIASES.items():
+            for raw in items:
+                if not isinstance(raw, dict):
+                    continue
+                link = str(raw.get("link") or raw.get("link_name") or raw.get("name") or raw.get("id") or "")
+                if link in aliases and str(raw.get("geometry_type") or "").lower() == "mesh":
+                    bounds = _world_bounds_for_visual(repo_root, raw)
+                    if bounds is not None:
+                        by_link[canonical] = {"link": link, "bounds": bounds, "source": "scene_visual_mesh_index_fallback"}
+                        break
     errors: list[str] = []
     checked: list[dict[str, Any]] = []
     for parent, child in UR5_RENDERED_MESH_ADJACENT_PAIRS:
+        if final_draw_items and (parent in missing_final_bbox or child in missing_final_bbox):
+            errors.append(f"Missing final_draw_bbox diagnostics for UR5 adjacency pair {parent}->{child}")
+            continue
         if parent not in by_link or child not in by_link:
             errors.append(f"Missing rendered mesh/world bounds diagnostics for UR5 adjacency pair {parent}->{child}")
             continue
@@ -573,6 +610,7 @@ def _apply_ur5_rendered_mesh_adjacency(payload: dict[str, Any], *, repo_root: Pa
             "child": child,
             "parent_link": by_link[parent]["link"],
             "child_link": by_link[child]["link"],
+            "bounds_source": by_link[parent].get("source") if by_link[parent].get("source") == by_link[child].get("source") else f"{by_link[parent].get('source')}->{by_link[child].get('source')}",
             "separation_m": sep,
             "limit_m": RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M,
             "ok": ok,

--- a/workcell_builder/workcell_builder/gui/main.cpp
+++ b/workcell_builder/workcell_builder/gui/main.cpp
@@ -780,6 +780,9 @@ private:
         viewport->render_smoke_fallback_frame();
       }
       const auto rc = viewport ? viewport->render_debug_counters() : Scene3DViewportWidget::RenderDebugCounters{};
+      const QJsonArray final_draw_diagnostics = viewport->final_draw_diagnostics_export();
+      root["final_draw_diagnostics"] = final_draw_diagnostics;
+      counters["final_draw_diagnostics_count"] = final_draw_diagnostics.size();
       counters["preview_items_count"] = rc.preview_items_count;
       counters["total_payload_count"] = rc.total_payload_count;
       counters["viewport_received_count"] = rc.viewport_received_count;

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -1487,6 +1487,7 @@ void Scene3DViewportWidget::ingest_preview_items(const QVector<ScenePreviewWidge
         root["robot_aabb_max"] = QJsonArray{last_robot_aabb_max_.x(), last_robot_aabb_max_.y(), last_robot_aabb_max_.z()};
       }
       root["mesh_diagnostics"] = mesh_diagnostics_export();
+      root["final_draw_diagnostics"] = final_draw_diagnostics_export();
       QJsonObject render_debug;
       const auto counters = render_debug_counters();
       render_debug["locked_generated_urdf_visual_count"] = counters.locked_generated_urdf_visual_count;
@@ -2943,6 +2944,75 @@ bool Scene3DViewportWidget::validate_mesh_final_span(const ScenePreviewWidget::P
   return true;
 }
 
+
+namespace {
+QJsonArray scene3d_matrix_to_json(const QMatrix4x4 & matrix)
+{
+  QJsonArray out;
+  for (int row = 0; row < 4; ++row) {
+    for (int col = 0; col < 4; ++col) out.append(matrix(row, col));
+  }
+  return out;
+}
+
+QJsonArray scene3d_vec_to_json(const QVector3D & v)
+{
+  return QJsonArray{v.x(), v.y(), v.z()};
+}
+
+QJsonObject scene3d_bbox_to_json(const QVector3D & min, const QVector3D & max)
+{
+  QJsonObject bbox;
+  bbox["min"] = scene3d_vec_to_json(min);
+  bbox["max"] = scene3d_vec_to_json(max);
+  bbox["span"] = scene3d_vec_to_json(max - min);
+  return bbox;
+}
+
+QJsonArray scene3d_pose_to_json(double x, double y, double z, double roll, double pitch, double yaw)
+{
+  return QJsonArray{x, y, z, roll, pitch, yaw};
+}
+
+QString scene3d_link_name_for_item(const ScenePreviewWidget::PreviewItem & item)
+{
+  if (!item.frame_id.trimmed().isEmpty()) return item.frame_id.trimmed();
+  const QString id = item.id.trimmed();
+  for (const QString & sep : {QStringLiteral("::"), QStringLiteral("/visual"), QStringLiteral("__visual")}) {
+    const int idx = id.indexOf(sep);
+    if (idx > 0) return id.left(idx);
+  }
+  return id;
+}
+
+bool scene3d_final_draw_bbox_for_mesh(const Scene3DViewportWidget::InternalTriangleMesh & mesh,
+                                      const QMatrix4x4 & transform,
+                                      QVector3D & out_min,
+                                      QVector3D & out_max)
+{
+  bool initialized = false;
+  for (const auto & tri : mesh.triangles) {
+    for (const auto & vertex : tri.vertices) {
+      const QVector3D mapped = transform.map(vertex);
+      if (!qIsFinite(mapped.x()) || !qIsFinite(mapped.y()) || !qIsFinite(mapped.z())) continue;
+      if (!initialized) {
+        out_min = mapped;
+        out_max = mapped;
+        initialized = true;
+      } else {
+        out_min.setX(qMin(out_min.x(), mapped.x()));
+        out_min.setY(qMin(out_min.y(), mapped.y()));
+        out_min.setZ(qMin(out_min.z(), mapped.z()));
+        out_max.setX(qMax(out_max.x(), mapped.x()));
+        out_max.setY(qMax(out_max.y(), mapped.y()));
+        out_max.setZ(qMax(out_max.z(), mapped.z()));
+      }
+    }
+  }
+  return initialized;
+}
+}  // namespace
+
 QJsonArray Scene3DViewportWidget::mesh_diagnostics_export() const
 {
   QJsonArray out;
@@ -3005,6 +3075,58 @@ QJsonArray Scene3DViewportWidget::mesh_diagnostics_export() const
       guard_details.append(gd);
     }
     row["guard_decision_details"] = guard_details;
+    out.append(row);
+  }
+  return out;
+}
+
+
+QJsonArray Scene3DViewportWidget::final_draw_diagnostics_export() const
+{
+  QJsonArray out;
+  for (const auto & item : items) {
+    const QString source_layer = item.source_layer.trimmed().toLower();
+    const bool generated_locked_visual = item.locked || source_layer == QStringLiteral("locked_generated_urdf_visual") ||
+      source_layer == QStringLiteral("generated_urdf_visual") || item.has_baked_world_visual_transform;
+    if (!generated_locked_visual || !item_has_mesh_surface_candidate(item)) continue;
+
+    const QString mesh_source = !item.mesh_path.trimmed().isEmpty() ? item.mesh_path : item.source_path;
+    QString canonical_mesh_source;
+    if (!try_resolve_canonical_mesh_path(mesh_source, canonical_mesh_source, &item)) {
+      canonical_mesh_source = QFileInfo(mesh_source).absoluteFilePath();
+    }
+    const auto cache_it = mesh_cache_.constFind(canonical_mesh_source);
+    if (cache_it == mesh_cache_.constEnd()) continue;
+    const MeshCacheEntry & entry = cache_it.value();
+    if (!entry.loaded || entry.oversized || !entry.valid || entry.mesh.triangles.isEmpty()) continue;
+
+    const QMatrix4x4 final_transform = final_mesh_transform_matrix(item);
+    QVector3D bbox_min;
+    QVector3D bbox_max;
+    const bool has_final_bbox = scene3d_final_draw_bbox_for_mesh(entry.mesh, final_transform, bbox_min, bbox_max);
+
+    QJsonObject row;
+    const QString link_name = scene3d_link_name_for_item(item);
+    row["item_id"] = item.id;
+    row["link_name"] = link_name;
+    row["link"] = link_name;
+    row["mesh_path"] = item.mesh_path;
+    row["source_path"] = item.source_path;
+    row["canonical_path"] = canonical_mesh_source;
+    row["baked_world_visual_pose"] = scene3d_pose_to_json(item.x, item.y, item.z, item.roll, item.pitch, item.yaw);
+    row["baked_world_visual_matrix"] = scene3d_matrix_to_json(authoritative_world_visual_transform(item));
+    row["visual_origin_applied"] = item.visual_origin_applied;
+    row["visual_origin"] = scene3d_pose_to_json(item.visual_origin_x, item.visual_origin_y, item.visual_origin_z,
+                                                 item.visual_origin_roll, item.visual_origin_pitch, item.visual_origin_yaw);
+    row["mesh_rpy"] = QJsonArray{item.mesh_r, item.mesh_p, item.mesh_y};
+    row["mesh_roll_pitch_yaw"] = QJsonArray{item.mesh_roll, item.mesh_pitch, item.mesh_yaw};
+    row["origin_offset"] = QJsonArray{item.origin_offset_x, item.origin_offset_y, item.origin_offset_z};
+    row["origin_offset_applied"] = item.has_origin_offset && !item.has_baked_world_visual_transform;
+    row["mesh_scale"] = QJsonArray{item.mesh_scale_x, item.mesh_scale_y, item.mesh_scale_z};
+    row["final_draw_model_matrix"] = scene3d_matrix_to_json(final_transform);
+    row["final_draw_world_pose"] = scene3d_pose_to_json(final_transform(0, 3), final_transform(1, 3), final_transform(2, 3), 0.0, 0.0, 0.0);
+    row["final_draw_bbox_available"] = has_final_bbox;
+    row["final_draw_bbox"] = has_final_bbox ? scene3d_bbox_to_json(bbox_min, bbox_max) : QJsonObject{};
     out.append(row);
   }
   return out;

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -133,6 +133,7 @@ public:
   RenderDebugCounters render_debug_counters() const;
   bool render_smoke_fallback_frame(QImage * out_image = nullptr);
   QJsonArray mesh_diagnostics_export() const;
+  QJsonArray final_draw_diagnostics_export() const;
 
   static bool parse_stl_bytes_for_test(const QByteArray & bytes, const QString & source_hint,
                                        InternalTriangleMesh & out_mesh, QString & out_error,


### PR DESCRIPTION
### Motivation
- Provide a per-item authoritative record of the exact final draw transform and bounds used by `draw_mesh_preview_if_available()` for generated/locked URDF visual mesh items so offline smoke checks and downstream consumers can trust runtime-rendered geometry positions. 
- Make the UR5 rendered-mesh adjacency checker use runtime final-draw evidence where available instead of relying on static `scene_visual_mesh_index.json`, and fail explicitly when required UR5 pairs are missing final-draw bbox data.

### Description
- Added a public `Scene3DViewportWidget::final_draw_diagnostics_export()` API and hooked its output into the existing `SCENE3D_MESH_DIAGNOSTICS_JSON` emission so the diagnostics JSON now contains `final_draw_diagnostics`. (files: `scene3d_viewport_widget.h`, `scene3d_viewport_widget.cpp`) 
- For each visible generated/locked URDF visual mesh item the export computes `QMatrix4x4 final_transform = final_mesh_transform_matrix(item)` and emits fields including `item_id`, `link_name`/`link`, `mesh_path`/`source_path`/`canonical_path`, `baked_world_visual_pose`, `baked_world_visual_matrix`, `visual_origin_applied`, `visual_origin`, `mesh_rpy`/legacy mesh RPY fields, `origin_offset` (`origin_offset_applied`), `mesh_scale`, `final_draw_model_matrix`, `final_draw_world_pose`, and `final_draw_bbox` (with min/max/span). (file: `scene3d_viewport_widget.cpp`) 
- Added shared JSON helper converters and a mesh->final-bbox routine used to compute the final draw bbox from the runtime final transform and triangle mesh vertices, using the same transform path as rendering. (file: `scene3d_viewport_widget.cpp`) 
- Plumbed `final_draw_diagnostics` into the GUI smoke JSON payload emitted by the app so `scene3d_gui_smoke.json` receives the runtime final-draw data as `root.final_draw_diagnostics`. (file: `main.cpp`) 
- Updated `scripts/run_workcell_builder_scene3d_gui_smoke.py` to prefer app-exported `final_draw_bbox` items for `ur5_2f_test`, to record bounds source, to treat `scene_visual_mesh_index.json` only as fallback static context, and to fail the UR5 adjacency check when required UR5 pairs lack final-draw bbox diagnostics. (file: `scripts/run_workcell_builder_scene3d_gui_smoke.py`) 

### Testing
- Compiled the modified smoke script: `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke.py` — PASS.
- Ran repository diff-checks: `git diff --check` — PASS (no whitespace/merge errors reported).
- GUI build/colcon validation not executed in this environment because ROS Humble is not available in the container, so `colcon build --packages-select workcell_builder` was not run and is blocked by a missing `/opt/ros/humble/setup.bash`.
- Note: the smoke checker now prefers `final_draw_bbox` and will add explicit errors for missing UR5 pair final-bbox diagnostics as required by the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a340601a33c83319dec364206ccd4ce)