### PR TITLE
Log fake-hardware preview launch details

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -4686,6 +4686,11 @@ void MainWindow::run_fake_hardware_preview(){
   append_studio_log("RViz Truth Preview launch started");
   set_preview_state("PREVIEW_RUNNING");
   write_preview_launch_transcript(true, command, "preview_started");
+  append_studio_log(QString("RViz Truth Preview launch command: scene=%1 package=%2 fake_hardware=true launch_path=%3 command=%4")
+    .arg(QString::fromStdString(scene.scene_name),
+      QString::fromStdString(scene.scene_name),
+      QString::fromStdString((scene.scene_dir / "launch" / "demo.launch.py").string()),
+      command));
   preview_process_->start("bash", {"-lc", command});
   refresh_new_cell_checklist();
 }


### PR DESCRIPTION
### Motivation
- Add a concise Studio log entry immediately before starting a fake-hardware preview so operators and logs can record the selected scene, package, launch path, fake-hardware marker, and the full launch command for diagnostics and auditability.

### Description
- Inserted an `append_studio_log(...)` call in `MainWindow::run_fake_hardware_preview()` (file `workcell_builder/workcell_builder/gui/mainwindow.cpp`) that logs `scene.scene_name`, the package name, `fake_hardware=true`, the launch path (`scene.scene_dir / "launch" / "demo.launch.py"`), and the full command string immediately prior to `preview_process_->start(...)`, while preserving the existing fake-hardware-only behavior and not adding any real-hardware flags or motion commands.

### Testing
- Ran `git diff --check` which passed; ran `rg -n "RViz Truth Preview launch command|use_fake_hardware:=true|run_fake_hardware_preview"` to verify the log insertion which passed; a full `colcon build` was not run because `/opt/ros/humble/setup.bash` is not present in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36882ad4a083319805ddad5b0a7771)