### PR TITLE
Fix Scene3D generated visual ordering to preserve visual_0 (base_link_inertia)

### DIFF
--- a/scripts/validate_scene3d_visual0_preview_handoff.py
+++ b/scripts/validate_scene3d_visual0_preview_handoff.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Validate that scene_visual_mesh_index visual_0 maps to the Scene3D PreviewItem contract.
+
+This is a focused regression guard for the UR5 base handoff from the generated
+URDF visual mesh index into Workcell Builder preview assembly. It does not audit
+renderer mesh loading and does not create fallback geometry.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _token(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _preview_item_from_visual_row(row: dict[str, Any], source_row_index: int) -> dict[str, Any]:
+    link = str(row.get("link_name") or row.get("link") or "").strip()
+    visual = str(row.get("visual_name") or row.get("visual") or row.get("id") or "").strip()
+    row_index = str(row.get("source_row_index") if row.get("source_row_index") is not None else source_row_index)
+    package_uri = str(row.get("package_uri") or row.get("mesh_uri") or "").strip()
+    source_mix = "|".join(
+        str(row.get(key) or "")
+        for key in ("package_uri", "mesh_uri", "source_path", "resolved_source_path", "resolved_path")
+    ).lower()
+    category = "robot/ur5" if "ur_description/meshes/ur5/" in source_mix else "URDF Visual"
+    return {
+        "id": f"generated_urdf::{_token(link) or 'link_missing'}::{_token(visual) or 'visual_missing'}::{_token(row_index)}",
+        "canonical_link_name": link,
+        "source_layer": "locked_generated_urdf_visual",
+        "active_visual_source": "mesh_preview" if _token(row.get("geometry_type")) == "mesh" else "urdf_primitive",
+        "category": category,
+        "type": _token(row.get("geometry_type")),
+        "package_uri": package_uri,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "index",
+        nargs="?",
+        default="scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
+        help="Path to generated/scene_visual_mesh_index.json",
+    )
+    args = parser.parse_args()
+    path = Path(args.index)
+    payload = json.loads(path.read_text())
+    items = payload.get("visual_items")
+    if not isinstance(items, list) or not items:
+        raise SystemExit(f"FAIL: {path} has no visual_items")
+    row = items[0]
+    preview = _preview_item_from_visual_row(row, 0)
+    checks = {
+        "id_includes_visual0_base": "generated_urdf::base_link_inertia::visual_0" in preview["id"],
+        "canonical_link_name": preview["canonical_link_name"] == "base_link_inertia",
+        "source_layer": preview["source_layer"] == "locked_generated_urdf_visual",
+        "active_visual_source": preview["active_visual_source"] == "mesh_preview",
+        "category": preview["category"] in {"robot", "robot/ur5"},
+        "type": preview["type"] == "mesh",
+        "package_uri": "ur_description/meshes/ur5/visual/base.dae" in preview["package_uri"],
+    }
+    failures = [name for name, ok in checks.items() if not ok]
+    if failures:
+        print(json.dumps({"status": "FAIL", "failures": failures, "visual_0": row, "preview_item": preview}, indent=2))
+        return 1
+    print(json.dumps({"status": "PASS", "preview_item": preview}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -9801,6 +9801,30 @@ void MainWindow::populate_scene_hierarchy()
     }
   }
 
+  // The generated URDF visual mesh index is the authoritative renderer handoff
+  // source for locked robot/tool/environment mesh previews.  Keep those rows
+  // ahead of semantic/editor overlays in the assembled PreviewItem payload so
+  // visual_items[0] (for UR5, base_link_inertia/visual_0/base.dae) cannot be
+  // displaced by environment.yaml's semantic robot_base or other helper rows
+  // before Scene3DViewportWidget ingest.
+  std::stable_sort(preview_items.begin(), preview_items.end(), [](const auto & a, const auto & b) {
+    const auto generated_rank = [](const ScenePreviewWidget::PreviewItem & item) {
+      const QString source_layer = canonical_scene3d_token(item.source_layer);
+      const QString visual_source = canonical_scene3d_token(item.active_visual_source);
+      const bool locked_generated_visual =
+        source_layer == QStringLiteral("locked_generated_urdf_visual") ||
+        source_layer == QStringLiteral("generated_urdf_visual");
+      const bool mesh_preview = visual_source == QStringLiteral("mesh_preview");
+      return (locked_generated_visual && mesh_preview) ? 0 : 1;
+    };
+    return generated_rank(a) < generated_rank(b);
+  });
+  if (!preview_items.isEmpty() &&
+      canonical_scene3d_token(preview_items.front().source_layer) == QStringLiteral("locked_generated_urdf_visual")) {
+    append_studio_log(QStringLiteral("Scene3D generated URDF visuals ordered before semantic overlays for renderer handoff: first_item=%1 source_layer=%2 active_visual_source=%3")
+      .arg(preview_items.front().id, preview_items.front().source_layer, preview_items.front().active_visual_source));
+  }
+
   if (preview_items.empty()) {
     const QString scene_source = QString::fromStdString(s.scene_dir.string());
     add_preview_item("robot_base", "robot base", "Robot", "robot", "ready", scene_source, true);


### PR DESCRIPTION
### Motivation
- The URDF-generated visual row for the UR5 base (`visual_0` / `base_link_inertia`) was being displaced before the Scene3D renderer ingest, causing the base mesh to be dropped from the viewport ingest pipeline.
- The intent is to ensure the authoritative generated URDF mesh index rows reach the renderer unchanged and ahead of semantic/editor overlay rows coming from `environment.yaml`.

### Description
- Reordered assembled `PreviewItem` payload so locked/generated URDF mesh preview items (source `locked_generated_urdf_visual` + `mesh_preview`) are stably sorted ahead of semantic/editor overlay items prior to renderer handoff by adding a `std::stable_sort` on `preview_items` in `MainWindow::populate_scene_hierarchy()`; file modified: `workcell_builder/workcell_builder/gui/mainwindow.cpp`.
- Added a focused regression validator `scripts/validate_scene3d_visual0_preview_handoff.py` that verifies `scene_visual_mesh_index.json` `visual_items[0]` maps to the expected PreviewItem contract (id namespace includes `generated_urdf::base_link_inertia::visual_0`, `canonical_link_name == base_link_inertia`, `source_layer == locked_generated_urdf_visual`, `active_visual_source == mesh_preview`, `category` indicates UR5 robot, `type == mesh`, and package uri contains `ur_description/meshes/ur5/visual/base.dae`).
- Logging: the code now emits a studio log when generated URDF visuals are ordered before semantic overlays to help trace the renderer handoff.
- This change only touches preview assembly ordering and a validator; it does not alter renderer mesh loading, EPD, Gazebo, Isaac, launch files, controllers, or real-hardware paths.

### Testing
- Ran the focused validator: `python3 scripts/validate_scene3d_visual0_preview_handoff.py` — PASS (preview item matched expected contract).
- Ran repository checks: `git diff --check` — PASS (no whitespace or diff-check errors).
- Attempted to build for full smoke validation: `source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select workcell_builder` — NOT RUN due to missing `/opt/ros/humble/setup.bash` in this container.
- Attempted GUI smoke: `python3 scripts/run_workcell_builder_scene3d_gui_smoke.py --scene ur5_2f_test --output /tmp/smoke.json --timeout-sec 20` — BLOCKED because the built `workcell_builder` executable was not present in the expected workspace install paths in this environment.
- Safety: confirmed fake-hardware defaults and runtime/hardware-related code were not modified and the change is limited to preview item ordering.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38274fc27483319be83c64dd007946)