### PR TITLE
Guard Scene3D visual row identities

### DIFF
--- a/tests/test_scene3d_visual_loader_filtering.py
+++ b/tests/test_scene3d_visual_loader_filtering.py
@@ -10,7 +10,7 @@ def _token(value: str) -> str:
     return "".join(ch.lower() if ch.isalnum() else "_" for ch in (value or "")).strip("_")
 
 
-def _final_identity(item: dict) -> str:
+def _final_identity(item: dict, source_row_index: int) -> str:
     visual = item.get("visual") or item.get("visual_name") or "visual_missing"
     parts = [
         "urdf_visual_final",
@@ -23,6 +23,10 @@ def _final_identity(item: dict) -> str:
         parts.append("source_" + _token(item["source"]))
     if item.get("category"):
         parts.append("category_" + _token(item["category"]))
+    row_index = item.get("source_row_index")
+    if row_index in (None, ""):
+        row_index = source_row_index
+    parts.append("row_" + _token(str(row_index)))
     return "__".join(parts)
 
 
@@ -41,30 +45,34 @@ def _is_lower_fidelity_fallback(item: dict) -> bool:
     )
 
 
-def _filtered_links(items: list[dict]) -> set[str]:
+def _retained_rows(items: list[dict]) -> list[dict]:
     flattened_links = {
         _token(item.get("link") or item.get("object_id") or item.get("object") or item.get("id"))
         for item in items
         if _token(item.get("source", "")) == "urdf_flattened" and _token(item.get("geometry_type", "")) == "mesh"
     }
     retained_ids = set()
-    retained_links = set()
-    for item in sorted(items, key=lambda i: _token(i.get("source", "")) != "urdf_flattened"):
-        identity = _final_identity(item)
+    retained_rows = []
+    for source_row_index, item in enumerate(sorted(items, key=lambda i: _token(i.get("source", "")) != "urdf_flattened")):
+        identity = _final_identity(item, source_row_index)
         link_key = _token(item.get("link") or item.get("object_id") or item.get("object") or item.get("id"))
         if identity in retained_ids:
             continue
         if link_key in flattened_links and _is_lower_fidelity_fallback(item):
             continue
         retained_ids.add(identity)
-        retained_links.add(_token(item.get("link", "")))
-    return retained_links
+        retained_rows.append({**item, "_final_identity": identity})
+    return retained_rows
+
+
+def _filtered_links(items: list[dict]) -> set[str]:
+    return {_token(item.get("link", "")) for item in _retained_rows(items)}
 
 
 def test_mainwindow_visual_loader_distinguishes_identity_fallback_and_shared_mesh_uri() -> None:
     src = MAINWINDOW.read_text(encoding="utf-8")
     assert "source_%1" in src and "category_%1" in src
-    assert "uri_%1" not in src and "row_%1" not in src
+    assert "row_%1" in src and "source_row_index" in src
     assert "visual_item_is_lower_fidelity_fallback" in src
     assert "suppressed_by_urdf_flattened_visual_mesh" in src
     assert "retention check passed for ur5_2f_test" in src
@@ -72,7 +80,18 @@ def test_mainwindow_visual_loader_distinguishes_identity_fallback_and_shared_mes
 
 def test_ur5_2f_visual_loader_filter_retains_robot_and_robotiq_rows() -> None:
     items = json.loads(UR5_INDEX.read_text(encoding="utf-8"))["visual_items"]
-    retained = _filtered_links(items)
+    retained_rows = _retained_rows(items)
+    retained = {_token(item.get("link", "")) for item in retained_rows}
+    identities = [item["_final_identity"] for item in retained_rows]
+    valid_mesh_rows = [
+        item
+        for item in items
+        if _token(item.get("source", "")) == "urdf_flattened" and _token(item.get("geometry_type", "")) == "mesh"
+    ]
+
+    assert len(items) == 18
+    assert len(retained_rows) in {18, len(valid_mesh_rows)}
+    assert len(identities) == len(set(identities))
     assert {"base_link", "base_link_inertia"} & retained
     assert {
         "shoulder_link",
@@ -87,3 +106,29 @@ def test_ur5_2f_visual_loader_filter_retains_robot_and_robotiq_rows() -> None:
         assert any(token in link for link in retained)
     assert "table" in retained
     assert "camera_link" in retained
+
+
+def test_editable_layout_semantic_ids_do_not_suppress_generated_urdf_rows() -> None:
+    items = [
+        {
+            "id": "robot_base",
+            "link": "robot_base",
+            "visual": "editable_robot_base",
+            "source": "layout",
+            "category": "editable_layout",
+            "geometry_type": "box",
+        },
+        {
+            "link": "base_link",
+            "visual": "base_link_visual",
+            "visual_index": 0,
+            "source": "urdf_flattened",
+            "category": "locked_generated_urdf_visual",
+            "geometry_type": "mesh",
+        },
+    ]
+
+    retained = _filtered_links(items)
+
+    assert "robot_base" in retained
+    assert "base_link" in retained

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -8627,7 +8627,6 @@ void MainWindow::populate_scene_hierarchy()
           return info.exists() && info.isFile();
         };
         auto visual_item_final_identity_key = [](const YAML::Node & node, int source_row_index) {
-          Q_UNUSED(source_row_index);
           auto value = [&](const char * key) {
             const YAML::Node field = workcell_builder::yaml_map_key(node, key);
             if (!field || !field.IsScalar()) return QString();
@@ -8639,6 +8638,8 @@ void MainWindow::populate_scene_hierarchy()
           const QString visual_index = value("visual_index");
           const QString source = value("source");
           const QString category = value("category");
+          QString row_index = value("source_row_index");
+          if (row_index.isEmpty()) row_index = QString::number(source_row_index);
           QStringList parts;
           parts << QStringLiteral("urdf_visual_final");
           parts << (link.isEmpty() ? QStringLiteral("link_missing") : canonical_scene3d_token(link));
@@ -8646,6 +8647,7 @@ void MainWindow::populate_scene_hierarchy()
           if (!visual_index.isEmpty()) parts << QStringLiteral("visual_index_%1").arg(canonical_scene3d_token(visual_index));
           if (!source.isEmpty()) parts << QStringLiteral("source_%1").arg(canonical_scene3d_token(source));
           if (!category.isEmpty()) parts << QStringLiteral("category_%1").arg(canonical_scene3d_token(category));
+          parts << QStringLiteral("row_%1").arg(canonical_scene3d_token(row_index));
           return parts.join(QStringLiteral("__"));
         };
         auto visual_item_is_lower_fidelity_fallback = [&](const YAML::Node & node) {


### PR DESCRIPTION
### Motivation
- Prevent distinct generated URDF visual rows from collapsing into duplicates when other identity fields overlap by including a row component in the final identity key.
- Keep the Python loader mirror tests aligned with the production GUI logic so test expectations reflect the actual `mainwindow.cpp` behavior.
- Ensure `ur5_2f_test` visual extraction remains reproducible and that editable/layout semantic IDs do not accidentally suppress generated URDF rows.

### Description
- Updated the tests mirror in `tests/test_scene3d_visual_loader_filtering.py` to change `_final_identity` to `_final_identity(item, source_row_index)` and append a `row_` component that prefers `source_row_index` from the item or falls back to the enumerated row index, and replaced the filtering helper to return retained rows with `_final_identity` metadata.
- Added assertions in the test mirror that the GUI loader supports `row_%1` and `source_row_index` in `mainwindow.cpp` and preserved checks for fallback suppression logic.
- Modified `workcell_builder/workcell_builder/gui/mainwindow.cpp` to include the same `row_%1` component in the `visual_item_final_identity_key` lambda by reading `source_row_index` (falling back to the enumerated `source_row_index`) so production and tests compute matching identities.
- Extended `tests/test_scene3d_visual_loader_filtering.py` to assert `ur5_2f_test` has 18 visual rows, that retained rows count is `18` or the count of valid mesh rows, that retained identities are unique, that UR5 arm links, Robotiq gripper rows, `table`, and camera links are retained, and added a fixture test proving editable/layout semantic IDs (e.g. `robot_base`) do not suppress generated URDF rows (e.g. `base_link`).

### Testing
- Ran `pytest -q tests/test_scene3d_visual_loader_filtering.py tests/test_scene3d_ur5_visual_identity_and_root.py` and all tests passed (`8 passed`).
- Verified the updated `mainwindow.cpp` identity logic is present by inspecting the `visual_item_final_identity_key` lambda and ensuring `row_%1` is appended and `source_row_index` is read.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36a1fec1d88331b8b1aafe6559d9aa)