### PR TITLE
Improve rendered mesh adjacency reporting and add per-pair limit hook

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -412,6 +412,11 @@ UR5_RENDERED_MESH_ADJACENT_PAIRS: tuple[tuple[str, str], ...] = (
     ("wrist_2_link", "wrist_3_link"),
 )
 RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M = 0.20
+RENDERED_MESH_ADJACENCY_PAIR_LIMITS_M: dict[tuple[str, str], float] = {}
+
+
+def _rendered_mesh_adjacency_limit(parent: str, child: str) -> float:
+    return RENDERED_MESH_ADJACENCY_PAIR_LIMITS_M.get((parent, child), RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M)
 
 
 def _finite_float_list(value: Any, length: int) -> list[float] | None:
@@ -622,10 +627,32 @@ def _bbox_gap(parent_item: dict[str, Any] | None, child_item: dict[str, Any] | N
         return None
     return [max(0.0, max(float(cmin[i]) - float(pmax[i]), float(pmin[i]) - float(cmax[i]))) for i in range(3)]
 
-def _checked_pair_record(parent: str, child: str, parent_item: dict[str, Any] | None, child_item: dict[str, Any] | None, sep: float | None, ok: bool) -> dict[str, Any]:
+def _checked_pair_record(
+    parent: str,
+    child: str,
+    parent_item: dict[str, Any] | None,
+    child_item: dict[str, Any] | None,
+    sep: float | None,
+    limit_m: float,
+    ok: bool,
+) -> dict[str, Any]:
+    parent_link = (
+        (parent_item or {}).get("canonical_link_name")
+        or (parent_item or {}).get("link")
+        or (parent_item or {}).get("link_name")
+        or parent
+    )
+    child_link = (
+        (child_item or {}).get("canonical_link_name")
+        or (child_item or {}).get("link")
+        or (child_item or {}).get("link_name")
+        or child
+    )
     return {
         "parent": parent,
         "child": child,
+        "parent_link": parent_link,
+        "child_link": child_link,
         "parent_item_id": _item_id(parent_item or {}),
         "child_item_id": _item_id(child_item or {}),
         "parent_link_name": (parent_item or {}).get("link_name"),
@@ -640,9 +667,13 @@ def _checked_pair_record(parent: str, child: str, parent_item: dict[str, Any] | 
         "child_bbox_max": (child_item or {}).get("bounds", {}).get("max") if isinstance((child_item or {}).get("bounds"), dict) else None,
         "separation_m": sep,
         "bbox_gap_m": _bbox_gap(parent_item, child_item),
-        "limit_m": RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M,
+        "limit_m": limit_m,
+        "threshold_m": limit_m,
+        "passed": ok,
         "ok": ok,
     }
+
+
 def _final_draw_bbox_from_row(raw: dict[str, Any]) -> dict[str, list[float]] | None:
     bbox = raw.get("final_draw_bbox")
     if not isinstance(bbox, dict):
@@ -711,37 +742,67 @@ def _apply_ur5_rendered_mesh_adjacency(payload: dict[str, Any], *, repo_root: Pa
         child_item = by_link.get(child)
         if parent_item is None or child_item is None:
             errors.append(f"Missing final draw rendered mesh adjacency link for UR5 pair {parent}->{child}")
-            checked.append(_checked_pair_record(parent, child, parent_item, child_item, None, False))
+            checked.append(
+                _checked_pair_record(
+                    parent, child, parent_item, child_item, None, _rendered_mesh_adjacency_limit(parent, child), False
+                )
+            )
             continue
         if not isinstance(parent_item.get("bounds"), dict) or not isinstance(child_item.get("bounds"), dict):
             detail = parent_item.get("bbox_error") or child_item.get("bbox_error") or "bbox_missing"
             errors.append(f"Missing or non-finite final_draw_bbox diagnostics for UR5 adjacency pair {parent}->{child}: {detail}")
-            checked.append(_checked_pair_record(parent, child, parent_item, child_item, None, False))
+            checked.append(
+                _checked_pair_record(
+                    parent, child, parent_item, child_item, None, _rendered_mesh_adjacency_limit(parent, child), False
+                )
+            )
             continue
         sep = _aabb_separation(parent_item["bounds"], child_item["bounds"])
-        ok = math.isfinite(sep) and sep <= RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M
-        checked.append(_checked_pair_record(parent, child, parent_item, child_item, sep, ok))
+        limit_m = _rendered_mesh_adjacency_limit(parent, child)
+        ok = math.isfinite(sep) and sep <= limit_m
+        checked.append(_checked_pair_record(parent, child, parent_item, child_item, sep, limit_m, ok))
         if not ok:
             errors.append(
-                f"UR5 final draw bbox adjacency {parent}->{child} separated by {sep:.3f} m; expected <= {RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M:.3f} m"
+                f"UR5 final draw bbox adjacency {parent}->{child} separated by {sep:.3f} m; expected <= {limit_m:.3f} m"
             )
 
     tool_parent = by_link.get("tool0") or by_link.get("wrist_3_link")
     tool_parent_name = "tool0" if by_link.get("tool0") is not None else "wrist_3_link"
     if robotiq_base is None or tool_parent is None:
         errors.append("Robotiq base could not be associated with wrist_3_link or tool0 final draw diagnostics")
-        checked.append(_checked_pair_record(tool_parent_name, "robotiq_base", tool_parent, robotiq_base, None, False))
+        checked.append(
+            _checked_pair_record(
+                tool_parent_name,
+                "robotiq_base",
+                tool_parent,
+                robotiq_base,
+                None,
+                _rendered_mesh_adjacency_limit(tool_parent_name, "robotiq_base"),
+                False,
+            )
+        )
     elif not isinstance(tool_parent.get("bounds"), dict) or not isinstance(robotiq_base.get("bounds"), dict):
         detail = tool_parent.get("bbox_error") or robotiq_base.get("bbox_error") or "bbox_missing"
         errors.append(f"Missing or non-finite final_draw_bbox diagnostics for Robotiq base association with wrist_3_link/tool0: {detail}")
-        checked.append(_checked_pair_record(tool_parent_name, "robotiq_base", tool_parent, robotiq_base, None, False))
+        checked.append(
+            _checked_pair_record(
+                tool_parent_name,
+                "robotiq_base",
+                tool_parent,
+                robotiq_base,
+                None,
+                _rendered_mesh_adjacency_limit(tool_parent_name, "robotiq_base"),
+                False,
+            )
+        )
     else:
         sep = _aabb_separation(tool_parent["bounds"], robotiq_base["bounds"])
-        ok = math.isfinite(sep) and sep <= RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M
-        checked.append(_checked_pair_record(tool_parent_name, "robotiq_base", tool_parent, robotiq_base, sep, ok))
+        limit_m = _rendered_mesh_adjacency_limit(tool_parent_name, "robotiq_base")
+        ok = math.isfinite(sep) and sep <= limit_m
+        checked.append(_checked_pair_record(tool_parent_name, "robotiq_base", tool_parent, robotiq_base, sep, limit_m, ok))
         if not ok:
             errors.append(
-                f"Robotiq base final draw bbox separated from {tool_parent_name} by {sep:.3f} m; expected <= {RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M:.3f} m"
+                f"Robotiq base final draw bbox separated from {tool_parent_name} by {sep:.3f} m; expected <= {limit_m:.3f} m"
             )
 
     payload["rendered_mesh_adjacency_status"] = "PASS" if not errors else "FAIL"

--- a/tests/test_scene3d_gui_smoke_json_output_contract.py
+++ b/tests/test_scene3d_gui_smoke_json_output_contract.py
@@ -1,4 +1,6 @@
 import json, os, subprocess, sys
+
+import pytest
 from pathlib import Path
 
 
@@ -336,7 +338,54 @@ def test_ur5_rendered_mesh_adjacency_prefers_final_draw_bboxes():
     assert checked[-1]["parent_item_id"] == "draw_wrist_3_link"
     assert checked[-1]["child_item_id"] == "draw_robotiq_arg2f_base_link"
     assert checked[-1]["parent_bbox_min"] == [0.6, 0.0, 0.0]
+    assert checked[-1]["parent_bbox_max"] == [0.7, 0.1, 0.1]
+    assert checked[-1]["child_bbox_min"] == [0.7, 0.0, 0.0]
+    assert checked[-1]["child_bbox_max"] == [0.8, 0.1, 0.1]
+    assert checked[-1]["separation_m"] == 0.0
+    assert checked[-1]["limit_m"] == smoke.RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M
+    assert checked[-1]["threshold_m"] == smoke.RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M
+    assert checked[-1]["parent_link"] == "wrist_3_link"
+    assert checked[-1]["child_link"] == "robotiq_arg2f_base_link"
+    assert checked[-1]["passed"] is True
     assert checked[-1]["ok"] is True
+
+
+def test_ur5_rendered_mesh_adjacency_keeps_upper_arm_forearm_gap_strict():
+    import scripts.run_workcell_builder_scene3d_gui_smoke as smoke
+
+    def item(link: str, xmin: float, xmax: float) -> dict:
+        return {
+            "id": f"draw_{link}",
+            "link": link,
+            "mesh_path": f"meshes/{link}.dae",
+            "final_draw_bbox": {"min": [xmin, 0.0, 0.0], "max": [xmax, 0.1, 0.1]},
+        }
+
+    payload = {
+        "status": "PASS",
+        "final_draw_visual_items": [
+            item("base_link", 0.0, 0.1),
+            item("shoulder_link", 0.1, 0.2),
+            item("upper_arm_link", 0.2, 0.3),
+            item("forearm_link", 0.602, 0.702),
+            item("wrist_1_link", 0.702, 0.802),
+            item("wrist_2_link", 0.802, 0.902),
+            item("wrist_3_link", 0.902, 1.002),
+            item("robotiq_arg2f_base_link", 1.002, 1.102),
+        ],
+    }
+
+    smoke._apply_ur5_rendered_mesh_adjacency(
+        payload, repo_root=Path(__file__).resolve().parents[1], scene_name="ur5_2f_test", index_data={}
+    )
+
+    checked = payload["rendered_mesh_adjacency_checked_pairs"]
+    upper_forearm = next(pair for pair in checked if pair["parent"] == "upper_arm_link" and pair["child"] == "forearm_link")
+    assert payload["rendered_mesh_adjacency_status"] == "FAIL"
+    assert upper_forearm["separation_m"] == pytest.approx(0.302)
+    assert upper_forearm["limit_m"] == smoke.RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M
+    assert upper_forearm["ok"] is False
+    assert any("upper_arm_link->forearm_link" in error and "0.302 m" in error for error in payload["rendered_mesh_adjacency_errors"])
 
 
 def test_ur5_rendered_mesh_adjacency_final_draw_nonfinite_fails_without_index_fallback():


### PR DESCRIPTION
### Motivation
- Make the UR5 final-draw adjacency checker produce richer, diagnosable output so visual/manual inspection can justify any pair-specific tolerances. 
- Preserve the current strictness (global `0.20 m` limit) so real visible gaps (e.g. `upper_arm_link -> forearm_link` at ~0.302 m) still fail until manual evidence proves relaxation is safe.

### Description
- Introduced a per-pair limits map `RENDERED_MESH_ADJACENCY_PAIR_LIMITS_M` and helper `_rendered_mesh_adjacency_limit(parent, child)` that falls back to `RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M` when no pair-specific entry exists. 
- Expanded checked-pair JSON records produced by `_checked_pair_record(...)` to include `parent_link`, `child_link`, `parent_bbox_min`, `parent_bbox_max`, `child_bbox_min`, `child_bbox_max`, measured `separation_m`, the `limit_m`/`threshold_m` used, and both `passed` and `ok` booleans. 
- Updated `_apply_ur5_rendered_mesh_adjacency()` to use the per-pair limit lookup, to emit the selected limit in failure messages, and to populate the enhanced `rendered_mesh_adjacency_checked_pairs` entries. 
- Left the pair-limits dictionary empty (no pair-specific relaxations were added), and kept `RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M = 0.20` unchanged so no smoke PASS can be achieved by raising the global threshold. 
- Added/extended JSON-contract tests to assert the richer pair reporting and to ensure the `upper_arm_link -> forearm_link` gap remains a failure when the separation is ~0.302 m. Files changed: `scripts/run_workcell_builder_scene3d_gui_smoke.py` and `tests/test_scene3d_gui_smoke_json_output_contract.py`.

### Testing
- Ran `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke.py tests/test_scene3d_gui_smoke_json_output_contract.py` and it succeeded. 
- Ran `python3 -m pytest tests/test_scene3d_gui_smoke_json_output_contract.py -k 'ur5_rendered_mesh_adjacency_prefers_final_draw_bboxes or ur5_rendered_mesh_adjacency_keeps_upper_arm_forearm_gap_strict'` and the targeted tests passed. 
- Ran the full `python3 -m pytest tests/test_scene3d_gui_smoke_json_output_contract.py`; this run shows existing unrelated failures in the test file (some `BLOCKED` vs `FAIL` expectations and other non-adjacency contract assertions) that are pre-existing and not caused by the adjacency reporting changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3412dbcd4883318099c00cf02d2fa5)