### PR TITLE
Fix Scene3D generated visual transform root

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -157,6 +157,19 @@ void apply_urdf_pose_matrix(QMatrix4x4 & transform, double x, double y, double z
   apply_urdf_rpy_matrix(transform, roll, pitch, yaw);
 }
 
+QMatrix4x4 ros_to_viewport_basis_matrix()
+{
+  // Central ROS/RViz (X forward, Y left, Z up) to Scene3D/OpenGL viewport
+  // basis (X right, Y up, Z depth) conversion.  All generated visual preview
+  // model matrices enter this basis exactly once at the transform root.
+  QMatrix4x4 basis;
+  basis.setToIdentity();
+  basis(0, 0) = 1.0f; basis(0, 1) = 0.0f; basis(0, 2) = 0.0f;
+  basis(1, 0) = 0.0f; basis(1, 1) = 0.0f; basis(1, 2) = 1.0f;
+  basis(2, 0) = 0.0f; basis(2, 1) = -1.0f; basis(2, 2) = 0.0f;
+  return basis;
+}
+
 QMatrix4x4 authoritative_world_visual_transform(const ScenePreviewWidget::PreviewItem & item)
 {
   QMatrix4x4 transform;
@@ -180,9 +193,14 @@ QMatrix4x4 authoritative_world_visual_transform(const ScenePreviewWidget::Previe
   return transform;
 }
 
+QMatrix4x4 viewport_world_visual_transform(const ScenePreviewWidget::PreviewItem & item)
+{
+  return ros_to_viewport_basis_matrix() * authoritative_world_visual_transform(item);
+}
+
 void apply_authoritative_world_visual_transform_gl(const ScenePreviewWidget::PreviewItem & item)
 {
-  const QMatrix4x4 transform = authoritative_world_visual_transform(item);
+  const QMatrix4x4 transform = viewport_world_visual_transform(item);
   glMultMatrixf(transform.constData());
 }
 
@@ -260,9 +278,12 @@ bool item_has_non_identity_mesh_asset_local_correction(const ScenePreviewWidget:
 
 bool should_apply_baked_mesh_asset_local_correction(const ScenePreviewWidget::PreviewItem & item)
 {
-  return item.has_baked_world_visual_transform &&
-         item_references_ur5_baked_mesh_asset_local_correction(item) &&
-         item_has_non_identity_mesh_asset_local_correction(item);
+  Q_UNUSED(item);
+  // Generated visual mesh entries are already RViz/URDF-authored as
+  // world_T_link_or_object * visual_origin_T.  Do not reintroduce the old
+  // ad hoc UR5 DAE correction path; any asset-local correction must be part of
+  // the generated mesh-local transform, not a link-name/mesh-name special case.
+  return false;
 }
 
 QString baked_mesh_asset_local_correction_reason(const ScenePreviewWidget::PreviewItem & item)
@@ -335,7 +356,7 @@ void apply_mesh_local_correction_matrix(QMatrix4x4 & transform, const ScenePrevi
 
 QMatrix4x4 final_mesh_transform_matrix(const ScenePreviewWidget::PreviewItem & item)
 {
-  QMatrix4x4 transform = authoritative_world_visual_transform(item);
+  QMatrix4x4 transform = viewport_world_visual_transform(item);
   apply_mesh_local_correction_matrix(transform, item);
   transform.scale(static_cast<float>(item.mesh_scale_x),
                   static_cast<float>(item.mesh_scale_y),
@@ -3379,8 +3400,11 @@ QJsonArray Scene3DViewportWidget::final_draw_visual_items_export() const
     row["local_max"] = scene3d_vec_to_json(cache.local_max);
 
     const QMatrix4x4 baked_transform = authoritative_world_visual_transform(item);
+    const QMatrix4x4 viewport_root_transform = viewport_world_visual_transform(item);
     const QMatrix4x4 final_transform = final_mesh_transform_matrix(item);
     row["baked_world_visual_matrix"] = scene3d_matrix_to_json(baked_transform);
+    row["ros_to_viewport_basis_matrix"] = scene3d_matrix_to_json(ros_to_viewport_basis_matrix());
+    row["viewport_world_visual_matrix"] = scene3d_matrix_to_json(viewport_root_transform);
     row["final_draw_model_matrix"] = scene3d_matrix_to_json(final_transform);
     row["final_draw_world_pose"] = scene3d_vec_to_json(final_transform.map(QVector3D(0.0f, 0.0f, 0.0f)));
 

--- a/workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp
@@ -229,3 +229,59 @@ TEST(Scene3DMeshPreviewRegression, ProductWarningStateExcludesEditableAndOverlay
   const auto warning_selector = src.find("debug_overlays_mode\n    ? debug_view_has_full_diagnostic_warning_content(last_render_counters)\n    : product_view_has_generated_mesh_warning_content(last_render_counters)");
   EXPECT_NE(warning_selector, std::string::npos);
 }
+
+TEST(Scene3DMeshPreviewRegression, CentralizesRosToViewportBasisForGeneratedVisuals)
+{
+  const std::string src = load_file(std::string(WORKCELL_BUILDER_SOURCE_DIR) + "/gui/scene3d_viewport_widget.cpp");
+  ASSERT_FALSE(src.empty());
+
+  const auto basis = src.find("QMatrix4x4 ros_to_viewport_basis_matrix()");
+  ASSERT_NE(basis, std::string::npos);
+  const auto authoritative = src.find("QMatrix4x4 authoritative_world_visual_transform", basis);
+  ASSERT_NE(authoritative, std::string::npos);
+  const std::string basis_body = src.substr(basis, authoritative - basis);
+  EXPECT_NE(basis_body.find("basis(1, 2) = 1.0f"), std::string::npos);  // ROS Z becomes viewport up/Y.
+  EXPECT_NE(basis_body.find("basis(2, 1) = -1.0f"), std::string::npos); // ROS Y becomes viewport depth.
+
+  const auto viewport_root = src.find("QMatrix4x4 viewport_world_visual_transform", authoritative);
+  ASSERT_NE(viewport_root, std::string::npos);
+  const auto viewport_root_end = src.find("void apply_authoritative_world_visual_transform_gl", viewport_root);
+  ASSERT_NE(viewport_root_end, std::string::npos);
+  const std::string viewport_body = src.substr(viewport_root, viewport_root_end - viewport_root);
+  EXPECT_NE(viewport_body.find("return ros_to_viewport_basis_matrix() * authoritative_world_visual_transform(item);"), std::string::npos);
+
+  const auto final_mesh = src.find("QMatrix4x4 final_mesh_transform_matrix");
+  ASSERT_NE(final_mesh, std::string::npos);
+  const auto final_mesh_end = src.find("void apply_mesh_local_correction_gl", final_mesh);
+  ASSERT_NE(final_mesh_end, std::string::npos);
+  const std::string final_body = src.substr(final_mesh, final_mesh_end - final_mesh);
+  EXPECT_EQ(final_body.find("ros_to_viewport_basis_matrix()"), std::string::npos) << "basis must not be duplicated inside mesh-local composition";
+  EXPECT_NE(final_body.find("QMatrix4x4 transform = viewport_world_visual_transform(item);"), std::string::npos);
+  EXPECT_NE(final_body.find("apply_mesh_local_correction_matrix(transform, item);"), std::string::npos);
+  EXPECT_NE(final_body.find("transform.scale"), std::string::npos);
+}
+
+TEST(Scene3DMeshPreviewRegression, SuppressesFallbackBoxesWhenMeshSurfaceLoads)
+{
+  const std::string src = load_file(std::string(WORKCELL_BUILDER_SOURCE_DIR) + "/gui/scene3d_viewport_widget.cpp");
+  ASSERT_FALSE(src.empty());
+  EXPECT_NE(src.find("if (draw_mesh_preview_if_available(it, visual_color, true))"), std::string::npos);
+  EXPECT_NE(src.find("return true;\n  }\n  if (generated_or_locked_preview && item_has_valid_urdf_primitive(it))"), std::string::npos)
+    << "successful mesh draw must return before URDF primitive/fallback boxes are considered";
+  EXPECT_NE(src.find("WORKCELL_SCENE3D_DEBUG_FALLBACK_BOXES"), std::string::npos);
+  EXPECT_NE(src.find("if (!editable_layout_preview && !scene3d_debug_fallback_boxes_enabled())"), std::string::npos);
+}
+
+TEST(Scene3DMeshPreviewRegression, BakedUrdfVisualsDoNotUseAdHocUr5MeshCorrections)
+{
+  const std::string src = load_file(std::string(WORKCELL_BUILDER_SOURCE_DIR) + "/gui/scene3d_viewport_widget.cpp");
+  ASSERT_FALSE(src.empty());
+  const auto helper = src.find("bool should_apply_baked_mesh_asset_local_correction");
+  ASSERT_NE(helper, std::string::npos);
+  const auto helper_end = src.find("QString baked_mesh_asset_local_correction_reason", helper);
+  ASSERT_NE(helper_end, std::string::npos);
+  const std::string body = src.substr(helper, helper_end - helper);
+  EXPECT_NE(body.find("return false;"), std::string::npos);
+  EXPECT_NE(body.find("Do not reintroduce the old"), std::string::npos);
+  EXPECT_EQ(body.find("item_references_ur5_baked_mesh_asset_local_correction(item)"), std::string::npos);
+}


### PR DESCRIPTION
Summary:
- Centralized the ROS/RViz Z-up to Scene3D/OpenGL viewport basis conversion in `ros_to_viewport_basis_matrix()`.
- Routed generated visual preview transforms through a single viewport transform root before composing mesh-local transforms and scale.
- Disabled the old ad hoc baked UR5 mesh correction path for generated URDF visuals so URDF/world/visual-origin semantics remain the visual source of truth.
- Added regression coverage for basis inversion, duplicate basis conversion, fallback-box suppression after successful mesh draw, and avoiding UR5-specific mesh correction reliance.

Validation:
- `git diff --check` passed.
- Static Scene3D transform assertions passed.
- `colcon build --symlink-install --packages-select workcell_builder` was not run because `/opt/ros/humble/setup.bash` is missing in this container.
- `scripts/run_workcell_builder_scene3d_gui_smoke.py` screenshot/JSON smoke was not run because `/opt/ros/humble/setup.bash` is missing in this container.

Safety:
- Change is limited to Workcell Builder Scene3D preview rendering and static regression tests.
- No launch files, controllers, runtime services, hardware parameters, or real robot execution paths were changed.
- Fake-hardware defaults and guarded real-hardware behavior are unchanged.

Risks / rollback:
- Needs validation in a ROS 2 Humble workspace with Qt/OpenGL available to confirm the `ur5_2f_test` screenshot and JSON smoke output.
- If unexpected viewport orientation regressions appear, revert commit `1babf88` to restore the previous Scene3D transform behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a351711ce00833190a19a88bad6f3e2)