### PR TITLE
Add audit cleanup-candidate script and pytest coverage

### DIFF
--- a/scripts/audit_workcell_cleanup_candidates.py
+++ b/scripts/audit_workcell_cleanup_candidates.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Audit obvious cleanup candidates without deleting anything.
+
+This utility classifies local workspace artifacts so maintainers can review
+candidate cleanup items while protecting scene/runtime files by default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable, TypedDict
+
+
+class CleanupClassification(TypedDict):
+    path: str
+    category: str
+    confidence: str
+    safe_to_delete_now: bool
+    reason: str
+
+
+PROTECTED_EXTENSIONS = {".launch.py", ".xacro", ".urdf", ".stl", ".dae", ".obj", ".ply", ".mesh"}
+PROTECTED_NAMES = {
+    "scene_manifest.yaml",
+    "scene_manifest.yml",
+    "environment.yaml",
+    "environment.yml",
+    "cell_definition.yaml",
+    "cell_definition.yml",
+}
+SAFETY_PATH_PARTS = {"launch", "urdf", "meshes", "mesh", "config", "controllers", "runtime", "safety"}
+
+
+def _rel_parts(path: Path, repo_root: Path | None = None) -> tuple[str, ...]:
+    candidate = path
+    if repo_root is not None:
+        try:
+            candidate = path.resolve().relative_to(repo_root.resolve())
+        except ValueError:
+            candidate = path
+    return candidate.as_posix().split("/")
+
+
+def _has_protected_suffix(path: Path) -> bool:
+    text = path.name
+    return any(text.endswith(suffix) for suffix in PROTECTED_EXTENSIONS)
+
+
+def classify_cleanup_candidate(path: Path | str, repo_root: Path | str | None = None) -> CleanupClassification:
+    """Classify a path as a reviewable cleanup candidate or protected file."""
+
+    path = Path(path)
+    root = Path(repo_root) if repo_root is not None else None
+    parts = _rel_parts(path, root)
+    rel = "/".join(parts)
+    name = path.name
+    lowered_name = name.lower()
+    lowered_parts = tuple(part.lower() for part in parts)
+
+    if "__pycache__" in lowered_parts or lowered_name.endswith((".pyc", ".pyo")):
+        return {
+            "path": rel,
+            "category": "python_cache",
+            "confidence": "high",
+            "safe_to_delete_now": True,
+            "reason": "Python bytecode/cache artifact.",
+        }
+
+    if ".pytest_cache" in lowered_parts:
+        return {
+            "path": rel,
+            "category": "python_cache",
+            "confidence": "high",
+            "safe_to_delete_now": True,
+            "reason": "Pytest cache artifact.",
+        }
+
+    if lowered_name.endswith((".stdout.log", ".stderr.log", ".log")):
+        return {
+            "path": rel,
+            "category": "generated_logs",
+            "confidence": "medium",
+            "safe_to_delete_now": True,
+            "reason": "Generated log output.",
+        }
+
+    if lowered_name.startswith("scene3d_gui_smoke_") and lowered_name.endswith(".json"):
+        return {
+            "path": rel,
+            "category": "generated_smoke_outputs",
+            "confidence": "medium",
+            "safe_to_delete_now": True,
+            "reason": "Scene3D GUI smoke-test output.",
+        }
+
+    if lowered_name.endswith((".bak", ".backup", "~", ".orig")):
+        return {
+            "path": rel,
+            "category": "temp_backup_files",
+            "confidence": "medium",
+            "safe_to_delete_now": True,
+            "reason": "Temporary backup file.",
+        }
+
+    if name in PROTECTED_NAMES or _has_protected_suffix(path) or any(part in SAFETY_PATH_PARTS for part in lowered_parts):
+        return {
+            "path": rel,
+            "category": "protected_scene_runtime_asset",
+            "confidence": "high",
+            "safe_to_delete_now": False,
+            "reason": "Scene, launch, mesh, URDF/Xacro, config, runtime, or safety-related path.",
+        }
+
+    return {
+        "path": rel,
+        "category": "unknown_review_required",
+        "confidence": "low",
+        "safe_to_delete_now": False,
+        "reason": "No cleanup classification matched; manual review required.",
+    }
+
+
+def audit_paths(paths: Iterable[Path | str], repo_root: Path | str | None = None) -> list[CleanupClassification]:
+    """Classify multiple paths without mutating the filesystem."""
+
+    return [classify_cleanup_candidate(path, repo_root) for path in paths]
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", type=Path, help="Paths to classify. No files are deleted or modified.")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd(), help="Repository root used for relative output paths.")
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    results = audit_paths(args.paths, args.repo_root)
+    if args.json:
+        print(json.dumps(results, indent=2, sort_keys=True))
+    else:
+        for result in results:
+            print(
+                f"{result['path']}: {result['category']} "
+                f"confidence={result['confidence']} safe_to_delete_now={result['safe_to_delete_now']}"
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_audit_workcell_cleanup_candidates.py
+++ b/tests/test_audit_workcell_cleanup_candidates.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.audit_workcell_cleanup_candidates import (  # noqa: E402
+    audit_paths,
+    build_arg_parser,
+    classify_cleanup_candidate,
+)
+
+
+def _touch(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("demo\n", encoding="utf-8")
+    return path
+
+
+def test_audit_workcell_cleanup_candidates_classifies_generated_artifacts(tmp_path: Path) -> None:
+    files = {
+        "python_bytecode": _touch(tmp_path / "pkg/__pycache__/mod.cpython-310.pyc"),
+        "pytest_cache": _touch(tmp_path / ".pytest_cache/CACHEDIR.TAG"),
+        "log": _touch(tmp_path / "build/workcell_studio/example.stdout.log"),
+        "smoke": _touch(tmp_path / "build/workcell_studio/scene3d_gui_smoke_ur5_2f_test.json"),
+        "backup": _touch(tmp_path / "notes.bak"),
+    }
+
+    classifications = {name: classify_cleanup_candidate(path, tmp_path) for name, path in files.items()}
+
+    assert classifications["python_bytecode"]["category"] == "python_cache"
+    assert classifications["python_bytecode"]["confidence"] == "high"
+    assert classifications["python_bytecode"]["safe_to_delete_now"] is True
+    assert classifications["pytest_cache"]["category"] == "python_cache"
+    assert classifications["pytest_cache"]["confidence"] == "high"
+    assert classifications["pytest_cache"]["safe_to_delete_now"] is True
+    assert classifications["log"]["category"] == "generated_logs"
+    assert classifications["smoke"]["category"] == "generated_smoke_outputs"
+    assert classifications["backup"]["category"] == "temp_backup_files"
+
+
+def test_audit_workcell_cleanup_candidates_protects_scene_runtime_assets(tmp_path: Path) -> None:
+    protected_paths = [
+        _touch(tmp_path / "scenes/demo/scene_manifest.yaml"),
+        _touch(tmp_path / "scenes/demo/launch/demo.launch.py"),
+        _touch(tmp_path / "scenes/demo/urdf/scene.urdf.xacro"),
+        _touch(tmp_path / "scenes/demo/meshes/workpiece.stl"),
+    ]
+
+    classifications = audit_paths(protected_paths, tmp_path)
+
+    assert classifications
+    assert all(result["safe_to_delete_now"] is False for result in classifications)
+    assert all(result["category"] == "protected_scene_runtime_asset" for result in classifications)
+
+
+def test_audit_workcell_cleanup_candidates_has_no_delete_or_apply_cli_option() -> None:
+    parser = build_arg_parser()
+    option_strings = {
+        option
+        for action in parser._actions
+        for option in action.option_strings
+    }
+
+    assert "--delete" not in option_strings
+    assert "--apply" not in option_strings


### PR DESCRIPTION
### Motivation
- Provide a read-only, local audit utility to classify common cleanup candidates (caches, logs, smoke outputs, backups) so maintainers can review deletable artifacts without risking scene/runtime files.
- Ensure conservative protection for scene/runtime assets (manifests, launch files, URDF/Xacro, meshes, config/runtime/safety paths) by default.
- Add automated tests to prevent regressions in classification logic and to assert the CLI exposes no delete/apply options.

### Description
- Added `scripts/audit_workcell_cleanup_candidates.py` implementing `classify_cleanup_candidate`, `audit_paths`, and a read-only CLI via `build_arg_parser()` that returns classifications but provides no `--delete`/`--apply` options.
- Classification rules cover `python_cache`, `generated_logs`, `generated_smoke_outputs`, `temp_backup_files`, and `protected_scene_runtime_asset` for protected extensions/names/path parts.
- Added `tests/test_audit_workcell_cleanup_candidates.py` which uses `tmp_path` to create a miniature repo tree with the requested artifacts and asserts expected categories and protections.
- The test also asserts the CLI parser does not expose destructive options like `--delete` or `--apply`.

### Testing
- Ran `python3 -m pytest tests/test_audit_workcell_cleanup_candidates.py -q`, which passed (`3 passed`).
- Ran `python3 -m py_compile scripts/audit_workcell_cleanup_candidates.py tests/test_audit_workcell_cleanup_candidates.py`, which passed with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36c1c1a1b08331a57fbcf0787e6ad7)