### PR TITLE
Tighten UR5 Scene3D smoke visibility evidence

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -784,18 +784,17 @@ def _apply_ur5_rendered_mesh_adjacency(payload: dict[str, Any], *, repo_root: Pa
     if not isinstance(final_draw_items, list) or not final_draw_items:
         index_items = index_data.get("visual_items") or index_data.get("items") or []
         if isinstance(index_items, list):
-            source = "visual_index_fallback"
-            _record_rendered_mesh_adjacency_fallback_warning(payload)
-        if isinstance(index_items, list) and index_items:
-            final_draw_items = index_items
-        else:
-            errors.append("Final draw diagnostics and scene_visual_mesh_index fallback records are missing for ur5_2f_test")
-            payload["rendered_mesh_adjacency_source"] = source if source == "visual_index_fallback" else "missing_final_draw_diagnostics"
-            payload["rendered_mesh_adjacency_status"] = "FAIL"
-            payload["rendered_mesh_adjacency_errors"] = errors
-            payload["rendered_mesh_adjacency_checked_pairs"] = []
-            _record_rendered_mesh_adjacency_failure(payload, errors)
-            return
+            payload["rendered_mesh_adjacency_visual_index_supplemental_count"] = len(index_items)
+        errors.append(
+            "Final Scene3D viewport/renderable diagnostics are missing; "
+            "visual-index metadata cannot prove UR5 arm visibility"
+        )
+        payload["rendered_mesh_adjacency_source"] = "missing_final_draw_diagnostics"
+        payload["rendered_mesh_adjacency_status"] = "FAIL"
+        payload["rendered_mesh_adjacency_errors"] = errors
+        payload["rendered_mesh_adjacency_checked_pairs"] = []
+        _record_rendered_mesh_adjacency_failure(payload, errors)
+        return
 
     payload["rendered_mesh_adjacency_source"] = source
     alias_to_canonical: dict[str, str] = {}
@@ -812,24 +811,34 @@ def _apply_ur5_rendered_mesh_adjacency(payload: dict[str, Any], *, repo_root: Pa
             6: "wrist_3_link",
         }
         final_links = {str(row.get("link") or row.get("link_name") or "").strip() for row in final_rows}
-        missing_ur5 = [link for link in expected_source_rows.values() if link not in final_links]
+        final_canonical_links = {
+            canonical
+            for row in final_rows
+            for canonical in _stable_metadata_candidates(row)
+        }
+        missing_ur5 = [
+            link
+            for link in expected_source_rows.values()
+            if link not in final_links and _canonical_ur5_rendered_mesh_link_name(link) not in final_canonical_links
+        ]
         if missing_ur5:
             errors.append("Final Scene3D payload is missing visible/rendered UR5 arm links: " + ",".join(missing_ur5))
-        for row_index, expected_link in expected_source_rows.items():
-            row = by_source_row.get(row_index)
-            actual_link = str((row or {}).get("link") or (row or {}).get("link_name") or "").strip()
-            if actual_link != expected_link:
-                errors.append(
-                    f"Final Scene3D payload source_row_index={row_index} expected {expected_link} but got {actual_link or '<missing>'}"
-                )
-        replacement_links = {"gripper_base_link", "table", "camera", "camera_link"}
-        for row_index in expected_source_rows:
-            row = by_source_row.get(row_index)
-            actual_link = str((row or {}).get("link") or (row or {}).get("link_name") or "").strip()
-            if actual_link in replacement_links:
-                errors.append(
-                    f"Final Scene3D payload source_row_index={row_index} was replaced by non-UR5 logical row {actual_link}"
-                )
+        if by_source_row:
+            for row_index, expected_link in expected_source_rows.items():
+                row = by_source_row.get(row_index)
+                actual_link = str((row or {}).get("link") or (row or {}).get("link_name") or "").strip()
+                if actual_link != expected_link:
+                    errors.append(
+                        f"Final Scene3D payload source_row_index={row_index} expected {expected_link} but got {actual_link or '<missing>'}"
+                    )
+            replacement_links = {"gripper_base_link", "table", "camera", "camera_link"}
+            for row_index in expected_source_rows:
+                row = by_source_row.get(row_index)
+                actual_link = str((row or {}).get("link") or (row or {}).get("link_name") or "").strip()
+                if actual_link in replacement_links:
+                    errors.append(
+                        f"Final Scene3D payload source_row_index={row_index} was replaced by non-UR5 logical row {actual_link}"
+                    )
 
     for canonical, aliases in UR5_RENDERED_MESH_LINK_ALIASES.items():
         for alias in aliases:

--- a/tests/test_scene3d_gui_smoke_json_output_contract.py
+++ b/tests/test_scene3d_gui_smoke_json_output_contract.py
@@ -606,11 +606,28 @@ def test_ur5_rendered_mesh_adjacency_final_draw_nonfinite_fails_without_index_fa
     assert any(pair["parent"] == "base_link" and pair["child"] == "shoulder_link" and pair["ok"] is False for pair in payload["rendered_mesh_adjacency_checked_pairs"])
 
 
-def test_ur5_rendered_mesh_adjacency_marks_index_fallback_warning_when_final_draw_missing():
+def test_ur5_rendered_mesh_adjacency_rejects_index_fallback_when_final_draw_missing():
     import scripts.run_workcell_builder_scene3d_gui_smoke as smoke
 
     payload = {"status": "PASS"}
-    smoke._apply_ur5_rendered_mesh_adjacency(payload, repo_root=Path(__file__).resolve().parents[1], scene_name="ur5_2f_test", index_data={"items": []})
+    index_items = [
+        {"link": "base_link"},
+        {"link": "shoulder_link"},
+        {"link": "upper_arm_link"},
+    ]
+    smoke._apply_ur5_rendered_mesh_adjacency(
+        payload,
+        repo_root=Path(__file__).resolve().parents[1],
+        scene_name="ur5_2f_test",
+        index_data={"items": index_items},
+    )
 
-    assert payload["rendered_mesh_adjacency_source"] == "visual_index_fallback"
-    assert "rendered_mesh_adjacency_used_index_fallback" in payload["warnings"]
+    assert payload["rendered_mesh_adjacency_source"] == "missing_final_draw_diagnostics"
+    assert payload["rendered_mesh_adjacency_status"] == "FAIL"
+    assert payload["rendered_mesh_adjacency_checked_pairs"] == []
+    assert payload["rendered_mesh_adjacency_visual_index_supplemental_count"] == len(index_items)
+    assert "rendered_mesh_adjacency_used_index_fallback" not in payload.get("warnings", [])
+    assert "scene3d_rendered_mesh_adjacency_failed" in payload["warnings"]
+    assert payload["rendered_mesh_adjacency_errors"] == [
+        "Final Scene3D viewport/renderable diagnostics are missing; visual-index metadata cannot prove UR5 arm visibility"
+    ]


### PR DESCRIPTION
### Motivation
- Prevent visual-index records from being treated as pass/fail evidence for UR5 arm visibility when final Scene3D viewport/renderable diagnostics are missing or empty.
- Keep visual-index data only as supplemental debug context and require final rendered/visible items for UR5 visibility proof.
- Avoid false positives where UR5 names appear only in metadata but are not present in final visible/rendered viewport items.

### Description
- Updated `scripts/run_workcell_builder_scene3d_gui_smoke.py` so that when `final_draw_visual_items`/`final_draw_diagnostics` are missing or empty the smoke now fails with the explicit error `Final Scene3D viewport/renderable diagnostics are missing; visual-index metadata cannot prove UR5 arm visibility` and only records a supplemental `rendered_mesh_adjacency_visual_index_supplemental_count` rather than using the index as fallback evidence.
- Made final-source row order and replacement checks conditional on the presence of `source_row_index` diagnostics so those validations do not falsely trigger when rows lack source indices.
- Added a check that treats stable/generated canonical link names (from `_stable_metadata_candidates`) as supplemental evidence when present in final rows but still requires final viewport/rendered items to pass.
- Updated JSON-contract tests in `tests/test_scene3d_gui_smoke_json_output_contract.py` to assert that visual-index-only UR5 metadata no longer passes and to expect the new explicit error and supplemental-count field.

### Testing
- Ran targeted unit tests: `pytest -q tests/test_scene3d_gui_smoke_json_output_contract.py::test_ur5_rendered_mesh_adjacency_rejects_index_fallback_when_final_draw_missing tests/test_scene3d_gui_smoke_json_output_contract.py::test_ur5_rendered_mesh_adjacency_prefers_final_draw_bboxes tests/test_scene3d_gui_smoke_json_output_contract.py::test_ur5_rendered_mesh_adjacency_passes_with_generated_urdf_ids_and_stable_metadata tests/test_scene3d_gui_smoke_json_output_contract.py::test_reported_ur5_2f_smoke_json_generated_urdf_contract_passes` — all passed.
- Performed `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke.py` and `git diff --check` — both passed.
- Ran the full `tests/test_scene3d_gui_smoke_json_output_contract.py` in-container and observed unrelated pre-existing failures (ROS Humble availability and other wrapper/C++ static-token expectations); the new UR5 visibility tests behaved as intended in the focused runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3701ae4a648331a5db0272f5caf68f)