### PR TITLE
Fix RViz preview --scene determinism validation

### DIFF
--- a/scripts/validate_rviz_truth_preview_ui_path.py
+++ b/scripts/validate_rviz_truth_preview_ui_path.py
@@ -68,7 +68,7 @@ def main() -> int:
     if not setup_bash.is_file():
         blockers.append("install/setup.bash missing under workspace root")
 
-    if launch_command != _build_launch_command(args.scene_pkg):
+    if launch_command != _build_launch_command(scene_pkg):
         blockers.append("launch command build is non-deterministic")
 
     lower = launch_command.lower()

--- a/tests/test_validate_rviz_truth_preview_ui_path.py
+++ b/tests/test_validate_rviz_truth_preview_ui_path.py
@@ -19,6 +19,43 @@ def _run(scene: str, workspace: Path, *extra: str) -> subprocess.CompletedProces
     )
 
 
+def _run_scene_option(scene: str, workspace: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--scene",
+            scene,
+            "--workspace-root",
+            str(workspace),
+            "--repo-root",
+            str(ROOT),
+            "--json",
+            *extra,
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_scene_option_exact_command_has_no_false_non_determinism_blocker(tmp_path: Path):
+    (tmp_path / "scenes" / "ur5_2f_test" / "launch").mkdir(parents=True)
+    (tmp_path / "scenes" / "ur5_2f_test" / "package.xml").write_text("<package/>", encoding="utf-8")
+    (tmp_path / "scenes" / "ur5_2f_test" / "launch" / "demo.launch.py").write_text("# launch", encoding="utf-8")
+    (tmp_path / "install").mkdir()
+    (tmp_path / "install" / "setup.bash").write_text("# setup", encoding="utf-8")
+
+    proc = _run_scene_option("ur5_2f_test", tmp_path)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    payload = json.loads(proc.stdout)
+
+    expected = "ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true"
+    assert payload["exact_launch_command"] == expected
+    assert "launch command build is non-deterministic" not in payload["blockers"]
+
+
 def test_exact_command_and_required_tokens_for_ur5_2f_test(tmp_path: Path):
     (tmp_path / "scenes" / "ur5_2f_test" / "launch").mkdir(parents=True)
     (tmp_path / "scenes" / "ur5_2f_test" / "package.xml").write_text("<package/>", encoding="utf-8")


### PR DESCRIPTION
### Motivation
- Avoid spurious non-determinism blockers when the validator is invoked with the `--scene` option by ensuring the determinism check compares against the already-normalized `scene_pkg` value.

### Description
- Updated `scripts/validate_rviz_truth_preview_ui_path.py` to compare `launch_command` against `_build_launch_command(scene_pkg)` instead of `_build_launch_command(args.scene_pkg)`, and added a regression test in `tests/test_validate_rviz_truth_preview_ui_path.py` that invokes the script with `--scene ur5_2f_test` and verifies a zero return code, the exact `exact_launch_command`, and absence of the false non-determinism blocker.

### Testing
- Ran `pytest -q tests/test_validate_rviz_truth_preview_ui_path.py` and the test suite passed (6 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a368c0383e083318527e16fb8b4f891)