### PR TITLE
Retain generated UR5 base visual in Scene3D

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -1290,6 +1290,7 @@ bool item_is_enabled_for_fit(const ScenePreviewWidget::PreviewItem & it)
 
 bool is_overlay_only_item(const ScenePreviewWidget::PreviewItem & it)
 {
+  if (is_generated_urdf_visual_item(it) || is_locked_urdf_item(it)) return false;
   const NormalizedRole role = classify_item_role(it);
   if (role == NormalizedRole::RobotReach || role == NormalizedRole::SafetyZone || role == NormalizedRole::WarningAnchor) return true;
   const QString role_text = it.role.trimmed().toLower();
@@ -2827,12 +2828,13 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
   if (semantic_role == NormalizedRole::WarningAnchor) {
     return false;
   }
-  if (is_intentional_semantic_editor_primitive(it) && draw_clean_semantic_primitive(it)) {
+  if (!generated_or_locked_preview && is_intentional_semantic_editor_primitive(it) && draw_clean_semantic_primitive(it)) {
     if (out_editable_primitive_count) ++(*out_editable_primitive_count);
     return true;
   }
   const bool semantic_without_mesh_handoff =
     is_clean_semantic_primitive_role(semantic_role) &&
+    !generated_or_locked_preview &&
     !item_has_credible_mesh_handoff(it);
   if (semantic_without_mesh_handoff && draw_clean_semantic_primitive(it)) {
     if (out_editable_primitive_count) ++(*out_editable_primitive_count);

--- a/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
@@ -294,6 +294,45 @@ TEST(Scene3DRenderRoleClassifier, RobotReachIdIsSemanticEvenWhenLockedWithoutMes
   EXPECT_EQ(counters.editable_primitive_rendered_count, 1);
 }
 
+TEST(Scene3DRenderRoleClassifier, GeneratedUrdfBaseLinkInertiaIsMeshNotSemanticHelper)
+{
+  ASSERT_NE(ensure_app(), nullptr);
+
+  auto base_link_inertia = make_item("generated_urdf::base_link_inertia::visual_0::0");
+  base_link_inertia.display_name = "base_link_inertia";
+  base_link_inertia.role = "robot";
+  base_link_inertia.category = "robot/ur5";
+  base_link_inertia.source_layer = "locked_generated_urdf_visual";
+  base_link_inertia.active_visual_source = "mesh_preview";
+  base_link_inertia.locked = true;
+  base_link_inertia.editable = false;
+  base_link_inertia.lock_reason = "generated URDF visual";
+  base_link_inertia.visual_index_link = "base_link_inertia";
+  base_link_inertia.visual_index_link_name = "base_link_inertia";
+  base_link_inertia.visual_index_visual = "visual_0";
+  base_link_inertia.visual_index_visual_name = "visual_0";
+  base_link_inertia.package_uri = "package://ur_description/meshes/ur5/visual/base.dae";
+  base_link_inertia.mesh_path = "assets/robots/universal_robot/ur_description/meshes/ur5/visual/base.dae";
+  base_link_inertia.source_path = base_link_inertia.mesh_path;
+  base_link_inertia.mesh_available = true;
+  base_link_inertia.has_mesh_metadata = true;
+
+  EXPECT_EQ(Scene3DViewportWidget::render_role_for_test(base_link_inertia), "generated_urdf_mesh");
+  EXPECT_TRUE(Scene3DViewportWidget::should_include_in_default_fit_for_test(base_link_inertia));
+  EXPECT_FALSE(Scene3DViewportWidget::should_draw_clean_semantic_primitive_for_test(base_link_inertia));
+  EXPECT_FALSE(Scene3DViewportWidget::should_suppress_missing_geometry_marker_for_test(base_link_inertia));
+
+  Scene3DViewportWidget viewport;
+  viewport.ingest_preview_items(QVector<ScenePreviewWidget::PreviewItem>{ base_link_inertia });
+  const QJsonArray final_draw = viewport.final_draw_visual_items_export();
+  ASSERT_EQ(final_draw.size(), 1);
+  const QJsonObject row = final_draw.at(0).toObject();
+  EXPECT_EQ(row.value("source_layer").toString(), "locked_generated_urdf_visual");
+  EXPECT_EQ(row.value("active_visual_source").toString(), "mesh_preview");
+  EXPECT_EQ(row.value("canonical_link_name").toString(), "base_link_inertia");
+  EXPECT_TRUE(row.value("package_uri").toString().contains("ur_description/meshes/ur5/visual/base.dae"));
+}
+
 TEST(Scene3DRenderRoleClassifier, EditableLayoutPrimitivesDoNotCountAsGeneratedFallbacks)
 {
   ASSERT_NE(ensure_app(), nullptr);


### PR DESCRIPTION
### Motivation
- The UR5 `base_link_inertia` generated visual was being dropped from the final render because it was misclassified as an overlay/helper and suppressed by semantic helper filters, leaving the UR5 incomplete in the smoke audit.
- Keep the authoritative generated URDF visuals (locked/generated) visible while still skipping true editor helper overlays like `robot_base`, `robot_reach`, and warnings.

### Description
- Treat locked/generated URDF visuals as first-class physical visuals by ensuring `is_overlay_only_item(...)` returns false for items where `is_generated_urdf_visual_item(...)` or `is_locked_urdf_item(...)` is true, so generated URDF rows (e.g., `generated_urdf::base_link_inertia::visual_0`) are not misclassified as overlays.
- Prevent semantic-editor primitive rendering from taking precedence for locked/generated preview items by gating the `is_intentional_semantic_editor_primitive` early with `!generated_or_locked_preview` so generated/locked URDF items go through mesh-backed draw path first.
- Add a regression unit test `GeneratedUrdfBaseLinkInertiaIsMeshNotSemanticHelper` that constructs a `PreviewItem` matching the `base_link_inertia` row (package URI `package://ur_description/meshes/ur5/visual/base.dae`) and asserts it is treated as a `generated_urdf_mesh`, included in default fit, and appears in `final_draw_visual_items` with `source_layer=locked_generated_urdf_visual` and `active_visual_source=mesh_preview`.
- Limited, focused changes in `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp` and new test in `workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp` to avoid broad refactors or touching the renderer.

### Testing
- Ran unit tests covering Scene3D visual/ingestion and fallback logic: `python3 -m pytest tests/test_scene3d_real_geometry_not_placeholder_only.py tests/test_scene3d_generated_fallback_shapes.py tests/test_scene3d_canvas_contract.py` — all tests passed (9 passed).
- Ran additional Scene3D ingestion/render tests: `python3 -m pytest tests/test_scene3d_viewport_render_cache_handoff.py tests/test_scene3d_real_visual_ingestion.py` — all tests passed (7 passed).
- Attempted to build and run the GUI smoke harness but was blocked by the environment: `colcon build --packages-select workcell_builder` and the headless GUI smoke run are blocked because `/opt/ros/humble/setup.bash` is not present in this container and the `workcell_builder` executable/install tree is therefore unavailable; smoke execution could not be completed here.
- No changes to launch files, controllers, or any real-hardware paths; fake-hardware defaults are preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37edb19ea08331943a40eecf67bb97)