### PR TITLE
Normalize generated URDF link identity for viewport audit

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -586,28 +586,37 @@ QJsonObject audit_ur5_2f_test_committed_viewport_items(
   int rendered_table_count = 0;
   int rendered_camera_count = 0;
   QSet<QString> visible_ur5_link_tokens;
+  QSet<QString> added_required_ur5_link_tokens;
   QJsonArray rendered_ur5_link_records;
 
   if (viewport) {
     const QJsonArray final_draw_records = viewport->final_draw_visual_items_export();
     for (const QJsonValue & value : final_draw_records) {
       const QJsonObject item = value.toObject();
+      const QString canonical_link_field = field_text(item, QStringLiteral("canonical_link_name")).trimmed();
+      const QString link_name_field = field_text(item, QStringLiteral("link_name")).trimmed();
+      const QString link_field = field_text(item, QStringLiteral("link")).trimmed();
+      const QString link_token = canonical_scene3d_token(
+        !canonical_link_field.isEmpty() ? canonical_link_field :
+        (!link_name_field.isEmpty() ? link_name_field : link_field));
+      if (required_visible_ur5_links.contains(link_token)) {
+        added_required_ur5_link_tokens.insert(link_token);
+      }
       if (!final_draw_proves_visibility(item)) {
         continue;
       }
 
-      const QString link_token = canonical_scene3d_token(
-        !field_text(item, QStringLiteral("canonical_link_name")).trimmed().isEmpty() ? field_text(item, QStringLiteral("canonical_link_name")) :
-        (!field_text(item, QStringLiteral("link_name")).trimmed().isEmpty() ? field_text(item, QStringLiteral("link_name")) :
-         field_text(item, QStringLiteral("link"))));
+      const QStringList normalized_link_tokens = {
+        link_token,
+        canonical_scene3d_token(canonical_link_field),
+        canonical_scene3d_token(link_name_field),
+        canonical_scene3d_token(link_field)
+      };
       const QStringList classification_tokens = {
         link_token,
-        canonical_scene3d_token(field_text(item, QStringLiteral("canonical_link_name"))),
-        canonical_scene3d_token(field_text(item, QStringLiteral("link_name"))),
-        canonical_scene3d_token(field_text(item, QStringLiteral("link"))),
-        canonical_scene3d_token(field_text(item, QStringLiteral("item_id"))),
-        canonical_scene3d_token(field_text(item, QStringLiteral("id"))),
-        canonical_scene3d_token(field_text(item, QStringLiteral("display_name"))),
+        canonical_scene3d_token(canonical_link_field),
+        canonical_scene3d_token(link_name_field),
+        canonical_scene3d_token(link_field),
         canonical_scene3d_token(field_text(item, QStringLiteral("object_name"))),
         canonical_scene3d_token(field_text(item, QStringLiteral("visual_name"))),
         canonical_scene3d_token(field_text(item, QStringLiteral("parent_link")))
@@ -626,8 +635,15 @@ QJsonObject audit_ur5_2f_test_committed_viewport_items(
         ++rendered_camera_count;
       }
 
+      const auto has_exact_normalized_link_classification = [&normalized_link_tokens](const QSet<QString> & tokens) {
+        for (const QString & token : normalized_link_tokens) {
+          if (!token.isEmpty() && tokens.contains(token)) return true;
+        }
+        return false;
+      };
+
       const bool is_robotiq = has_exact_classification(robotiq_link_tokens);
-      const bool is_required_ur5 = required_visible_ur5_links.contains(link_token);
+      const bool is_required_ur5 = has_exact_normalized_link_classification(required_visible_ur5_links);
 
       if (is_robotiq) {
         ++rendered_robotiq_link_count;
@@ -653,8 +669,15 @@ QJsonObject audit_ur5_2f_test_committed_viewport_items(
     *missing_required_visible_links = missing;
   }
 
+  QString blocker;
+  if (!missing.isEmpty() && added_required_ur5_link_tokens.size() >= required_visible_ur5_links.size()) {
+    blocker = QStringLiteral("generated_urdf_visuals_added_but_required_ur5_links_not_rendered");
+  }
+
   return QJsonObject{
     {QStringLiteral("rendered_ur5_link_count"), rendered_ur5_link_count},
+    {QStringLiteral("added_required_ur5_link_count"), added_required_ur5_link_tokens.size()},
+    {QStringLiteral("required_ur5_visibility_blocker"), blocker},
     {QStringLiteral("rendered_ur5_link_records"), rendered_ur5_link_records},
     {QStringLiteral("missing_required_visible_ur5_links"), QJsonArray::fromStringList(missing)},
     {QStringLiteral("rendered_table_count"), rendered_table_count},

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -3414,6 +3414,8 @@ QJsonArray scene3d_pose_to_json(double x, double y, double z, double roll, doubl
 
 QString scene3d_link_name_for_item(const ScenePreviewWidget::PreviewItem & item)
 {
+  if (!item.visual_index_link_name.trimmed().isEmpty()) return item.visual_index_link_name.trimmed();
+  if (!item.visual_index_link.trimmed().isEmpty()) return item.visual_index_link.trimmed();
   if (!item.frame_id.trimmed().isEmpty()) return item.frame_id.trimmed();
   const QString display = item.display_name.trimmed();
   if (!display.isEmpty() && display != item.id.trimmed()) return display;
@@ -3441,7 +3443,13 @@ QString scene3d_canonical_link_name_for_item(const ScenePreviewWidget::PreviewIt
 {
   const QString direct = scene3d_link_name_for_item(item);
   QString canonical = scene3d_canonical_link_name(direct);
-  if (!canonical.isEmpty() && canonical != item.id.trimmed()) return canonical;
+  const QString id = item.id.trimmed();
+  const bool has_normalized_identity =
+    !item.visual_index_link_name.trimmed().isEmpty() ||
+    !item.visual_index_link.trimmed().isEmpty() ||
+    !item.frame_id.trimmed().isEmpty() ||
+    (!item.display_name.trimmed().isEmpty() && item.display_name.trimmed() != id);
+  if (!canonical.isEmpty() && (has_normalized_identity || canonical != id)) return canonical;
   const QString haystack = QStringList{item.id, item.display_name, item.frame_id, item.package_uri, item.mesh_path, item.source_path}.join(QStringLiteral(" ")).toLower();
   const QStringList ur5_links{
     QStringLiteral("base_link_inertia"), QStringLiteral("base_link"), QStringLiteral("shoulder_link"),
@@ -3603,12 +3611,11 @@ QJsonArray Scene3DViewportWidget::final_draw_visual_items_export() const
     row["item_id"] = item.id;
     row["id"] = item.id;
     row["display_name"] = item.display_name;
-    const QString link_name = !item.visual_index_link_name.trimmed().isEmpty() ? item.visual_index_link_name.trimmed() :
-      (!item.visual_index_link.trimmed().isEmpty() ? item.visual_index_link.trimmed() : scene3d_link_name_for_item(item));
+    const QString link_name = scene3d_link_name_for_item(item);
     const QString canonical_link_name = scene3d_canonical_link_name_for_item(item);
+    row["link"] = link_name;
     row["link_name"] = link_name;
     row["canonical_link_name"] = canonical_link_name;
-    row["link"] = !item.visual_index_link.trimmed().isEmpty() ? item.visual_index_link.trimmed() : link_name;
     if (!item.visual_index_object_name.trimmed().isEmpty()) row["object_name"] = item.visual_index_object_name.trimmed();
     const int visual_index = item.visual_index_value >= 0 ? item.visual_index_value : scene3d_visual_index_for_item(item);
     if (visual_index >= 0) row["visual_index"] = visual_index;


### PR DESCRIPTION
### Motivation
- Replace fragile substring/ID inference with the normalized generated-URDF identity so viewport diagnostics and the ur5 audit reliably classify generated visual rows. 

### Description
- Prefer generated visual metadata in `scene3d_link_name_for_item()` by checking `visual_index_link_name`, then `visual_index_link`, then `frame_id`/`display_name` fallback. 
- Make `scene3d_canonical_link_name_for_item()` respect a normalized/generated identity before falling back to legacy haystack substring detection. 
- Emit consistent identity fields in `final_draw_visual_items_export()` so locked/generated-URDF visual rows always include `link`, `link_name`, and `canonical_link_name` (in addition to `source_layer`, `package_uri`, and `mesh_uri`/`mesh_source`). 
- Update `audit_ur5_2f_test_committed_viewport_items()` to classify required UR5 visibility from the normalized `canonical_link_name`/`link_name`/`link` fields first while still requiring `final_draw_proves_visibility()` to count as rendered. 
- Add bookkeeping and a clear blocker (`generated_urdf_visuals_added_but_required_ur5_links_not_rendered`) when generated-URDF visual rows exist for all required UR5 links but final-draw diagnostics cannot prove they were rendered. 

### Testing
- Ran `git diff --check` which passed. 
- Verified changes were staged and committed (`git commit`) locally in the branch; commit message: `Normalize URDF link identity in viewport audit`. 
- Attempted to run `colcon build --packages-select workcell_builder` but the container lacks ROS Humble (`/opt/ros/humble/setup.bash`), so a full build was not executed in this environment. 
- No automated unit tests were modified; behavior preserved that only final-draw/`ok`-status records count as rendered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37c34358ec8331882497ce4d35af26)