### PR TITLE
Export final-draw Scene3D diagnostics and tighten UR5 rendered-mesh adjacency check

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -642,80 +642,40 @@ def _apply_ur5_rendered_mesh_adjacency(payload: dict[str, Any], *, repo_root: Pa
         return
 
     final_draw_items = payload.get("final_draw_visual_items")
-    use_final_draw = isinstance(final_draw_items, list) and len(final_draw_items) > 0
-    source_items: list[Any]
-    if use_final_draw:
-        source_items = final_draw_items
-        payload["rendered_mesh_adjacency_source"] = "final_draw_visual_items"
-    else:
-        source_items = index_data.get("visual_items") or index_data.get("items") or []
-        if not isinstance(source_items, list):
-            source_items = []
-        payload["rendered_mesh_adjacency_source"] = "visual_index_fallback"
-        _record_rendered_mesh_adjacency_fallback_warning(payload)
+    if not isinstance(final_draw_items, list) or not final_draw_items:
+        final_draw_items = payload.get("final_draw_diagnostics")
+    errors: list[str] = []
+    if not isinstance(final_draw_items, list) or not final_draw_items:
+        errors.append("Final draw diagnostics are missing; rendered mesh adjacency cannot use scene_visual_mesh_index fallback for ur5_2f_test")
+        payload["rendered_mesh_adjacency_source"] = "missing_final_draw_diagnostics"
+        payload["rendered_mesh_adjacency_status"] = "FAIL"
+        payload["rendered_mesh_adjacency_errors"] = errors
+        payload["rendered_mesh_adjacency_checked_pairs"] = []
+        _record_rendered_mesh_adjacency_failure(payload, errors)
+        return
 
-    by_link: dict[str, dict[str, Any]] = {}
+    payload["rendered_mesh_adjacency_source"] = "final_draw_visual_items"
     alias_to_canonical: dict[str, str] = {}
     for canonical, aliases in UR5_RENDERED_MESH_LINK_ALIASES.items():
         for alias in aliases:
             alias_to_canonical[alias] = canonical
-    # tool0 is an accepted wrist/tool attachment diagnostic for Robotiq association.
     alias_to_canonical["tool0"] = "tool0"
 
-    robotiq_base: dict[str, Any] | None = None
-    final_draw_items = payload.get("final_draw_diagnostics")
-    if not isinstance(final_draw_items, list):
-        final_draw_items = []
     by_link: dict[str, dict[str, Any]] = {}
-    missing_final_bbox: list[str] = []
-    for canonical, aliases in UR5_RENDERED_MESH_LINK_ALIASES.items():
-        matched_final_item = False
-        for raw in final_draw_items:
-            if not isinstance(raw, dict):
-                continue
-            link = str(raw.get("link") or raw.get("link_name") or raw.get("name") or raw.get("id") or "")
-            if link in aliases:
-                matched_final_item = True
-                bounds = _final_draw_bbox_from_row(raw)
-                if bounds is not None:
-                    by_link[canonical] = {"link": link, "bounds": bounds, "source": "app_final_draw_diagnostics"}
-                    break
-        if matched_final_item and canonical not in by_link:
-            missing_final_bbox.append(canonical)
-    payload["rendered_mesh_adjacency_source"] = "app_final_draw_diagnostics" if final_draw_items else "scene_visual_mesh_index_fallback"
-
-    # The static scene_visual_mesh_index.json is retained only as fallback context for
-    # older app smoke payloads that do not yet export final draw diagnostics.
-    if not final_draw_items:
-        items = index_data.get("visual_items") or index_data.get("items") or []
-        if not isinstance(items, list):
-            items = []
-        for canonical, aliases in UR5_RENDERED_MESH_LINK_ALIASES.items():
-            for raw in items:
-                if not isinstance(raw, dict):
-                    continue
-                link = str(raw.get("link") or raw.get("link_name") or raw.get("name") or raw.get("id") or "")
-                if link in aliases and str(raw.get("geometry_type") or "").lower() == "mesh":
-                    bounds = _world_bounds_for_visual(repo_root, raw)
-                    if bounds is not None:
-                        by_link[canonical] = {"link": link, "bounds": bounds, "source": "scene_visual_mesh_index_fallback"}
-                        break
-    errors: list[str] = []
-    for raw in source_items:
+    robotiq_base: dict[str, Any] | None = None
+    for raw in final_draw_items:
         if not isinstance(raw, dict):
             continue
-        link_values = [str(raw.get("link") or "").strip(), str(raw.get("link_name") or "").strip()]
-        if not use_final_draw and str(raw.get("geometry_type") or "").lower() != "mesh":
-            continue
-        bounds = _bbox_from_final_draw(raw) if use_final_draw else _world_bounds_for_visual(repo_root, raw)
+        bounds = _bbox_from_final_draw(raw) or _final_draw_bbox_from_row(raw)
         normalized = dict(raw)
-        if use_final_draw and "final_draw_bbox" in raw and bounds is None:
-            normalized["bbox_error"] = "final_draw_bbox_missing_or_non_finite"
         if bounds is not None:
             normalized["bounds"] = bounds
+        elif str(raw.get("final_draw_status") or "") == "ok":
+            normalized["bbox_error"] = "final_draw_bbox_missing_or_non_finite"
         if _is_robotiq_base_record(raw) and robotiq_base is None:
             robotiq_base = normalized
-        for link in link_values:
+        for key in ("link", "link_name", "frame_id", "id", "item_id"):
+            link = str(raw.get(key) or "").strip()
             canonical = alias_to_canonical.get(link)
             if canonical and canonical not in by_link:
                 by_link[canonical] = normalized
@@ -725,48 +685,30 @@ def _apply_ur5_rendered_mesh_adjacency(payload: dict[str, Any], *, repo_root: Pa
         parent_item = by_link.get(parent)
         child_item = by_link.get(child)
         if parent_item is None or child_item is None:
-            errors.append(f"Missing rendered mesh adjacency link for UR5 pair {parent}->{child}")
+            errors.append(f"Missing final draw rendered mesh adjacency link for UR5 pair {parent}->{child}")
             checked.append(_checked_pair_record(parent, child, parent_item, child_item, None, False))
             continue
         if not isinstance(parent_item.get("bounds"), dict) or not isinstance(child_item.get("bounds"), dict):
             detail = parent_item.get("bbox_error") or child_item.get("bbox_error") or "bbox_missing"
-            errors.append(f"Missing or non-finite bbox diagnostics for UR5 adjacency pair {parent}->{child}: {detail}")
+            errors.append(f"Missing or non-finite final_draw_bbox diagnostics for UR5 adjacency pair {parent}->{child}: {detail}")
             checked.append(_checked_pair_record(parent, child, parent_item, child_item, None, False))
             continue
         sep = _aabb_separation(parent_item["bounds"], child_item["bounds"])
         ok = math.isfinite(sep) and sep <= RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M
         checked.append(_checked_pair_record(parent, child, parent_item, child_item, sep, ok))
-        if final_draw_items and (parent in missing_final_bbox or child in missing_final_bbox):
-            errors.append(f"Missing final_draw_bbox diagnostics for UR5 adjacency pair {parent}->{child}")
-            continue
-        if parent not in by_link or child not in by_link:
-            errors.append(f"Missing rendered mesh/world bounds diagnostics for UR5 adjacency pair {parent}->{child}")
-            continue
-        sep = _aabb_separation(by_link[parent]["bounds"], by_link[child]["bounds"])
-        ok = sep <= RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M
-        checked.append({
-            "parent": parent,
-            "child": child,
-            "parent_link": by_link[parent]["link"],
-            "child_link": by_link[child]["link"],
-            "bounds_source": by_link[parent].get("source") if by_link[parent].get("source") == by_link[child].get("source") else f"{by_link[parent].get('source')}->{by_link[child].get('source')}",
-            "separation_m": sep,
-            "limit_m": RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M,
-            "ok": ok,
-        })
         if not ok:
             errors.append(
-                f"UR5 rendered mesh bbox adjacency {parent}->{child} separated by {sep:.3f} m; expected <= {RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M:.3f} m"
+                f"UR5 final draw bbox adjacency {parent}->{child} separated by {sep:.3f} m; expected <= {RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M:.3f} m"
             )
 
     tool_parent = by_link.get("tool0") or by_link.get("wrist_3_link")
     tool_parent_name = "tool0" if by_link.get("tool0") is not None else "wrist_3_link"
     if robotiq_base is None or tool_parent is None:
-        errors.append("Robotiq base could not be associated with wrist_3_link or tool0 rendered mesh diagnostics")
+        errors.append("Robotiq base could not be associated with wrist_3_link or tool0 final draw diagnostics")
         checked.append(_checked_pair_record(tool_parent_name, "robotiq_base", tool_parent, robotiq_base, None, False))
     elif not isinstance(tool_parent.get("bounds"), dict) or not isinstance(robotiq_base.get("bounds"), dict):
         detail = tool_parent.get("bbox_error") or robotiq_base.get("bbox_error") or "bbox_missing"
-        errors.append(f"Missing or non-finite bbox diagnostics for Robotiq base association with wrist_3_link/tool0: {detail}")
+        errors.append(f"Missing or non-finite final_draw_bbox diagnostics for Robotiq base association with wrist_3_link/tool0: {detail}")
         checked.append(_checked_pair_record(tool_parent_name, "robotiq_base", tool_parent, robotiq_base, None, False))
     else:
         sep = _aabb_separation(tool_parent["bounds"], robotiq_base["bounds"])
@@ -774,14 +716,13 @@ def _apply_ur5_rendered_mesh_adjacency(payload: dict[str, Any], *, repo_root: Pa
         checked.append(_checked_pair_record(tool_parent_name, "robotiq_base", tool_parent, robotiq_base, sep, ok))
         if not ok:
             errors.append(
-                f"Robotiq base bbox separated from {tool_parent_name} by {sep:.3f} m; expected <= {RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M:.3f} m"
+                f"Robotiq base final draw bbox separated from {tool_parent_name} by {sep:.3f} m; expected <= {RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M:.3f} m"
             )
 
     payload["rendered_mesh_adjacency_status"] = "PASS" if not errors else "FAIL"
     payload["rendered_mesh_adjacency_errors"] = errors
     payload["rendered_mesh_adjacency_checked_pairs"] = checked
     _record_rendered_mesh_adjacency_failure(payload, errors)
-
 
 
 def _xyz_from_array(value: Any) -> list[float] | None:

--- a/workcell_builder/workcell_builder/gui/main.cpp
+++ b/workcell_builder/workcell_builder/gui/main.cpp
@@ -782,6 +782,7 @@ private:
       const auto rc = viewport ? viewport->render_debug_counters() : Scene3DViewportWidget::RenderDebugCounters{};
       const QJsonArray final_draw_diagnostics = viewport->final_draw_diagnostics_export();
       root["final_draw_diagnostics"] = final_draw_diagnostics;
+      root["final_draw_visual_items"] = final_draw_diagnostics;
       counters["final_draw_diagnostics_count"] = final_draw_diagnostics.size();
       counters["preview_items_count"] = rc.preview_items_count;
       counters["total_payload_count"] = rc.total_payload_count;

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -3109,18 +3109,6 @@ QJsonArray Scene3DViewportWidget::final_draw_visual_items_export() const
 {
   QJsonArray out;
   for (const auto & item : items) {
-    const QString mesh_source = !item.mesh_path.trimmed().isEmpty() ? item.mesh_path : item.source_path;
-    if (mesh_source.trimmed().isEmpty()) continue;
-    QString canonical_mesh_source;
-    if (!try_resolve_canonical_mesh_path(mesh_source, canonical_mesh_source, &item)) {
-      canonical_mesh_source = QFileInfo(mesh_source).absoluteFilePath();
-    }
-    const auto cache_it = mesh_cache_.constFind(canonical_mesh_source);
-    if (cache_it == mesh_cache_.constEnd()) continue;
-    const MeshCacheEntry & cache = cache_it.value();
-    if (!cache.loaded || !cache.valid || !cache.has_bounds) continue;
-
-    const QMatrix4x4 baked_transform = authoritative_world_visual_transform(item);
     if (!is_generated_urdf_visual_item(item) && !is_locked_urdf_item(item)) continue;
     if (!item.has_mesh_metadata) continue;
 
@@ -3134,17 +3122,34 @@ QJsonArray Scene3DViewportWidget::final_draw_visual_items_export() const
 
     QJsonObject row;
     row["item_id"] = item.id;
+    row["id"] = item.id;
     row["display_name"] = item.display_name;
+    row["link_name"] = scene3d_link_name_for_item(item);
+    row["link"] = scene3d_link_name_for_item(item);
+    row["frame_id"] = item.frame_id;
     row["source_layer"] = item.source_layer;
     row["active_visual_source"] = item.active_visual_source;
     row["locked"] = item.locked;
+    row["editable"] = item.editable;
     row["lock_reason"] = item.lock_reason;
     row["mesh_source"] = mesh_source;
+    row["mesh_path"] = item.mesh_path;
+    row["source_path"] = item.source_path;
     row["mesh_source_field"] = !item.mesh_path.trimmed().isEmpty() ? QStringLiteral("mesh_path") : QStringLiteral("source_path");
     row["canonical_mesh_source"] = canonical_mesh_source;
     row["path_resolved"] = path_resolved;
     row["resolve_failure_reason"] = resolve_failure_reason;
     row["has_mesh_metadata"] = item.has_mesh_metadata;
+    row["has_baked_world_visual_transform"] = item.has_baked_world_visual_transform;
+    row["has_baked_world_visual_matrix"] = item.has_baked_world_visual_matrix;
+    row["baked_world_visual_pose"] = scene3d_pose_to_json(item.x, item.y, item.z, item.roll, item.pitch, item.yaw);
+    row["visual_origin_applied"] = item.visual_origin_applied;
+    row["visual_origin_pose"] = scene3d_pose_to_json(item.visual_origin_x, item.visual_origin_y, item.visual_origin_z,
+                                                      item.visual_origin_roll, item.visual_origin_pitch, item.visual_origin_yaw);
+    row["local_mesh_correction_rpy"] = QJsonArray{item.mesh_r, item.mesh_p, item.mesh_y};
+    row["origin_offset"] = QJsonArray{item.origin_offset_x, item.origin_offset_y, item.origin_offset_z};
+    row["has_origin_offset"] = item.has_origin_offset;
+    row["mesh_scale"] = QJsonArray{item.mesh_scale_x, item.mesh_scale_y, item.mesh_scale_z};
 
     const auto cache_it = mesh_cache_.constFind(canonical_mesh_source);
     if (cache_it == mesh_cache_.constEnd()) {
@@ -3160,55 +3165,54 @@ QJsonArray Scene3DViewportWidget::final_draw_visual_items_export() const
     row["cache_warning"] = cache.warning;
     row["cache_failure_reason_code"] = cache.failure_reason_code;
     row["triangle_count"] = static_cast<int>(cache.mesh.triangles.size());
-    row["local_min"] = QJsonArray{cache.local_min.x(), cache.local_min.y(), cache.local_min.z()};
-    row["local_max"] = QJsonArray{cache.local_max.x(), cache.local_max.y(), cache.local_max.z()};
+    row["local_min"] = scene3d_vec_to_json(cache.local_min);
+    row["local_max"] = scene3d_vec_to_json(cache.local_max);
 
-    if (!cache.has_bounds) {
-      row["final_draw_status"] = QStringLiteral("missing_bounds");
+    const QMatrix4x4 baked_transform = authoritative_world_visual_transform(item);
+    const QMatrix4x4 final_transform = final_mesh_transform_matrix(item);
+    row["baked_world_visual_matrix"] = scene3d_matrix_to_json(baked_transform);
+    row["final_draw_model_matrix"] = scene3d_matrix_to_json(final_transform);
+    row["final_draw_world_pose"] = scene3d_vec_to_json(final_transform.map(QVector3D(0.0f, 0.0f, 0.0f)));
+
+    if (!cache.loaded || !cache.valid || !cache.has_bounds || cache.mesh.triangles.isEmpty()) {
+      row["final_draw_status"] = cache.has_bounds ? QStringLiteral("invalid_mesh") : QStringLiteral("missing_bounds");
       out.append(row);
       continue;
     }
 
-    const QMatrix4x4 final_transform = final_mesh_transform_matrix(item);
-    QVector3D final_min(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
-    QVector3D final_max(std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest());
-    for (int xi = 0; xi < 2; ++xi) {
-      for (int yi = 0; yi < 2; ++yi) {
-        for (int zi = 0; zi < 2; ++zi) {
-          const QVector3D corner(xi ? cache.local_max.x() : cache.local_min.x(),
-                                 yi ? cache.local_max.y() : cache.local_min.y(),
-                                 zi ? cache.local_max.z() : cache.local_min.z());
-          const QVector3D mapped = final_transform.map(corner);
-          final_min.setX(qMin(final_min.x(), mapped.x()));
-          final_min.setY(qMin(final_min.y(), mapped.y()));
-          final_min.setZ(qMin(final_min.z(), mapped.z()));
-          final_max.setX(qMax(final_max.x(), mapped.x()));
-          final_max.setY(qMax(final_max.y(), mapped.y()));
-          final_max.setZ(qMax(final_max.z(), mapped.z()));
-        }
-      }
+    QVector3D final_min;
+    QVector3D final_max;
+    if (!scene3d_final_draw_bbox_for_mesh(cache.mesh, final_transform, final_min, final_max)) {
+      row["final_draw_status"] = QStringLiteral("non_finite_bounds");
+      out.append(row);
+      continue;
     }
-    QJsonObject row;
-    row["item_id"] = item.id;
-    row["frame_id"] = item.frame_id;
-    row["locked"] = item.locked;
-    row["editable"] = item.editable;
-    row["mesh_source"] = mesh_source;
-    row["canonical_mesh_source"] = canonical_mesh_source;
-    row["baked_world_visual_matrix"] = matrix_to_json_array(baked_transform);
-    row["final_draw_model_matrix"] = matrix_to_json_array(final_transform);
-    row["final_draw_bbox_min"] = vector_to_json_array(final_min);
-    row["final_draw_bbox_max"] = vector_to_json_array(final_max);
-    row["final_draw_bbox_span"] = vector_to_json_array(final_max - final_min);
-    row["has_baked_world_visual_transform"] = item.has_baked_world_visual_transform;
     const QVector3D final_span = final_max - final_min;
+    row["final_draw_bbox"] = scene3d_bbox_to_json(final_min, final_max);
+    row["final_draw_bbox_min"] = scene3d_vec_to_json(final_min);
+    row["final_draw_bbox_max"] = scene3d_vec_to_json(final_max);
+    row["final_draw_bbox_span"] = scene3d_vec_to_json(final_span);
     row["final_draw_status"] = QStringLiteral("ok");
-    row["final_draw_min"] = QJsonArray{final_min.x(), final_min.y(), final_min.z()};
-    row["final_draw_max"] = QJsonArray{final_max.x(), final_max.y(), final_max.z()};
-    row["final_draw_span"] = QJsonArray{final_span.x(), final_span.y(), final_span.z()};
     out.append(row);
+
+    if (scene3d_debug_logs_enabled()) {
+      qInfo().noquote() << QStringLiteral(
+        "Scene3D final draw: item_id=%1 link=%2 mesh=%3 baked_pose=[%4,%5,%6,%7,%8,%9] scale=[%10,%11,%12] final_matrix=%13 bbox_min=[%14,%15,%16] bbox_max=[%17,%18,%19]")
+        .arg(item.id, scene3d_link_name_for_item(item), mesh_source)
+        .arg(item.x, 0, 'g', 8).arg(item.y, 0, 'g', 8).arg(item.z, 0, 'g', 8)
+        .arg(item.roll, 0, 'g', 8).arg(item.pitch, 0, 'g', 8).arg(item.yaw, 0, 'g', 8)
+        .arg(item.mesh_scale_x, 0, 'g', 8).arg(item.mesh_scale_y, 0, 'g', 8).arg(item.mesh_scale_z, 0, 'g', 8)
+        .arg(QString::fromUtf8(QJsonDocument(scene3d_matrix_to_json(final_transform)).toJson(QJsonDocument::Compact)))
+        .arg(final_min.x(), 0, 'g', 8).arg(final_min.y(), 0, 'g', 8).arg(final_min.z(), 0, 'g', 8)
+        .arg(final_max.x(), 0, 'g', 8).arg(final_max.y(), 0, 'g', 8).arg(final_max.z(), 0, 'g', 8);
+    }
   }
   return out;
+}
+
+QJsonArray Scene3DViewportWidget::final_draw_diagnostics_export() const
+{
+  return final_draw_visual_items_export();
 }
 
 bool Scene3DViewportWidget::draw_mesh_preview_if_available(const ScenePreviewWidget::PreviewItem & it, const QColor & color, bool preview_path)

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -134,6 +134,7 @@ public:
   bool render_smoke_fallback_frame(QImage * out_image = nullptr);
   QJsonArray mesh_diagnostics_export() const;
   QJsonArray final_draw_visual_items_export() const;
+  QJsonArray final_draw_diagnostics_export() const;
 
   static bool parse_stl_bytes_for_test(const QByteArray & bytes, const QString & source_hint,
                                        InternalTriangleMesh & out_mesh, QString & out_error,


### PR DESCRIPTION
### Motivation
- Validators reported the UR5 scene as OK because they used indexed/authoritative pose data instead of the actual final OpenGL model matrix used when drawing meshes, producing a false-positive `rendered_mesh_adjacency_status` for `ur5_2f_test`.
- The goal is to capture and export the exact final model matrix and mesh-derived bbox used immediately before OpenGL drawing and make the smoke check compare final-draw data, not precomputed index data.

### Description
- Export per-URDF-visual final-draw diagnostics from the same transform used for rendering by adding `final_draw_model_matrix`, `final_draw_world_pose`, `final_draw_bbox` and related metadata (link name, `baked_world_visual_matrix`/pose, mesh path, mesh-local correction, scale, lock/editable state) in `Scene3DViewportWidget::final_draw_visual_items_export()` and expose it through `final_draw_diagnostics_export()` for the smoke report; changes in `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp` and `.h` implement this and use `final_mesh_transform_matrix()` for consistency.
- Include the final-draw diagnostics in the app smoke JSON under both `final_draw_diagnostics` and `final_draw_visual_items` so downstream smoke tooling reads the actual draw output; change in `workcell_builder/workcell_builder/gui/main.cpp`.
- Tighten the UR5 rendered-mesh adjacency smoke logic to require final-draw diagnostics (fail when missing) and compute adjacency using final-draw bboxes rather than silently falling back to the scene visual index; update in `scripts/run_workcell_builder_scene3d_gui_smoke.py` (`_apply_ur5_rendered_mesh_adjacency`).
- Added debug logging of final-draw records when `scene3d_debug_logs_enabled()` to aid manual inspection and troubleshooting.
- Files changed: `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp`, `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h`, `workcell_builder/workcell_builder/gui/main.cpp`, `scripts/run_workcell_builder_scene3d_gui_smoke.py`.

### Testing
- `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke.py` — passed.
- Local Python regression check calling `_apply_ur5_rendered_mesh_adjacency(...)` to assert strict-failure when final-draw diagnostics are absent — passed (script-level unit assertion executed successfully).
- `git diff --check` / basic repo checks — passed.
- `colcon build --packages-select workcell_builder` and manual GUI screenshot/visual acceptance were not run in this container because ROS Humble/`colcon` and the expected ROS workspace GUI runtime were not available here; these should be run in the normal dev environment per the provided validation commands before merge.

Safety: this change only modifies diagnostics and smoke validation paths, preserves fake-hardware defaults, and does not touch launch files, controllers, runtime execution nodes, or real-hardware motion paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3408301a608331a9466eba792abd51)