### PR TITLE
Fix Scene3D link helper declaration

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -423,6 +423,7 @@ bool is_generated_urdf_visual_item(const ScenePreviewWidget::PreviewItem & it);
 bool is_locked_urdf_item(const ScenePreviewWidget::PreviewItem & it);
 bool is_overlay_only_item(const ScenePreviewWidget::PreviewItem & it);
 bool is_required_ur5_viewport_link(const ScenePreviewWidget::PreviewItem & item);
+QString scene3d_link_name_for_item(const ScenePreviewWidget::PreviewItem & item);
 
 bool item_has_mesh_surface_candidate(const ScenePreviewWidget::PreviewItem & item)
 {


### PR DESCRIPTION
### Motivation
- Fix a compile break in `scene3d_viewport_widget.cpp` where `scene3d_link_name_for_item` was referenced before it was visible to earlier functions, causing build failures in `workcell_builder` and related tests.

### Description
- Add a local forward declaration `QString scene3d_link_name_for_item(const ScenePreviewWidget::PreviewItem & item);` in `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp` near the other anonymous-namespace Scene3D helpers so earlier code can compile without changing the existing helper implementation or touching `mainwindow.cpp` or rendering behavior.

### Testing
- Verified the change footprint with `git diff --stat` and file inspection to confirm only a single forward-declaration line was added; attempted `colcon build --symlink-install --packages-select workcell_builder` but the automated build could not be executed in this container because `/opt/ros/humble/setup.bash` or the expected workspace path was not available, so the full compile was not run here; the change is compile-only and should resolve the prior `scene3d_link_name_for_item` not-declared error in a normal ROS/Humble build environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37df714e048331bce6232028464a4a)