### PR TITLE
Fix Scene3D visual index filtering

### DIFF
--- a/tests/test_scene3d_visual_loader_filtering.py
+++ b/tests/test_scene3d_visual_loader_filtering.py
@@ -1,0 +1,89 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MAINWINDOW = ROOT / "workcell_builder/workcell_builder/gui/mainwindow.cpp"
+UR5_INDEX = ROOT / "scenes/ur5_2f_test/generated/scene_visual_mesh_index.json"
+
+
+def _token(value: str) -> str:
+    return "".join(ch.lower() if ch.isalnum() else "_" for ch in (value or "")).strip("_")
+
+
+def _final_identity(item: dict) -> str:
+    visual = item.get("visual") or item.get("visual_name") or "visual_missing"
+    parts = [
+        "urdf_visual_final",
+        _token(item.get("link") or "link_missing"),
+        _token(visual),
+    ]
+    if item.get("visual_index") not in (None, ""):
+        parts.append("visual_index_" + _token(str(item["visual_index"])))
+    if item.get("source"):
+        parts.append("source_" + _token(item["source"]))
+    if item.get("category"):
+        parts.append("category_" + _token(item["category"]))
+    return "__".join(parts)
+
+
+def _is_lower_fidelity_fallback(item: dict) -> bool:
+    source = _token(item.get("source", ""))
+    geometry = _token(item.get("geometry_type", ""))
+    category = _token(item.get("category", ""))
+    transform_status = _token(item.get("transform_status", ""))
+    return source != "urdf_flattened" and (
+        geometry != "mesh"
+        or "fallback" in category
+        or "fallback" in source
+        or "static" in source
+        or bool(item.get("primitive_fallback"))
+        or transform_status in {"static_fallback", "static_fallback_parent"}
+    )
+
+
+def _filtered_links(items: list[dict]) -> set[str]:
+    flattened_links = {
+        _token(item.get("link") or item.get("object_id") or item.get("object") or item.get("id"))
+        for item in items
+        if _token(item.get("source", "")) == "urdf_flattened" and _token(item.get("geometry_type", "")) == "mesh"
+    }
+    retained_ids = set()
+    retained_links = set()
+    for item in sorted(items, key=lambda i: _token(i.get("source", "")) != "urdf_flattened"):
+        identity = _final_identity(item)
+        link_key = _token(item.get("link") or item.get("object_id") or item.get("object") or item.get("id"))
+        if identity in retained_ids:
+            continue
+        if link_key in flattened_links and _is_lower_fidelity_fallback(item):
+            continue
+        retained_ids.add(identity)
+        retained_links.add(_token(item.get("link", "")))
+    return retained_links
+
+
+def test_mainwindow_visual_loader_distinguishes_identity_fallback_and_shared_mesh_uri() -> None:
+    src = MAINWINDOW.read_text(encoding="utf-8")
+    assert "source_%1" in src and "category_%1" in src
+    assert "uri_%1" not in src and "row_%1" not in src
+    assert "visual_item_is_lower_fidelity_fallback" in src
+    assert "suppressed_by_urdf_flattened_visual_mesh" in src
+    assert "retention check passed for ur5_2f_test" in src
+
+
+def test_ur5_2f_visual_loader_filter_retains_robot_and_robotiq_rows() -> None:
+    items = json.loads(UR5_INDEX.read_text(encoding="utf-8"))["visual_items"]
+    retained = _filtered_links(items)
+    assert {"base_link", "base_link_inertia"} & retained
+    assert {
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link",
+        "wrist_1_link",
+        "wrist_2_link",
+        "wrist_3_link",
+    } <= retained
+    assert "gripper_base_link" in retained
+    for token in ("finger_link", "knuckle_link", "finger_tip_link"):
+        assert any(token in link for link in retained)
+    assert "table" in retained
+    assert "camera_link" in retained

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -8594,6 +8594,7 @@ void MainWindow::populate_scene_hierarchy()
           return info.exists() && info.isFile();
         };
         auto visual_item_final_identity_key = [](const YAML::Node & node, int source_row_index) {
+          Q_UNUSED(source_row_index);
           auto value = [&](const char * key) {
             const YAML::Node field = workcell_builder::yaml_map_key(node, key);
             if (!field || !field.IsScalar()) return QString();
@@ -8603,19 +8604,30 @@ void MainWindow::populate_scene_hierarchy()
           QString visual = value("visual");
           if (visual.isEmpty()) visual = value("visual_name");
           const QString visual_index = value("visual_index");
-          QString uri = value("package_uri");
-          if (uri.isEmpty()) uri = value("mesh_uri");
-          if (uri.isEmpty()) uri = value("source_path");
+          const QString source = value("source");
+          const QString category = value("category");
           QStringList parts;
           parts << QStringLiteral("urdf_visual_final");
           parts << (link.isEmpty() ? QStringLiteral("link_missing") : canonical_scene3d_token(link));
           parts << (visual.isEmpty() ? QStringLiteral("visual_missing") : canonical_scene3d_token(visual));
           if (!visual_index.isEmpty()) parts << QStringLiteral("visual_index_%1").arg(canonical_scene3d_token(visual_index));
-          if (!uri.isEmpty()) parts << QStringLiteral("uri_%1").arg(canonical_scene3d_token(uri));
-          QString row_index = value("source_row_index");
-          if (row_index.isEmpty()) row_index = QString::number(source_row_index);
-          parts << QStringLiteral("row_%1").arg(canonical_scene3d_token(row_index));
+          if (!source.isEmpty()) parts << QStringLiteral("source_%1").arg(canonical_scene3d_token(source));
+          if (!category.isEmpty()) parts << QStringLiteral("category_%1").arg(canonical_scene3d_token(category));
           return parts.join(QStringLiteral("__"));
+        };
+        auto visual_item_is_lower_fidelity_fallback = [&](const YAML::Node & node) {
+          const QString source = visual_item_source_token(node);
+          const QString geometry = canonical_scene3d_token(QString::fromStdString(workcell_builder::yaml_map_value_or_empty(node, "geometry_type")));
+          const QString category = canonical_scene3d_token(QString::fromStdString(workcell_builder::yaml_map_value_or_empty(node, "category")));
+          const QString transform_status = canonical_scene3d_token(QString::fromStdString(workcell_builder::yaml_map_value_or_empty(node, "transform_status")));
+          return source != QStringLiteral("urdf_flattened") &&
+                 (geometry != QStringLiteral("mesh") ||
+                  category.contains(QStringLiteral("fallback")) ||
+                  source.contains(QStringLiteral("fallback")) ||
+                  source.contains(QStringLiteral("static")) ||
+                  workcell_builder::yaml_map_key(node, "primitive_fallback").as<bool>(false) ||
+                  transform_status == QStringLiteral("static_fallback") ||
+                  transform_status == QStringLiteral("static_fallback_parent"));
         };
         for (const auto & item_node : visual_items) ordered_visual_items.push_back(YAML::Clone(item_node));
         std::stable_sort(ordered_visual_items.begin(), ordered_visual_items.end(), [&](const YAML::Node & a, const YAML::Node & b) {
@@ -8657,7 +8669,7 @@ void MainWindow::populate_scene_hierarchy()
           const QString visual_item_key = visual_item_link_object_key(v);
           const bool flattened_mesh_loaded_for_same_link = !visual_item_key.isEmpty() && flattened_visual_mesh_keys.contains(visual_item_key);
           const bool suppress_lower_fidelity_for_flattened_mesh =
-            flattened_mesh_loaded_for_same_link && visual_item_source_token != QStringLiteral("urdf_flattened");
+            flattened_mesh_loaded_for_same_link && visual_item_is_lower_fidelity_fallback(v);
           if (suppress_lower_fidelity_for_flattened_mesh) {
             add_skip_reason(QStringLiteral("suppressed_by_urdf_flattened_visual_mesh"));
             append_studio_log(QString("Suppressed lower-fidelity visual for %1 because source=urdf_flattened mesh is available for the same link/object (source=%2 geometry=%3)")
@@ -9106,6 +9118,41 @@ void MainWindow::populate_scene_hierarchy()
           ++visual_preview_added_count;
           preview_ids.insert(id);
           if (include_preview_item_in_hierarchy(p)) add_tree_node(p);
+        }
+        if (scene_name == QStringLiteral("ur5_2f_test")) {
+          const QSet<QString> required_ur5_links = {
+            QStringLiteral("base_link"), QStringLiteral("base_link_inertia"),
+            QStringLiteral("shoulder_link"), QStringLiteral("upper_arm_link"),
+            QStringLiteral("forearm_link"), QStringLiteral("wrist_1_link"),
+            QStringLiteral("wrist_2_link"), QStringLiteral("wrist_3_link")};
+          const QStringList required_robotiq_tokens = {
+            QStringLiteral("gripper_base_link"), QStringLiteral("finger_link"),
+            QStringLiteral("knuckle_link"), QStringLiteral("finger_tip_link")};
+          QSet<QString> retained_links;
+          for (const auto & item : preview_items) {
+            if (item.source_layer != QStringLiteral("locked_generated_urdf_visual")) continue;
+            retained_links.insert(canonical_scene3d_token(item.display_name));
+          }
+          bool has_ur5_base = retained_links.contains(QStringLiteral("base_link")) || retained_links.contains(QStringLiteral("base_link_inertia"));
+          QStringList missing_required_links;
+          for (const QString & link : required_ur5_links) {
+            if ((link == QStringLiteral("base_link") || link == QStringLiteral("base_link_inertia")) && has_ur5_base) continue;
+            if (!retained_links.contains(link)) missing_required_links << link;
+          }
+          QStringList missing_required_robotiq_tokens;
+          for (const QString & token : required_robotiq_tokens) {
+            bool found = false;
+            for (const QString & link : retained_links) {
+              if (link.contains(token)) { found = true; break; }
+            }
+            if (!found) missing_required_robotiq_tokens << token;
+          }
+          if (!missing_required_links.isEmpty() || !missing_required_robotiq_tokens.isEmpty()) {
+            append_studio_log(QString("Preview warning: ur5_2f_test retained visual rows missing after loader filtering: ur5_links=[%1] robotiq_tokens=[%2]")
+              .arg(missing_required_links.join(QStringLiteral(",")), missing_required_robotiq_tokens.join(QStringLiteral(","))));
+          } else {
+            append_studio_log(QStringLiteral("Visual mesh index retention check passed for ur5_2f_test UR5 and Robotiq generated visual rows after loader filtering."));
+          }
         }
       }
       int visual_skipped_total = 0;


### PR DESCRIPTION
### Motivation
- The Scene3D visual-index loader was over-eager when suppressing duplicate rows, collapsing distinct URDF visual rows that shared mesh URIs or differing metadata; the intent is to preserve legitimate separate URDF visuals while still suppressing true low-fidelity fallback rows.
- Keep scene preview stability and reproducibility (especially for `ur5_2f_test`) by ensuring required UR5 and Robotiq generated visual rows survive loader filtering.

### Description
- Reworked final visual identity keying so duplicate suppression is based on final identity built from `link`/`visual` plus `source` and `category` metadata instead of `mesh_uri` or `source_row_index`; this preserves distinct URDF visual rows that happen to share the same mesh. (`workcell_builder/workcell_builder/gui/mainwindow.cpp`)
- Added `visual_item_is_lower_fidelity_fallback` predicate and limited `urdf_flattened` suppression to only suppress lower-fidelity fallback/static/primitive rows for the same link/object rather than all non-`urdf_flattened` rows. (`mainwindow.cpp`)
- Added a post-filter retention diagnostic that explicitly checks `ur5_2f_test` retained generated UR5 visual rows (`base_link`/`base_link_inertia`, `shoulder_link`, `upper_arm_link`, `forearm_link`, `wrist_1_link`, `wrist_2_link`, `wrist_3_link`) and Robotiq visual tokens (`gripper_base_link`, finger/knuckle/fingertip tokens) and logs a warning if any are missing; this uses canonical link/category/source metadata and does not introduce scene-specific hacks. (`mainwindow.cpp`)
- Left table/workbench and camera/Realsense mesh rows unchanged; behavior only affects URDF-generated locked visuals and fallback suppression logic.
- Added regression tests mirroring the loader's intent and retention checks: `tests/test_scene3d_visual_loader_filtering.py`.

### Testing
- Ran `python3 -m pytest tests/test_scene3d_visual_loader_filtering.py -q` and the new tests passed. (2 passed)
- Ran `python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json` and the scene validation completed successfully (returned JSON readiness output with existing optional artifact warnings but no new failures).
- Attempted to build `workcell_builder` with `source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select workcell_builder` but the container does not provide `/opt/ros/humble/setup.bash`, so the full C++ build was not executed in this environment; no runtime/launch files or hardware defaults were changed by this PR and fake-hardware defaults remain intact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a369bfa98888331bd73c73f3bfb6dfe)