### PR TITLE
Make generated URDF visual preview IDs deterministic (row suffix + duplicate repair)

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -8627,7 +8627,6 @@ void MainWindow::populate_scene_hierarchy()
           return info.exists() && info.isFile();
         };
         auto visual_item_final_identity_key = [](const YAML::Node & node, int source_row_index) {
-          Q_UNUSED(source_row_index);
           auto value = [&](const char * key) {
             const YAML::Node field = workcell_builder::yaml_map_key(node, key);
             if (!field || !field.IsScalar()) return QString();
@@ -8639,6 +8638,8 @@ void MainWindow::populate_scene_hierarchy()
           const QString visual_index = value("visual_index");
           const QString source = value("source");
           const QString category = value("category");
+          QString row_index = value("source_row_index");
+          if (row_index.isEmpty()) row_index = QString::number(source_row_index);
           QStringList parts;
           parts << QStringLiteral("urdf_visual_final");
           parts << (link.isEmpty() ? QStringLiteral("link_missing") : canonical_scene3d_token(link));
@@ -8646,6 +8647,7 @@ void MainWindow::populate_scene_hierarchy()
           if (!visual_index.isEmpty()) parts << QStringLiteral("visual_index_%1").arg(canonical_scene3d_token(visual_index));
           if (!source.isEmpty()) parts << QStringLiteral("source_%1").arg(canonical_scene3d_token(source));
           if (!category.isEmpty()) parts << QStringLiteral("category_%1").arg(canonical_scene3d_token(category));
+          parts << QStringLiteral("row_%1").arg(canonical_scene3d_token(row_index));
           return parts.join(QStringLiteral("__"));
         };
         auto visual_item_is_lower_fidelity_fallback = [&](const YAML::Node & node) {
@@ -8688,16 +8690,20 @@ void MainWindow::populate_scene_hierarchy()
           }
           ++visual_index_loaded_count;
           const QString raw_id = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "id"));
-          const QString id = visual_item_final_identity_key(v, source_row_index);
+          QString id = visual_item_final_identity_key(v, source_row_index);
           if (id.isEmpty()) {
             ++skipped_other; const QString reason = add_skip_reason(QStringLiteral("parse_error"));
             append_visual_ingestion_diagnostic(v, raw_id, id, reason);
             continue;
           }
           if (preview_ids.contains(id)) {
-            const QString reason = add_skip_reason(QStringLiteral("duplicate_id"));
-            append_visual_ingestion_diagnostic(v, raw_id, id, reason);
-            continue;
+            const QString original_id = id;
+            int duplicate_repair_index = 1;
+            do {
+              id = QStringLiteral("%1__duplicate_repair_%2").arg(original_id).arg(duplicate_repair_index++);
+            } while (preview_ids.contains(id));
+            append_studio_log(QStringLiteral("Repaired duplicate generated URDF visual preview ID collision: %1 -> %2")
+              .arg(original_id, id));
           }
           const QString geometry_type = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "geometry_type"));
           const QString visual_item_source = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "source")).trimmed();


### PR DESCRIPTION
### Motivation
- Prevent non-deterministic duplicate preview IDs from generated URDF visuals and ensure stable, repeatable preview rows for scene generation and validation.
- Ensure `duplicate_id_count` is zero for the `ur5_2f_test` scene and avoid silently skipping rows when pre-repair IDs collide.

### Description
- Removed the `Q_UNUSED(source_row_index)` and made the identity key prefer a scalar `source_row_index` field from the visual row, falling back to the loader-provided loop index.
- Appended a deterministic row component as `__row_<row_index>` to the existing `urdf_visual_final__...` identity while preserving the original prefix and other identity pieces (`link`, `visual`, `visual_index`, `source`, `category`).
- Replaced skipping-on-duplicate behavior with a deterministic repair loop that appends `__duplicate_repair_<n>` when an ID collision still occurs, and added a studio log entry for repaired collisions.
- Preserved `ScenePreviewWidget::PreviewItem` fields and behaviors including `source_layer = locked_generated_urdf_visual`, `editable = false`, mesh/source resolution metadata, and hierarchy inclusion.

### Testing
- Ran `python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json` which completed successfully and reported no blocking errors for the scene.
- Ran a custom parity check against `scenes/ur5_2f_test/generated/scene_visual_mesh_index.json` which produced `duplicate_id_count: 0` and found no required duplicate repairs for that scene.
- Attempted to run `colcon build --packages-select workcell_builder` but could not perform the build because `/opt/ros/humble/setup.bash` is not available in this container, so full compile-time validation was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36a1ec831883319d47751433577c59)