### PR TITLE
Improve visual-index robot base frame resolution

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -8462,6 +8462,85 @@ void MainWindow::populate_scene_hierarchy()
     }
   }
   QString robot_base_frame = QStringLiteral("unknown");
+  struct RobotBaseFrameCandidate {
+    QString frame;
+    int score{-100000};
+  };
+  auto robot_base_frame_reject_or_downrank_score = [](const QString & frame) {
+    const QString token = canonical_scene3d_token(frame);
+    if (token.isEmpty()) return -100000;
+    if (token == QStringLiteral("world")) return 10000;
+    if (token == QStringLiteral("base_link")) return 9000;
+    if (token == QStringLiteral("base_link_inertia")) return 8000;
+
+    const QStringList non_robot_root_terms = {
+      QStringLiteral("gripper_base_link"),
+      QStringLiteral("robotiq"),
+      QStringLiteral("finger"),
+      QStringLiteral("knuckle"),
+      QStringLiteral("tool0"),
+      QStringLiteral("tool_"),
+      QStringLiteral("_tool"),
+      QStringLiteral("tool_link"),
+      QStringLiteral("end_effector"),
+      QStringLiteral("endeffector"),
+      QStringLiteral("ee_link"),
+      QStringLiteral("eef"),
+      QStringLiteral("camera"),
+      QStringLiteral("realsense"),
+      QStringLiteral("d435"),
+      QStringLiteral("d455"),
+      QStringLiteral("table"),
+      QStringLiteral("workbench")
+    };
+    for (const QString & term : non_robot_root_terms) {
+      if (token.contains(term)) return -9000;
+    }
+
+    int score = 0;
+    if (token == QStringLiteral("root_link")) score = 7000;
+    else if (token.endsWith(QStringLiteral("_root_link")) || token.contains(QStringLiteral("root_link"))) score = 6500;
+    else if (token.endsWith(QStringLiteral("_base_link")) || token.contains(QStringLiteral("base_link"))) score = 6000;
+    else if (token == QStringLiteral("base") || token.endsWith(QStringLiteral("_base"))) score = 5500;
+    else if ((token.startsWith(QStringLiteral("ur")) || token.contains(QStringLiteral("_ur"))) &&
+             (token.contains(QStringLiteral("root")) || token.contains(QStringLiteral("base")))) score = 5200;
+    else if (token.contains(QStringLiteral("shoulder_link"))) score = 1000;
+    else score = 100;
+    return score;
+  };
+  auto consider_robot_base_frame_candidate = [&](RobotBaseFrameCandidate & best, const QString & frame, int source_bonus = 0) {
+    const QString candidate = frame.trimmed();
+    if (candidate.isEmpty()) return;
+    const int score = robot_base_frame_reject_or_downrank_score(candidate) + source_bonus;
+    if (score > best.score) {
+      best.frame = candidate;
+      best.score = score;
+    }
+  };
+  auto yaml_scalar_string = [](const YAML::Node & node, const char * key) {
+    const YAML::Node value = workcell_builder::yaml_map_key(node, key);
+    if (!value || !value.IsScalar()) return QString();
+    return QString::fromStdString(value.as<std::string>("")).trimmed();
+  };
+  auto consider_robot_base_frame_chain = [&](RobotBaseFrameCandidate & best, const YAML::Node & node, const char * key, int source_bonus = 0) {
+    const YAML::Node chain = workcell_builder::yaml_map_key(node, key);
+    if (!chain) return;
+    if (chain.IsSequence()) {
+      int chain_index = 0;
+      for (const YAML::Node & entry : chain) {
+        if (entry.IsScalar()) {
+          consider_robot_base_frame_candidate(best, QString::fromStdString(entry.as<std::string>("")).trimmed(), source_bonus - chain_index);
+        }
+        ++chain_index;
+      }
+    } else if (chain.IsScalar()) {
+      const QString chain_text = QString::fromStdString(chain.as<std::string>("")).trimmed();
+      for (const QString & part : chain_text.split(QRegularExpression(QStringLiteral("[,>\\s]+")), Qt::SkipEmptyParts)) {
+        consider_robot_base_frame_candidate(best, part, source_bonus);
+      }
+    }
+  };
+  RobotBaseFrameCandidate best_robot_base_frame_candidate;
   QString robot_world_pose = QStringLiteral("unknown");
   int mesh_item_count = 0;
   int primitive_item_count = 0;
@@ -8476,6 +8555,11 @@ void MainWindow::populate_scene_hierarchy()
       visual_index_safe_for_preview = workcell_builder::yaml_map_key(urdf_index, "safe_for_preview").as<bool>(false);
       visual_index_extraction_mode = QString::fromStdString(
         workcell_builder::yaml_map_value_or_empty(urdf_index, "extraction_mode"));
+      consider_robot_base_frame_candidate(best_robot_base_frame_candidate, yaml_scalar_string(urdf_index, "root_link"), 300);
+      consider_robot_base_frame_candidate(best_robot_base_frame_candidate, yaml_scalar_string(urdf_index, "robot_root_link"), 300);
+      consider_robot_base_frame_candidate(best_robot_base_frame_candidate, yaml_scalar_string(urdf_index, "base_link"), 250);
+      consider_robot_base_frame_chain(best_robot_base_frame_candidate, urdf_index, "link_chain", 200);
+      consider_robot_base_frame_chain(best_robot_base_frame_candidate, urdf_index, "urdf_link_chain", 200);
       stale_or_absolute_only_mesh_index_count =
         workcell_builder::yaml_map_key(urdf_index, "stale_or_unsafe_count").as<int>(0);
       if (stale_or_absolute_only_mesh_index_count == 0 && workcell_builder::yaml_map_key(urdf_index, "stale_index").as<bool>(false)) {
@@ -8610,7 +8694,11 @@ void MainWindow::populate_scene_hierarchy()
           if (parent_link.isEmpty()) {
             parent_link = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "base_frame")).trimmed();
           }
-          if (robot_base_frame == QStringLiteral("unknown") && !parent_link.isEmpty()) robot_base_frame = parent_link;
+          consider_robot_base_frame_candidate(best_robot_base_frame_candidate, yaml_scalar_string(v, "root_link"), 300);
+          consider_robot_base_frame_candidate(best_robot_base_frame_candidate, parent_link, 150);
+          consider_robot_base_frame_candidate(best_robot_base_frame_candidate, yaml_scalar_string(v, "link"), 0);
+          consider_robot_base_frame_chain(best_robot_base_frame_candidate, v, "link_chain", 200);
+          if (!best_robot_base_frame_candidate.frame.isEmpty()) robot_base_frame = best_robot_base_frame_candidate.frame;
           const bool has_visual_metadata =
             !id.trimmed().isEmpty() &&
             !QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "link")).trimmed().isEmpty() &&


### PR DESCRIPTION
### Motivation
- The visual-index ingestion previously set `robot_base_frame` to the first non-empty `parent_link`, which can incorrectly choose gripper/tool or camera links (e.g. `gripper_base_link`) for some generated scenes such as `ur5_2f_test`.
- Prefer an explicit, score-based resolver so the chosen base link is predictable and favors actual robot roots like `world`, `base_link`, or UR-style roots.

### Description
- Replaced the first-non-empty `parent_link` assignment with a scored resolver helper (`RobotBaseFrameCandidate`, `robot_base_frame_reject_or_downrank_score`, `consider_robot_base_frame_candidate`, `consider_robot_base_frame_chain`, and `yaml_scalar_string`).
- Resolver logic gives highest preference to `world`, then `base_link`, then `base_link_inertia`, then `root_link`/`base`/UR root patterns, while heavily down-ranking links containing gripper/tool/end-effector/camera/table/finger/knuckle terms.
- Ingests candidate roots from visual-index/top-level fields and per-row fields using existing metadata fields: `root_link`, `robot_root_link`, `base_link`, `link_chain`, `urdf_link_chain`, `parent_link`, and `link`.
- When a scored candidate is available the code sets `robot_base_frame` to the highest-scoring frame; otherwise it remains `"unknown"`.

### Testing
- Ran `git diff --check`, which completed successfully.
- Attempted to run the build validation with `source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select workcell_builder`, but `colcon` is not installed in the container so compile-time validation could not be executed.
- Change is UI/metadata-only and does not modify launch files, controllers, runtime services, hardware parameters, or robot motion behavior, and fake-hardware defaults remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a369b4b93d8833190d0ebfc3eee7704)