### PR TITLE
Tighten UR5 final viewport audit contract

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -476,6 +476,7 @@ QJsonObject audit_ur5_2f_test_committed_viewport_items(
   }
 
   const QSet<QString> required_visible_ur5_links = {
+    QStringLiteral("base_link"),
     QStringLiteral("base_link_inertia"),
     QStringLiteral("shoulder_link"),
     QStringLiteral("upper_arm_link"),
@@ -522,6 +523,41 @@ QJsonObject audit_ur5_2f_test_committed_viewport_items(
 
   const auto final_draw_proves_visibility = [](const QJsonObject & record) {
     const QString status = canonical_scene3d_token(record.value(QStringLiteral("final_draw_status")).toString());
+    const auto field_text = [](const QJsonObject & item, const QString & key) {
+      const QJsonValue value = item.value(key);
+      if (value.isString()) return value.toString();
+      if (value.isDouble()) return QString::number(value.toInt());
+      return QString();
+    };
+    const QString link_token = canonical_scene3d_token(
+      !field_text(record, QStringLiteral("canonical_link_name")).trimmed().isEmpty() ? field_text(record, QStringLiteral("canonical_link_name")) :
+      (!field_text(record, QStringLiteral("link_name")).trimmed().isEmpty() ? field_text(record, QStringLiteral("link_name")) :
+       field_text(record, QStringLiteral("link"))));
+    const QHash<QString, QString> expected_ur5_visual_meshes{
+      {QStringLiteral("base_link"), QStringLiteral("base.dae")},
+      {QStringLiteral("base_link_inertia"), QStringLiteral("base.dae")},
+      {QStringLiteral("shoulder_link"), QStringLiteral("shoulder.dae")},
+      {QStringLiteral("upper_arm_link"), QStringLiteral("upperarm.dae")},
+      {QStringLiteral("forearm_link"), QStringLiteral("forearm.dae")},
+      {QStringLiteral("wrist_1_link"), QStringLiteral("wrist1.dae")},
+      {QStringLiteral("wrist_2_link"), QStringLiteral("wrist2.dae")},
+      {QStringLiteral("wrist_3_link"), QStringLiteral("wrist3.dae")}
+    };
+    const QString expected_mesh = expected_ur5_visual_meshes.value(link_token);
+    if (!expected_mesh.isEmpty()) {
+      const QString expected_uri = QStringLiteral("package://ur_description/meshes/ur5/visual/%1").arg(expected_mesh);
+      const QString mesh_source = field_text(record, QStringLiteral("mesh_source")).trimmed();
+      const QString mesh_uri = field_text(record, QStringLiteral("mesh_uri")).trimmed();
+      const QString canonical_source = field_text(record, QStringLiteral("canonical_mesh_source")).trimmed();
+      const bool uri_matches = mesh_source == expected_uri || mesh_uri == expected_uri;
+      const bool path_resolved = record.value(QStringLiteral("path_resolved")).toBool(false);
+      const bool canonical_matches_repo_asset =
+        canonical_source.endsWith(QStringLiteral("/assets/robots/universal_robot/ur_description/meshes/ur5/visual/%1").arg(expected_mesh)) ||
+        canonical_source.endsWith(QStringLiteral("/ur_description/meshes/ur5/visual/%1").arg(expected_mesh));
+      if (!uri_matches || !path_resolved || !canonical_matches_repo_asset) {
+        return false;
+      }
+    }
     if (status == QStringLiteral("ok")) return true;
 
     // Emergency fallback visibility is only accepted when the draw/export path explicitly
@@ -530,7 +566,8 @@ QJsonObject audit_ur5_2f_test_committed_viewport_items(
     // proof that anything was submitted to OpenGL.
     return status == QStringLiteral("ur5_emergency_fallback") ||
            status == QStringLiteral("ur5_emergency_fallback_ok") ||
-           status == QStringLiteral("ur5_emergency_fallback_drawn");
+           status == QStringLiteral("ur5_emergency_fallback_drawn") ||
+           status == QStringLiteral("ur5_emergency_visible_fallback");
   };
 
   const auto field_text = [](const QJsonObject & record, const QString & key) {
@@ -604,6 +641,12 @@ QJsonObject audit_ur5_2f_test_committed_viewport_items(
 
   QStringList missing;
   for (const QString & required_link : required_visible_ur5_links) {
+    if ((required_link == QStringLiteral("base_link") &&
+         visible_ur5_link_tokens.contains(QStringLiteral("base_link_inertia"))) ||
+        (required_link == QStringLiteral("base_link_inertia") &&
+         visible_ur5_link_tokens.contains(QStringLiteral("base_link")))) {
+      continue;
+    }
     if (!visible_ur5_link_tokens.contains(required_link)) {
       missing << required_link;
     }

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -27,6 +27,7 @@
 #include <QMimeData>
 #include <QJsonDocument>
 #include <QJsonArray>
+#include <QHash>
 #include <QXmlStreamReader>
 #include <QImage>
 #include <QRegularExpression>
@@ -3595,6 +3596,39 @@ QJsonArray Scene3DViewportWidget::final_draw_visual_items_export() const
     row["canonical_mesh_source"] = canonical_mesh_source;
     row["path_resolved"] = path_resolved;
     row["resolve_failure_reason"] = resolve_failure_reason;
+    if (is_required_ur5_viewport_link(item)) {
+      const QString required_link = scene3d_canonical_link_name_for_item(item);
+      const QHash<QString, QString> expected_ur5_visual_meshes{
+        {QStringLiteral("base_link"), QStringLiteral("base.dae")},
+        {QStringLiteral("base_link_inertia"), QStringLiteral("base.dae")},
+        {QStringLiteral("shoulder_link"), QStringLiteral("shoulder.dae")},
+        {QStringLiteral("upper_arm_link"), QStringLiteral("upperarm.dae")},
+        {QStringLiteral("forearm_link"), QStringLiteral("forearm.dae")},
+        {QStringLiteral("wrist_1_link"), QStringLiteral("wrist1.dae")},
+        {QStringLiteral("wrist_2_link"), QStringLiteral("wrist2.dae")},
+        {QStringLiteral("wrist_3_link"), QStringLiteral("wrist3.dae")}
+      };
+      const QString expected_mesh = expected_ur5_visual_meshes.value(required_link);
+      const QString expected_uri = expected_mesh.trimmed().isEmpty()
+        ? QString()
+        : QStringLiteral("package://ur_description/meshes/ur5/visual/%1").arg(expected_mesh);
+      const QString exported_mesh_uri = row.value(QStringLiteral("mesh_uri")).toString().trimmed();
+      const QString exported_mesh_source = row.value(QStringLiteral("mesh_source")).toString().trimmed();
+      const bool expected_uri_matches = !expected_uri.isEmpty() &&
+        (exported_mesh_uri == expected_uri || exported_mesh_source == expected_uri);
+      const bool canonical_matches_expected_asset = !expected_mesh.isEmpty() &&
+        (canonical_mesh_source.endsWith(QStringLiteral("/assets/robots/universal_robot/ur_description/meshes/ur5/visual/%1").arg(expected_mesh)) ||
+         canonical_mesh_source.endsWith(QStringLiteral("/ur_description/meshes/ur5/visual/%1").arg(expected_mesh)));
+      row["expected_ur5_mesh_uri"] = expected_uri;
+      row["ur5_final_viewport_uri_matches_expected"] = expected_uri_matches;
+      row["ur5_final_viewport_canonical_asset_matches_expected"] = canonical_matches_expected_asset;
+      row["ur5_final_viewport_path_resolution_required"] = true;
+      row["ur5_final_viewport_contract_ok"] =
+        expected_uri_matches && path_resolved && canonical_matches_expected_asset;
+      if (!expected_uri_matches || !path_resolved || !canonical_matches_expected_asset) {
+        row["ur5_final_viewport_blocker"] = QStringLiteral("ur5_final_viewport_links_missing");
+      }
+    }
     row["has_mesh_metadata"] = item.has_mesh_metadata;
     row["has_baked_world_visual_transform"] = item.has_baked_world_visual_transform;
     row["has_baked_world_visual_matrix"] = item.has_baked_world_visual_matrix;


### PR DESCRIPTION
### Motivation
- Ensure the final Scene3D viewport audit only counts required UR5 links as visible when each record proves it references the expected UR5 visual mesh URI, successfully resolved the path, and points to the canonical repo/workspace UR5 asset to avoid false-positive viewport validation.

### Description
- Added per-record UR5 contract checks in `audit_ur5_2f_test_committed_viewport_items` (mainwindow.cpp) so required UR5 link records are only treated as visibility proof when their `mesh_source`/`mesh_uri` matches `package://ur_description/meshes/ur5/visual/*.dae`, `path_resolved == true`, and `canonical_mesh_source` points at the workspace/repo asset path.
- Extended the final draw exporter `final_draw_visual_items_export()` (scene3d_viewport_widget.cpp) to emit explicit UR5 diagnostics per record: `expected_ur5_mesh_uri`, `ur5_final_viewport_uri_matches_expected`, `ur5_final_viewport_canonical_asset_matches_expected`, `ur5_final_viewport_path_resolution_required`, `ur5_final_viewport_contract_ok`, and `ur5_final_viewport_blocker` (set to `ur5_final_viewport_links_missing` when contract fails).
- Preserved acceptance of the UR5 emergency fallback draw statuses but only after the contract checks where applicable, and added the `ur5_emergency_visible_fallback` token into acceptance list for compatibility.
- Added base/base_inertia alias handling so `base_link` and `base_link_inertia` do not cause unnecessary blockers when one or the other is present.
- Added a `QHash` include and small diagnostic fields; changes are limited to viewport diagnostics/exporting and audit gating.
- Modified files: `workcell_builder/workcell_builder/gui/mainwindow.cpp`, `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp`.

### Testing
- Ran `git diff --check` and repository static checks (passed).
- Verified workspace UR5 visual assets exist at `assets/robots/universal_robot/ur_description/meshes/ur5/visual/*.dae` (found `base.dae`, `shoulder.dae`, `upperarm.dae`, `forearm.dae`, `wrist1.dae`, `wrist2.dae`, `wrist3.dae`).
- Attempted build with `colcon build --symlink-install --packages-select workcell_builder` but could not run because `/opt/ros/humble/setup.bash` is not available in this container; build was not executed.
- No runtime/launch behavior was changed; the change is diagnostic/audit-only and preserves fake-hardware defaults.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a371a2ba0f4833180c39ecf92929835)