### PR TITLE
Restrict UR5 viewport audit link counting

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -484,9 +484,37 @@ QJsonObject audit_ur5_2f_test_committed_viewport_items(
     QStringLiteral("wrist_2_link"),
     QStringLiteral("wrist_3_link")
   };
-  const QStringList robotiq_tokens = {
-    QStringLiteral("robotiq"),
+  const QSet<QString> table_link_tokens = {
+    QStringLiteral("table"),
+    QStringLiteral("table_link"),
+    QStringLiteral("workbench"),
+    QStringLiteral("workbench_link"),
+    QStringLiteral("support_surface"),
+    QStringLiteral("support_surface_link")
+  };
+  const QSet<QString> camera_link_tokens = {
+    QStringLiteral("camera"),
+    QStringLiteral("camera_link"),
+    QStringLiteral("sensor"),
+    QStringLiteral("sensor_link")
+  };
+  const QSet<QString> robotiq_link_tokens = {
+    QStringLiteral("robotiq_arg2f_base_link"),
+    QStringLiteral("robotiq_arg2f_85_base_link"),
+    QStringLiteral("robotiq_arg2f_140_base_link"),
+    QStringLiteral("robotiq_85_base_link"),
+    QStringLiteral("robotiq_140_base_link"),
     QStringLiteral("gripper_base_link"),
+    QStringLiteral("left_outer_knuckle"),
+    QStringLiteral("left_outer_finger"),
+    QStringLiteral("left_inner_finger"),
+    QStringLiteral("left_inner_finger_pad"),
+    QStringLiteral("left_inner_knuckle"),
+    QStringLiteral("right_outer_knuckle"),
+    QStringLiteral("right_outer_finger"),
+    QStringLiteral("right_inner_finger"),
+    QStringLiteral("right_inner_finger_pad"),
+    QStringLiteral("right_inner_knuckle"),
     QStringLiteral("finger_link"),
     QStringLiteral("knuckle_link"),
     QStringLiteral("finger_tip_link")
@@ -531,46 +559,39 @@ QJsonObject audit_ur5_2f_test_committed_viewport_items(
         !field_text(item, QStringLiteral("canonical_link_name")).trimmed().isEmpty() ? field_text(item, QStringLiteral("canonical_link_name")) :
         (!field_text(item, QStringLiteral("link_name")).trimmed().isEmpty() ? field_text(item, QStringLiteral("link_name")) :
          field_text(item, QStringLiteral("link"))));
-      const QString combined = canonical_scene3d_token(
-        field_text(item, QStringLiteral("item_id")) + QStringLiteral(" ") +
-        field_text(item, QStringLiteral("id")) + QStringLiteral(" ") +
-        field_text(item, QStringLiteral("display_name")) + QStringLiteral(" ") +
-        field_text(item, QStringLiteral("object_name")) + QStringLiteral(" ") +
-        field_text(item, QStringLiteral("visual_name")) + QStringLiteral(" ") +
-        field_text(item, QStringLiteral("visual")) + QStringLiteral(" ") +
-        field_text(item, QStringLiteral("parent_link")) + QStringLiteral(" ") +
-        field_text(item, QStringLiteral("mesh_source")) + QStringLiteral(" ") +
-        field_text(item, QStringLiteral("mesh_uri")) + QStringLiteral(" ") +
-        field_text(item, QStringLiteral("source_layer")));
+      const QStringList classification_tokens = {
+        link_token,
+        canonical_scene3d_token(field_text(item, QStringLiteral("canonical_link_name"))),
+        canonical_scene3d_token(field_text(item, QStringLiteral("link_name"))),
+        canonical_scene3d_token(field_text(item, QStringLiteral("link"))),
+        canonical_scene3d_token(field_text(item, QStringLiteral("item_id"))),
+        canonical_scene3d_token(field_text(item, QStringLiteral("id"))),
+        canonical_scene3d_token(field_text(item, QStringLiteral("display_name"))),
+        canonical_scene3d_token(field_text(item, QStringLiteral("object_name"))),
+        canonical_scene3d_token(field_text(item, QStringLiteral("visual_name"))),
+        canonical_scene3d_token(field_text(item, QStringLiteral("parent_link")))
+      };
+      const auto has_exact_classification = [&classification_tokens](const QSet<QString> & tokens) {
+        for (const QString & token : classification_tokens) {
+          if (!token.isEmpty() && tokens.contains(token)) return true;
+        }
+        return false;
+      };
 
-      if (combined.contains(QStringLiteral("table")) ||
-          combined.contains(QStringLiteral("workbench")) ||
-          combined.contains(QStringLiteral("support_surface"))) {
+      if (has_exact_classification(table_link_tokens)) {
         ++rendered_table_count;
       }
-      if (combined.contains(QStringLiteral("camera")) ||
-          combined.contains(QStringLiteral("sensor"))) {
+      if (has_exact_classification(camera_link_tokens)) {
         ++rendered_camera_count;
       }
 
-      bool is_robotiq = false;
-      for (const QString & token : robotiq_tokens) {
-        if (combined.contains(token) || link_token.contains(token)) {
-          is_robotiq = true;
-          break;
-        }
-      }
+      const bool is_robotiq = has_exact_classification(robotiq_link_tokens);
       const bool is_required_ur5 = required_visible_ur5_links.contains(link_token);
-      const bool is_other_ur5 =
-        combined.contains(QStringLiteral("ur5")) ||
-        combined.contains(QStringLiteral("universal_robot")) ||
-        link_token.endsWith(QStringLiteral("_link")) ||
-        link_token == QStringLiteral("base_link");
 
       if (is_robotiq) {
         ++rendered_robotiq_link_count;
       }
-      if (is_required_ur5 || (is_other_ur5 && !is_robotiq)) {
+      if (is_required_ur5) {
         ++rendered_ur5_link_count;
         visible_ur5_link_tokens.insert(link_token);
         QJsonObject record = item;


### PR DESCRIPTION
### Motivation
- Prevent non-UR5 items (generic `*_link`, `base_link`, camera/table/Robotiq links, etc.) from being miscounted as UR5 visibility evidence in the viewport audit.
- Make the UR5 visibility audit deterministic by only accepting the canonical set of UR5 link names as rendering evidence.

### Description
- In `audit_ur5_2f_test_committed_viewport_items()` replaced the broad `is_other_ur5` matching with an exact check against the canonical UR5 link set (`base_link_inertia`, `shoulder_link`, `upper_arm_link`, `forearm_link`, `wrist_1_link`, `wrist_2_link`, `wrist_3_link`).
- Added explicit canonical classification token sets `table_link_tokens`, `camera_link_tokens`, and `robotiq_link_tokens` and a small `classification_tokens`/`has_exact_classification` helper so table, camera, and Robotiq counters are computed only from exact/canonical tokens.
- Built classification tokens from `link_token`, `canonical_link_name`, `link_name`, `link`, `item_id`, `id`, `display_name`, `object_name`, `visual_name`, and `parent_link` when performing exact token set checks.
- Kept separate counters for `rendered_table_count`, `rendered_camera_count`, and `rendered_robotiq_link_count`, and ensured only canonical-required UR5 links are appended to `rendered_ur5_link_records`.

### Testing
- Ran `git diff --check` and verified no whitespace or diff check issues (success).
- Verified the new token & branch-free logic via pattern searches with `rg` for `const bool is_required_ur5`, `is_other_ur5`, `rendered_ur5_link_records.append`, and the new token set identifiers (success).
- Attempted to build with `colcon` using `source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select workcell_builder`, but the container is missing `/opt/ros/humble/setup.bash` so the build step was not executed (blocked).
- No automated runtime or launch tests were changed; fake-hardware defaults and runtime safety-related code paths were not modified (no automated test impact observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a371783706c83318364fe61c1e6e767)