### PR TITLE
Preserve UR5 Scene3D mesh preview rows

### DIFF
--- a/workcell_builder/workcell_builder/gui/preview_item_suppression.cpp
+++ b/workcell_builder/workcell_builder/gui/preview_item_suppression.cpp
@@ -123,8 +123,52 @@ bool is_resolved_mesh_path_or_resolvable_package_uri(const QString & value)
 }
 }  // namespace
 
+
+bool is_required_ur5_generated_visual_mesh_index_row(const ScenePreviewWidget::PreviewItem & item)
+{
+  static const QSet<QString> required_links{
+    QStringLiteral("base_link_inertia"),
+    QStringLiteral("shoulder_link"),
+    QStringLiteral("upper_arm_link"),
+    QStringLiteral("forearm_link"),
+    QStringLiteral("wrist_1_link"),
+    QStringLiteral("wrist_2_link"),
+    QStringLiteral("wrist_3_link")
+  };
+  const QString link = normalized_equivalence_token(
+    !item.visual_index_link_name.trimmed().isEmpty() ? item.visual_index_link_name : item.visual_index_link);
+  if (!required_links.contains(link)) return false;
+
+  const QStringList mesh_identity_fields = {
+    item.package_uri,
+    item.visual_index_package_uri,
+    item.visual_index_mesh_uri,
+    item.mesh_path,
+    item.source_path,
+    item.resolved_source_path_original
+  };
+  bool references_ur5_visual_mesh = false;
+  for (QString value : mesh_identity_fields) {
+    value = value.trimmed().toLower();
+    if (value.startsWith(QStringLiteral("package://ur_description/meshes/ur5/visual/"))) {
+      references_ur5_visual_mesh = true;
+      break;
+    }
+    if (value.contains(QStringLiteral("/ur_description/meshes/ur5/visual/"))) {
+      references_ur5_visual_mesh = true;
+      break;
+    }
+  }
+  if (!references_ur5_visual_mesh) return false;
+
+  return item.locked && !item.editable && !item.linked_to_editable_layout_state &&
+         canonical_scene3d_token(item.source_layer) == QStringLiteral("locked_generated_urdf_visual") &&
+         canonical_scene3d_token(item.active_visual_source) == QStringLiteral("mesh_preview");
+}
+
 bool is_authoritative_generated_urdf_mesh_preview_item(const ScenePreviewWidget::PreviewItem & item)
 {
+  if (is_required_ur5_generated_visual_mesh_index_row(item)) return true;
   const auto is_protected_generated_mesh_index_visual = [](const ScenePreviewWidget::PreviewItem & candidate) {
     if (!candidate.id.trimmed().startsWith(QStringLiteral("generated_urdf::"))) return false;
     if (!candidate.locked || candidate.linked_to_editable_layout_state || candidate.editable) return false;

--- a/workcell_builder/workcell_builder/test/preview_item_suppression_test.cpp
+++ b/workcell_builder/workcell_builder/test/preview_item_suppression_test.cpp
@@ -121,3 +121,42 @@ TEST(PreviewItemSuppression, PreservesAuthoritativeGeneratedUrdfMeshesAndSuppres
   }
   EXPECT_GT(result.suppressed_preview_placeholder_count, 0);
 }
+
+TEST(PreviewItemSuppression, ExplicitlyPreservesUr5VisualMeshIndexRowsAgainstSemanticPlaceholders)
+{
+  QVector<ScenePreviewWidget::PreviewItem> items = make_visual_index_rows();
+
+  ScenePreviewWidget::PreviewItem robot_base;
+  robot_base.id = QStringLiteral("robot_base");
+  robot_base.display_name = QStringLiteral("Robot Base");
+  robot_base.category = QStringLiteral("robot");
+  robot_base.role = QStringLiteral("robot_base");
+  robot_base.source_layer = QStringLiteral("primitive_fallback");
+  robot_base.active_visual_source = QStringLiteral("primitive_fallback");
+  robot_base.locked = true;
+  robot_base.editable = false;
+  robot_base.selectable = true;
+  robot_base.mesh_available = false;
+  robot_base.has_mesh_metadata = false;
+  robot_base.warnings = QStringList{QStringLiteral("semantic placeholder")};
+  items << robot_base;
+
+  const auto result = workcell_builder::suppress_lower_fidelity_preview_items(items, true);
+
+  QSet<QString> retained_ur5_links;
+  bool retained_robot_base_placeholder = false;
+  for (const auto & item : result.items) {
+    if (item.package_uri.startsWith(QStringLiteral("package://ur_description/meshes/ur5/visual/")) &&
+        item.source_layer == QStringLiteral("locked_generated_urdf_visual") &&
+        item.active_visual_source == QStringLiteral("mesh_preview")) {
+      retained_ur5_links.insert(item.visual_index_link_name);
+      EXPECT_TRUE(item.mesh_available);
+      EXPECT_TRUE(item.has_mesh_metadata);
+      EXPECT_TRUE(item.selectable);
+    }
+    if (item.id == QStringLiteral("robot_base")) retained_robot_base_placeholder = true;
+  }
+
+  EXPECT_EQ(retained_ur5_links.size(), 7);
+  EXPECT_FALSE(retained_robot_base_placeholder);
+}


### PR DESCRIPTION
Summary:
- Added an explicit UR5 generated visual mesh-index preservation check for the required UR5 links from `package://ur_description/meshes/ur5/visual/`.
- Ensured those locked generated URDF mesh-preview rows remain authoritative during lower-fidelity placeholder suppression.
- Added a targeted suppression regression covering semantic `robot_base` placeholder suppression without dropping the seven UR5 mesh rows.

Validation:
- `git diff --check` passed.
- Static assertion confirmed the new UR5 preservation hook and package URI scope are present.
- Existing `scenes/ur5_2f_test/generated/scene_visual_mesh_index.json` inspection confirmed 18 visual items, all 7 required UR5 links, and 0 fallback generated rows.
- `colcon build --symlink-install --packages-select workcell_builder` was not run because `/opt/ros/humble/setup.bash` is not present in this container.
- `scripts/run_workcell_builder_scene3d_gui_smoke.py` was attempted but blocked because no built Workcell Builder executable exists under the searched install paths.

Safety:
- No launch, controller, runtime execution, hardware parameter, EPD, or real-robot motion paths were changed.
- Fake-hardware-first behavior is unchanged.

Risks / rollback:
- The change is narrowly scoped to Scene3D preview item suppression and its regression test.
- Roll back by reverting commit `935443d` if the preservation predicate needs to be generalized further.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38fda262e08331b9259bb6df4ebded)