### PR TITLE
Wire generated URDF visuals into Scene3D renderer

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -9388,6 +9388,19 @@ void MainWindow::populate_scene_hierarchy()
           p.visual_index_mesh_uri = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "mesh_uri")).trimmed();
           p.visual_index_package_uri = package_uri;
           p.visual_index_source = visual_item_source;
+          // Normalize the generated visual-index row on the PreviewItem that is
+          // submitted to the native Scene3D viewport.  The renderer, final draw
+          // export, and smoke audit all consume this PreviewItem payload.
+          p.source_layer = QStringLiteral("locked_generated_urdf_visual");
+          p.locked = true;
+          p.editable = false;
+          p.selectable = true;
+          if (geometry_type == QStringLiteral("mesh")) {
+            p.active_visual_source = QStringLiteral("mesh_preview");
+          }
+          if (!p.visual_index_mesh_uri.trimmed().isEmpty() && p.package_uri.trimmed().isEmpty()) {
+            p.package_uri = p.visual_index_mesh_uri.trimmed();
+          }
           const YAML::Node link_chain_node = workcell_builder::yaml_map_key(v, "link_chain");
           if (link_chain_node && link_chain_node.IsSequence()) {
             for (const YAML::Node & chain_entry : link_chain_node) {
@@ -9631,6 +9644,30 @@ void MainWindow::populate_scene_hierarchy()
               p.mesh_available = true;
               p.has_mesh_metadata = true;
             }
+          }
+          if (geometry_type == QStringLiteral("mesh") && !p.mesh_path.trimmed().isEmpty()) {
+            p.source_path = p.mesh_path;
+            p.mesh_available = true;
+            p.has_mesh_metadata = true;
+            p.active_visual_source = QStringLiteral("mesh_preview");
+          }
+          normalize_generated_urdf_visual_identity(p);
+          classify_generated_urdf_visual(p, !p.mesh_path.trimmed().isEmpty() ? p.mesh_path : resolved_source_path);
+          const QString viewport_link_token = scene3d_viewport_link_token(p);
+          if (viewport_link_token == QStringLiteral("base_link_inertia") ||
+              viewport_link_token == QStringLiteral("shoulder_link") ||
+              viewport_link_token == QStringLiteral("upper_arm_link") ||
+              viewport_link_token == QStringLiteral("forearm_link") ||
+              viewport_link_token == QStringLiteral("wrist_1_link") ||
+              viewport_link_token == QStringLiteral("wrist_2_link") ||
+              viewport_link_token == QStringLiteral("wrist_3_link")) {
+            append_studio_log(QStringLiteral(
+              "Scene3D UR5 visual submitted to native renderer: link=%1 mesh_path=%2 source_layer=%3 active_visual_source=%4 baked_world_visual_pose=%5")
+              .arg(viewport_link_token,
+                   p.mesh_path.trimmed().isEmpty() ? p.source_path : p.mesh_path,
+                   p.source_layer,
+                   p.active_visual_source,
+                   QString::fromUtf8(QJsonDocument(scene3d_viewport_pose_json(p)).toJson(QJsonDocument::Compact))));
           }
           if (unresolved_package_uri) ++unresolved_package_uri_count;
           if (unresolved_package_uri && !is_primitive) add_skip_reason(QStringLiteral("missing_source_path"));


### PR DESCRIPTION
Summary:
- Normalized generated scene_visual_mesh_index rows directly on the Scene3D PreviewItem payload submitted to the native renderer.
- Preserved locked generated URDF visual identity, mesh_preview source, resolved mesh paths, baked pose metadata, and robot/UR5 classification for UR5 link rows.
- Reused the existing Scene3D viewport link/pose helpers in the actual submission path so they no longer remain unused metadata-only helpers.
- Affected package/file: workcell_builder/workcell_builder/gui/mainwindow.cpp.

Validation:
- Ran `git diff --check` successfully.
- Attempted ROS build command from the repository checkout, but `/opt/ros/humble/setup.bash` is missing in this container.
- Acceptance GUI smoke was not run because the expected `/home/user/workcell_ws` workspace and ROS Humble setup are unavailable in this container.

Safety:
- Fake-hardware defaults and launch/runtime execution paths were not changed.
- No real-hardware path, controller, runtime service, or robot motion behavior was enabled.
- No EPD, Gazebo, or Isaac integration was touched.

Risks / rollback:
- The change is scoped to Scene3D PreviewItem normalization for generated URDF visual rows.
- If validation in a full ROS Humble workspace shows an unexpected Scene3D regression, revert commit `ea6464f` to return to the prior visual-row handling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37d9caf31c833187882e69f37dfff8)