### PR TITLE
Preserve UR5 base_link_inertia in Scene3D final draw and add targeted trace

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -602,7 +602,9 @@ QJsonObject audit_ur5_2f_test_committed_viewport_items(
       if (required_visible_ur5_links.contains(link_token)) {
         added_required_ur5_link_tokens.insert(link_token);
       }
-      if (!final_draw_proves_visibility(item)) {
+      const bool renderable = final_draw_proves_visibility(item);
+      const bool visible = renderable;
+      if (!visible) {
         continue;
       }
 
@@ -649,6 +651,13 @@ QJsonObject audit_ur5_2f_test_committed_viewport_items(
         ++rendered_robotiq_link_count;
       }
       if (is_required_ur5) {
+        if (link_token == QStringLiteral("base_link_inertia")) {
+          qInfo().noquote() << QStringLiteral("Scene3D base_link_inertia trace: stage=rendered_ur5_link_count_audit result=counted item_id=%1 final_draw_status=%2 mesh_source=%3 canonical_mesh_source=%4")
+            .arg(field_text(item, QStringLiteral("item_id")),
+                 field_text(item, QStringLiteral("final_draw_status")),
+                 field_text(item, QStringLiteral("mesh_source")),
+                 field_text(item, QStringLiteral("canonical_mesh_source")));
+        }
         ++rendered_ur5_link_count;
         visible_ur5_link_tokens.insert(link_token);
         QJsonObject record = item;
@@ -7595,10 +7604,18 @@ void MainWindow::apply_scene3d_preview_layer_filters(bool log_change)
   };
   for (const auto & p : all_scene_preview_items_) {
     if (workcell_builder::include_preview_item_for_scene3d(p, enabled_layers)) {
+      if (scene3d_viewport_link_token(p) == QStringLiteral("base_link_inertia")) {
+        append_studio_log(QStringLiteral("Scene3D base_link_inertia trace: stage=visible/filter result=visible item_id=%1 source_layer=%2 active_visual_source=%3")
+          .arg(p.id, p.source_layer, p.active_visual_source));
+      }
       filtered_items.push_back(p);
       continue;
     }
     const QString hidden_reason = hidden_reason_for_item(p);
+    if (scene3d_viewport_link_token(p) == QStringLiteral("base_link_inertia")) {
+      append_studio_log(QStringLiteral("Scene3D base_link_inertia trace: stage=visible/filter result=hidden item_id=%1 hidden_reason=%2 source_layer=%3 active_visual_source=%4")
+        .arg(p.id, hidden_reason, p.source_layer, p.active_visual_source));
+    }
     hidden_reason_counts[hidden_reason] += 1;
     if (hidden_item_summaries_json.size() < 20) {
       QJsonObject summary;
@@ -7750,7 +7767,8 @@ void MainWindow::apply_scene3d_preview_layer_filters(bool log_change)
     scene3d_filter_diagnostics_[QStringLiteral("camera_fit_target")] = viewport->last_camera_fit_target();
     scene3d_filter_diagnostics_[QStringLiteral("camera_fit_includes_robot")] = viewport->last_initial_fit_included_ur5_bounds();
   }
-  if (selected_ur5_2f_test) {
+  if (has_selected_scene() && selected_scene_name() == QStringLiteral("ur5_2f_test")) {
+    // audit_ur5_2f_test_committed_viewport_items(viewport, &missing_required_visible_links) is computed above after final ingest.
     scene3d_filter_diagnostics_[QStringLiteral("ur5_2f_test_final_viewport_audit")] = viewport_audit;
     append_studio_log(
       QStringLiteral("Scene3D final viewport audit for ur5_2f_test: %1")
@@ -9089,6 +9107,17 @@ void MainWindow::populate_scene_hierarchy()
           const QString visual_link_name_field = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "link_name")).trimmed();
           const QString visual_link_name = visual_link_name_field.isEmpty() ? visual_link : visual_link_name_field;
           const QString canonical_visual_link_name = canonical_scene3d_token(visual_link_name);
+          if (canonical_visual_link_name == QStringLiteral("base_link_inertia")) {
+            append_studio_log(QStringLiteral("Scene3D base_link_inertia trace: stage=scene_visual_mesh_index_visual_0_read source_row_index=%1 link_name=%2 visual=%3 mesh_uri=%4 source=%5 item_id=%6")
+              .arg(source_row_index)
+              .arg(visual_link_name)
+              .arg(QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "visual_name")).trimmed().isEmpty()
+                ? QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "visual")).trimmed()
+                : QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "visual_name")).trimmed())
+              .arg(QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "mesh_uri")).trimmed())
+              .arg(visual_item_source.isEmpty() ? QStringLiteral("<missing>") : visual_item_source)
+              .arg(id));
+          }
           if (source_row_index >= 0 && source_row_index <= 6 &&
               required_ur5_visual_links.contains(canonical_visual_link_name) &&
               !logged_required_ur5_ingestion_links.contains(canonical_visual_link_name)) {
@@ -9655,6 +9684,12 @@ void MainWindow::populate_scene_hierarchy()
           normalize_generated_urdf_visual_identity(p);
           classify_generated_urdf_visual(p, !p.mesh_path.trimmed().isEmpty() ? p.mesh_path : resolved_source_path);
           const QString viewport_link_token = scene3d_viewport_link_token(p);
+          if (viewport_link_token == QStringLiteral("base_link_inertia")) {
+            append_studio_log(QStringLiteral("Scene3D base_link_inertia trace: stage=PreviewItem_creation item_id=%1 link=%2 canonical_link=%3 mesh_path=%4 package_uri=%5 source_layer=%6 active_visual_source=%7 category=%8 role=%9")
+              .arg(p.id, p.visual_index_link, viewport_link_token,
+                   p.mesh_path.trimmed().isEmpty() ? p.source_path : p.mesh_path,
+                   p.package_uri, p.source_layer, p.active_visual_source, p.category, p.role));
+          }
           if (viewport_link_token == QStringLiteral("base_link_inertia") ||
               viewport_link_token == QStringLiteral("shoulder_link") ||
               viewport_link_token == QStringLiteral("upper_arm_link") ||
@@ -9849,6 +9884,12 @@ void MainWindow::populate_scene_hierarchy()
       continue;
     }
     unsuppressed_preview_items.push_back(item);
+  }
+  for (const auto & item : unsuppressed_preview_items) {
+    if (scene3d_viewport_link_token(item) == QStringLiteral("base_link_inertia")) {
+      append_studio_log(QStringLiteral("Scene3D base_link_inertia trace: stage=dedupe result=retained item_id=%1 source_layer=%2 active_visual_source=%3")
+        .arg(item.id, item.source_layer, item.active_visual_source));
+    }
   }
   preview_items = unsuppressed_preview_items;
   if (suppressed_preview_placeholder_count > 0) {

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -1196,7 +1196,8 @@ bool include_in_fit_bounds(const ScenePreviewWidget::PreviewItem & it, bool incl
 
   const QString source_layer = normalized_scene3d_layer_token(it.source_layer);
   const QString visual_source = normalized_scene3d_layer_token(it.active_visual_source);
-  const bool helper_overlay = is_overlay_only_item(it) || source_layer == "overlay" || visual_source == "overlay";
+  const bool generated_or_locked_preview = is_generated_urdf_visual_item(it) || is_locked_urdf_item(it);
+  const bool helper_overlay = !generated_or_locked_preview && (is_overlay_only_item(it) || source_layer == "overlay" || visual_source == "overlay");
   if (helper_overlay) return false;
 
   const bool generated_urdf_visual = is_generated_urdf_visual_item(it) || is_locked_urdf_item(it);
@@ -1428,12 +1429,17 @@ std::vector<const ScenePreviewWidget::PreviewItem *> build_final_generated_urdf_
   for (const auto & item : source_items) {
     const NormalizedRole role = classify_item_role(item);
     if (!show_safety_layer && role == NormalizedRole::SafetyZone) continue;
-    const bool overlay_helper = is_overlay_only_item(item) || is_overlay_visual_role(role);
     const bool generated_or_locked = is_generated_urdf_visual_item(item) || is_locked_urdf_item(item);
-    if (overlay_helper) {
-      overlay_items.push_back(&item);
-    } else if (generated_or_locked) {
+    const bool overlay_helper = !generated_or_locked && (is_overlay_only_item(item) || is_overlay_visual_role(role));
+    if (scene3d_canonical_link_name_for_item(item) == QStringLiteral("base_link_inertia")) {
+      qInfo().noquote() << QStringLiteral("Scene3D base_link_inertia trace: stage=dedupe/final_renderable_assembly item_id=%1 generated_or_locked=%2 overlay_helper=%3 source_layer=%4 active_visual_source=%5")
+        .arg(item.id, generated_or_locked ? QStringLiteral("true") : QStringLiteral("false"),
+             overlay_helper ? QStringLiteral("true") : QStringLiteral("false"), item.source_layer, item.active_visual_source);
+    }
+    if (generated_or_locked) {
       generated_robot_items.push_back(&item);
+    } else if (overlay_helper) {
+      overlay_items.push_back(&item);
     } else {
       physical_items.push_back(&item);
     }
@@ -1653,8 +1659,10 @@ void Scene3DViewportWidget::invalidate_mesh_cache()
   warned_mesh_fallbacks_.clear();
   for (const auto & it : items) {
     const NormalizedRole role = classify_item_role(it);
-    const bool overlay_helper = is_overlay_only_item(it) || is_overlay_visual_role(role);
-    if (overlay_helper || is_intentional_semantic_editor_primitive(it) || !item_has_credible_mesh_handoff(it)) continue;
+    const bool generated_or_locked = is_generated_urdf_visual_item(it) || is_locked_urdf_item(it);
+    const bool overlay_helper = !generated_or_locked && (is_overlay_only_item(it) || is_overlay_visual_role(role));
+    const bool semantic_editor_primitive = !generated_or_locked && is_intentional_semantic_editor_primitive(it);
+    if (overlay_helper || semantic_editor_primitive || !item_has_credible_mesh_handoff(it)) continue;
     const QString mesh_source = !it.mesh_path.trimmed().isEmpty() ? it.mesh_path : it.source_path;
     if (!mesh_source.trimmed().isEmpty()) ensure_mesh_cached(it, mesh_source);
   }
@@ -1685,8 +1693,15 @@ void Scene3DViewportWidget::ingest_preview_items(const QVector<ScenePreviewWidge
     ++visible_item_count;
     unique_visible_ids.insert(it.id);
     const bool generated_urdf = is_generated_urdf_visual_item(it) || is_locked_urdf_item(it);
-    const bool overlay_helper = is_overlay_only_item(it) || is_overlay_visual_role(role);
-    const bool semantic_editor_primitive = is_intentional_semantic_editor_primitive(it);
+    const bool overlay_helper = !generated_urdf && (is_overlay_only_item(it) || is_overlay_visual_role(role));
+    const bool semantic_editor_primitive = !generated_urdf && is_intentional_semantic_editor_primitive(it);
+    if (scene3d_canonical_link_name_for_item(it) == QStringLiteral("base_link_inertia")) {
+      qInfo().noquote() << QStringLiteral("Scene3D base_link_inertia trace: stage=Scene3DViewportWidget_ingest item_id=%1 source_layer=%2 active_visual_source=%3 generated_urdf=%4 overlay_helper=%5 semantic_editor_primitive=%6 mesh_path=%7 source_path=%8")
+        .arg(it.id, it.source_layer, it.active_visual_source, generated_urdf ? QStringLiteral("true") : QStringLiteral("false"),
+             overlay_helper ? QStringLiteral("true") : QStringLiteral("false"), semantic_editor_primitive ? QStringLiteral("true") : QStringLiteral("false"),
+             it.mesh_path.trimmed().isEmpty() ? QStringLiteral("<empty>") : it.mesh_path.trimmed(),
+             it.source_path.trimmed().isEmpty() ? QStringLiteral("<empty>") : it.source_path.trimmed());
+    }
     const QString generated_mesh_source = !it.mesh_path.trimmed().isEmpty() ? it.mesh_path : it.source_path;
     QString generated_cache_result = QStringLiteral("not_attempted");
     if (!overlay_helper && !semantic_editor_primitive && item_has_credible_mesh_handoff(it)) {
@@ -2804,7 +2819,8 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
   const QString source_layer = normalized_scene3d_layer_token(it.source_layer);
   const QString visual_source = normalized_scene3d_layer_token(it.active_visual_source);
   const NormalizedRole semantic_role = classify_item_role(it);
-  const bool helper_overlay = is_overlay_only_item(it) || source_layer == "overlay" || visual_source == "overlay";
+  const bool generated_or_locked_preview = is_generated_urdf_visual_item(it) || is_locked_urdf_item(it);
+  const bool helper_overlay = !generated_or_locked_preview && (is_overlay_only_item(it) || source_layer == "overlay" || visual_source == "overlay");
   if (helper_overlay) {
     if (is_clean_semantic_primitive_role(semantic_role) && draw_clean_semantic_primitive(it)) {
       if (out_editable_primitive_count) ++(*out_editable_primitive_count);
@@ -2823,7 +2839,6 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
   // path so they do not emit REJECT_MESH_METADATA_MISSING or increment missing
   // geometry/fallback counters.
   QColor visual_color = item_color(it, diagnostic_transparency_mode);
-  const bool generated_or_locked_preview = is_generated_urdf_visual_item(it) || is_locked_urdf_item(it);
   const bool editable_layout_preview = it.linked_to_editable_layout_state || item_is_editable_for_gizmo(it);
   if (semantic_role == NormalizedRole::WarningAnchor) {
     return false;
@@ -3689,6 +3704,10 @@ QJsonArray Scene3DViewportWidget::final_draw_visual_items_export() const
       }
     }
     row["active_visual_source"] = item.active_visual_source;
+    if (canonical_link_name == QStringLiteral("base_link_inertia")) {
+      qInfo().noquote() << QStringLiteral("Scene3D base_link_inertia trace: stage=final_draw_visual_items item_id=%1 link=%2 canonical_link=%3 mesh_source=%4 source_layer=%5 active_visual_source=%6")
+        .arg(item.id, link_name, canonical_link_name, mesh_source, item.source_layer, item.active_visual_source);
+    }
     row["locked"] = item.locked;
     row["editable"] = item.editable;
     row["lock_reason"] = item.lock_reason;
@@ -3932,6 +3951,14 @@ bool Scene3DViewportWidget::draw_mesh_preview_if_available(const ScenePreviewWid
     return false;
   }
   const MeshCacheEntry & entry = cache_it.value();
+  if (scene3d_canonical_link_name_for_item(it) == QStringLiteral("base_link_inertia")) {
+    qInfo().noquote() << QStringLiteral("Scene3D base_link_inertia trace: stage=mesh_cache_load item_id=%1 requested_path=%2 canonical_path=%3 loaded=%4 valid=%5 triangles=%6 path_resolved=%7 reason=%8")
+      .arg(it.id, mesh_source, canonical_mesh_source, entry.loaded ? QStringLiteral("true") : QStringLiteral("false"),
+           entry.valid ? QStringLiteral("true") : QStringLiteral("false"))
+      .arg(static_cast<int>(entry.mesh.triangles.size()))
+      .arg(entry.path_resolved ? QStringLiteral("true") : QStringLiteral("false"),
+           entry.failure_reason_code.trimmed().isEmpty() ? QStringLiteral("ok") : entry.failure_reason_code.trimmed());
+  }
   auto reject = [&](const QString & code, const QString & detail = QString()) {
     const QString diagnostics = mesh_rejection_diagnostic_detail(it, mesh_source, canonical_mesh_source, &entry, detail);
     const QString reason = QStringLiteral("%1: %2").arg(code, diagnostics);


### PR DESCRIPTION
### Motivation
- The Scene3D smoke showed the UR5 `base_link_inertia` visual was present in the mesh index but absent from the final draw/audit, leaving a UR5-link blocker. 
- Investigation indicated the generated URDF base visual was being suppressed by helper/overlay classification or omitted before mesh-cache/load/final_draw export. 
- The fix must retain the real generated URDF mesh (not a placeholder) for `base_link_inertia` while keeping semantic helpers and overlays suppression intact. 

### Description
- Prioritize locked/generated URDF visuals over overlay/helper classification so generated robot visuals (including `base_link_inertia`) are treated as physical mesh candidates before overlay suppression. (changes in `scene3d_viewport_widget.cpp`) 
- Ensure generated/locked URDF visuals remain eligible for mesh-cache ingestion and final-draw export even when their canonical link looks like a base/helper role. (mesh cache and final_draw path in `scene3d_viewport_widget.cpp`) 
- Add targeted trace logging for `base_link_inertia` at the key stages: reading `generated/scene_visual_mesh_index.json` rows, `PreviewItem` creation, visible/filter outcome, dedupe/final renderable assembly, viewport ingest, mesh cache load, final_draw export, and UR5 rendered-link audit. (trace additions in `mainwindow.cpp` and `scene3d_viewport_widget.cpp`) 
- Keep semantic helper/overlay suppression behavior for non-generated items unchanged and preserve UR5 audit rules that require final-draw proof before counting links. (changes limited to preview/viewport routing and diagnostics in `mainwindow.cpp` and `scene3d_viewport_widget.cpp`) 

### Testing
- Unit/UI tests: ran `pytest tests/test_scene3d_visual_loader_filtering.py tests/test_scene3d_viewport_mesh_preview_static.py tests/test_scene3d_full_payload_handoff.py` and the suite passed (14 passed). 
- Sanity checks: ran inline static checks (`git diff --check`) and local test slices used in development; those passed. 
- Build/smoke: full Scene3D GUI smoke/colcon build was not executed in this environment because `colcon` / a built `workcell_builder` executable were not available in the container, so smoke runs were skipped and noted as blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37fbead8348331a5cf8c78415e33c0)