### PR TITLE
Wire generated robot visibility filter

### DIFF
--- a/tests/test_scene3d_filter_behavior.py
+++ b/tests/test_scene3d_filter_behavior.py
@@ -13,10 +13,29 @@ class Item:
     status: str = ""
     warnings: list[str] = field(default_factory=list)
     mesh_load_warning: str = ""
+    locked: bool = False
+    lock_reason: str = ""
 
 
 def _tok(s: str) -> str:
-    return s.strip().lower()
+    return s.strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def is_generated_robot_visual(item: Item) -> bool:
+    source_layer = _tok(item.source_layer)
+    visual_source = _tok(item.active_visual_source)
+    combined = "|".join([_tok(item.role), _tok(item.category), _tok(item.id), _tok(item.lock_reason)])
+    if source_layer in {"locked_generated_urdf_visual", "generated_urdf_visual"}:
+        return True
+    if visual_source in {
+        "locked_generated_urdf_visual",
+        "generated_urdf_visual",
+        "generated_urdf_visual_fallback",
+    }:
+        return True
+    if _tok(item.id).startswith("generated_urdf_fallback::"):
+        return True
+    return item.locked and any(token in combined for token in ("urdf", "generated", "robot_link", "robot_model"))
 
 
 def include_item(item: Item, enabled_layers: set[str]) -> bool:
@@ -26,10 +45,10 @@ def include_item(item: Item, enabled_layers: set[str]) -> bool:
     is_warning_or_missing = "warning" in combined or "missing" in combined or item.mesh_load_warning.strip() != ""
     is_overlay_or_helper = "overlay" in combined or "helper" in combined or "safety zone" in combined
 
+    if is_generated_robot_visual(item):
+        return "locked_generated_urdf_visual" in enabled_layers
     if source_layer == "editable_layout":
         return "editable_layout" in enabled_layers
-    if source_layer in {"locked_generated_urdf_visual", "generated_urdf_visual"}:
-        return "locked_generated_urdf_visual" in enabled_layers
     if source_layer == "primitive_fallback":
         return "primitive_fallback" in enabled_layers
     if visual_source == "mesh_preview":
@@ -122,3 +141,31 @@ def test_fixture_approx_failing_scene_does_not_end_at_zero_visible_items() -> No
     assert "robot" in ids
     assert ids
     assert "blocker" not in logs
+
+
+def test_generated_robot_layer_overrides_mesh_and_label_style_filters() -> None:
+    ids, _ = apply_filter(
+        [
+            Item(
+                "ur5_link_mesh",
+                source_layer="locked_generated_urdf_visual",
+                active_visual_source="mesh_preview",
+                role="robot link",
+                category="URDF Visual",
+                locked=True,
+            ),
+            Item(
+                "generated_urdf_fallback::forearm_link",
+                source_layer="locked_generated_urdf_visual",
+                active_visual_source="generated_urdf_visual_fallback",
+                role="robot link",
+                category="URDF Visual Fallback",
+                locked=True,
+            ),
+            Item("loose_mesh_preview", active_visual_source="mesh_preview"),
+        ],
+        {"locked_generated_urdf_visual"},
+    )
+    assert "ur5_link_mesh" in ids
+    assert "generated_urdf_fallback::forearm_link" in ids
+    assert "loose_mesh_preview" not in ids

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -1830,7 +1830,9 @@ void MainWindow::setup_studio_shell()
   auto * preview_layers_group = new QGroupBox("Scene3D Preview Layers", hierarchy_card);
   auto * preview_layers_layout = new QVBoxLayout(preview_layers_group);
   preview_layer_editable_layout_box_ = new QCheckBox("editable layout", preview_layers_group);
-  preview_layer_generated_urdf_visual_box_ = new QCheckBox("generated URDF visuals", preview_layers_group);
+  preview_layer_generated_urdf_visual_box_ = new QCheckBox("Show Robot Links (generated)", preview_layers_group);
+  preview_layer_generated_urdf_visual_box_->setToolTip(
+    "Shows locked generated robot/URDF visuals, including generated robot mesh previews and fallback link items.");
   preview_layer_mesh_preview_box_ = new QCheckBox("mesh previews", preview_layers_group);
   preview_layer_primitive_fallback_box_ = new QCheckBox("primitive fallbacks", preview_layers_group);
   preview_layer_overlays_helpers_box_ = new QCheckBox("overlays/helpers", preview_layers_group);

--- a/workcell_builder/workcell_builder/gui/scene3d_candidate_assembly.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_candidate_assembly.cpp
@@ -1,7 +1,30 @@
 #include "scene3d_candidate_assembly.h"
 
 namespace {
-QString token(QString s) { return s.trimmed().toLower(); }
+QString token(QString s) { return s.trimmed().toLower().replace('-', '_').replace(' ', '_'); }
+
+bool is_generated_robot_visual(const ScenePreviewWidget::PreviewItem & item)
+{
+  const QString source_layer = token(item.source_layer);
+  const QString visual_source = token(item.active_visual_source);
+  const QString role = token(item.role);
+  const QString category = token(item.category);
+  const QString id = token(item.id);
+  const QString lock_reason = token(item.lock_reason);
+  const QString combined = role + "|" + category + "|" + id + "|" + lock_reason;
+
+  if (source_layer == "locked_generated_urdf_visual" || source_layer == "generated_urdf_visual") return true;
+  if (visual_source == "locked_generated_urdf_visual" || visual_source == "generated_urdf_visual" ||
+      visual_source == "generated_urdf_visual_fallback")
+  {
+    return true;
+  }
+  if (id.startsWith(QStringLiteral("generated_urdf_fallback::"))) return true;
+  return item.locked && (combined.contains(QStringLiteral("urdf")) ||
+                         combined.contains(QStringLiteral("generated")) ||
+                         combined.contains(QStringLiteral("robot_link")) ||
+                         combined.contains(QStringLiteral("robot_model")));
+}
 }
 
 namespace workcell_builder {
@@ -18,11 +41,13 @@ bool include_preview_item_for_scene3d(
   const bool is_warning_or_missing = combined.contains("warning") || combined.contains("missing") || !item.mesh_load_warning.trimmed().isEmpty();
   const bool is_overlay_or_helper = combined.contains("overlay") || combined.contains("helper") || combined.contains("safety zone");
 
+  // Treat generated robot visuals as a first-class layer, equivalent to the
+  // legacy "Show Robot Links" control.  This check intentionally precedes
+  // mesh-preview, label/selection, warning, and primitive-fallback decisions:
+  // generated robot meshes and locked generated fallback link visuals must
+  // stay visible whenever the generated robot layer is enabled.
+  if (is_generated_robot_visual(item)) return enabled_layers.contains("locked_generated_urdf_visual");
   if (source_layer == "editable_layout") return enabled_layers.contains("editable_layout");
-  // Generated URDF robot fallbacks are locked generated visuals, not generic
-  // primitive-fallback diagnostics. Keep them controlled by the generated URDF
-  // layer so they remain visible when diagnostic primitive fallbacks are hidden.
-  if (source_layer == "locked_generated_urdf_visual" || source_layer == "generated_urdf_visual") return enabled_layers.contains("locked_generated_urdf_visual");
   if (source_layer == "primitive_fallback") return enabled_layers.contains("primitive_fallback");
   if (visual_source == "mesh_preview") return enabled_layers.contains("mesh_preview");
   if (is_overlay_or_helper) return enabled_layers.contains("overlay");


### PR DESCRIPTION
### Motivation
- Ensure generated/locked URDF robot visuals behave like the legacy “Show Robot Links” control so robot meshes and locked fallback link visuals are not accidentally hidden by other Scene3D filters. 
- Prevent `Mesh Preview Auto`, label/selection, and primitive-fallback logic from hiding generated robot visuals or the `locked_generated_urdf_visual` fallbacks. 
- Keep the change scoped to the Scene3D preview layer controls and filtering path (no new primary UI actions). 

### Description
- Added a classifier `is_generated_robot_visual(...)` and normalized token handling in `workcell_builder/gui/scene3d_candidate_assembly.cpp` and wired it into `include_preview_item_for_scene3d` so generated/locked URDF visuals are checked first and gated by the generated robot layer. 
- Kept generated robot fallbacks (`generated_urdf_fallback::...`) and visual-source variants visible when the generated robot layer is enabled, even when mesh-preview or label-style filters would otherwise suppress them. 
- Updated the existing Scene3D preview layer control text in `workcell_builder/gui/mainwindow.cpp` to `Show Robot Links (generated)` and added a tooltip explaining it covers generated mesh previews and fallback link items (no new main-page buttons added). 
- Added regression coverage in `tests/test_scene3d_filter_behavior.py` to assert generated robot mesh-preview and generated URDF fallback items remain visible when only the generated robot layer is enabled, and adjusted test helpers to match new token/lock checks. 

### Testing
- Ran unit tests: `pytest -q tests/test_scene3d_filter_behavior.py` — 5 passed. 
- Attempted workspace build: `source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select workcell_builder` — not executed in this container because `/opt/ros/humble/setup.bash` was not available. 
- Safety: this is a UI/filter-only change and does not modify launch files, controllers, runtime services, or hardware parameters, and fake-hardware defaults remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37037921648331bbf29bd859a92047)