### PR TITLE
Classify generated URDF visual first-drop stages

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -46,6 +46,46 @@ def _append_unique(values: list[str], value: str) -> None:
         values.append(value)
 
 
+def _apply_generated_urdf_visual_first_drop_smoke_stage(payload: dict[str, Any]) -> None:
+    diagnostics = payload.get("visual_ingestion_diagnostics")
+    if not isinstance(diagnostics, dict):
+        diagnostics = payload.get("scene3d_visual_ingestion_diagnostics")
+    if not isinstance(diagnostics, dict):
+        return
+    rows = diagnostics.get("generated_urdf_visual_row_diagnostics")
+    if not isinstance(rows, list):
+        return
+    final_draw_rows = payload.get("final_draw_visual_items")
+    if not isinstance(final_draw_rows, list):
+        final_draw_rows = payload.get("final_draw_diagnostics")
+    if not isinstance(final_draw_rows, list):
+        return
+    final_draw_ids = {
+        str(row.get("item_id") or row.get("id") or "").strip()
+        for row in final_draw_rows
+        if isinstance(row, dict)
+    }
+    if not final_draw_ids:
+        return
+    updated_rows: list[Any] = []
+    changed = False
+    for row in rows:
+        if not isinstance(row, dict):
+            updated_rows.append(row)
+            continue
+        updated = dict(row)
+        row_id = str(updated.get("id") or "").strip()
+        if row_id in final_draw_ids and not str(updated.get("first_drop_stage") or "").strip():
+            updated["first_drop_stage"] = "smoke_output_or_audit_only"
+            changed = True
+        updated_rows.append(updated)
+    if changed:
+        diagnostics["generated_urdf_visual_row_diagnostics"] = updated_rows
+        payload["visual_ingestion_diagnostics"] = diagnostics
+        if isinstance(payload.get("scene3d_visual_ingestion_diagnostics"), dict):
+            payload["scene3d_visual_ingestion_diagnostics"] = diagnostics
+
+
 def _record_ros_humble_missing(payload: dict[str, Any], *, as_blocker: bool) -> None:
     _add_ros_humble_context(payload)
     if payload.get("ros_humble_available") is True:
@@ -1923,6 +1963,7 @@ def main() -> int:
         )
         if any(key in payload for key in ("final_draw_visual_items", "final_draw_diagnostics", "viewport_visible_items")):
             _apply_ur5_final_viewport_payload_contract(payload)
+        _apply_generated_urdf_visual_first_drop_smoke_stage(payload)
         _apply_ur5_transform_parity(payload, repo_root=repo_root, args=args)
         _apply_ur5_final_draw_bbox_regression(payload)
         if args.scene_path:

--- a/tests/test_scene3d_gui_smoke_json_output_contract.py
+++ b/tests/test_scene3d_gui_smoke_json_output_contract.py
@@ -936,3 +936,26 @@ def test_generated_robot_fallback_blocks_when_generated_mesh_rows_missing_render
     assert payload["generated_robot_fallback_required"] is True
     assert "generated_robot_fallback_not_activated" in payload["blockers"]
     assert payload["status"] == "FAIL"
+
+
+def test_generated_urdf_visual_first_drop_smoke_stage_marks_final_draw_audit_only():
+    from scripts.run_workcell_builder_scene3d_gui_smoke import _apply_generated_urdf_visual_first_drop_smoke_stage
+
+    payload = {
+        "visual_ingestion_diagnostics": {
+            "generated_urdf_visual_row_diagnostics": [
+                {"id": "generated_urdf::base_link::visual_0::0", "visual_name": "visual_0"},
+                {"id": "generated_urdf::shoulder_link::visual_1::1", "visual_name": "visual_1", "first_drop_stage": "visual_index_loop_skip"},
+            ]
+        },
+        "final_draw_visual_items": [
+            {"item_id": "generated_urdf::base_link::visual_0::0", "final_draw_status": "ok"},
+            {"item_id": "generated_urdf::shoulder_link::visual_1::1", "final_draw_status": "ok"},
+        ],
+    }
+
+    _apply_generated_urdf_visual_first_drop_smoke_stage(payload)
+
+    rows = payload["visual_ingestion_diagnostics"]["generated_urdf_visual_row_diagnostics"]
+    assert rows[0]["first_drop_stage"] == "smoke_output_or_audit_only"
+    assert rows[1]["first_drop_stage"] == "visual_index_loop_skip"

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -7749,8 +7749,14 @@ void MainWindow::apply_scene3d_preview_layer_filters(bool log_change)
     for (const QJsonValue & value : rows) {
       QJsonObject row = value.toObject();
       const QString id = row.value(QStringLiteral("id")).toString();
-      row[QStringLiteral("survived_filter")] =
+      const bool survived_filter =
         row.value(QStringLiteral("appended_to_preview_items")).toBool(false) && filtered_ids.contains(id);
+      row[QStringLiteral("survived_filter")] = survived_filter;
+      if (row.value(QStringLiteral("survived_suppression")).toBool(false) && !survived_filter) {
+        if (row.value(QStringLiteral("first_drop_stage")).toString().trimmed().isEmpty()) {
+          row[QStringLiteral("first_drop_stage")] = QStringLiteral("apply_scene3d_preview_layer_filters");
+        }
+      }
       filter_diagnostics.append(row);
     }
     scene3d_visual_ingestion_diagnostics_[QStringLiteral("generated_urdf_visual_row_diagnostics")] = filter_diagnostics;
@@ -8784,10 +8790,31 @@ void MainWindow::populate_scene_hierarchy()
     row[QStringLiteral("survived_filter")] = false;
     return row;
   };
+  auto set_generated_visual_first_drop_stage_once = [](QJsonObject & row, const QString & first_drop_stage) {
+    if (first_drop_stage.trimmed().isEmpty()) return;
+    if (!row.value(QStringLiteral("first_drop_stage")).toString().trimmed().isEmpty()) return;
+    row[QStringLiteral("first_drop_stage")] = first_drop_stage;
+  };
+  auto visual_index_loop_drop_stage_for_branch = [](const QString & skip_branch) {
+    if (skip_branch == QStringLiteral("duplicate_generated_visual_index_row")) {
+      return QStringLiteral("duplicate_generated_visual_index_row");
+    }
+    if (skip_branch == QStringLiteral("suppressed_by_urdf_flattened_visual_mesh")) {
+      return QStringLiteral("suppressed_by_urdf_flattened_visual_mesh");
+    }
+    if (skip_branch == QStringLiteral("duplicate_generated_urdf_fallback_link")) {
+      return QStringLiteral("mesh_resolution_or_fallback_branch");
+    }
+    if (skip_branch == QStringLiteral("appended_to_preview_items") || skip_branch.trimmed().isEmpty()) {
+      return QString();
+    }
+    return QStringLiteral("visual_index_loop_skip");
+  };
   auto append_generated_visual_row_diagnostic = [&](QJsonObject row, const QString & skip_branch, const QString & skip_reason = QString(), bool appended_to_preview_items = false, const QString & final_mesh_path = QString()) {
     row[QStringLiteral("appended_to_preview_items")] = appended_to_preview_items;
     row[QStringLiteral("skip_branch")] = skip_branch;
     row[QStringLiteral("skip_reason")] = skip_reason;
+    set_generated_visual_first_drop_stage_once(row, visual_index_loop_drop_stage_for_branch(skip_branch));
     if (!final_mesh_path.trimmed().isEmpty()) {
       row[QStringLiteral("mesh_path")] = final_mesh_path;
     }
@@ -9850,6 +9877,7 @@ void MainWindow::populate_scene_hierarchy()
             continue;
           }
           if (mesh_fallback) {
+            set_generated_visual_first_drop_stage_once(generated_row_diagnostic, QStringLiteral("mesh_resolution_or_fallback_branch"));
             const QString fallback_link = p.visual_index_link.trimmed().isEmpty() ? p.display_name.trimmed() : p.visual_index_link.trimmed();
             const QString robot_identity = canonical_scene3d_token(
               fallback_link + QStringLiteral(" ") + p.visual_index_parent_link + QStringLiteral(" ") +
@@ -10152,8 +10180,14 @@ void MainWindow::populate_scene_hierarchy()
     for (const QJsonValue & value : rows) {
       QJsonObject row = value.toObject();
       const QString id = row.value(QStringLiteral("id")).toString();
-      row[QStringLiteral("survived_suppression")] =
+      const bool survived_suppression =
         row.value(QStringLiteral("appended_to_preview_items")).toBool(false) && unsuppressed_ids.contains(id);
+      row[QStringLiteral("survived_suppression")] = survived_suppression;
+      if (row.value(QStringLiteral("appended_to_preview_items")).toBool(false) && !survived_suppression) {
+        if (row.value(QStringLiteral("first_drop_stage")).toString().trimmed().isEmpty()) {
+          row[QStringLiteral("first_drop_stage")] = QStringLiteral("suppression_helper");
+        }
+      }
       suppression_diagnostics.append(row);
     }
     scene3d_visual_ingestion_diagnostics_[QStringLiteral("generated_urdf_visual_row_diagnostics")] = suppression_diagnostics;


### PR DESCRIPTION
### Motivation
- Make Scene3D generated-URDF ingestion diagnostics record exactly one "first_drop_stage" for each generated visual row so consumers can tell why a visual row was first excluded or suppressed.
- Provide reliable lifecycle classification points: visual-index loop skips, duplicate rows, flattened-URDF suppression, mesh-resolution/fallback branch, suppression helper, preview-layer filters, and smoke/audit-only final-draw cases.

### Description
- Add a one-shot helper `set_generated_visual_first_drop_stage_once` and a mapper `visual_index_loop_drop_stage_for_branch` and call them when emitting generated-row diagnostics in the visual-index ingest loop to capture `visual_index_loop_skip`, `duplicate_generated_visual_index_row`, and `mesh_resolution_or_fallback_branch` cases (file: `workcell_builder/workcell_builder/gui/mainwindow.cpp`).
- Mark flattened-URDF suppression rows with `suppressed_by_urdf_flattened_visual_mesh` at the visual-index loop point (existing skip path now records the stage).
- After `suppress_lower_fidelity_preview_items(...)` record `suppression_helper` on rows that were appended but then removed by suppression (file: `workcell_builder/workcell_builder/gui/mainwindow.cpp`).
- After `apply_scene3d_preview_layer_filters(...)` record `apply_scene3d_preview_layer_filters` on rows that survived suppression but were later filtered out (file: `workcell_builder/workcell_builder/gui/mainwindow.cpp`).
- Add smoke-stage post-processing `_apply_generated_urdf_visual_first_drop_smoke_stage(...)` that marks rows present in final-draw output but missing from diagnostic counts as `smoke_output_or_audit_only` without overwriting any existing `first_drop_stage` (file: `scripts/run_workcell_builder_scene3d_gui_smoke.py`).
- Ensure `first_drop_stage` is only set once (preserved if already present) and never introduce fallback visuals or placeholder robot geometry.
- Add a focused regression test to assert smoke post-processing preserves existing `first_drop_stage` and marks otherwise-unset final-draw rows as `smoke_output_or_audit_only` (file: `tests/test_scene3d_gui_smoke_json_output_contract.py`).

### Testing
- Ran targeted unit test `python3 -m pytest tests/test_scene3d_gui_smoke_json_output_contract.py::test_generated_urdf_visual_first_drop_smoke_stage_marks_final_draw_audit_only` which passed.
- Verified Python smoke helper compiles with `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke.py` which succeeded.
- Ran `git diff --check` with no trailing whitespace/format issues.
- Ran the full Scene3D smoke JSON contract test file (`python3 -m pytest tests/test_scene3d_gui_smoke_json_output_contract.py -q`) in this environment; several unrelated wrapper/ROS-Humble environment expectations caused failures outside the scope of this focused diagnostic change (the focused new test still passes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a384c36363083318c0393e5ad5fcd84)