### PR TITLE
Use scene launch metadata for preview commands

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -343,6 +343,13 @@ if(BUILD_TESTING)
     test/command_builders_test.cpp
     src_workcell_builder_command_builders.cpp)
 
+  ament_add_gtest(workcell_rviz_preview_metadata_command_test
+    test/rviz_preview_metadata_command_test.cpp
+    src_rviz_preview_runner.cpp
+    src_workcell_studio_scene_browser.cpp
+    src_workcell_warning_once.cpp
+    src_workcell_yaml_utils.cpp)
+
   ament_add_gtest(workcell_scene_preview_widget_ui_test
     test/scene_preview_widget_ui_test.cpp
     gui/scene_preview_widget.cpp
@@ -376,6 +383,10 @@ if(BUILD_TESTING)
 
   if(TARGET workcell_workspace_validation_test)
     target_link_libraries(workcell_workspace_validation_test Qt5::Widgets)
+  endif()
+
+  if(TARGET workcell_rviz_preview_metadata_command_test)
+    target_link_libraries(workcell_rviz_preview_metadata_command_test Qt5::Core)
   endif()
 
   if(TARGET workcell_scene3d_stl_parser_test)

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -3925,7 +3925,7 @@ QString MainWindow::selected_scene_launch_command() const
 {
   if (selected_scene_index_ < 0 || selected_scene_index_ >= static_cast<int>(scene_browser_result_.scenes.size())) return "";
   const auto & scene = scene_browser_result_.scenes[static_cast<size_t>(selected_scene_index_)];
-  return workcell_builder::build_command(QString::fromStdString(scene.scene_name));
+  return workcell_builder::build_command(scene);
 }
 
 
@@ -4391,7 +4391,7 @@ QString MainWindow::detect_workspace_root() const
   return QDir::homePath();
 }
 
-QString MainWindow::selected_scene_build_command() const { if (selected_scene_index_ < 0) return ""; return QString("cd %1 && source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select %2").arg(detect_workspace_root(), QString::fromStdString(scene_browser_result_.scenes[(size_t)selected_scene_index_].scene_name)); }
+QString MainWindow::selected_scene_build_command() const { if (selected_scene_index_ < 0) return ""; const auto & scene = scene_browser_result_.scenes[(size_t)selected_scene_index_]; return QString("cd %1 && source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select %2").arg(detect_workspace_root(), QString::fromStdString(scene.launch_package.empty() ? scene.scene_name : scene.launch_package)); }
 QString MainWindow::selected_scene_source_command() const { return QString("cd %1 && source install/setup.bash").arg(detect_workspace_root()); }
 QString MainWindow::selected_scene_preview_command_block() const { return selected_scene_build_command()+"\n"+selected_scene_source_command()+"\ncd "+detect_workspace_root()+" && "+selected_scene_launch_command(); }
 
@@ -4444,14 +4444,14 @@ void MainWindow::refresh_preview_launch_ui()
   QStringList blockers;
   if (has_scene) {
     const auto & s = scene_browser_result_.scenes[(size_t)selected_scene_index_];
-    if (!s.has_launch_demo) readiness = "BLOCKED_MISSING_LAUNCH";
+    if (!s.has_launch_demo && s.launch_file.empty()) readiness = "BLOCKED_MISSING_LAUNCH";
     else if (!s.has_task_intent) readiness = "BLOCKED_MISSING_TASK_INTENT";
     else if (!selected_scene_preview_ready(&blockers)) readiness = "WARNINGS_PRESENT";
     else readiness = "READY_FOR_FAKE_HARDWARE_PREVIEW";
     const auto metadata = selected_scene_metadata_summary(s);
     if (preview_scene_label_) preview_scene_label_->setText(QString("<b>Selected Scene</b><br/>scene name: %1<br/>scene path: %2<br/>robot: %3<br/>robot source: %4<br/>end effector: %5<br/>end effector source: %6<br/>task file status: %7<br/>launch/demo.launch.py status: %8<br/>package.xml/CMakeLists status: %9<br/>preview snapshot path: %10")
       .arg(metadata.scene_name, metadata.scene_path, metadata.robot, metadata.robot_source, metadata.end_effector, metadata.end_effector_source,
-      s.has_task_recipe ? "present" : "missing", s.has_launch_demo ? "present" : "missing", (s.has_package_xml && s.has_launch_demo) ? "present" : "missing")
+      s.has_task_recipe ? "present" : "missing", s.has_launch_demo ? "present" : "missing", (s.has_package_xml && (s.has_launch_demo || !s.launch_file.empty())) ? "present" : "missing")
       .arg(QString::fromStdString((s.scene_dir / "preview" / "workcell_studio_canvas_snapshot.png").string())));
     if (validation_summary_label_) validation_summary_label_->setText(QString("<b>Validation Summary</b><br/>Scene: %1<br/>Readiness Gate: %2").arg(QString::fromStdString(s.scene_name), readiness));
   }

--- a/workcell_builder/workcell_builder/include/rviz_preview_runner.hpp
+++ b/workcell_builder/workcell_builder/include/rviz_preview_runner.hpp
@@ -20,7 +20,9 @@ struct PreviewReadinessStatus
 };
 
 QString build_command(const QString & scene_pkg);
+QString build_command(const WorkcellStudioSceneInfo & scene_info);
 QString build_shell_command(const QString & scene_pkg, const boost::filesystem::path & workspace_root);
+QString build_shell_command(const WorkcellStudioSceneInfo & scene_info, const boost::filesystem::path & workspace_root);
 PreviewReadinessStatus validate_readiness(
   const WorkcellStudioSceneInfo & scene_info,
   const boost::filesystem::path & workspace_root);

--- a/workcell_builder/workcell_builder/include/workcell_studio_scene_browser.hpp
+++ b/workcell_builder/workcell_builder/include/workcell_studio_scene_browser.hpp
@@ -24,6 +24,11 @@ struct WorkcellStudioSceneInfo
   bool has_static_preview_svg{false};
   bool has_static_preview_html{false};
   bool has_scene_manifest_yaml{false};
+  std::string launch_package;
+  std::string launch_file;
+  bool launch_metadata_present{false};
+  bool launch_metadata_file_exists{false};
+  std::string launch_metadata_warning;
   std::string status{"BLOCKED"};
   std::string robot_summary{"unknown"};
   std::string gripper_summary{"unknown"};

--- a/workcell_builder/workcell_builder/src_rviz_preview_runner.cpp
+++ b/workcell_builder/workcell_builder/src_rviz_preview_runner.cpp
@@ -50,7 +50,7 @@ bool launch_command_is_safe(const QString & command, QString * reason)
 
   const QString trimmed = command.trimmed();
   const QRegularExpression expected_launch_re(
-    R"(\bros2\s+launch\s+\S+\s+demo\.launch\.py(?:\s+.*)?$)");
+    R"(\bros2\s+launch\s+\S+\s+\S+\.launch\.py(?:\s+.*)?$)");
   if (!expected_launch_re.match(trimmed).hasMatch()) {
     return reject();
   }
@@ -65,11 +65,28 @@ QString build_command(const QString & scene_pkg)
   return QString("ros2 launch %1 demo.launch.py use_fake_hardware:=true launch_rviz:=true").arg(scene_pkg);
 }
 
+QString build_command(const WorkcellStudioSceneInfo & scene_info)
+{
+  const QString launch_package = QString::fromStdString(
+    scene_info.launch_package.empty() ? scene_info.scene_name : scene_info.launch_package);
+  const QString launch_file = QString::fromStdString(
+    scene_info.launch_file.empty() ? std::string("demo.launch.py") : scene_info.launch_file);
+  return QString("ros2 launch %1 %2 use_fake_hardware:=true launch_rviz:=true")
+    .arg(launch_package, launch_file);
+}
+
 QString build_shell_command(const QString & scene_pkg, const boost::filesystem::path & workspace_root)
 {
   const QString workspace_setup = QString::fromStdString((workspace_root / "install" / "setup.bash").string());
   return QString("bash -lc 'source /opt/ros/humble/setup.bash && source %1 && %2'")
     .arg(workspace_setup, build_command(scene_pkg));
+}
+
+QString build_shell_command(const WorkcellStudioSceneInfo & scene_info, const boost::filesystem::path & workspace_root)
+{
+  const QString workspace_setup = QString::fromStdString((workspace_root / "install" / "setup.bash").string());
+  return QString("bash -lc 'source /opt/ros/humble/setup.bash && source %1 && %2'")
+    .arg(workspace_setup, build_command(scene_info));
 }
 
 PreviewReadinessStatus validate_readiness(
@@ -81,7 +98,10 @@ PreviewReadinessStatus validate_readiness(
   if (!scene_info.has_package_xml) return blocked("package.xml missing");
   if (scene_info.status.find("BLOCKED") != std::string::npos) return blocked("BLOCKED acceptance scene");
   if (scene_info.status.find("PREVIEW_ONLY") != std::string::npos) return blocked("PREVIEW_ONLY scenes cannot run");
-  if (!scene_info.has_launch_demo) return blocked("launch/demo.launch.py missing");
+  if (scene_info.launch_metadata_present && !scene_info.launch_metadata_warning.empty()) {
+    return blocked(QString::fromStdString(scene_info.launch_metadata_warning));
+  }
+  if (!scene_info.has_launch_demo && scene_info.launch_file.empty()) return blocked("launch/demo.launch.py missing");
   if (!scene_info.has_task_intent) return blocked("Missing config/workcell_builder_task_intent.yaml");
 
   const boost::filesystem::path workspace_setup = workspace_root / "install" / "setup.bash";
@@ -145,7 +165,7 @@ PreviewReadinessStatus dry_run(
 {
   const PreviewReadinessStatus readiness = validate_readiness(scene_info, workspace_root);
   if (!readiness.ready) return readiness;
-  const QString generated = build_shell_command(QString::fromStdString(scene_info.scene_name), workspace_root);
+  const QString generated = build_shell_command(scene_info, workspace_root);
   if (command) {
     *command = generated;
   }
@@ -160,7 +180,7 @@ PreviewReadinessStatus dry_run(
       "-lc",
       QString("source /opt/ros/humble/setup.bash && source '%1' && ros2 pkg prefix %2")
         .arg(QString::fromStdString((workspace_root / "install" / "setup.bash").string()))
-        .arg(QString::fromStdString(scene_info.scene_name))});
+        .arg(QString::fromStdString(scene_info.launch_package.empty() ? scene_info.scene_name : scene_info.launch_package))});
   pkg_check.start();
   if (!pkg_check.waitForFinished(10000) ||
     pkg_check.exitStatus() != QProcess::NormalExit || pkg_check.exitCode() != 0)

--- a/workcell_builder/workcell_builder/src_workcell_studio_scene_browser.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_scene_browser.cpp
@@ -69,6 +69,47 @@ std::string compute_status(const WorkcellStudioSceneInfo & s)
   return "BLOCKED";
 }
 
+
+std::string scalar_string(const YAML::Node & node)
+{
+  if (!node || !node.IsScalar()) return "";
+  return node.as<std::string>("");
+}
+
+void try_parse_manifest_launch_metadata(WorkcellStudioSceneInfo * s)
+{
+  if (s == nullptr || !s->has_scene_manifest_yaml) return;
+  const fs::path manifest_yaml = s->scene_dir / "scene_manifest.yaml";
+  try {
+    const YAML::Node n = YAML::LoadFile(manifest_yaml.string());
+    const std::string package_name = scalar_string(n["scene"]["package"]);
+    const std::string launch_path = scalar_string(n["files"]["launch"]);
+    if (!package_name.empty()) {
+      s->launch_package = package_name;
+      s->launch_metadata_present = true;
+    }
+    if (!launch_path.empty()) {
+      const fs::path manifest_launch_path(launch_path);
+      s->launch_file = manifest_launch_path.filename().string();
+      s->launch_metadata_present = true;
+      const fs::path resolved = manifest_launch_path.is_absolute() ? manifest_launch_path : (s->scene_dir / manifest_launch_path);
+      s->launch_metadata_file_exists = exists_file(resolved);
+      if (!s->launch_metadata_file_exists) {
+        s->launch_metadata_warning = "scene_manifest.yaml launch file missing: " + resolved.string();
+      }
+    }
+  } catch (const std::exception & e) {
+    const std::string msg = std::string("Could not parse scene_manifest.yaml launch metadata: ") + e.what() +
+      " (file: " + manifest_yaml.string() + ")";
+    if (s->parse_warning.empty()) {
+      s->parse_warning = msg;
+    } else {
+      s->parse_warning += "; " + msg;
+    }
+    log_warning_once_per_context_path_reason("scene_browser_load", manifest_yaml, "scene manifest YAML parse failed");
+  }
+}
+
 void try_parse_env(WorkcellStudioSceneInfo * s)
 {
   if (s == nullptr) return;
@@ -143,6 +184,7 @@ WorkcellStudioSceneBrowserResult discover_workcell_studio_scenes(const fs::path 
       s.has_static_preview_svg = exists_file(s.scene_dir / "preview" / "static_preview.svg");
       s.has_static_preview_html = exists_file(s.scene_dir / "preview" / "static_preview.html");
       s.has_scene_manifest_yaml = exists_file(s.scene_dir / "scene_manifest.yaml");
+      if (s.has_scene_manifest_yaml) try_parse_manifest_launch_metadata(&s);
       if (!is_valid_scene_package(s)) {
         continue;
       }

--- a/workcell_builder/workcell_builder/test/rviz_preview_metadata_command_test.cpp
+++ b/workcell_builder/workcell_builder/test/rviz_preview_metadata_command_test.cpp
@@ -1,0 +1,105 @@
+#include <gtest/gtest.h>
+
+#include <boost/filesystem.hpp>
+
+#include <fstream>
+
+#include "rviz_preview_runner.hpp"
+#include "workcell_studio_scene_browser.hpp"
+
+namespace fs = boost::filesystem;
+
+namespace {
+
+workcell_builder::WorkcellStudioSceneInfo runnable_scene()
+{
+  workcell_builder::WorkcellStudioSceneInfo scene;
+  scene.scene_name = "ur5_2f_test";
+  scene.has_package_xml = true;
+  scene.has_launch_demo = true;
+  scene.has_task_intent = true;
+  scene.status = "READY";
+  return scene;
+}
+
+}  // namespace
+
+TEST(RvizPreviewMetadataCommandTest, UsesMetadataDerivedLaunchPackageAndFile)
+{
+  auto scene = runnable_scene();
+  scene.launch_metadata_present = true;
+  scene.launch_package = "custom_generated_pkg";
+  scene.launch_file = "custom_preview.launch.py";
+  scene.launch_metadata_file_exists = true;
+
+  const QString command = workcell_builder::build_command(scene);
+
+  EXPECT_EQ(
+    command,
+    "ros2 launch custom_generated_pkg custom_preview.launch.py use_fake_hardware:=true launch_rviz:=true");
+}
+
+TEST(RvizPreviewMetadataCommandTest, FallsBackToSceneNameAndDemoLaunch)
+{
+  const auto scene = runnable_scene();
+
+  const QString command = workcell_builder::build_command(scene);
+
+  EXPECT_EQ(command, "ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true");
+}
+
+TEST(RvizPreviewMetadataCommandTest, BlocksMissingMetadataLaunchFileClearly)
+{
+  auto scene = runnable_scene();
+  scene.launch_metadata_present = true;
+  scene.launch_package = "custom_generated_pkg";
+  scene.launch_file = "missing_preview.launch.py";
+  scene.launch_metadata_file_exists = false;
+  scene.launch_metadata_warning = "scene_manifest.yaml launch file missing: /tmp/scene/launch/missing_preview.launch.py";
+
+  const auto status = workcell_builder::validate_readiness(scene, fs::current_path());
+
+  EXPECT_FALSE(status.ready);
+  EXPECT_NE(status.blocker_reason.indexOf("scene_manifest.yaml launch file missing"), -1);
+  EXPECT_NE(status.blocker_reason.indexOf("missing_preview.launch.py"), -1);
+}
+
+TEST(RvizPreviewMetadataCommandTest, DiscoversManifestLaunchMetadata)
+{
+  const fs::path root = fs::temp_directory_path() / fs::unique_path("workcell_scene_metadata_test_%%%%%%");
+  const fs::path scene_dir = root / "src" / "easy_manipulation_deployment" / "scenes" / "metadata_scene";
+  fs::create_directories(scene_dir / "launch");
+  std::ofstream(scene_dir / "environment.yaml") << "robot: {name: ur5}\n";
+  std::ofstream(scene_dir / "package.xml") << "<package format=\"3\"><name>metadata_pkg</name></package>\n";
+  std::ofstream(scene_dir / "launch" / "custom.launch.py") << "# launch\n";
+  std::ofstream(scene_dir / "scene_manifest.yaml")
+    << "scene:\n"
+    << "  name: metadata_scene\n"
+    << "  package: metadata_pkg\n"
+    << "files:\n"
+    << "  launch: launch/custom.launch.py\n";
+
+  const auto result = workcell_builder::discover_workcell_studio_scenes(root);
+
+  ASSERT_EQ(result.scenes.size(), 1U);
+  EXPECT_EQ(result.scenes[0].launch_package, "metadata_pkg");
+  EXPECT_EQ(result.scenes[0].launch_file, "custom.launch.py");
+  EXPECT_TRUE(result.scenes[0].launch_metadata_file_exists);
+
+  fs::remove_all(root);
+}
+
+TEST(RvizPreviewMetadataCommandTest, FakeHardwareAndRvizRemainDefaultWithoutRealHardwareFlags)
+{
+  auto scene = runnable_scene();
+  scene.launch_package = "custom_generated_pkg";
+  scene.launch_file = "custom_preview.launch.py";
+
+  const QString command = workcell_builder::build_command(scene);
+
+  EXPECT_NE(command.indexOf("use_fake_hardware:=true"), -1);
+  EXPECT_NE(command.indexOf("launch_rviz:=true"), -1);
+  EXPECT_EQ(command.indexOf("use_fake_hardware:=false"), -1);
+  EXPECT_EQ(command.indexOf("real_hardware:=true"), -1);
+  EXPECT_EQ(command.indexOf("runtime_execution_enabled:=true"), -1);
+}


### PR DESCRIPTION
### Motivation
- Ensure the selected-scene preview/dry-run flow can prefer scene-generated launch metadata (package + launch file) when available in `scene_manifest.yaml` so previews run the intended generated package.  
- Preserve safety defaults by always enforcing `use_fake_hardware:=true` and `launch_rviz:=true` and by surfacing clear blockers when manifest metadata points to a missing launch file.  
- Fall back to the existing `scene_name` + `demo.launch.py` behavior when no manifest metadata is present.

### Description
- Added optional launch metadata fields to `WorkcellStudioSceneInfo`: `launch_package`, `launch_file`, `launch_metadata_present`, `launch_metadata_file_exists`, and `launch_metadata_warning` in `include/workcell_studio_scene_browser.hpp`.  
- Parse `scene_manifest.yaml` during scene discovery and populate the new fields via `try_parse_manifest_launch_metadata` (added in `src_workcell_studio_scene_browser.cpp`), resolving relative paths and recording a clear warning when the referenced launch file does not exist.  
- Added metadata-aware overloads of the preview command builders in `rviz_preview_runner`: `build_command(const WorkcellStudioSceneInfo&)` and `build_shell_command(const WorkcellStudioSceneInfo&, ...)`, which prefer manifest-derived `package`/`launch` and fall back to `scene_name`/`demo.launch.py`.  
- Updated `validate_readiness`/`dry_run` to: prefer manifest metadata, block when the manifest indicates a missing launch file, and check the package prefix against the manifest-derived package name when generating the dry-run command.  
- Wired UI code to use the metadata-aware command path: `selected_scene_launch_command()` now calls the `WorkcellStudioSceneInfo` variant and `selected_scene_build_command()` prefers `launch_package` when present (`gui/mainwindow.cpp`).  
- Added focused unit tests in `test/rviz_preview_metadata_command_test.cpp` covering metadata-derived command generation, fallback behavior for `ur5_2f_test`, explicit blocking when manifest launch file is missing, discovery of manifest launch metadata, and enforcement of fake-hardware/RViz flags; and registered the new test in `CMakeLists.txt`.

### Testing
- Ran static verification `git diff --check` which passed locally.  
- Attempted to build the package with `source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select workcell_builder`, but the build was not executed because this container lacks `/opt/ros/humble/setup.bash` (environment not provisioned); therefore the new tests were not run here.  
- New automated coverage: added `workcell_rviz_preview_metadata_command_test` (GTest) to exercise the metadata parsing and command generation logic; these tests should be executed in a CI or developer environment with ROS/Humble and Qt/yaml-cpp available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a368a68369883318bd484ea13431cd7)