### PR TITLE
Restrict UR5 viewport link counting to final render identities

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -493,6 +493,18 @@ REQUIRED_UR5_FINAL_VIEWPORT_LINKS: tuple[str, ...] = (
     "wrist_3_link",
 )
 RETAINED_VISUAL_ROWS_MISSING_WARNING = "retained visual rows missing after loader filtering"
+UR5_ACCEPTED_FINAL_RENDER_STATUSES: frozenset[str] = frozenset(
+    {
+        "ok",
+        "ur5_emergency_visible_fallback",
+        "ur5_emergency_fallback",
+        "ur5_emergency_fallback_ok",
+        "ur5_emergency_fallback_drawn",
+    }
+)
+UR5_FINAL_RENDER_SOURCE_LAYERS: frozenset[str] = frozenset(
+    {"locked_generated_urdf_visual", "generated_urdf_visual"}
+)
 
 
 def _rendered_mesh_adjacency_limit(parent: str, child: str) -> float:
@@ -543,6 +555,30 @@ def _row_canonical_link_candidates(row: dict[str, Any]) -> set[str]:
     return candidates
 
 
+def _accepted_final_render_status(row: dict[str, Any]) -> bool:
+    return str(row.get("final_draw_status") or "").strip().lower() in UR5_ACCEPTED_FINAL_RENDER_STATUSES
+
+
+def _canonical_final_render_identity(value: Any) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip().lower()
+    canonical = _canonical_ur5_rendered_mesh_link_name(value)
+    if canonical == "base_link" and raw == "base_link_inertia":
+        return "base_link_inertia"
+    return canonical or raw
+
+
+def _row_final_rendered_ur5_link_identities(row: dict[str, Any]) -> set[str]:
+    """Return only actual final draw identity fields, not chain/index metadata."""
+    links: set[str] = set()
+    for key in ("canonical_link_name", "link", "link_name"):
+        canonical = _canonical_final_render_identity(row.get(key))
+        if canonical:
+            links.add(canonical)
+    return links
+
+
 def _row_is_final_visible_renderable(row: dict[str, Any]) -> bool:
     if row.get("visible") is False or row.get("rendered") is False:
         return False
@@ -583,21 +619,19 @@ def _apply_ur5_final_viewport_payload_contract(payload: dict[str, Any]) -> None:
 
     rows = _final_visible_viewport_rows(payload)
     visible_rows = [row for row in rows if _row_is_final_visible_renderable(row)]
-    visible_links: set[str] = set()
-    for row in visible_rows:
-        visible_links.update(_row_canonical_link_candidates(row))
 
     visible_robot_render_rows = [
         row for row in visible_rows
-        if str(row.get("source_layer") or "").strip().lower() in {"locked_generated_urdf_visual", "generated_urdf_visual"}
-        and (
-            str(row.get("final_draw_status") or "").strip().lower() == "ok"
-            or str(row.get("final_draw_status") or "").strip().lower()
-            in {"ur5_emergency_visible_fallback", "ur5_emergency_fallback", "ur5_emergency_fallback_ok", "ur5_emergency_fallback_drawn"}
-        )
+        if str(row.get("source_layer") or "").strip().lower() in UR5_FINAL_RENDER_SOURCE_LAYERS
+        and _accepted_final_render_status(row)
     ]
+    required_ur5_links = set(REQUIRED_UR5_FINAL_VIEWPORT_LINKS)
+    visible_links: set[str] = set()
+    for row in visible_robot_render_rows:
+        visible_links.update(_row_final_rendered_ur5_link_identities(row) & required_ur5_links)
+
     robot_mesh_rows = [row for row in visible_robot_render_rows if _bbox_from_final_draw(row) is not None]
-    ur5_mesh_rows = [row for row in visible_robot_render_rows if _row_canonical_link_candidates(row) & set(REQUIRED_UR5_FINAL_VIEWPORT_LINKS)]
+    ur5_mesh_rows = [row for row in visible_robot_render_rows if _row_final_rendered_ur5_link_identities(row) & required_ur5_links]
     robotiq_mesh_rows = [row for row in visible_robot_render_rows if _is_robotiq_base_record(row) or "robotiq" in " ".join(
         str(row.get(key) or "")
         for key in ("canonical_link_name", "link", "link_name", "visual_name", "item_id", "id", "mesh_uri", "package_uri", "mesh_path")
@@ -624,7 +658,7 @@ def _apply_ur5_final_viewport_payload_contract(payload: dict[str, Any]) -> None:
 
     missing = [link for link in REQUIRED_UR5_FINAL_VIEWPORT_LINKS if link not in visible_links]
     rendered_ur5_link_count = len([link for link in REQUIRED_UR5_FINAL_VIEWPORT_LINKS if link in visible_links])
-    payload["rendered_ur5_link_count"] = max(_counter(payload, "rendered_ur5_link_count"), rendered_ur5_link_count)
+    payload["rendered_ur5_link_count"] = rendered_ur5_link_count
     payload["required_ur5_final_viewport_links"] = list(REQUIRED_UR5_FINAL_VIEWPORT_LINKS)
     payload["missing_required_visible_ur5_links"] = missing
 

--- a/tests/test_scene3d_gui_smoke_json_output_contract.py
+++ b/tests/test_scene3d_gui_smoke_json_output_contract.py
@@ -835,6 +835,85 @@ def test_ur5_final_viewport_payload_rejects_metadata_or_index_only_names():
     assert "rendered_ur5_link_count_below_7" in payload["blockers"]
 
 
+def test_ur5_final_viewport_payload_counts_only_final_render_identity_fields():
+    import scripts.run_workcell_builder_scene3d_gui_smoke as smoke
+
+    required = [
+        "base_link_inertia",
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link",
+        "wrist_1_link",
+        "wrist_2_link",
+        "wrist_3_link",
+    ]
+    payload = {
+        "scene": "ur5_2f_test",
+        "status": "PASS",
+        "rendered_ur5_link_count": 7,
+        "final_draw_visual_items": [
+            {
+                "item_id": f"generated_urdf::{link}",
+                "link_chain": [link],
+                "metadata": {"canonical_link_name": link},
+                "source_layer": "locked_generated_urdf_visual",
+                "has_mesh_metadata": True,
+                "mesh_source": f"package://ur_description/meshes/ur5/visual/{link}.dae",
+                "final_draw_status": "ok",
+                "final_draw_bbox": {"min": [0, 0, 0], "max": [1, 1, 1]},
+                "visible": True,
+                "rendered": True,
+            }
+            for link in required[:3]
+        ]
+        + [
+            {
+                "link": "forearm_link",
+                "source_layer": "layout_preview",
+                "has_mesh_metadata": True,
+                "final_draw_status": "ok",
+                "final_draw_bbox": {"min": [0, 0, 0], "max": [1, 1, 1]},
+                "visible": True,
+                "rendered": True,
+            },
+            {
+                "link": "wrist_1_link",
+                "source_layer": "locked_generated_urdf_visual",
+                "has_mesh_metadata": True,
+                "final_draw_status": "skipped",
+                "final_draw_bbox": {"min": [0, 0, 0], "max": [1, 1, 1]},
+                "visible": True,
+                "rendered": True,
+            },
+            {
+                "canonical_link_name": "wrist_2_link",
+                "source_layer": "generated_urdf_visual",
+                "has_mesh_metadata": True,
+                "final_draw_status": "ok",
+                "final_draw_bbox": {"min": [0, 0, 0], "max": [1, 1, 1]},
+                "visible": True,
+                "rendered": True,
+            },
+            {"link_name": "wrist_3_link", "source_layer": "locked_generated_urdf_visual", "final_draw_status": "ok", "visible": False, "rendered": True},
+            {"id": "layout_table", "display_name": "table", "visible": True, "rendered": True, "geometry_type": "box"},
+            {"id": "camera_sensor", "display_name": "camera", "visible": True, "rendered": True, "geometry_type": "box"},
+        ],
+    }
+
+    smoke._apply_ur5_final_viewport_payload_contract(payload)
+
+    assert payload["rendered_ur5_link_count"] == 1
+    assert payload["missing_required_visible_ur5_links"] == [
+        "base_link_inertia",
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link",
+        "wrist_1_link",
+        "wrist_3_link",
+    ]
+    assert "ur5_final_viewport_links_missing" in payload["blockers"]
+
+
 def test_ur5_final_viewport_payload_fails_stale_retained_rows_warning_when_links_visible():
     import scripts.run_workcell_builder_scene3d_gui_smoke as smoke
 


### PR DESCRIPTION
### Motivation
- Make UR5 final-viewport validation stricter and correct by counting only evidence that corresponds to actual final-draw robot visuals instead of metadata/index-only sources.
- Avoid false positives where `link_chain`, metadata blocks, visual-index-only fields, or non-generated source layers cause required UR5 links to be reported as present.

### Description
- Added allowlists for accepted final-render statuses (`UR5_ACCEPTED_FINAL_RENDER_STATUSES`) and for generated URDF visual source layers (`UR5_FINAL_RENDER_SOURCE_LAYERS`).
- Introduced helpers `_accepted_final_render_status`, `_canonical_final_render_identity`, and `_row_final_rendered_ur5_link_identities` to canonicalize and restrict identity extraction to only `canonical_link_name`, `link`, and `link_name` from final-draw rows.
- Restricted `visible_links`, `ur5_mesh_rows`, `rendered_ur5_link_count`, and `missing_required_visible_ur5_links` to consider only rows that are final-visible-renderable, come from the generated URDF visual layers, have an accepted final status, and expose one of the three final identity fields.
- Added a regression test `test_ur5_final_viewport_payload_counts_only_final_render_identity_fields` to assert that chain/index/metadata-only fields and non-generated/invalid rows do not satisfy the UR5 required links contract (file modified: `tests/test_scene3d_gui_smoke_json_output_contract.py`).

### Testing
- Ran `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke.py tests/test_scene3d_gui_smoke_json_output_contract.py` and it succeeded.
- Ran targeted tests with `python3 -m pytest tests/test_scene3d_gui_smoke_json_output_contract.py -k 'ur5_final_viewport_payload'` and the UR5 viewport tests passed (selected tests succeeded).
- Ran the full file with `python3 -m pytest tests/test_scene3d_gui_smoke_json_output_contract.py`; the changes caused the UR5-focused tests to pass but unrelated wrapper-level tests failed in this environment due to ROS-Humble availability / wrapper expectations (these failures are environmental and not caused by the UR5 counting changes).
- Verified `git diff --check` for whitespace/format issues as part of validation and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a384d3dcd148331993ef40fbd2cbdd8)