### PR TITLE
Fix final-draw UR5 link association diagnostics

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -400,6 +400,8 @@ UR5_RENDERED_MESH_LINK_ALIASES: dict[str, tuple[str, ...]] = {
     "wrist_1_link": ("wrist_1_link",),
     "wrist_2_link": ("wrist_2_link",),
     "wrist_3_link": ("wrist_3_link",),
+    "tool0": ("tool0",),
+    "robotiq_base": ("robotiq_base", "gripper_base_link", "robotiq_85_base_link", "robotiq base visual item"),
 }
 UR5_RENDERED_MESH_ADJACENT_PAIRS: tuple[tuple[str, str], ...] = (
     ("base_link", "shoulder_link"),
@@ -600,12 +602,25 @@ def _mesh_path(record: dict[str, Any]) -> str | None:
 
 
 def _is_robotiq_base_record(record: dict[str, Any]) -> bool:
+    canonical = str(record.get("canonical_link_name") or record.get("link_name") or record.get("link") or "").strip().lower()
+    if canonical in {"gripper_base_link", "robotiq_85_base_link", "robotiq_base"}:
+        return True
     haystack = " ".join(
         str(record.get(key) or "")
-        for key in ("link", "link_name", "name", "id", "item_id", "label", "mesh_path", "resolved_source_path", "resolved_path", "source_path")
+        for key in ("canonical_link_name", "link", "link_name", "visual_name", "name", "id", "item_id", "label", "mesh_uri", "package_uri", "mesh_path", "resolved_source_path", "resolved_path", "source_path")
     ).lower()
     return "robotiq" in haystack and ("base" in haystack or "2f" in haystack or "arg2f" in haystack)
 
+
+def _bbox_gap(parent_item: dict[str, Any] | None, child_item: dict[str, Any] | None) -> list[float] | None:
+    pb = (parent_item or {}).get("bounds")
+    cb = (child_item or {}).get("bounds")
+    if not isinstance(pb, dict) or not isinstance(cb, dict):
+        return None
+    pmin, pmax, cmin, cmax = pb.get("min"), pb.get("max"), cb.get("min"), cb.get("max")
+    if not all(isinstance(v, list) and len(v) == 3 for v in (pmin, pmax, cmin, cmax)):
+        return None
+    return [max(0.0, max(float(cmin[i]) - float(pmax[i]), float(pmin[i]) - float(cmax[i]))) for i in range(3)]
 
 def _checked_pair_record(parent: str, child: str, parent_item: dict[str, Any] | None, child_item: dict[str, Any] | None, sep: float | None, ok: bool) -> dict[str, Any]:
     return {
@@ -613,6 +628,10 @@ def _checked_pair_record(parent: str, child: str, parent_item: dict[str, Any] | 
         "child": child,
         "parent_item_id": _item_id(parent_item or {}),
         "child_item_id": _item_id(child_item or {}),
+        "parent_link_name": (parent_item or {}).get("link_name"),
+        "child_link_name": (child_item or {}).get("link_name"),
+        "parent_canonical_link_name": (parent_item or {}).get("canonical_link_name") or (parent_item or {}).get("link"),
+        "child_canonical_link_name": (child_item or {}).get("canonical_link_name") or (child_item or {}).get("link"),
         "parent_mesh_path": _mesh_path(parent_item or {}),
         "child_mesh_path": _mesh_path(child_item or {}),
         "parent_bbox_min": (parent_item or {}).get("bounds", {}).get("min") if isinstance((parent_item or {}).get("bounds"), dict) else None,
@@ -620,6 +639,7 @@ def _checked_pair_record(parent: str, child: str, parent_item: dict[str, Any] | 
         "child_bbox_min": (child_item or {}).get("bounds", {}).get("min") if isinstance((child_item or {}).get("bounds"), dict) else None,
         "child_bbox_max": (child_item or {}).get("bounds", {}).get("max") if isinstance((child_item or {}).get("bounds"), dict) else None,
         "separation_m": sep,
+        "bbox_gap_m": _bbox_gap(parent_item, child_item),
         "limit_m": RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M,
         "ok": ok,
     }
@@ -674,11 +694,16 @@ def _apply_ur5_rendered_mesh_adjacency(payload: dict[str, Any], *, repo_root: Pa
             normalized["bbox_error"] = "final_draw_bbox_missing_or_non_finite"
         if _is_robotiq_base_record(raw) and robotiq_base is None:
             robotiq_base = normalized
-        for key in ("link", "link_name", "frame_id", "id", "item_id"):
+        for key in ("canonical_link_name", "link", "link_name", "frame_id", "visual_name", "id", "item_id", "mesh_uri", "package_uri", "mesh_path", "source_path"):
             link = str(raw.get(key) or "").strip()
-            canonical = alias_to_canonical.get(link)
-            if canonical and canonical not in by_link:
-                by_link[canonical] = normalized
+            candidates = {link, link.lower()}
+            for alias, canonical_value in alias_to_canonical.items():
+                if alias and alias in link:
+                    candidates.add(alias)
+            for candidate in candidates:
+                canonical = alias_to_canonical.get(candidate)
+                if canonical and canonical not in by_link:
+                    by_link[canonical] = normalized
 
     checked: list[dict[str, Any]] = []
     for parent, child in UR5_RENDERED_MESH_ADJACENT_PAIRS:

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -8501,6 +8501,7 @@ void MainWindow::populate_scene_hierarchy()
           p.id = id;
           p.display_name = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "link"));
           if (p.display_name.trimmed().isEmpty()) p.display_name = id;
+          p.frame_id = p.display_name;
           p.category = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "category"));
           if (p.category.trimmed().isEmpty()) p.category = "URDF Visual";
           p.role = p.category;

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -28,6 +28,7 @@
 #include <QJsonArray>
 #include <QXmlStreamReader>
 #include <QImage>
+#include <QRegularExpression>
 #include <cstring>
 #include <QtMath>
 
@@ -3001,12 +3002,55 @@ QJsonArray scene3d_pose_to_json(double x, double y, double z, double roll, doubl
 QString scene3d_link_name_for_item(const ScenePreviewWidget::PreviewItem & item)
 {
   if (!item.frame_id.trimmed().isEmpty()) return item.frame_id.trimmed();
+  const QString display = item.display_name.trimmed();
+  if (!display.isEmpty() && display != item.id.trimmed()) return display;
   const QString id = item.id.trimmed();
   for (const QString & sep : {QStringLiteral("::"), QStringLiteral("/visual"), QStringLiteral("__visual")}) {
     const int idx = id.indexOf(sep);
     if (idx > 0) return id.left(idx);
   }
   return id;
+}
+
+QString scene3d_canonical_link_name(const QString & raw_link)
+{
+  QString link = raw_link.trimmed();
+  if (link.isEmpty()) return link;
+  if (link == QStringLiteral("base_link_inertia")) return QStringLiteral("base_link");
+  const QString lower = link.toLower();
+  if (lower.contains(QStringLiteral("robotiq")) && lower.contains(QStringLiteral("base"))) {
+    return QStringLiteral("robotiq_85_base_link");
+  }
+  if (lower.contains(QStringLiteral("gripper_base_link"))) return QStringLiteral("gripper_base_link");
+  return link;
+}
+
+QString scene3d_canonical_link_name_for_item(const ScenePreviewWidget::PreviewItem & item)
+{
+  const QString direct = scene3d_link_name_for_item(item);
+  QString canonical = scene3d_canonical_link_name(direct);
+  if (!canonical.isEmpty() && canonical != item.id.trimmed()) return canonical;
+  const QString haystack = QStringList{item.id, item.display_name, item.frame_id, item.package_uri, item.mesh_path, item.source_path}.join(QStringLiteral(" ")).toLower();
+  const QStringList ur5_links{
+    QStringLiteral("base_link_inertia"), QStringLiteral("base_link"), QStringLiteral("shoulder_link"),
+    QStringLiteral("upper_arm_link"), QStringLiteral("forearm_link"), QStringLiteral("wrist_1_link"),
+    QStringLiteral("wrist_2_link"), QStringLiteral("wrist_3_link"), QStringLiteral("tool0")
+  };
+  for (const QString & alias : ur5_links) {
+    if (haystack.contains(alias)) return scene3d_canonical_link_name(alias);
+  }
+  if (haystack.contains(QStringLiteral("robotiq")) && haystack.contains(QStringLiteral("base"))) {
+    return QStringLiteral("robotiq_85_base_link");
+  }
+  return canonical;
+}
+
+int scene3d_visual_index_for_item(const ScenePreviewWidget::PreviewItem & item)
+{
+  QRegularExpression re(QStringLiteral("(?:visual[_-]?|/visual)(\\d+)"));
+  const QRegularExpressionMatch match = re.match(item.id);
+  if (match.hasMatch()) return match.captured(1).toInt();
+  return -1;
 }
 
 bool scene3d_final_draw_bbox_for_mesh(const Scene3DViewportWidget::InternalTriangleMesh & mesh,
@@ -3124,8 +3168,14 @@ QJsonArray Scene3DViewportWidget::final_draw_visual_items_export() const
     row["item_id"] = item.id;
     row["id"] = item.id;
     row["display_name"] = item.display_name;
-    row["link_name"] = scene3d_link_name_for_item(item);
-    row["link"] = scene3d_link_name_for_item(item);
+    const QString link_name = scene3d_link_name_for_item(item);
+    const QString canonical_link_name = scene3d_canonical_link_name_for_item(item);
+    row["link_name"] = link_name;
+    row["canonical_link_name"] = canonical_link_name;
+    row["link"] = canonical_link_name.isEmpty() ? link_name : canonical_link_name;
+    const int visual_index = scene3d_visual_index_for_item(item);
+    if (visual_index >= 0) row["visual_index"] = visual_index;
+    row["visual_name"] = visual_index >= 0 ? QStringLiteral("visual_%1").arg(visual_index) : item.display_name;
     row["frame_id"] = item.frame_id;
     row["source_layer"] = item.source_layer;
     row["active_visual_source"] = item.active_visual_source;
@@ -3133,6 +3183,9 @@ QJsonArray Scene3DViewportWidget::final_draw_visual_items_export() const
     row["editable"] = item.editable;
     row["lock_reason"] = item.lock_reason;
     row["mesh_source"] = mesh_source;
+    row["mesh_uri"] = mesh_source;
+    row["package_uri"] = item.package_uri;
+    row["source_type"] = QStringLiteral("generated_urdf_visual_mesh");
     row["mesh_path"] = item.mesh_path;
     row["source_path"] = item.source_path;
     row["mesh_source_field"] = !item.mesh_path.trimmed().isEmpty() ? QStringLiteral("mesh_path") : QStringLiteral("source_path");


### PR DESCRIPTION
### Motivation
- The Scene3D final-draw diagnostics could not reliably associate generated URDF visual items with canonical UR5 link names, causing “Missing final draw rendered mesh adjacency link” errors instead of measured pair distances. 
- The rendered mesh adjacency checker must report measured separations and bbox gaps for canonical UR5 pairs (and Robotiq/tool association) while preserving existing baked-transform behavior. 

### Description
- Add canonicalization and visual identifier helpers in `scene3d_viewport_widget.cpp`: `scene3d_canonical_link_name`, `scene3d_canonical_link_name_for_item`, and `scene3d_visual_index_for_item`, and prefer `display_name` for link inference. 
- Enrich final-draw export in `Scene3DViewportWidget::final_draw_visual_items_export()` with stable fields: `canonical_link_name`, `visual_index`/`visual_name`, `mesh_uri`, `package_uri`, and `source_type`, while preserving `baked_world_visual_pose`, `baked_world_visual_matrix`, `final_draw_model_matrix`, and final bbox fields. 
- Ensure generated URDF visual `frame_id` is populated from the visual `link` in `mainwindow.cpp` so final-draw rows retain link metadata. 
- Improve the UR5 adjacency checker in `scripts/run_workcell_builder_scene3d_gui_smoke.py` by adding `tool0`/`robotiq_base` aliases, normalizing records via `canonical_link_name`, matching by more fields (`canonical_link_name`, `visual_name`, `mesh_uri`, `package_uri`, etc.), and emitting measured entries including `separation_m` and `bbox_gap_m` plus parent/child canonical/link names and item ids. 
- Add `_bbox_gap` helper and extend `_checked_pair_record` to include bounding-box gap data, canonical link names, and link_name fields. 
- Preserve existing baked transform, transform-chain, visual-origin counters and behavior; no URDF FK, baked transform generation, or mesh-indexing logic was changed. 

### Testing
- Ran `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke.py` and it succeeded. 
- Executed a synthetic invocation of `_apply_ur5_rendered_mesh_adjacency` in the smoke script which produced 7 checked UR5 adjacency pairs and returned `PASS` for the synthetic data. 
- Attempted requested `colcon build`/GUI smoke run but it was blocked in this environment because `/opt/ros/humble/setup.bash` and the ROS workspace were not available, so the full GUI smoke and manual screenshot checks were not run here. 
- No runtime, launch, controller, or hardware motion code was modified and fake-hardware-first behavior was preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a340dd50ac883319723006e6090f76f)