### PR TITLE
Register preview_item_suppression_test in CMake test registry

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -631,6 +631,7 @@ if(BUILD_TESTING)
     workcell_studio_canvas_model_mesh_test.cpp
     asset_catalog_discovery_test.cpp
     transform_clipboard_utils_test.cpp
+    preview_item_suppression_test.cpp
     layout_serialization_contract_test.cpp
     workcell_studio_layout_editor_test.cpp
     mainwindow_rviz_preview_compile_test.cpp


### PR DESCRIPTION
### Motivation
- Fix the CMake configure failure caused by an orphan/unregistered test source (`preview_item_suppression_test.cpp`) flagged by the orphan-test-source guard.

### Description
- Add `preview_item_suppression_test.cpp` to `workcell_builder_registered_cpp_tests` in `workcell_builder/workcell_builder/CMakeLists.txt` and preserve the existing `ament_add_gtest` registration, with no other changes to renderer, suppression logic, EPD/Gazebo/launch files, or safety defaults.

### Testing
- Ran a static registered-vs-discovered test-source check which reports 30 registered and 30 discovered C++ test sources with no missing or extra entries, and `git diff --check` passed; a full `colcon build` could not be executed in this environment because `/home/user/workcell_ws` and the ROS setup script are not present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a383def4ccc8331bce707ea32677a89)