### PR TITLE
Refactor generated URDF preview suppression into testable helper and add regression test

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -62,6 +62,8 @@ add_executable(workcell_builder
     gui/scene3d_viewport_widget.h
     gui/scene3d_candidate_assembly.cpp
     gui/scene3d_candidate_assembly.h
+    gui/preview_item_suppression.cpp
+    gui/preview_item_suppression.h
     src_scene3d_visual_backend.cpp
     include/scene3d_visual_backend.hpp
 
@@ -370,6 +372,9 @@ if(BUILD_TESTING)
   ament_add_gtest(workcell_transform_clipboard_utils_test
     test/transform_clipboard_utils_test.cpp
     gui/transform_clipboard_utils.cpp)
+  ament_add_gtest(workcell_preview_item_suppression_test
+    test/preview_item_suppression_test.cpp
+    gui/preview_item_suppression.cpp)
   ament_add_gtest(workcell_layout_serialization_contract_test
     test/layout_serialization_contract_test.cpp)
   ament_add_gtest(workcell_studio_layout_editor_test
@@ -427,6 +432,11 @@ if(BUILD_TESTING)
   if(TARGET workcell_transform_clipboard_utils_test)
     target_link_libraries(workcell_transform_clipboard_utils_test Qt5::Core)
     target_include_directories(workcell_transform_clipboard_utils_test PRIVATE gui)
+  endif()
+
+  if(TARGET workcell_preview_item_suppression_test)
+    target_link_libraries(workcell_preview_item_suppression_test Qt5::Widgets)
+    target_include_directories(workcell_preview_item_suppression_test PRIVATE gui)
   endif()
 
   if(TARGET workcell_studio_canvas_model_mesh_test)

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -15,6 +15,7 @@
 
 #include "gui/mainwindow.h"
 #include "gui/scene3d_viewport_widget.h"
+#include "gui/preview_item_suppression.h"
 #include "visual_mesh_source_resolver.hpp"
 #include <QFileDialog>
 #include <QAction>
@@ -10045,63 +10046,15 @@ void MainWindow::populate_scene_hierarchy()
     unresolved_package_uri_count == 0 &&
     unsupported_extension_count == 0;
 
-  QHash<QString, QStringList> authoritative_visual_equivalence_map;
-  for (const auto & item : preview_items) {
-    if (!is_authoritative_mesh_index_visual(item)) continue;
-    for (const QString & key : equivalence_keys_for_item(item)) {
-      authoritative_visual_equivalence_map[key].append(item.id);
-    }
-  }
-
-  auto suppression_reason_for_equivalence_key = [](const QString & key) {
-    if (key.startsWith(QStringLiteral("role_link:"))) return QStringLiteral("normalized_role_plus_link_or_display_name");
-    if (key.startsWith(QStringLiteral("role_source_basename:"))) return QStringLiteral("normalized_role_plus_source_basename");
-    if (key.startsWith(QStringLiteral("role_pose:"))) return QStringLiteral("normalized_role_plus_approximate_pose");
-    if (key.startsWith(QStringLiteral("source_pose:"))) return QStringLiteral("normalized_source_basename_plus_approximate_pose");
-    return QStringLiteral("equivalent_authoritative_mesh_index_visual");
-  };
-
-  QMap<QString, int> placeholder_suppression_reason_counts;
-  QStringList placeholder_suppression_diagnostics;
-  int suppressed_preview_placeholder_count = 0;
-  int preserved_editable_source_count = 0;
-  QVector<ScenePreviewWidget::PreviewItem> unsuppressed_preview_items;
-  unsuppressed_preview_items.reserve(preview_items.size());
-  for (const auto & item : preview_items) {
-    if (is_true_editable_source_of_truth(item)) {
-      ++preserved_editable_source_count;
-      unsuppressed_preview_items.push_back(item);
-      continue;
-    }
-    QString matched_equivalence_key;
-    const bool lower_fidelity_generated_placeholder = is_lower_fidelity_generated_placeholder(item);
-    if (lower_fidelity_generated_placeholder) {
-      for (const QString & key : equivalence_keys_for_item(item)) {
-        if (authoritative_visual_equivalence_map.contains(key)) {
-          matched_equivalence_key = key;
-          break;
-        }
-      }
-    }
-    const bool suppress_because_mesh_index_is_healthy =
-      authoritative_mesh_index_healthy && lower_fidelity_generated_placeholder && matched_equivalence_key.isEmpty();
-    if (!matched_equivalence_key.isEmpty() || suppress_because_mesh_index_is_healthy) {
-      ++suppressed_preview_placeholder_count;
-      const QString reason = suppress_because_mesh_index_is_healthy
-        ? QStringLiteral("healthy_xacro_mesh_index_omits_legacy_placeholder")
-        : suppression_reason_for_equivalence_key(matched_equivalence_key);
-      placeholder_suppression_reason_counts[reason] += 1;
-      if (placeholder_suppression_diagnostics.size() < 12) {
-        const QString matched_ids = suppress_because_mesh_index_is_healthy
-          ? QStringLiteral("authoritative_xacro_mesh_index")
-          : authoritative_visual_equivalence_map.value(matched_equivalence_key).join(QLatin1Char('|'));
-        placeholder_suppression_diagnostics << QStringLiteral("%1=>%2 via %3")
-          .arg(item.id, matched_ids, reason);
-      }
-      continue;
-    }
-    unsuppressed_preview_items.push_back(item);
-  }
+  const auto suppression_result = workcell_builder::suppress_lower_fidelity_preview_items(
+    preview_items,
+    authoritative_mesh_index_healthy);
+  const QMap<QString, int> placeholder_suppression_reason_counts = suppression_result.suppression_reason_counts;
+  const QStringList placeholder_suppression_diagnostics = suppression_result.suppression_diagnostics;
+  const int suppressed_preview_placeholder_count = suppression_result.suppressed_preview_placeholder_count;
+  const int preserved_editable_source_count = suppression_result.preserved_editable_source_count;
+  const int authoritative_visual_equivalence_key_count = suppression_result.authoritative_visual_equivalence_key_count;
+  const QVector<ScenePreviewWidget::PreviewItem> unsuppressed_preview_items = suppression_result.items;
   for (const auto & item : unsuppressed_preview_items) {
     if (scene3d_viewport_link_token(item) == QStringLiteral("base_link_inertia")) {
       append_studio_log(QStringLiteral("Scene3D base_link_inertia trace: stage=dedupe result=retained item_id=%1 source_layer=%2 active_visual_source=%3")
@@ -10119,16 +10072,16 @@ void MainWindow::populate_scene_hierarchy()
     append_studio_log(QString("Preview placeholder suppression diagnostics: %1 (examples=%2 authoritative_mesh_index_equivalence_keys=%3 preserved_editable_source_of_truth=%4; authoritative_mesh_index_healthy=%5; suppressed items are omitted without viewport warning placeholders)")
       .arg(suppression_tokens.join(' '))
       .arg(placeholder_suppression_diagnostics.join(QStringLiteral("; ")))
-      .arg(authoritative_visual_equivalence_map.size())
+      .arg(authoritative_visual_equivalence_key_count)
       .arg(preserved_editable_source_count)
       .arg(authoritative_mesh_index_healthy ? QStringLiteral("true") : QStringLiteral("false")));
     if (authoritative_mesh_index_healthy) {
       append_studio_log(QString("Preview placeholder suppression: omitted %1 legacy placeholders because authoritative xacro/xacro-lite mesh index is healthy")
         .arg(suppressed_preview_placeholder_count));
     }
-  } else if (!authoritative_visual_equivalence_map.isEmpty()) {
+  } else if (authoritative_visual_equivalence_key_count > 0) {
     append_studio_log(QString("Preview placeholder suppression: none (authoritative_mesh_index_equivalence_keys=%1 preserved_editable_source_of_truth=%2)")
-      .arg(authoritative_visual_equivalence_map.size())
+      .arg(authoritative_visual_equivalence_key_count)
       .arg(preserved_editable_source_count));
   }
 

--- a/workcell_builder/workcell_builder/gui/preview_item_suppression.cpp
+++ b/workcell_builder/workcell_builder/gui/preview_item_suppression.cpp
@@ -1,0 +1,270 @@
+#include "preview_item_suppression.h"
+
+#include <QFileInfo>
+#include <QHash>
+#include <QRegularExpression>
+
+#include <cmath>
+
+namespace workcell_builder
+{
+namespace
+{
+QString canonical_scene3d_token(QString value)
+{
+  const QString normalized = value.trimmed().toLower().replace('-', '_').replace(' ', '_');
+  if (normalized == QStringLiteral("generated_preview") ||
+      normalized == QStringLiteral("generated_urdf_visual") ||
+      normalized == QStringLiteral("locked_generated_urdf") ||
+      normalized == QStringLiteral("locked_generated_urdf_visual")) {
+    return QStringLiteral("locked_generated_urdf_visual");
+  }
+  if (normalized == QStringLiteral("legacy_static_fallback")) return QStringLiteral("primitive_fallback");
+  if (normalized == QStringLiteral("overlays") || normalized == QStringLiteral("helper_overlay")) return QStringLiteral("overlay");
+  return normalized;
+}
+
+QString normalize_role(const QString & raw_role, const QString & fallback_text)
+{
+  const QString lower = (raw_role + " " + fallback_text).toLower();
+  if (lower.contains("robot")) return QStringLiteral("robot");
+  if (lower.contains("end_effector") || lower.contains("gripper") || lower.contains("tool")) return QStringLiteral("end_effector/tool");
+  if (lower.contains("camera") || lower.contains("sensor")) return QStringLiteral("camera");
+  if (lower.contains("support_surface") || lower.contains("table") || lower.contains("workbench")) return QStringLiteral("support_surface/table");
+  if (lower.contains("conveyor")) return QStringLiteral("conveyor");
+  if (lower.contains("pick_source") || lower.contains("pick zone") || lower.contains("pick_zone")) return QStringLiteral("pick source/zone");
+  if (lower.contains("place_target") || lower.contains("place zone") || lower.contains("place_zone") || lower.contains("bin")) return QStringLiteral("place target/bin");
+  if (lower.contains("home") || lower.contains("safe_joint_state") || lower.contains("safe joint") || lower.contains("safety pose")) return QStringLiteral("home/safety pose");
+  if (lower.contains("safety")) return QStringLiteral("safety zone");
+  if (lower.contains("object") || lower.contains("fixture") || lower.contains("asset")) return QStringLiteral("object");
+  return QStringLiteral("object");
+}
+
+QString normalized_equivalence_token(QString value)
+{
+  value = value.trimmed().toLower().replace('-', '_').replace(' ', '_');
+  value.replace(QRegularExpression(QStringLiteral("[^a-z0-9_]+")), QStringLiteral("_"));
+  value.replace(QRegularExpression(QStringLiteral("_+")), QStringLiteral("_"));
+  while (value.startsWith('_')) value.remove(0, 1);
+  while (value.endsWith('_')) value.chop(1);
+  return value;
+}
+
+bool path_has_mesh_asset_extension(QString path)
+{
+  path = path.trimmed();
+  const int fragment_index = path.indexOf(QLatin1Char('#'));
+  if (fragment_index >= 0) path = path.left(fragment_index);
+  const int query_index = path.indexOf(QLatin1Char('?'));
+  if (query_index >= 0) path = path.left(query_index);
+  const QString suffix = QFileInfo(path).suffix().toLower();
+  return suffix == QStringLiteral("dae") || suffix == QStringLiteral("stl") || suffix == QStringLiteral("obj") ||
+         suffix == QStringLiteral("glb") || suffix == QStringLiteral("gltf");
+}
+
+QString normalized_equivalence_basename(const QString & value)
+{
+  QString trimmed = value.trimmed();
+  const int fragment_index = trimmed.indexOf(QLatin1Char('#'));
+  if (fragment_index >= 0) trimmed = trimmed.left(fragment_index);
+  const int query_index = trimmed.indexOf(QLatin1Char('?'));
+  if (query_index >= 0) trimmed = trimmed.left(query_index);
+  if (trimmed.startsWith(QStringLiteral("package://"))) trimmed = trimmed.mid(QStringLiteral("package://").size());
+  if (trimmed.startsWith(QStringLiteral("file://"))) trimmed = trimmed.mid(QStringLiteral("file://").size());
+  const QString basename = QFileInfo(trimmed).fileName();
+  return normalized_equivalence_token(basename.isEmpty() ? trimmed : basename);
+}
+
+QString approximate_pose_token(double value)
+{
+  return QString::number(static_cast<int>(std::llround(value * 20.0)));
+}
+
+QString normalized_item_role(const ScenePreviewWidget::PreviewItem & item)
+{
+  return normalized_equivalence_token(normalize_role(item.role, item.category + " " + item.display_name + " " + item.id));
+}
+
+bool physical_asset_role(const ScenePreviewWidget::PreviewItem & item)
+{
+  const QString role = normalized_item_role(item);
+  return role == QStringLiteral("robot") || role == QStringLiteral("gripper") ||
+         role == QStringLiteral("end_effector_tool") || role == QStringLiteral("camera") ||
+         role == QStringLiteral("table") || role == QStringLiteral("workbench") ||
+         role == QStringLiteral("support_surface_table") || role == QStringLiteral("conveyor") ||
+         role == QStringLiteral("object");
+}
+
+bool is_true_editable_source_of_truth(const ScenePreviewWidget::PreviewItem & item)
+{
+  return item.source_layer == QStringLiteral("editable_layout") && item.linked_to_editable_layout_state && item.editable && !item.locked;
+}
+
+bool is_syntactically_resolvable_package_mesh_uri(QString uri)
+{
+  uri = uri.trimmed();
+  if (!uri.startsWith(QStringLiteral("package://"))) return false;
+  if (!path_has_mesh_asset_extension(uri)) return false;
+  const QString remainder = uri.mid(QStringLiteral("package://").size());
+  const int slash_index = remainder.indexOf(QLatin1Char('/'));
+  return slash_index > 0 && slash_index < remainder.size() - 1;
+}
+
+bool is_resolved_mesh_path_or_resolvable_package_uri(const QString & value)
+{
+  const QString trimmed = value.trimmed();
+  if (trimmed.isEmpty() || !path_has_mesh_asset_extension(trimmed)) return false;
+  if (is_syntactically_resolvable_package_mesh_uri(trimmed)) return true;
+  QString local_path = trimmed;
+  if (local_path.startsWith(QStringLiteral("file://"))) local_path = local_path.mid(QStringLiteral("file://").size());
+  if (local_path.startsWith(QStringLiteral("package://"))) return false;
+  const QFileInfo info(local_path);
+  return info.exists() && info.isFile();
+}
+}  // namespace
+
+bool is_authoritative_generated_urdf_mesh_preview_item(const ScenePreviewWidget::PreviewItem & item)
+{
+  const auto is_protected_generated_mesh_index_visual = [](const ScenePreviewWidget::PreviewItem & candidate) {
+    if (!candidate.id.trimmed().startsWith(QStringLiteral("generated_urdf::"))) return false;
+    if (!candidate.locked || candidate.linked_to_editable_layout_state || candidate.editable) return false;
+    const QString source_layer = canonical_scene3d_token(candidate.source_layer);
+    const QString visual_source = canonical_scene3d_token(candidate.active_visual_source);
+    if (source_layer != QStringLiteral("locked_generated_urdf_visual") || visual_source != QStringLiteral("mesh_preview")) return false;
+    if (candidate.visual_index_link_name.trimmed().isEmpty() && candidate.visual_index_link.trimmed().isEmpty()) return false;
+    const QStringList mesh_identity_fields = {candidate.package_uri, candidate.visual_index_package_uri, candidate.visual_index_mesh_uri,
+      candidate.mesh_path, candidate.source_path, candidate.resolved_source_path_original};
+    bool has_mesh_identity = false;
+    bool has_resolvable_mesh_identity = false;
+    for (const QString & value : mesh_identity_fields) {
+      if (!path_has_mesh_asset_extension(value)) continue;
+      has_mesh_identity = true;
+      if (is_resolved_mesh_path_or_resolvable_package_uri(value)) {
+        has_resolvable_mesh_identity = true;
+        break;
+      }
+    }
+    return has_mesh_identity && (candidate.mesh_available || has_resolvable_mesh_identity);
+  };
+  if (is_protected_generated_mesh_index_visual(item)) return true;
+  if (!physical_asset_role(item)) return false;
+  if (!item.locked || item.linked_to_editable_layout_state || item.editable) return false;
+  const QString visual_source = canonical_scene3d_token(item.active_visual_source);
+  const QString source_layer = canonical_scene3d_token(item.source_layer);
+  if (source_layer != QStringLiteral("locked_generated_urdf_visual") || visual_source != QStringLiteral("mesh_preview")) return false;
+  const bool has_valid_mesh_reference = path_has_mesh_asset_extension(item.resolved_source_path_original) ||
+    path_has_mesh_asset_extension(item.mesh_path) || path_has_mesh_asset_extension(item.package_uri) ||
+    path_has_mesh_asset_extension(item.visual_index_package_uri) || path_has_mesh_asset_extension(item.visual_index_mesh_uri) ||
+    path_has_mesh_asset_extension(item.source_path);
+  return item.mesh_available || item.has_mesh_metadata || has_valid_mesh_reference;
+}
+
+bool is_lower_fidelity_generated_placeholder(const ScenePreviewWidget::PreviewItem & item)
+{
+  if (is_true_editable_source_of_truth(item)) return false;
+  if (item.editable || item.linked_to_editable_layout_state) return false;
+  if (is_authoritative_generated_urdf_mesh_preview_item(item)) return false;
+  if (!physical_asset_role(item)) return false;
+  const QString layer = canonical_scene3d_token(item.source_layer);
+  const QString visual_source = canonical_scene3d_token(item.active_visual_source);
+  if (visual_source == QStringLiteral("urdf_primitive")) return false;
+  const QString text = normalized_equivalence_token(item.id + " " + item.display_name + " " + item.category + " " + item.lock_reason + " " + item.mesh_load_warning + " " + item.warnings.join(" "));
+  if (visual_source == QStringLiteral("primitive_fallback") || layer == QStringLiteral("primitive_fallback")) return true;
+  if (text.contains(QStringLiteral("placeholder")) || text.contains(QStringLiteral("generated_bounds")) || text.contains(QStringLiteral("bounds_only")) || text.contains(QStringLiteral("raw_bounds"))) return true;
+  if (layer == QStringLiteral("static_fallback") || layer == QStringLiteral("legacy_static_fallback")) return true;
+  if (layer == QStringLiteral("locked_generated_urdf_visual")) {
+    const bool lacks_mesh_identity = item.visual_index_link_name.trimmed().isEmpty() && item.visual_index_link.trimmed().isEmpty() &&
+      !path_has_mesh_asset_extension(item.package_uri) && !path_has_mesh_asset_extension(item.visual_index_package_uri) &&
+      !path_has_mesh_asset_extension(item.visual_index_mesh_uri) && !path_has_mesh_asset_extension(item.mesh_path) &&
+      !path_has_mesh_asset_extension(item.source_path) && !path_has_mesh_asset_extension(item.resolved_source_path_original);
+    if (lacks_mesh_identity) return true;
+  }
+  if (text.contains(QStringLiteral("legacy")) && text.contains(QStringLiteral("primitive_preview"))) return true;
+  if (text.contains(QStringLiteral("mesh_metadata_missing_or_legacy"))) return true;
+  return false;
+}
+
+QSet<QString> generated_urdf_preview_equivalence_keys_for_item(const ScenePreviewWidget::PreviewItem & item)
+{
+  QSet<QString> keys;
+  const QString role = normalized_item_role(item);
+  if (role.isEmpty()) return keys;
+  const QString link = normalized_equivalence_token(item.display_name.isEmpty() ? item.id : item.display_name);
+  const QString id_token = normalized_equivalence_token(item.id);
+  const QString pose = QStringLiteral("%1_%2_%3_%4_%5_%6")
+    .arg(approximate_pose_token(item.x), approximate_pose_token(item.y), approximate_pose_token(item.z),
+         approximate_pose_token(item.roll), approximate_pose_token(item.pitch), approximate_pose_token(item.yaw));
+  if (!link.isEmpty()) keys.insert(QStringLiteral("role_link:%1:%2").arg(role, link));
+  if (!id_token.isEmpty()) keys.insert(QStringLiteral("role_link:%1:%2").arg(role, id_token));
+  for (const QString & path_value : {item.package_uri, item.mesh_path, item.source_path, item.resolved_source_path_original}) {
+    const QString source_basename = normalized_equivalence_basename(path_value);
+    if (source_basename.isEmpty()) continue;
+    keys.insert(QStringLiteral("role_source_basename:%1:%2").arg(role, source_basename));
+    keys.insert(QStringLiteral("source_pose:%1:%2").arg(source_basename, pose));
+  }
+  keys.insert(QStringLiteral("role_pose:%1:%2").arg(role, pose));
+  return keys;
+}
+
+QString generated_urdf_preview_suppression_reason_for_equivalence_key(const QString & key)
+{
+  if (key.startsWith(QStringLiteral("role_link:"))) return QStringLiteral("normalized_role_plus_link_or_display_name");
+  if (key.startsWith(QStringLiteral("role_source_basename:"))) return QStringLiteral("normalized_role_plus_source_basename");
+  if (key.startsWith(QStringLiteral("role_pose:"))) return QStringLiteral("normalized_role_plus_approximate_pose");
+  if (key.startsWith(QStringLiteral("source_pose:"))) return QStringLiteral("normalized_source_basename_plus_approximate_pose");
+  return QStringLiteral("equivalent_authoritative_mesh_index_visual");
+}
+
+PreviewSuppressionResult suppress_lower_fidelity_preview_items(
+  const QVector<ScenePreviewWidget::PreviewItem> & preview_items,
+  bool authoritative_mesh_index_healthy)
+{
+  QHash<QString, QStringList> authoritative_visual_equivalence_map;
+  for (const auto & item : preview_items) {
+    if (!is_authoritative_generated_urdf_mesh_preview_item(item)) continue;
+    for (const QString & key : generated_urdf_preview_equivalence_keys_for_item(item)) {
+      authoritative_visual_equivalence_map[key].append(item.id);
+    }
+  }
+
+  PreviewSuppressionResult result;
+  result.authoritative_visual_equivalence_key_count = authoritative_visual_equivalence_map.size();
+  result.items.reserve(preview_items.size());
+  for (const auto & item : preview_items) {
+    if (is_true_editable_source_of_truth(item)) {
+      ++result.preserved_editable_source_count;
+      result.items.push_back(item);
+      continue;
+    }
+    QString matched_equivalence_key;
+    const bool lower_fidelity_generated_placeholder = is_lower_fidelity_generated_placeholder(item);
+    if (lower_fidelity_generated_placeholder) {
+      for (const QString & key : generated_urdf_preview_equivalence_keys_for_item(item)) {
+        if (authoritative_visual_equivalence_map.contains(key)) {
+          matched_equivalence_key = key;
+          break;
+        }
+      }
+    }
+    const bool suppress_because_mesh_index_is_healthy =
+      authoritative_mesh_index_healthy && lower_fidelity_generated_placeholder && matched_equivalence_key.isEmpty();
+    if (!matched_equivalence_key.isEmpty() || suppress_because_mesh_index_is_healthy) {
+      ++result.suppressed_preview_placeholder_count;
+      const QString reason = suppress_because_mesh_index_is_healthy
+        ? QStringLiteral("healthy_xacro_mesh_index_omits_legacy_placeholder")
+        : generated_urdf_preview_suppression_reason_for_equivalence_key(matched_equivalence_key);
+      result.suppression_reason_counts[reason] += 1;
+      if (result.suppression_diagnostics.size() < 12) {
+        const QString matched_ids = suppress_because_mesh_index_is_healthy
+          ? QStringLiteral("authoritative_xacro_mesh_index")
+          : authoritative_visual_equivalence_map.value(matched_equivalence_key).join(QLatin1Char('|'));
+        result.suppression_diagnostics << QStringLiteral("%1=>%2 via %3").arg(item.id, matched_ids, reason);
+      }
+      continue;
+    }
+    result.items.push_back(item);
+  }
+  return result;
+}
+
+}  // namespace workcell_builder

--- a/workcell_builder/workcell_builder/gui/preview_item_suppression.h
+++ b/workcell_builder/workcell_builder/gui/preview_item_suppression.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "scene_preview_widget.h"
+
+#include <QMap>
+#include <QSet>
+#include <QString>
+#include <QStringList>
+#include <QVector>
+
+namespace workcell_builder
+{
+
+struct PreviewSuppressionResult
+{
+  QVector<ScenePreviewWidget::PreviewItem> items;
+  QMap<QString, int> suppression_reason_counts;
+  QStringList suppression_diagnostics;
+  int suppressed_preview_placeholder_count{0};
+  int preserved_editable_source_count{0};
+  int authoritative_visual_equivalence_key_count{0};
+};
+
+bool is_authoritative_generated_urdf_mesh_preview_item(const ScenePreviewWidget::PreviewItem & item);
+bool is_lower_fidelity_generated_placeholder(const ScenePreviewWidget::PreviewItem & item);
+QSet<QString> generated_urdf_preview_equivalence_keys_for_item(const ScenePreviewWidget::PreviewItem & item);
+QString generated_urdf_preview_suppression_reason_for_equivalence_key(const QString & key);
+PreviewSuppressionResult suppress_lower_fidelity_preview_items(
+  const QVector<ScenePreviewWidget::PreviewItem> & preview_items,
+  bool authoritative_mesh_index_healthy);
+
+}  // namespace workcell_builder

--- a/workcell_builder/workcell_builder/test/preview_item_suppression_test.cpp
+++ b/workcell_builder/workcell_builder/test/preview_item_suppression_test.cpp
@@ -1,0 +1,123 @@
+#include "preview_item_suppression.h"
+
+#include <gtest/gtest.h>
+
+#include <QHash>
+#include <QStringList>
+
+namespace
+{
+ScenePreviewWidget::PreviewItem make_generated_visual(int visual_index, const QString & link_name, const QString & category, const QString & role, const QString & mesh_uri)
+{
+  ScenePreviewWidget::PreviewItem item;
+  item.id = QStringLiteral("generated_urdf::%1::visual_%2::%2").arg(link_name).arg(visual_index);
+  item.display_name = link_name;
+  item.category = category;
+  item.role = role;
+  item.source_layer = QStringLiteral("locked_generated_urdf_visual");
+  item.active_visual_source = QStringLiteral("mesh_preview");
+  item.mesh_path = mesh_uri;
+  item.package_uri = mesh_uri;
+  item.visual_index_mesh_uri = mesh_uri;
+  item.visual_index_package_uri = mesh_uri;
+  item.visual_index_link_name = link_name;
+  item.visual_index_link = link_name;
+  item.visual_index_visual = QStringLiteral("visual_%1").arg(visual_index);
+  item.visual_index_visual_name = item.visual_index_visual;
+  item.visual_index_value = visual_index;
+  item.source_row_index = visual_index;
+  item.mesh_available = true;
+  item.has_mesh_metadata = true;
+  item.locked = true;
+  item.editable = false;
+  item.selectable = true;
+  item.linked_to_editable_layout_state = false;
+  item.x = visual_index * 0.01;
+  item.y = visual_index * 0.02;
+  item.z = visual_index * 0.03;
+  return item;
+}
+
+ScenePreviewWidget::PreviewItem make_helper_placeholder(const ScenePreviewWidget::PreviewItem & authoritative, const QString & id_suffix)
+{
+  ScenePreviewWidget::PreviewItem helper = authoritative;
+  helper.id = QStringLiteral("semantic_helper::%1::%2_placeholder").arg(authoritative.visual_index_link_name, id_suffix);
+  helper.source_layer = QStringLiteral("primitive_fallback");
+  helper.active_visual_source = QStringLiteral("primitive_fallback");
+  helper.mesh_path.clear();
+  helper.package_uri.clear();
+  helper.visual_index_mesh_uri.clear();
+  helper.visual_index_package_uri.clear();
+  helper.visual_index_link.clear();
+  helper.visual_index_link_name.clear();
+  helper.visual_index_value = -1;
+  helper.source_row_index = -1;
+  helper.mesh_available = false;
+  helper.has_mesh_metadata = false;
+  helper.locked = true;
+  helper.editable = false;
+  helper.linked_to_editable_layout_state = false;
+  helper.lock_reason = QStringLiteral("legacy generated_bounds placeholder");
+  helper.warnings = QStringList{QStringLiteral("mesh_metadata_missing_or_legacy primitive_preview")};
+  return helper;
+}
+
+QVector<ScenePreviewWidget::PreviewItem> make_visual_index_rows()
+{
+  QVector<ScenePreviewWidget::PreviewItem> rows;
+  rows << make_generated_visual(0, QStringLiteral("base_link_inertia"), QStringLiteral("robot/ur5"), QStringLiteral("robot"), QStringLiteral("package://ur_description/meshes/ur5/visual/base.dae"));
+  rows << make_generated_visual(1, QStringLiteral("shoulder_link"), QStringLiteral("robot/ur5"), QStringLiteral("robot"), QStringLiteral("package://ur_description/meshes/ur5/visual/shoulder.dae"));
+  rows << make_generated_visual(2, QStringLiteral("upper_arm_link"), QStringLiteral("robot/ur5"), QStringLiteral("robot"), QStringLiteral("package://ur_description/meshes/ur5/visual/upperarm.dae"));
+  rows << make_generated_visual(3, QStringLiteral("forearm_link"), QStringLiteral("robot/ur5"), QStringLiteral("robot"), QStringLiteral("package://ur_description/meshes/ur5/visual/forearm.dae"));
+  rows << make_generated_visual(4, QStringLiteral("wrist_1_link"), QStringLiteral("robot/ur5"), QStringLiteral("robot"), QStringLiteral("package://ur_description/meshes/ur5/visual/wrist1.dae"));
+  rows << make_generated_visual(5, QStringLiteral("wrist_2_link"), QStringLiteral("robot/ur5"), QStringLiteral("robot"), QStringLiteral("package://ur_description/meshes/ur5/visual/wrist2.dae"));
+  rows << make_generated_visual(6, QStringLiteral("wrist_3_link"), QStringLiteral("robot/ur5"), QStringLiteral("robot"), QStringLiteral("package://ur_description/meshes/ur5/visual/wrist3.dae"));
+  rows << make_generated_visual(7, QStringLiteral("workbench_top"), QStringLiteral("table/workbench"), QStringLiteral("workbench"), QStringLiteral("package://workbench_description/meshes/workbench_top.dae"));
+  rows << make_generated_visual(8, QStringLiteral("camera_link"), QStringLiteral("camera"), QStringLiteral("camera"), QStringLiteral("package://realsense2_description/meshes/d435.dae"));
+  for (int i = 9; i <= 17; ++i) {
+    rows << make_generated_visual(i, QStringLiteral("robotiq_visual_%1_link").arg(i), QStringLiteral("gripper"), QStringLiteral("gripper"), QStringLiteral("package://robotiq_85_description/meshes/visual/robotiq_%1.dae").arg(i));
+  }
+  return rows;
+}
+}  // namespace
+
+TEST(PreviewItemSuppression, PreservesAuthoritativeGeneratedUrdfMeshesAndSuppressesSemanticHelpers)
+{
+  QVector<ScenePreviewWidget::PreviewItem> items = make_visual_index_rows();
+  for (int i = 0; i < items.size(); ++i) {
+    if (i <= 6 || i >= 9) {
+      items << make_helper_placeholder(items[i], QStringLiteral("matching_pose"));
+    }
+  }
+
+  ASSERT_TRUE(workcell_builder::is_authoritative_generated_urdf_mesh_preview_item(items.front()));
+  ASSERT_TRUE(workcell_builder::is_lower_fidelity_generated_placeholder(items.back()));
+
+  const auto result = workcell_builder::suppress_lower_fidelity_preview_items(items, true);
+
+  QHash<int, int> visual_counts;
+  QHash<QString, int> id_counts;
+  for (const auto & item : result.items) {
+    if (item.visual_index_value >= 0) ++visual_counts[item.visual_index_value];
+    ++id_counts[item.id];
+    EXPECT_FALSE(item.id.contains(QStringLiteral("::dedupe_1"))) << item.id.toStdString();
+  }
+
+  for (int visual = 0; visual <= 17; ++visual) {
+    EXPECT_EQ(visual_counts.value(visual), 1) << "visual_" << visual << " should be retained exactly once";
+  }
+
+  EXPECT_EQ(id_counts.value(QStringLiteral("generated_urdf::base_link_inertia::visual_0::0")), 1);
+  for (int visual = 1; visual <= 6; ++visual) {
+    EXPECT_EQ(visual_counts.value(visual), 1) << "UR5 visual_" << visual << " should survive";
+  }
+  for (int visual = 9; visual <= 17; ++visual) {
+    const QString expected_id = QStringLiteral("generated_urdf::robotiq_visual_%1_link::visual_%1::%1").arg(visual);
+    EXPECT_EQ(id_counts.value(expected_id), 1) << expected_id.toStdString();
+  }
+
+  for (const auto & item : result.items) {
+    EXPECT_FALSE(item.id.startsWith(QStringLiteral("semantic_helper::"))) << item.id.toStdString();
+  }
+  EXPECT_GT(result.suppressed_preview_placeholder_count, 0);
+}


### PR DESCRIPTION
### Motivation

- Make the generated-URDF preview protection, placeholder classification, and suppression/dedupe logic testable at the GUI/module layer without changing runtime behavior in `MainWindow::populate_scene_hierarchy()`.
- Preserve production-equivalent inputs and diagnostics so the scene-hierarchy behavior and logging remain unchanged while enabling unit regression tests.

### Description

- Extracted suppression/dedupe logic into a small helper API in `gui/preview_item_suppression.h`/`gui/preview_item_suppression.cpp` providing `is_authoritative_generated_urdf_mesh_preview_item`, `is_lower_fidelity_generated_placeholder`, equivalence-key generation, and `suppress_lower_fidelity_preview_items` returning diagnostics and filtered items.
- Updated `MainWindow::populate_scene_hierarchy()` to call the new helper and wire the helper results back into the existing diagnostic/logging flow so runtime behavior is preserved.
- Added a C++ gtest regression `test/preview_item_suppression_test.cpp` that constructs `ScenePreviewWidget::PreviewItem` rows for `visual_0..17` (UR5 links, gripper rows, table/camera) with production-equivalent IDs, `locked_generated_urdf_visual` source layer, `mesh_preview` active source, mesh URIs, and matching lower-fidelity helper rows, then asserts authoritative rows survive exactly once and helper rows are suppressed.
- Wired the helper into the `workcell_builder` sources and registered the new gtest in `CMakeLists.txt` so it runs under the existing test/CTest setup.

### Testing

- Ran `git diff --check` which succeeded and verified no whitespace/git diff errors were introduced.
- Attempted `source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select workcell_builder` but the container lacks `/opt/ros/humble/setup.bash`, so the build could not be executed here.
- Attempted a local CMake build (`cmake -S workcell_builder/workcell_builder -B /tmp/... -DBUILD_TESTING=ON`) but configuration failed because `ament_cmake` is not available in this environment.
- Attempted a direct compile of the helper/test with `g++` and `pkg-config` but the environment lacks Qt5 development metadata (`Qt5Widgets`), so the test could not be executed here; the test is added and wired and should run in a standard ROS 2 Humble / Qt5 dev setup using the package CMake/CTest configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a383a6c7188833184361cbe244efcf3)