### PR TITLE
Preserve raw UR5 visual rows in Scene3D suppression

### DIFF
--- a/workcell_builder/workcell_builder/gui/preview_item_suppression.cpp
+++ b/workcell_builder/workcell_builder/gui/preview_item_suppression.cpp
@@ -3,6 +3,7 @@
 #include <QFileInfo>
 #include <QHash>
 #include <QRegularExpression>
+#include <QStringList>
 
 #include <cmath>
 
@@ -75,7 +76,7 @@ QString normalized_equivalence_basename(const QString & value)
   return normalized_equivalence_token(basename.isEmpty() ? trimmed : basename);
 }
 
-QString approximate_pose_token(double value)
+double approximate_pose_token(double value)
 {
   return QString::number(static_cast<int>(std::llround(value * 20.0)));
 }
@@ -121,12 +122,10 @@ bool is_resolved_mesh_path_or_resolvable_package_uri(const QString & value)
   const QFileInfo info(local_path);
   return info.exists() && info.isFile();
 }
-}  // namespace
 
-
-bool is_required_ur5_generated_visual_mesh_index_row(const ScenePreviewWidget::PreviewItem & item)
+const QSet<QString> & required_ur5_scene3d_links()
 {
-  static const QSet<QString> required_links{
+  static const QSet<QString> links{
     QStringLiteral("base_link_inertia"),
     QStringLiteral("shoulder_link"),
     QStringLiteral("upper_arm_link"),
@@ -135,11 +134,20 @@ bool is_required_ur5_generated_visual_mesh_index_row(const ScenePreviewWidget::P
     QStringLiteral("wrist_2_link"),
     QStringLiteral("wrist_3_link")
   };
-  const QString link = normalized_equivalence_token(
-    !item.visual_index_link_name.trimmed().isEmpty() ? item.visual_index_link_name : item.visual_index_link);
-  if (!required_links.contains(link)) return false;
+  return links;
+}
 
-  const QStringList mesh_identity_fields = {
+QString required_ur5_link_name_from_preview_item(const ScenePreviewWidget::PreviewItem & item)
+{
+  const QStringList candidates{
+    item.visual_index_link_name,
+    item.visual_index_link,
+    item.visual_index_object_name,
+    item.display_name,
+    item.id,
+    item.frame_id,
+    item.visual_index_visual,
+    item.visual_index_visual_name,
     item.package_uri,
     item.visual_index_package_uri,
     item.visual_index_mesh_uri,
@@ -147,34 +155,110 @@ bool is_required_ur5_generated_visual_mesh_index_row(const ScenePreviewWidget::P
     item.source_path,
     item.resolved_source_path_original
   };
-  bool references_ur5_visual_mesh = false;
-  for (QString value : mesh_identity_fields) {
-    value = value.trimmed().toLower();
-    if (value.startsWith(QStringLiteral("package://ur_description/meshes/ur5/visual/"))) {
-      references_ur5_visual_mesh = true;
-      break;
-    }
-    if (value.contains(QStringLiteral("/ur_description/meshes/ur5/visual/"))) {
-      references_ur5_visual_mesh = true;
-      break;
+
+  for (const QString & value : candidates) {
+    const QString token = normalized_equivalence_token(value);
+    for (const QString & required : required_ur5_scene3d_links()) {
+      if (token == required || token.contains(required)) return required;
     }
   }
-  if (!references_ur5_visual_mesh) return false;
 
-  return item.locked && !item.editable && !item.linked_to_editable_layout_state &&
-         canonical_scene3d_token(item.source_layer) == QStringLiteral("locked_generated_urdf_visual") &&
-         canonical_scene3d_token(item.active_visual_source) == QStringLiteral("mesh_preview");
+  const QString mesh_hint = normalized_equivalence_token(candidates.join(QStringLiteral(" ")));
+  if (mesh_hint.contains(QStringLiteral("base_dae"))) return QStringLiteral("base_link_inertia");
+  if (mesh_hint.contains(QStringLiteral("shoulder_dae"))) return QStringLiteral("shoulder_link");
+  if (mesh_hint.contains(QStringLiteral("upperarm_dae")) || mesh_hint.contains(QStringLiteral("upper_arm_dae"))) return QStringLiteral("upper_arm_link");
+  if (mesh_hint.contains(QStringLiteral("forearm_dae"))) return QStringLiteral("forearm_link");
+  if (mesh_hint.contains(QStringLiteral("wrist1_dae")) || mesh_hint.contains(QStringLiteral("wrist_1_dae"))) return QStringLiteral("wrist_1_link");
+  if (mesh_hint.contains(QStringLiteral("wrist2_dae")) || mesh_hint.contains(QStringLiteral("wrist_2_dae"))) return QStringLiteral("wrist_2_link");
+  if (mesh_hint.contains(QStringLiteral("wrist3_dae")) || mesh_hint.contains(QStringLiteral("wrist_3_dae"))) return QStringLiteral("wrist_3_link");
+  return {};
+}
+
+bool preview_item_references_ur5_visual_mesh(const ScenePreviewWidget::PreviewItem & item)
+{
+  const QString mesh_hint = normalized_equivalence_token(QStringList{
+    item.package_uri,
+    item.visual_index_package_uri,
+    item.visual_index_mesh_uri,
+    item.mesh_path,
+    item.source_path,
+    item.resolved_source_path_original,
+    item.id
+  }.join(QStringLiteral(" ")));
+
+  if (mesh_hint.contains(QStringLiteral("ur_description")) &&
+      mesh_hint.contains(QStringLiteral("meshes_ur5_visual"))) {
+    return true;
+  }
+
+  return mesh_hint.contains(QStringLiteral("base_dae")) ||
+         mesh_hint.contains(QStringLiteral("shoulder_dae")) ||
+         mesh_hint.contains(QStringLiteral("upperarm_dae")) ||
+         mesh_hint.contains(QStringLiteral("upper_arm_dae")) ||
+         mesh_hint.contains(QStringLiteral("forearm_dae")) ||
+         mesh_hint.contains(QStringLiteral("wrist1_dae")) ||
+         mesh_hint.contains(QStringLiteral("wrist_1_dae")) ||
+         mesh_hint.contains(QStringLiteral("wrist2_dae")) ||
+         mesh_hint.contains(QStringLiteral("wrist_2_dae")) ||
+         mesh_hint.contains(QStringLiteral("wrist3_dae")) ||
+         mesh_hint.contains(QStringLiteral("wrist_3_dae"));
+}
+
+QString item_equivalence_link_name(const ScenePreviewWidget::PreviewItem & item)
+{
+  const QString required_ur5_link = required_ur5_link_name_from_preview_item(item);
+  if (!required_ur5_link.isEmpty()) return required_ur5_link;
+  if (!item.visual_index_link_name.trimmed().isEmpty()) return item.visual_index_link_name;
+  if (!item.visual_index_link.trimmed().isEmpty()) return item.visual_index_link;
+  if (!item.display_name.trimmed().isEmpty()) return item.display_name;
+  return item.id;
+}
+
+}  // namespace
+
+bool is_required_ur5_generated_visual_mesh_index_row(const ScenePreviewWidget::PreviewItem & item)
+{
+  const QString required_link = required_ur5_link_name_from_preview_item(item);
+  if (required_link.isEmpty()) return false;
+  if (!preview_item_references_ur5_visual_mesh(item)) return false;
+  if (is_true_editable_source_of_truth(item) || item.linked_to_editable_layout_state) return false;
+
+  const QString source_layer = canonical_scene3d_token(item.source_layer);
+  const QString visual_source = canonical_scene3d_token(item.active_visual_source);
+  const QString id_token = normalized_equivalence_token(item.id);
+  const QString visual_index_source = normalized_equivalence_token(item.visual_index_source);
+
+  const bool generated_visual_row =
+    item.id.startsWith(QStringLiteral("generated_urdf::"), Qt::CaseInsensitive) ||
+    item.id.startsWith(QStringLiteral("urdf_visual_"), Qt::CaseInsensitive) ||
+    id_token.contains(QStringLiteral("urdf_visual")) ||
+    source_layer == QStringLiteral("locked_generated_urdf_visual") ||
+    source_layer.contains(QStringLiteral("generated_urdf")) ||
+    source_layer.contains(QStringLiteral("urdf_visual")) ||
+    visual_index_source.contains(QStringLiteral("urdf_flattened")) ||
+    visual_index_source.contains(QStringLiteral("xacro"));
+
+  const bool mesh_preview_source = visual_source.isEmpty() ||
+    visual_source == QStringLiteral("mesh_preview") ||
+    visual_source.contains(QStringLiteral("mesh"));
+
+  return generated_visual_row && mesh_preview_source;
 }
 
 bool is_authoritative_generated_urdf_mesh_preview_item(const ScenePreviewWidget::PreviewItem & item)
 {
   if (is_required_ur5_generated_visual_mesh_index_row(item)) return true;
   const auto is_protected_generated_mesh_index_visual = [](const ScenePreviewWidget::PreviewItem & candidate) {
-    if (!candidate.id.trimmed().startsWith(QStringLiteral("generated_urdf::"))) return false;
-    if (!candidate.locked || candidate.linked_to_editable_layout_state || candidate.editable) return false;
+    const bool generated_identity = candidate.id.trimmed().startsWith(QStringLiteral("generated_urdf::")) ||
+      candidate.id.trimmed().startsWith(QStringLiteral("urdf_visual_"));
+    if (!generated_identity) return false;
+    if (candidate.linked_to_editable_layout_state || candidate.editable) return false;
     const QString source_layer = canonical_scene3d_token(candidate.source_layer);
     const QString visual_source = canonical_scene3d_token(candidate.active_visual_source);
-    if (source_layer != QStringLiteral("locked_generated_urdf_visual") || visual_source != QStringLiteral("mesh_preview")) return false;
+    if (source_layer != QStringLiteral("locked_generated_urdf_visual") ||
+        !(visual_source == QStringLiteral("mesh_preview") || visual_source.contains(QStringLiteral("mesh")))) {
+      return false;
+    }
     if (candidate.visual_index_link_name.trimmed().isEmpty() && candidate.visual_index_link.trimmed().isEmpty()) return false;
     const QStringList mesh_identity_fields = {candidate.package_uri, candidate.visual_index_package_uri, candidate.visual_index_mesh_uri,
       candidate.mesh_path, candidate.source_path, candidate.resolved_source_path_original};
@@ -233,14 +317,15 @@ QSet<QString> generated_urdf_preview_equivalence_keys_for_item(const ScenePrevie
   QSet<QString> keys;
   const QString role = normalized_item_role(item);
   if (role.isEmpty()) return keys;
-  const QString link = normalized_equivalence_token(item.display_name.isEmpty() ? item.id : item.display_name);
+  const QString link = normalized_equivalence_token(item_equivalence_link_name(item));
   const QString id_token = normalized_equivalence_token(item.id);
   const QString pose = QStringLiteral("%1_%2_%3_%4_%5_%6")
     .arg(approximate_pose_token(item.x), approximate_pose_token(item.y), approximate_pose_token(item.z),
          approximate_pose_token(item.roll), approximate_pose_token(item.pitch), approximate_pose_token(item.yaw));
   if (!link.isEmpty()) keys.insert(QStringLiteral("role_link:%1:%2").arg(role, link));
   if (!id_token.isEmpty()) keys.insert(QStringLiteral("role_link:%1:%2").arg(role, id_token));
-  for (const QString & path_value : {item.package_uri, item.mesh_path, item.source_path, item.resolved_source_path_original}) {
+  for (const QString & path_value : {item.package_uri, item.visual_index_package_uri, item.visual_index_mesh_uri,
+                                    item.mesh_path, item.source_path, item.resolved_source_path_original}) {
     const QString source_basename = normalized_equivalence_basename(path_value);
     if (source_basename.isEmpty()) continue;
     keys.insert(QStringLiteral("role_source_basename:%1:%2").arg(role, source_basename));

--- a/workcell_builder/workcell_builder/test/preview_item_suppression_test.cpp
+++ b/workcell_builder/workcell_builder/test/preview_item_suppression_test.cpp
@@ -160,3 +160,46 @@ TEST(PreviewItemSuppression, ExplicitlyPreservesUr5VisualMeshIndexRowsAgainstSem
   EXPECT_EQ(retained_ur5_links.size(), 7);
   EXPECT_FALSE(retained_robot_base_placeholder);
 }
+
+TEST(PreviewItemSuppression, PreservesRawUrdfVisual0BaseRowFromMeshIndex)
+{
+  ScenePreviewWidget::PreviewItem raw_base = make_generated_visual(
+    0,
+    QStringLiteral("base_link_inertia"),
+    QStringLiteral("robot/ur5"),
+    QStringLiteral("robot"),
+    QStringLiteral("package://ur_description/meshes/ur5/visual/base.dae"));
+  raw_base.id = QStringLiteral("urdf_visual_0_base_link_inertia_visual_0_package_ur_description_meshes_ur5_visual_base_dae");
+  raw_base.visual_index_link_name.clear();
+  raw_base.visual_index_link.clear();
+  raw_base.visual_index_source = QStringLiteral("urdf_flattened");
+  raw_base.active_visual_source.clear();
+
+  ScenePreviewWidget::PreviewItem robot_base;
+  robot_base.id = QStringLiteral("robot_base");
+  robot_base.display_name = QStringLiteral("Robot Base");
+  robot_base.category = QStringLiteral("robot");
+  robot_base.role = QStringLiteral("robot_base");
+  robot_base.source_layer = QStringLiteral("primitive_fallback");
+  robot_base.active_visual_source = QStringLiteral("primitive_fallback");
+  robot_base.locked = true;
+  robot_base.editable = false;
+  robot_base.mesh_available = false;
+  robot_base.has_mesh_metadata = false;
+  robot_base.warnings = QStringList{QStringLiteral("semantic placeholder")};
+
+  ASSERT_TRUE(workcell_builder::is_authoritative_generated_urdf_mesh_preview_item(raw_base));
+
+  const auto result = workcell_builder::suppress_lower_fidelity_preview_items(
+    QVector<ScenePreviewWidget::PreviewItem>{raw_base, robot_base}, true);
+
+  bool retained_raw_base = false;
+  bool retained_robot_base_placeholder = false;
+  for (const auto & item : result.items) {
+    if (item.id == raw_base.id) retained_raw_base = true;
+    if (item.id == robot_base.id) retained_robot_base_placeholder = true;
+  }
+
+  EXPECT_TRUE(retained_raw_base);
+  EXPECT_FALSE(retained_robot_base_placeholder);
+}


### PR DESCRIPTION
## Summary
- Broaden Scene3D preview suppression protection for required UR5 mesh-index rows.
- Recognise raw `urdf_visual_*` rows and mesh/link identity from IDs, package URIs, and visual-index metadata.
- Add regression coverage for raw `visual_0` / `base_link_inertia` rows so semantic placeholders cannot suppress them.

## Why
Local smoke showed `scene_visual_mesh_index.json` contains the 7 UR5 rows, but `final_draw_visual_items` starts at Robotiq visual 9 and reports `rendered_ur5_link_count: 0`. This targets the handoff/suppression stage rather than xacro extraction or renderer parsing.

## Validation
Not run here: I edited via the GitHub connector and cannot execute the ROS Humble GUI smoke from this environment. Please run locally:

```bash
cd /home/ubuntu/workcell_ws
source /opt/ros/humble/setup.bash
colcon build --symlink-install --packages-select workcell_builder
source install/setup.bash

cd /home/ubuntu/workcell_ws/src/easy_manipulation_deployment
python3 scripts/run_workcell_builder_scene3d_gui_smoke.py \
  --repo-root "$PWD" \
  --workspace-root /home/ubuntu/workcell_ws \
  --scene ur5_2f_test \
  --output "$PWD/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json" \
  --screenshot "$PWD/scenes/ur5_2f_test/generated/scene3d_gui_smoke.png" \
  --timeout-sec 30
```

Acceptance target: `rendered_ur5_link_count >= 7` and `missing_required_visible_ur5_links == []`.