### PR TITLE
Fix RViz preview metadata test registration and linking

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -386,7 +386,7 @@ if(BUILD_TESTING)
   endif()
 
   if(TARGET workcell_rviz_preview_metadata_command_test)
-    target_link_libraries(workcell_rviz_preview_metadata_command_test Qt5::Core)
+    target_link_libraries(workcell_rviz_preview_metadata_command_test Qt5::Core yaml-cpp ${Boost_LIBRARIES})
   endif()
 
   if(TARGET workcell_scene3d_stl_parser_test)
@@ -624,6 +624,7 @@ if(BUILD_TESTING)
     layout_serialization_contract_test.cpp
     workcell_studio_layout_editor_test.cpp
     mainwindow_rviz_preview_compile_test.cpp
+    rviz_preview_metadata_command_test.cpp
     visual_mesh_source_resolver_test.cpp
   )
 


### PR DESCRIPTION
Fixes the Humble build break caused by rviz_preview_metadata_command_test.cpp.

Changes:
- Registers rviz_preview_metadata_command_test.cpp in workcell_builder_registered_cpp_tests.
- Links the test target with yaml-cpp and Boost libraries, matching the dependencies used by the test sources.

Validation:
- colcon build --symlink-install --packages-select workcell_builder passed in the real ROS Humble workspace.

Notes:
- No Scene3D changes.
- No generated JSON/smoke screenshot/log changes committed.