### PR TITLE
Emit generated URDF visual stage counters in Scene3D smoke output

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -342,6 +342,27 @@ def _apply_runtime_transform_counter_mapping(payload: dict[str, Any]) -> None:
     payload["warnings"] = warnings
 
 
+def _apply_generated_urdf_visual_number_stages(payload: dict[str, Any]) -> None:
+    counters = _first_present_mapping(payload, "counters")
+    filter_diagnostics = _first_present_mapping(payload, "filter_diagnostics")
+    counter_ingestion = _first_present_mapping(counters, "visual_ingestion_diagnostics")
+    filter_ingestion = _first_present_mapping(filter_diagnostics, "visual_ingestion_diagnostics")
+    sources = (filter_diagnostics, counters, counter_ingestion, filter_ingestion, payload)
+    stage_keys = {
+        "after_ingest": "generated_urdf_visual_numbers_after_ingest",
+        "after_suppression": "generated_urdf_visual_numbers_after_suppression",
+        "after_filter": "generated_urdf_visual_numbers_after_filter",
+    }
+    for short_key, full_key in stage_keys.items():
+        value = None
+        for source in sources:
+            if isinstance(source, dict) and isinstance(source.get(full_key), list):
+                value = source[full_key]
+                break
+        if value is not None:
+            payload[short_key] = value
+            payload[full_key] = value
+
 def _add_smoke_report_supplemental_evidence(payload: dict[str, Any], *, screenshot_path: str | None, screenshot_available: bool | None) -> dict[str, Any]:
     runtime_available = bool(payload.get("runtime_available"))
     if runtime_available:
@@ -353,6 +374,7 @@ def _add_smoke_report_supplemental_evidence(payload: dict[str, Any], *, screensh
     payload.setdefault("visible_item_labels", _visible_item_labels_from_payload(payload) if runtime_available else [])
     payload.setdefault("viewport_size", _viewport_size_from_payload(payload))
     payload.setdefault("camera_fit_target", _camera_fit_target_from_payload(payload))
+    _apply_generated_urdf_visual_number_stages(payload)
     if screenshot_path is not None:
         payload.setdefault("screenshot_path", screenshot_path)
     if screenshot_available is not None:

--- a/workcell_builder/workcell_builder/gui/main.cpp
+++ b/workcell_builder/workcell_builder/gui/main.cpp
@@ -646,6 +646,9 @@ private:
     copy_filter_counter("duplicate_id_count");
     copy_filter_counter("first_20_visual_items");
     copy_filter_counter("visual_ingestion_diagnostics");
+    copy_filter_counter("generated_urdf_visual_numbers_after_ingest");
+    copy_filter_counter("generated_urdf_visual_numbers_after_suppression");
+    copy_filter_counter("generated_urdf_visual_numbers_after_filter");
     copy_filter_counter("robot_visual_count");
     copy_filter_counter("robot_mesh_loaded_count");
     copy_filter_counter("robot_mesh_missing_count");


### PR DESCRIPTION
### Motivation
- Ensure the Scene3D smoke JSON consistently exposes the generated-URDF visual-number arrays so downstream smoke consumers and validators see non-null `after_ingest`, `after_suppression`, and `after_filter` values.
- Preserve existing ingestion diagnostics (`visual_ingestion_diagnostics`, `first_20_visual_items`, `skipped_count_by_reason`) while making the generated-URDF stage arrays explicitly copied and normalized into the wrapper payload.

### Description
- Added explicit copies for `generated_urdf_visual_numbers_after_ingest`, `generated_urdf_visual_numbers_after_suppression`, and `generated_urdf_visual_numbers_after_filter` in the Scene3D smoke `finalize()` counter collection in `workcell_builder/workcell_builder/gui/main.cpp` via the existing `copy_filter_counter(...)` helper.
- Implemented `_apply_generated_urdf_visual_number_stages(payload)` in `scripts/run_workcell_builder_scene3d_gui_smoke.py` to locate the arrays from `payload["filter_diagnostics"]`, `payload["counters"]`, and nested `visual_ingestion_diagnostics` sources and to populate both short aliases (`after_ingest`, `after_suppression`, `after_filter`) and the full diagnostic keys on the payload.
- Hooked the new extraction into the smoke post-processing path by calling `_apply_generated_urdf_visual_number_stages(...)` from `_add_smoke_report_supplemental_evidence(...)` so the wrapper emits normalized stage values regardless of where the app placed them.

### Testing
- Compiled the wrapper script with `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke.py` and it succeeded.
- Executed an inline automated extraction test that calls `_add_smoke_report_supplemental_evidence(...)` with synthetic `filter_diagnostics` / `counters` / nested `visual_ingestion_diagnostics` inputs and asserted that `after_ingest`, `after_suppression`, and `after_filter` (and their full-key equivalents) were populated as expected, and the assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a384a5d4c4c8331b49cda9b1b213c7f)