### PR TITLE
Handle baked world visual pose counters in Scene3D smoke report

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -304,14 +304,16 @@ def _apply_runtime_transform_counter_mapping(payload: dict[str, Any]) -> None:
     counters = _first_present_mapping(payload, "counters")
     render_debug = _first_present_mapping(payload, "render_debug_counters")
 
+    runtime_diagnostics = _first_present_mapping(payload, "runtime_scene3d_diagnostics", "runtime_diagnostics", "diagnostics")
+
     def runtime_counter(*keys: str) -> int:
-        for source in (render_debug, counters):
+        for source in (render_debug, counters, runtime_diagnostics, payload):
             if not isinstance(source, dict):
                 continue
             for key in keys:
                 if key in source:
                     return _as_int(source.get(key))
-        return _counter_from_sources(payload, keys)
+        return _counter_from_sources(payload, keys, runtime_diagnostics)
 
     transform_chain_applied_count = runtime_counter("transform_chain_applied_count")
     visual_origin_applied_count = runtime_counter("visual_origin_applied_count")
@@ -320,16 +322,22 @@ def _apply_runtime_transform_counter_mapping(payload: dict[str, Any]) -> None:
         "generated_visual_count",
         "generated_urdf_visual_count",
     )
+    baked_world_visual_pose_applied_count = runtime_counter(
+        "runtime_baked_world_visual_pose_applied_count",
+        "baked_world_visual_pose_count",
+        "baked_world_visual_transform_count",
+    )
     payload["transform_chain_applied_count"] = transform_chain_applied_count
     payload["visual_origin_applied_count"] = visual_origin_applied_count
     payload["locked_generated_urdf_visual_count"] = generated_visual_count
+    payload["runtime_baked_world_visual_pose_applied_count"] = baked_world_visual_pose_applied_count
 
     warnings = payload.get("warnings")
     if not isinstance(warnings, list):
         warnings = []
-    if generated_visual_count > 0 and transform_chain_applied_count <= 0:
+    if generated_visual_count > 0 and transform_chain_applied_count <= 0 and baked_world_visual_pose_applied_count <= 0:
         _append_unique(warnings, "runtime_transform_chain_applied_count_zero_with_generated_visuals")
-    if generated_visual_count > 0 and visual_origin_applied_count <= 0:
+    if generated_visual_count > 0 and visual_origin_applied_count <= 0 and baked_world_visual_pose_applied_count <= 0:
         _append_unique(warnings, "runtime_visual_origin_applied_count_zero_with_generated_visuals")
     payload["warnings"] = warnings
 

--- a/tests/test_scene3d_gui_smoke_json_output_contract.py
+++ b/tests/test_scene3d_gui_smoke_json_output_contract.py
@@ -302,6 +302,52 @@ def test_static_headless_counts_remain_non_pass_evidence_when_runtime_unavailabl
     assert payload["non_runtime_static_headless_renderability_counts"]["runtime_available"] is False
 
 
+def test_baked_world_visual_pose_counter_suppresses_zero_transform_warnings():
+    import scripts.run_workcell_builder_scene3d_gui_smoke as smoke
+
+    payload = {
+        "runtime_available": True,
+        "counters": {
+            "rendered_count": 1,
+            "locked_generated_urdf_visual_count": 4,
+            "transform_chain_applied_count": 0,
+            "visual_origin_applied_count": 0,
+        },
+        "runtime_scene3d_diagnostics": {
+            "baked_world_visual_pose_count": 4,
+        },
+    }
+
+    smoke._apply_runtime_transform_counter_mapping(payload)
+
+    assert payload["locked_generated_urdf_visual_count"] == 4
+    assert payload["transform_chain_applied_count"] == 0
+    assert payload["visual_origin_applied_count"] == 0
+    assert payload["runtime_baked_world_visual_pose_applied_count"] == 4
+    assert "runtime_transform_chain_applied_count_zero_with_generated_visuals" not in payload.get("warnings", [])
+    assert "runtime_visual_origin_applied_count_zero_with_generated_visuals" not in payload.get("warnings", [])
+
+
+def test_zero_transform_warnings_preserved_when_all_transform_evidence_zero():
+    import scripts.run_workcell_builder_scene3d_gui_smoke as smoke
+
+    payload = {
+        "runtime_available": True,
+        "counters": {
+            "rendered_count": 1,
+            "locked_generated_urdf_visual_count": 4,
+            "transform_chain_applied_count": 0,
+            "visual_origin_applied_count": 0,
+        },
+    }
+
+    smoke._apply_runtime_transform_counter_mapping(payload)
+
+    assert payload["runtime_baked_world_visual_pose_applied_count"] == 0
+    assert "runtime_transform_chain_applied_count_zero_with_generated_visuals" in payload["warnings"]
+    assert "runtime_visual_origin_applied_count_zero_with_generated_visuals" in payload["warnings"]
+
+
 def test_ur5_rendered_mesh_adjacency_prefers_final_draw_bboxes():
     import scripts.run_workcell_builder_scene3d_gui_smoke as smoke
 


### PR DESCRIPTION
### Motivation
- Prevent false runtime warnings for generated URDF visuals when the GUI/runtime reports baked-world visual pose/transform evidence. 
- Normalize baked transform counters into the smoke payload so downstream consumers can distinguish baked-applied transforms from missing transform evidence.

### Description
- Extend `_apply_runtime_transform_counter_mapping()` to search `runtime_scene3d_diagnostics`, `runtime_diagnostics`, and `diagnostics` in addition to existing `counters` and `render_debug_counters` when resolving runtime counters. 
- Read keys such as `runtime_baked_world_visual_pose_applied_count`, `baked_world_visual_pose_count`, and `baked_world_visual_transform_count` and record the normalized value as `runtime_baked_world_visual_pose_applied_count` in the payload. 
- Change the zero-evidence warning gates so `runtime_transform_chain_applied_count_zero_with_generated_visuals` and `runtime_visual_origin_applied_count_zero_with_generated_visuals` are suppressed when generated visuals exist and the baked-world-visual-pose counter is greater than zero, while preserving the legacy warnings when all transform evidence counters are zero. 
- Add focused unit tests in `tests/test_scene3d_gui_smoke_json_output_contract.py` that exercise the baked-counter suppression and the preserved legacy warning behavior.

### Testing
- Ran `python3 -m pytest tests/test_scene3d_gui_smoke_json_output_contract.py -q -k 'baked_world_visual_pose_counter or zero_transform_warnings'` and the new, focused tests passed. 
- Ran `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke.py tests/test_scene3d_gui_smoke_json_output_contract.py` and compilation succeeded. 
- Ran the full `python3 -m pytest tests/test_scene3d_gui_smoke_json_output_contract.py -q` and observed failures unrelated to this change (environment/contract expectations such as ROS Humble availability causing `BLOCKED` status, a C++ source-string contract, and an existing rendered-mesh-adjacency source expectation); these are pre-existing repository/environment issues not introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36c8e49eb48331b1e94329539719e1)