### PR TITLE
Add Scene3D final viewport payload validation and tests

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -421,10 +421,157 @@ UR5_RENDERED_MESH_ADJACENT_PAIRS: tuple[tuple[str, str], ...] = (
 )
 RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M = 0.20
 RENDERED_MESH_ADJACENCY_PAIR_LIMITS_M: dict[tuple[str, str], float] = {}
+REQUIRED_UR5_FINAL_VIEWPORT_LINKS: tuple[str, ...] = (
+    "base_link_inertia",
+    "shoulder_link",
+    "upper_arm_link",
+    "forearm_link",
+    "wrist_1_link",
+    "wrist_2_link",
+    "wrist_3_link",
+)
+RETAINED_VISUAL_ROWS_MISSING_WARNING = "retained visual rows missing after loader filtering"
 
 
 def _rendered_mesh_adjacency_limit(parent: str, child: str) -> float:
     return RENDERED_MESH_ADJACENCY_PAIR_LIMITS_M.get((parent, child), RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M)
+
+
+def _payload_scene_name(payload: dict[str, Any]) -> str | None:
+    scene = payload.get("scene")
+    if isinstance(scene, str) and scene.strip():
+        return scene.strip()
+    scene_path = payload.get("scene_path")
+    if isinstance(scene_path, str) and scene_path.strip():
+        return Path(scene_path).name
+    return None
+
+
+def _payload_message_values(payload: dict[str, Any]) -> list[str]:
+    values: list[str] = []
+    for key in ("warnings", "blockers", "messages", "log_lines", "stdout_tail", "stderr_tail"):
+        raw = payload.get(key)
+        if isinstance(raw, list):
+            values.extend(str(item) for item in raw)
+        elif isinstance(raw, str):
+            values.append(raw)
+    for key in ("warning_messages", "blocker_messages"):
+        raw = payload.get(key)
+        if isinstance(raw, dict):
+            values.extend(str(item) for item in raw.values())
+    return values
+
+
+def _final_visible_viewport_rows(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = _first_present_list(payload, "final_draw_visual_items", "final_draw_diagnostics", "viewport_visible_items", "rendered_items", "visible_items")
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def _row_canonical_link_candidates(row: dict[str, Any]) -> set[str]:
+    candidates: set[str] = set()
+    for key in ("link", "link_name", "canonical_link_name", "frame_id", "visual_name", "item_id", "id", "display_name"):
+        canonical = _canonical_ur5_rendered_mesh_link_name(row.get(key))
+        if canonical:
+            candidates.add(canonical)
+        value = row.get(key)
+        if isinstance(value, str) and value.strip():
+            candidates.add(value.strip())
+    for canonical in _normalized_link_chain(row):
+        candidates.add(canonical)
+    return candidates
+
+
+def _row_is_final_visible_renderable(row: dict[str, Any]) -> bool:
+    if row.get("visible") is False or row.get("rendered") is False:
+        return False
+    status = str(row.get("final_draw_status") or row.get("draw_status") or "").strip().lower()
+    if status in {"missing_mesh_cache", "missing_bounds", "invalid_mesh", "non_finite_bounds", "skipped", "filtered"}:
+        return False
+    if status == "ok":
+        return True
+    if row.get("final_draw_bbox") or row.get("final_draw_bbox_min"):
+        return True
+    if row.get("active_visual_source") in {"primitive_fallback", "urdf_primitive"}:
+        return True
+    return bool(row.get("has_mesh_metadata") or row.get("mesh_path") or row.get("mesh_source") or row.get("primitive_geometry_type"))
+
+
+def _table_camera_visible(payload: dict[str, Any], rows: list[dict[str, Any]]) -> tuple[bool, bool]:
+    audit = _first_present_mapping(_first_present_mapping(payload, "filter_diagnostics"), "ur5_2f_test_final_viewport_audit")
+    table_visible = _as_int(audit.get("rendered_table_count")) > 0
+    camera_visible = _as_int(audit.get("rendered_camera_count")) > 0
+    labels = [label.lower() for label in _visible_item_labels_from_payload(payload)]
+    if any("table" in label or "workbench" in label or "support_surface" in label for label in labels):
+        table_visible = True
+    if any("camera" in label or "sensor" in label for label in labels):
+        camera_visible = True
+    for row in rows:
+        text = " ".join(str(row.get(key) or "") for key in ("id", "item_id", "display_name", "link", "link_name", "category", "role")).lower()
+        if "table" in text or "workbench" in text or "support_surface" in text:
+            table_visible = True
+        if "camera" in text or "sensor" in text:
+            camera_visible = True
+    return table_visible, camera_visible
+
+
+def _apply_ur5_final_viewport_payload_contract(payload: dict[str, Any]) -> None:
+    """Validate UR5 evidence from final visible/rendered viewport rows only."""
+    if _payload_scene_name(payload) != "ur5_2f_test":
+        return
+
+    rows = _final_visible_viewport_rows(payload)
+    visible_rows = [row for row in rows if _row_is_final_visible_renderable(row)]
+    visible_links: set[str] = set()
+    for row in visible_rows:
+        visible_links.update(_row_canonical_link_candidates(row))
+
+    missing = [link for link in REQUIRED_UR5_FINAL_VIEWPORT_LINKS if link not in visible_links]
+    rendered_ur5_link_count = len([link for link in REQUIRED_UR5_FINAL_VIEWPORT_LINKS if link in visible_links])
+    payload["rendered_ur5_link_count"] = max(_counter(payload, "rendered_ur5_link_count"), rendered_ur5_link_count)
+    payload["required_ur5_final_viewport_links"] = list(REQUIRED_UR5_FINAL_VIEWPORT_LINKS)
+    payload["missing_required_visible_ur5_links"] = missing
+
+    blockers = payload.get("blockers") if isinstance(payload.get("blockers"), list) else []
+    if missing:
+        _append_unique(blockers, "ur5_final_viewport_links_missing")
+    if payload["rendered_ur5_link_count"] < len(REQUIRED_UR5_FINAL_VIEWPORT_LINKS):
+        _append_unique(blockers, "rendered_ur5_link_count_below_7")
+
+    table_visible, camera_visible = _table_camera_visible(payload, rows)
+    payload["table_visible_in_final_viewport"] = table_visible
+    payload["camera_visible_in_final_viewport"] = camera_visible
+    if not table_visible:
+        _append_unique(blockers, "table_not_visible_in_final_viewport")
+    if not camera_visible:
+        _append_unique(blockers, "camera_not_visible_in_final_viewport")
+
+    retained_warning_present = any(RETAINED_VISUAL_ROWS_MISSING_WARNING in value for value in _payload_message_values(payload))
+    if retained_warning_present and not missing:
+        _append_unique(blockers, "stale_retained_visual_rows_missing_warning")
+
+    generated_mesh_rows = [
+        row for row in rows
+        if str(row.get("source_layer") or "").strip().lower() in {"locked_generated_urdf_visual", "generated_urdf_visual"}
+        and (row.get("has_mesh_metadata") or row.get("mesh_source") or row.get("mesh_path"))
+    ]
+    generated_mesh_missing_renderables = bool(generated_mesh_rows) and not any(
+        _row_is_final_visible_renderable(row) and str(row.get("final_draw_status") or "").strip().lower() == "ok"
+        for row in generated_mesh_rows
+    )
+    fallback_count = _counter(
+        payload,
+        "generated_fallback_count",
+        "primitive_fallback_rendered_count",
+        "urdf_primitive_rendered_count",
+        "valid_physical_fallback_count",
+    )
+    payload["generated_robot_fallback_required"] = generated_mesh_missing_renderables
+    if generated_mesh_missing_renderables and fallback_count <= 0:
+        _append_unique(blockers, "generated_robot_fallback_not_activated")
+
+    if blockers:
+        payload["blockers"] = blockers
+        payload["status"] = "FAIL"
 
 
 def _finite_float_list(value: Any, length: int) -> list[float] | None:
@@ -1699,6 +1846,8 @@ def main() -> int:
             screenshot_path=diag.get("screenshot_path"),
             screenshot_available=diag.get("screenshot_available"),
         )
+        if any(key in payload for key in ("final_draw_visual_items", "final_draw_diagnostics", "viewport_visible_items")):
+            _apply_ur5_final_viewport_payload_contract(payload)
         _apply_ur5_transform_parity(payload, repo_root=repo_root, args=args)
         _apply_ur5_final_draw_bbox_regression(payload)
         if args.scene_path:

--- a/tests/test_scene3d_full_payload_handoff.py
+++ b/tests/test_scene3d_full_payload_handoff.py
@@ -64,3 +64,36 @@ def test_scene3d_smoke_load_keeps_generated_urdf_layer_additive_for_mesh_index_p
     assert '"editable_layout"' in smoke_block
     assert '"mesh_preview"' in smoke_block
     assert '"primitive_fallback"' in smoke_block
+
+
+def test_ur5_2f_final_viewport_audit_requires_renderable_ur5_links_table_and_camera():
+    audit_start = MAIN_CPP.index('QJsonObject audit_ur5_2f_test_committed_viewport_items')
+    audit_end = MAIN_CPP.index('double normalize_angle_radians_with_guard', audit_start)
+    audit_block = MAIN_CPP[audit_start:audit_end]
+
+    for link in [
+        'base_link_inertia',
+        'shoulder_link',
+        'upper_arm_link',
+        'forearm_link',
+        'wrist_1_link',
+        'wrist_2_link',
+        'wrist_3_link',
+    ]:
+        assert f'QStringLiteral("{link}")' in audit_block
+    assert 'rendered_ur5_link_count' in audit_block
+    assert 'rendered_table_count' in audit_block
+    assert 'rendered_camera_count' in audit_block
+    assert 'missing_required_visible_ur5_links' in audit_block
+    assert 'const bool visible = renderable;' in audit_block
+
+
+def test_loader_filter_warning_is_suppressed_when_required_final_viewport_links_are_visible():
+    filter_start = MAIN_CPP.index('if (has_selected_scene() && selected_scene_name() == QStringLiteral("ur5_2f_test"))')
+    filter_end = MAIN_CPP.index('const Scene3DTransformParityReadiness transform_parity', filter_start)
+    filter_block = MAIN_CPP[filter_start:filter_end]
+
+    assert 'audit_ur5_2f_test_committed_viewport_items(viewport, &missing_required_visible_links)' in filter_block
+    assert 'if (!missing_required_visible_links.isEmpty())' in filter_block
+    assert 'retained visual rows missing after loader filtering' in filter_block
+    assert 'final viewport audit passed for ur5_2f_test required visible UR5 viewport/renderable links' in filter_block

--- a/tests/test_scene3d_gui_smoke_json_output_contract.py
+++ b/tests/test_scene3d_gui_smoke_json_output_contract.py
@@ -631,3 +631,177 @@ def test_ur5_rendered_mesh_adjacency_rejects_index_fallback_when_final_draw_miss
     assert payload["rendered_mesh_adjacency_errors"] == [
         "Final Scene3D viewport/renderable diagnostics are missing; visual-index metadata cannot prove UR5 arm visibility"
     ]
+
+
+def test_ur5_final_viewport_payload_requires_visible_links_table_and_camera():
+    import scripts.run_workcell_builder_scene3d_gui_smoke as smoke
+
+    required = [
+        "base_link_inertia",
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link",
+        "wrist_1_link",
+        "wrist_2_link",
+        "wrist_3_link",
+    ]
+    payload = {
+        "scene": "ur5_2f_test",
+        "status": "PASS",
+        "counters": {"generated_fallback_count": 0},
+        "final_draw_visual_items": [
+            {
+                "item_id": f"generated_urdf::{link}",
+                "link": link,
+                "link_name": link,
+                "source_layer": "locked_generated_urdf_visual",
+                "final_draw_status": "ok",
+                "final_draw_bbox": {"min": [0, 0, 0], "max": [1, 1, 1]},
+                "visible": True,
+                "rendered": True,
+            }
+            for link in required
+        ]
+        + [
+            {"id": "layout_table", "display_name": "table", "visible": True, "rendered": True, "geometry_type": "box"},
+            {"id": "camera_sensor", "display_name": "camera", "visible": True, "rendered": True, "geometry_type": "box"},
+        ],
+    }
+
+    smoke._apply_ur5_final_viewport_payload_contract(payload)
+
+    assert payload["status"] == "PASS"
+    assert payload["rendered_ur5_link_count"] >= 7
+    assert payload["missing_required_visible_ur5_links"] == []
+    assert payload["table_visible_in_final_viewport"] is True
+    assert payload["camera_visible_in_final_viewport"] is True
+    assert "ur5_final_viewport_links_missing" not in payload.get("blockers", [])
+    assert "stale_retained_visual_rows_missing_warning" not in payload.get("blockers", [])
+
+
+def test_ur5_final_viewport_payload_rejects_metadata_or_index_only_names():
+    import scripts.run_workcell_builder_scene3d_gui_smoke as smoke
+
+    payload = {
+        "scene": "ur5_2f_test",
+        "status": "PASS",
+        "visual_index": {
+            "items": [
+                {"link": "base_link_inertia"},
+                {"link": "shoulder_link"},
+                {"link": "upper_arm_link"},
+                {"link": "forearm_link"},
+                {"link": "wrist_1_link"},
+                {"link": "wrist_2_link"},
+                {"link": "wrist_3_link"},
+            ]
+        },
+        "metadata": {"robot_links": ["base_link_inertia", "shoulder_link", "upper_arm_link", "forearm_link", "wrist_1_link", "wrist_2_link", "wrist_3_link"]},
+        "visible_items": [
+            {"id": "layout_table", "display_name": "table", "visible": True, "rendered": True, "geometry_type": "box"},
+            {"id": "camera_sensor", "display_name": "camera", "visible": True, "rendered": True, "geometry_type": "box"},
+        ],
+    }
+
+    smoke._apply_ur5_final_viewport_payload_contract(payload)
+
+    assert payload["status"] == "FAIL"
+    assert payload["rendered_ur5_link_count"] == 0
+    assert payload["missing_required_visible_ur5_links"] == [
+        "base_link_inertia",
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link",
+        "wrist_1_link",
+        "wrist_2_link",
+        "wrist_3_link",
+    ]
+    assert "ur5_final_viewport_links_missing" in payload["blockers"]
+    assert "rendered_ur5_link_count_below_7" in payload["blockers"]
+
+
+def test_ur5_final_viewport_payload_fails_stale_retained_rows_warning_when_links_visible():
+    import scripts.run_workcell_builder_scene3d_gui_smoke as smoke
+
+    required = [
+        "base_link_inertia",
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link",
+        "wrist_1_link",
+        "wrist_2_link",
+        "wrist_3_link",
+    ]
+    payload = {
+        "scene": "ur5_2f_test",
+        "status": "PASS",
+        "warnings": ["Preview warning: ur5_2f_test retained visual rows missing after loader filtering"],
+        "final_draw_visual_items": [
+            {"link": link, "final_draw_status": "ok", "final_draw_bbox": {"min": [0, 0, 0], "max": [1, 1, 1]}}
+            for link in required
+        ]
+        + [
+            {"id": "table", "display_name": "table", "geometry_type": "box"},
+            {"id": "camera", "display_name": "camera", "geometry_type": "box"},
+        ],
+    }
+
+    smoke._apply_ur5_final_viewport_payload_contract(payload)
+
+    assert payload["missing_required_visible_ur5_links"] == []
+    assert "stale_retained_visual_rows_missing_warning" in payload["blockers"]
+    assert payload["status"] == "FAIL"
+
+
+def test_generated_robot_fallback_required_when_generated_mesh_rows_are_not_renderable():
+    import scripts.run_workcell_builder_scene3d_gui_smoke as smoke
+
+    payload = {
+        "scene": "ur5_2f_test",
+        "status": "PASS",
+        "counters": {"generated_fallback_count": 3},
+        "final_draw_visual_items": [
+            {
+                "link": "base_link_inertia",
+                "link_name": "base_link_inertia",
+                "source_layer": "locked_generated_urdf_visual",
+                "has_mesh_metadata": True,
+                "mesh_source": "package://ur_description/meshes/visual/base.dae",
+                "final_draw_status": "missing_mesh_cache",
+            },
+            {"id": "table", "display_name": "table", "geometry_type": "box"},
+            {"id": "camera", "display_name": "camera", "geometry_type": "box"},
+        ],
+    }
+
+    smoke._apply_ur5_final_viewport_payload_contract(payload)
+
+    assert payload["generated_robot_fallback_required"] is True
+    assert "generated_robot_fallback_not_activated" not in payload.get("blockers", [])
+
+
+def test_generated_robot_fallback_blocks_when_generated_mesh_rows_missing_renderables_without_fallback():
+    import scripts.run_workcell_builder_scene3d_gui_smoke as smoke
+
+    payload = {
+        "scene": "ur5_2f_test",
+        "status": "PASS",
+        "counters": {"generated_fallback_count": 0},
+        "final_draw_visual_items": [
+            {
+                "link": "base_link_inertia",
+                "source_layer": "locked_generated_urdf_visual",
+                "has_mesh_metadata": True,
+                "mesh_source": "package://ur_description/meshes/visual/base.dae",
+                "final_draw_status": "missing_mesh_cache",
+            },
+            {"id": "table", "display_name": "table", "geometry_type": "box"},
+            {"id": "camera", "display_name": "camera", "geometry_type": "box"},
+        ],
+    }
+
+    smoke._apply_ur5_final_viewport_payload_contract(payload)
+
+    assert payload["generated_robot_fallback_required"] is True
+    assert "generated_robot_fallback_not_activated" in payload["blockers"]
+    assert payload["status"] == "FAIL"


### PR DESCRIPTION
### Motivation

- Ensure the final Scene3D viewport/renderable payload (not just metadata or mesh-index) proves that a UR5 arm is actually visible before marking smoke as passing.  
- Detect and block stale or misleading "retained visual rows missing after loader filtering" warnings when final viewport rows already show required items.  
- Provide smoke coverage for generated-mesh fallback behaviour when generated mesh rows exist but renderables are missing.

### Description

- Added a final-viewport contract and helpers in `scripts/run_workcell_builder_scene3d_gui_smoke.py` including `_payload_scene_name`, `_payload_message_values`, `_final_visible_viewport_rows`, `_row_canonical_link_candidates`, `_row_is_final_visible_renderable`, `_table_camera_visible`, and `_apply_ur5_final_viewport_payload_contract`.  
- Introduced `REQUIRED_UR5_FINAL_VIEWPORT_LINKS` and `RETAINED_VISUAL_ROWS_MISSING_WARNING` constants and wired the contract into the smoke wrapper only when final-render diagnostics are present.  
- The contract enforces presence of the seven UR5 link tokens, computes `rendered_ur5_link_count >= 7`, checks that a table and camera are visible, rejects metadata-only evidence, flags stale retained-rows warnings when appropriate, and requires generated-robot fallback activation when generated mesh rows exist but are not renderable.  
- Added unit/static tests: new JSON-smoke tests in `tests/test_scene3d_gui_smoke_json_output_contract.py` and static/C++ handoff checks in `tests/test_scene3d_full_payload_handoff.py` to cover the final-viewport contract and C++ audit gating.

### Testing

- Ran focused smoke contract tests with `python3 -m pytest tests/test_scene3d_gui_smoke_json_output_contract.py::test_ur5_final_viewport_payload_requires_visible_links_table_and_camera tests/test_scene3d_gui_smoke_json_output_contract.py::test_ur5_final_viewport_payload_rejects_metadata_or_index_only_names tests/test_scene3d_gui_smoke_json_output_contract.py::test_ur5_final_viewport_payload_fails_stale_retained_rows_warning_when_links_visible tests/test_scene3d_gui_smoke_json_output_contract.py::test_generated_robot_fallback_required_when_generated_mesh_rows_are_not_renderable tests/test_scene3d_gui_smoke_json_output_contract.py::test_generated_robot_fallback_blocks_when_generated_mesh_rows_missing_renderables_without_fallback` and all focused tests passed.  
- Compiled the smoke script with `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke.py` which succeeded.  
- Ran a broader set `python3 -m pytest tests/test_scene3d_gui_smoke_json_output_contract.py tests/test_scene3d_full_payload_handoff.py tests/test_scene3d_view_fit_and_scale.py` and observed failures in wrapper-level tests in this container due to `ROS Humble` being unavailable and an unrelated static-token expectation; these failures are environmental and not caused by the new final-viewport contract, while the newly added tests remain green.  
- No runtime/hardware launch files, controllers, or fake-hardware defaults were changed and safety defaults remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37037a0f7c8331a0f9c74b9ff3a008)