### PR TITLE
Distinguish generated URDF visual fallbacks and keep them visible

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -9171,20 +9171,76 @@ void MainWindow::populate_scene_hierarchy()
             continue;
           }
           if (mesh_fallback) {
-            p.status = "warning";
-            p.mesh_available = false;
-            p.has_mesh_metadata = true;
-            p.active_visual_source = QStringLiteral("primitive_fallback");
-            p.source_layer = QStringLiteral("locked_generated_urdf_visual");
-            p.editable = false;
-            p.selectable = true;
-            p.lock_reason = QStringLiteral("generated URDF visual");
-            p.warnings << QStringLiteral("Preview warning: URDF visual mesh unavailable; using primitive fallback");
+            const QString fallback_link = p.visual_index_link.trimmed().isEmpty() ? p.display_name.trimmed() : p.visual_index_link.trimmed();
+            const QString robot_identity = canonical_scene3d_token(
+              fallback_link + QStringLiteral(" ") + p.visual_index_parent_link + QStringLiteral(" ") +
+              p.visual_index_link_chain.join(QStringLiteral(" ")) + QStringLiteral(" ") + p.id + QStringLiteral(" ") +
+              p.category + QStringLiteral(" ") + p.role);
+            const bool excluded_non_robot_visual =
+              robot_identity.contains(QStringLiteral("camera")) ||
+              robot_identity.contains(QStringLiteral("realsense")) ||
+              robot_identity.contains(QStringLiteral("d435")) ||
+              robot_identity.contains(QStringLiteral("d455")) ||
+              robot_identity.contains(QStringLiteral("table")) ||
+              robot_identity.contains(QStringLiteral("workbench")) ||
+              robot_identity.contains(QStringLiteral("conveyor"));
+            const bool generated_robot_visual_link = !excluded_non_robot_visual &&
+              (robot_identity.contains(QStringLiteral("robot")) ||
+               robot_identity.contains(QStringLiteral("base_link")) ||
+               robot_identity.contains(QStringLiteral("shoulder")) ||
+               robot_identity.contains(QStringLiteral("upper_arm")) ||
+               robot_identity.contains(QStringLiteral("forearm")) ||
+               robot_identity.contains(QStringLiteral("wrist")) ||
+               robot_identity.contains(QStringLiteral("flange")) ||
+               robot_identity.contains(QStringLiteral("tool0")) ||
+               robot_identity.contains(QStringLiteral("gripper")) ||
+               robot_identity.contains(QStringLiteral("finger")) ||
+               robot_identity.contains(QStringLiteral("knuckle")));
+            if (generated_robot_visual_link) {
+              const QString fallback_id = QStringLiteral("generated_urdf_fallback::%1")
+                .arg(fallback_link.trimmed().isEmpty() ? canonical_scene3d_token(id) : fallback_link);
+              if (preview_ids.contains(fallback_id)) {
+                const QString reason = add_skip_reason(QStringLiteral("duplicate_generated_urdf_fallback_link"));
+                append_visual_ingestion_diagnostic(v, raw_id, fallback_id, reason);
+                continue;
+              }
+              p.id = fallback_id;
+              p.display_name = fallback_link.trimmed().isEmpty() ? p.display_name : fallback_link;
+              p.category = QStringLiteral("URDF Visual Fallback");
+              p.role = QStringLiteral("robot");
+              p.status = "warning";
+              p.mesh_available = false;
+              p.has_mesh_metadata = true;
+              p.active_visual_source = QStringLiteral("generated_urdf_visual_fallback");
+              p.source_layer = QStringLiteral("locked_generated_urdf_visual");
+              p.editable = false;
+              p.selectable = true;
+              p.locked = true;
+              p.lock_reason = QStringLiteral("generated URDF visual fallback");
+              p.has_material_color = true;
+              p.material_r = 1.0;
+              p.material_g = 0.82;
+              p.material_b = 0.05;
+              p.material_a = 1.0;
+              p.material_name = QStringLiteral("generated_urdf_visual_fallback_default_visible");
+              p.warnings << QStringLiteral("Preview warning: generated URDF robot mesh row did not produce a visible mesh renderable; using locked generated URDF visual fallback");
+              if (!render_expected) {
+                p.warnings << QStringLiteral("Preview warning: xacro-expanded visual kept as generated URDF visual fallback");
+              }
+            } else {
+              p.status = "warning";
+              p.mesh_available = false;
+              p.has_mesh_metadata = true;
+              p.active_visual_source = QStringLiteral("primitive_fallback");
+              p.source_layer = QStringLiteral("primitive_fallback");
+              p.editable = false;
+              p.selectable = true;
+              p.locked = true;
+              p.lock_reason = QStringLiteral("generated URDF visual primitive fallback diagnostic");
+              p.warnings << QStringLiteral("Preview warning: URDF visual mesh unavailable; using generic primitive fallback diagnostic");
+            }
             if (p.resolved_source_path_stale) {
               p.warnings << QStringLiteral("Preview warning: resolved_source_path is stale; package_uri fallback was attempted");
-            }
-            if (!render_expected) {
-              p.warnings << QStringLiteral("Preview warning: xacro-expanded visual kept as generated primitive fallback");
             }
           } else if (!resolved || (geometry_type == "mesh" && p.source_path.trimmed().isEmpty())) {
             p.status = "warning";

--- a/workcell_builder/workcell_builder/gui/scene3d_candidate_assembly.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_candidate_assembly.cpp
@@ -19,6 +19,9 @@ bool include_preview_item_for_scene3d(
   const bool is_overlay_or_helper = combined.contains("overlay") || combined.contains("helper") || combined.contains("safety zone");
 
   if (source_layer == "editable_layout") return enabled_layers.contains("editable_layout");
+  // Generated URDF robot fallbacks are locked generated visuals, not generic
+  // primitive-fallback diagnostics. Keep them controlled by the generated URDF
+  // layer so they remain visible when diagnostic primitive fallbacks are hidden.
   if (source_layer == "locked_generated_urdf_visual" || source_layer == "generated_urdf_visual") return enabled_layers.contains("locked_generated_urdf_visual");
   if (source_layer == "primitive_fallback") return enabled_layers.contains("primitive_fallback");
   if (visual_source == "mesh_preview") return enabled_layers.contains("mesh_preview");
@@ -91,7 +94,8 @@ Scene3DLayerVisibilityDefaults compute_scene3d_default_layer_visibility(
     const QString source_layer = token(item.source_layer);
     if ((source_layer == QStringLiteral("locked_generated_urdf_visual") ||
          source_layer == QStringLiteral("generated_urdf_visual")) &&
-        (item.mesh_available || item.has_mesh_metadata)) {
+        (item.mesh_available || item.has_mesh_metadata ||
+         item.id.startsWith(QStringLiteral("generated_urdf_fallback::")))) {
       ++authoritative_generated_mesh_count;
     }
   }

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -1013,6 +1013,16 @@ bool is_generated_urdf_visual_item(const ScenePreviewWidget::PreviewItem & it)
   return false;
 }
 
+bool is_generated_urdf_visual_fallback_item(const ScenePreviewWidget::PreviewItem & it)
+{
+  const QString source_layer = normalized_scene3d_layer_token(it.source_layer);
+  const QString visual_source = normalized_scene3d_layer_token(it.active_visual_source);
+  return it.id.startsWith(QStringLiteral("generated_urdf_fallback::")) &&
+         source_layer == QStringLiteral("locked_generated_urdf_visual") &&
+         (visual_source == QStringLiteral("generated_urdf_visual_fallback") ||
+          it.category.compare(QStringLiteral("URDF Visual Fallback"), Qt::CaseInsensitive) == 0);
+}
+
 bool is_locked_urdf_item(const ScenePreviewWidget::PreviewItem & it);
 
 QString clean_label_from_item(const ScenePreviewWidget::PreviewItem & it)
@@ -2659,12 +2669,14 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
     }
   }
   if (item_has_explicit_dimensions(it)) {
+    const bool locked_generated_urdf_visual_fallback = is_generated_urdf_visual_fallback_item(it);
     const bool intentional_primitive_fallback =
-      source_layer == QStringLiteral("primitive_fallback") || visual_source == QStringLiteral("primitive_fallback");
+      source_layer == QStringLiteral("primitive_fallback") || visual_source == QStringLiteral("primitive_fallback") ||
+      locked_generated_urdf_visual_fallback;
     const bool generated_mesh_to_primitive_fallback =
-      generated_or_locked_preview && item_has_credible_mesh_handoff(it);
+      generated_or_locked_preview && item_has_credible_mesh_handoff(it) && !locked_generated_urdf_visual_fallback;
     const bool raw_generated_bounds_only = is_raw_generated_bounds_only_item(it);
-    if (mesh_preview_mode == ScenePreviewWidget::MeshPreviewMode::Meshes || raw_generated_bounds_only) {
+    if ((mesh_preview_mode == ScenePreviewWidget::MeshPreviewMode::Meshes && !locked_generated_urdf_visual_fallback) || raw_generated_bounds_only) {
       if (raw_generated_bounds_only) {
         const QString mesh_source = !it.mesh_path.trimmed().isEmpty() ? it.mesh_path : it.source_path;
         const bool mesh_candidate = item_has_mesh_surface_candidate(it);
@@ -2709,11 +2721,13 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
     const QColor fallback_line = generated_or_locked_preview ? generated_primitive_fallback_outline()
       : (editable_layout_preview ? editable_layout_accent_outline() : QColor(148, 163, 184, 76));
     const float fallback_line_width = generated_or_locked_preview ? 0.7f : (editable_layout_preview ? 1.6f : 0.75f);
-    if (!editable_layout_preview && !scene3d_debug_fallback_boxes_enabled()) {
+    if (!editable_layout_preview && !scene3d_debug_fallback_boxes_enabled() && !locked_generated_urdf_visual_fallback) {
       if (!intentional_primitive_fallback && out_missing_geometry_count) ++(*out_missing_geometry_count);
       return false;
     }
-    if (scene3d_debug_fallback_boxes_enabled() || editable_layout_preview) {
+    if (locked_generated_urdf_visual_fallback) {
+      draw_box(it.x, it.y, it.z, it.sx, it.sy, it.sz, product_view_generated_locked_material(it, diagnostic_transparency_mode), false);
+    } else if (scene3d_debug_fallback_boxes_enabled() || editable_layout_preview) {
       draw_box(it.x, it.y, it.z, it.sx, it.sy, it.sz, fallback_fill, true);
     }
     // Generated primitive fallback outlines are bounds diagnostics; keep them out of normal Product View.


### PR DESCRIPTION
### Motivation

- Generated URDF visual rows in the ingest path sometimes fail to produce a visible mesh renderable, but generic primitive fallback diagnostics were hiding meaningful robot-linked fallbacks; the UI should surface deterministic, locked generated-URDF fallbacks so authors can see where a robot visual failed. 
- Keep diagnostics distinct: generic semantic/primitive fallback boxes remain diagnostic-only while generated URDF robot fallbacks are visible locked artifacts tied to the generated visuals layer. 

### Description

- When a generated URDF visual row cannot resolve to a visible mesh (`mesh_fallback`), create a locked generated fallback preview item for robot-linked visuals using a deterministic id `generated_urdf_fallback::<link>` and set `source_layer = locked_generated_urdf_visual`, `active_visual_source = generated_urdf_visual_fallback`, `category = "URDF Visual Fallback"`, `locked = true`, `selectable = true`, bright default material, and preserve baked world pose via the preview item. 
- Classify whether a fallback should be a robot-specific generated fallback or remain a generic primitive fallback via link/metadata token checks so cameras, tables, conveyors, etc. continue to produce the generic diagnostic fallback. 
- Add `is_generated_urdf_visual_fallback_item` and update scene rendering in `Scene3DViewportWidget::draw_truthful_item_geometry` to draw generated URDF fallbacks as visible locked generated geometry (using `product_view_generated_locked_material`) instead of suppressing them with diagnostic primitive fallback rules. 
- Update layer filtering/defaults in `include_preview_item_for_scene3d` and `compute_scene3d_default_layer_visibility` so items with `id` starting with `generated_urdf_fallback::` are considered part of the locked/generated URDF visuals layer and remain visible even when generic primitive fallback diagnostics are hidden. 

### Testing

- Ran `git diff --check` and there were no whitespace or simple diff issues (passed). 
- Ran `python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json` and the validator completed successfully and returned a passing readiness JSON. 
- Attempted `colcon build --packages-select workcell_builder` but the container lacks a sourced ROS environment (`/opt/ros/humble/setup.bash` missing) so an integrated build could not be run here; no build-time checks were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3701c14838833190a14ddc2cf06375)