### PR TITLE
Harden UR5 Scene3D visual index repair

### DIFF
--- a/scripts/repair_ur5_scene3d_visual_index.py
+++ b/scripts/repair_ur5_scene3d_visual_index.py
@@ -3,9 +3,10 @@
 
 The extractor is the source of truth for real xacro/URDF expansion, but some
 runtime paths have repeatedly emitted Robotiq/table/camera rows while dropping
-the UR5 arm rows.  This post-process is deliberately narrow: it only applies to
-UR5 scenes, only adds missing required UR5 mesh rows, and leaves existing
-Robotiq/table/camera rows untouched.
+or retaining non-renderable UR5 arm rows.  This post-process is deliberately
+narrow: it only applies to UR5 scenes or UR5-looking visual indexes, only adds
+missing/non-renderable required UR5 mesh rows, and leaves existing Robotiq/table/
+camera rows untouched.
 """
 from __future__ import annotations
 
@@ -74,16 +75,38 @@ REQUIRED_UR5_VISUALS: tuple[dict[str, Any], ...] = (
     },
 )
 
+REQUIRED_UR5_LINKS = tuple(str(spec["link"]) for spec in REQUIRED_UR5_VISUALS)
+RENDER_REJECT_STATUSES = {
+    "skip",
+    "skipped",
+    "hidden",
+    "reject",
+    "rejected",
+    "failed",
+    "error",
+    "missing",
+    "suppressed",
+}
+UR5_VISUAL_TOKEN_HINTS = (
+    "ur_description/meshes/ur5/visual/",
+    "package://ur_description/meshes/ur5/visual/",
+    "assets/robots/universal_robot/ur_description/meshes/ur5/visual/",
+)
+
 
 def _as_items(payload: dict[str, Any]) -> list[dict[str, Any]]:
-    raw = payload.get("visual_items")
-    return raw if isinstance(raw, list) else []
+    for key in ("visual_items", "items"):
+        raw = payload.get(key)
+        if isinstance(raw, list):
+            return [item for item in raw if isinstance(item, dict)]
+    return []
 
 
 def _token_values(item: dict[str, Any]) -> str:
     keys = (
         "link",
         "link_name",
+        "canonical_link_name",
         "object_name",
         "visual_index_link",
         "visual_index_link_name",
@@ -93,23 +116,72 @@ def _token_values(item: dict[str, Any]) -> str:
         "metadata_tags",
         "package_uri",
         "mesh_uri",
+        "mesh_source",
         "mesh_path",
         "source_path",
+        "resolved_source_path",
     )
-    return "|".join(str(item.get(key) or "") for key in keys).lower()
+    values = [str(item.get(key) or "") for key in keys]
+    metadata = item.get("metadata")
+    if isinstance(metadata, dict):
+        values.extend(str(metadata.get(key) or "") for key in ("link", "link_name", "canonical_link_name"))
+    return "|".join(values).lower()
+
+
+def _item_mentions_link(item: dict[str, Any], link: str) -> bool:
+    return link.lower() in _token_values(item)
+
+
+def _item_has_ur5_mesh_evidence(item: dict[str, Any]) -> bool:
+    tokens = _token_values(item)
+    if any(hint in tokens for hint in UR5_VISUAL_TOKEN_HINTS):
+        return True
+    mesh_name = str(item.get("mesh_file_name") or item.get("mesh") or "").lower()
+    return mesh_name in {str(spec["mesh"]).lower() for spec in REQUIRED_UR5_VISUALS}
+
+
+def _truthy_or_missing(value: Any) -> bool:
+    return value is not False
+
+
+def _item_is_renderable_required_link(item: dict[str, Any], link: str) -> bool:
+    if not _item_mentions_link(item, link):
+        return False
+    if not _truthy_or_missing(item.get("render_expected")):
+        return False
+    if not _truthy_or_missing(item.get("resolved")):
+        return False
+    if item.get("visible") is False or item.get("rendered") is False:
+        return False
+    status = str(item.get("final_draw_status") or item.get("draw_status") or "").strip().lower()
+    if status in RENDER_REJECT_STATUSES:
+        return False
+    render_skip_reason = str(item.get("render_skip_reason") or item.get("warning") or "").strip().lower()
+    if any(token in render_skip_reason for token in ("missing_parent", "file_not_found", "package_not_found", "mesh_parse_failed")):
+        return False
+    if _item_has_ur5_mesh_evidence(item):
+        return True
+    geometry_type = str(item.get("geometry_type") or item.get("primitive_geometry_type") or "").strip().lower()
+    return geometry_type == "mesh" and bool(str(item.get("mesh_uri") or item.get("mesh_path") or item.get("package_uri") or "").strip())
 
 
 def _present_required_links(items: list[dict[str, Any]]) -> set[str]:
     present: set[str] = set()
     for item in items:
-        if not isinstance(item, dict):
-            continue
-        mix = _token_values(item)
-        for spec in REQUIRED_UR5_VISUALS:
-            link = spec["link"]
-            if link.lower() in mix:
+        for link in REQUIRED_UR5_LINKS:
+            if _item_is_renderable_required_link(item, link):
                 present.add(link)
     return present
+
+
+def _payload_is_ur5_candidate(payload: dict[str, Any], items: list[dict[str, Any]], path: Path) -> bool:
+    scene_name = str(payload.get("scene_name") or payload.get("scene") or path.parents[1].name)
+    if scene_name.startswith("ur5_"):
+        return True
+    blob = "|".join(_token_values(item) for item in items)
+    if any(hint in blob for hint in UR5_VISUAL_TOKEN_HINTS):
+        return True
+    return sum(1 for link in REQUIRED_UR5_LINKS if link.lower() in blob) >= 2
 
 
 def _repo_relative_mesh_path(mesh_name: str) -> str:
@@ -128,15 +200,29 @@ def _ur5_item(spec: dict[str, Any], index: int) -> dict[str, Any]:
     xyz = list(spec["xyz"])
     rpy = list(spec["rpy"])
     pose = _pose(xyz, rpy)
+    item_id = f"generated_urdf::{link}::visual_{index}::{index}"
+    stable_item_id = f"generated_urdf::{link}"
     return {
-        "id": f"generated_urdf::{link}::visual_{index}::{index}",
+        "id": item_id,
+        "item_id": stable_item_id,
         "source": "urdf_flattened",
         "source_layer": "locked_generated_urdf_visual",
         "active_visual_source": "mesh_preview",
+        "category": "robot",
+        "role": "robot",
+        "robot_model": "ur5",
+        "preview_locked": True,
+        "editable": False,
+        "generated_urdf_visual": True,
+        "locked_generated_urdf_visual": True,
         "link": link,
         "link_name": link,
         "object_name": link,
         "canonical_link_name": link,
+        "render_identity": link,
+        "final_render_identity": link,
+        "final_render_link": link,
+        "final_draw_link": link,
         "visual": f"visual_{index}",
         "visual_name": f"visual_{index}",
         "visual_index": index,
@@ -157,10 +243,16 @@ def _ur5_item(spec: dict[str, Any], index: int) -> dict[str, Any]:
         "visual_origin": {"xyz": [0.0, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]},
         "geometry_type": "mesh",
         "primitive_geometry_type": "mesh",
+        "has_mesh_metadata": True,
+        "mesh_source": package_uri,
         "mesh_uri": package_uri,
         "package_uri": package_uri,
         "source_path": package_uri,
         "mesh_path": mesh_path,
+        "mesh_package": "ur_description",
+        "mesh_file_name": mesh_name,
+        "source_package": "ur_description",
+        "source_model": "ur5",
         "resolved_source_path": mesh_path,
         "resolved_source_path_is_repo_relative": True,
         "resolved": True,
@@ -185,17 +277,16 @@ def _ur5_item(spec: dict[str, Any], index: int) -> dict[str, Any]:
         "visual_index_mesh_uri": package_uri,
         "visual_index_package_uri": package_uri,
         "visual_index_source": "runtime_ur5_visual_index_repair",
-        "metadata_tags": "source=urdf_flattened;runtime_ur5_visual_index_repair;rviz_parity",
+        "metadata_tags": "source=urdf_flattened;runtime_ur5_visual_index_repair;rviz_parity;category=robot;robot_model=ur5",
     }
 
 
 def repair_index(path: Path) -> tuple[bool, list[str]]:
     payload = json.loads(path.read_text(encoding="utf-8"))
-    scene_name = str(payload.get("scene_name") or path.parents[1].name)
-    if not scene_name.startswith("ur5_"):
+    items = _as_items(payload)
+    if not _payload_is_ur5_candidate(payload, items, path):
         return False, []
 
-    items = _as_items(payload)
     present = _present_required_links(items)
     missing = [spec for spec in REQUIRED_UR5_VISUALS if spec["link"] not in present]
     if not missing:
@@ -204,13 +295,15 @@ def repair_index(path: Path) -> tuple[bool, list[str]]:
     repaired = [_ur5_item(spec, index) for index, spec in enumerate(REQUIRED_UR5_VISUALS)]
     # Keep non-UR5 rows from extraction, but remove partial/stale UR5 rows so the
     # viewport receives exactly one authoritative row per required UR5 link.
-    required_links = {spec["link"] for spec in REQUIRED_UR5_VISUALS}
     kept = [
         item for item in items
         if isinstance(item, dict)
-        and not any(link.lower() in _token_values(item) for link in required_links)
+        and not any(link.lower() in _token_values(item) for link in REQUIRED_UR5_LINKS)
     ]
-    payload["visual_items"] = repaired + kept
+    repaired_items = repaired + kept
+    payload["visual_items"] = repaired_items
+    if isinstance(payload.get("items"), list):
+        payload["items"] = repaired_items
     payload["visual_count"] = len(payload["visual_items"])
     payload["candidate_mesh_count"] = len(payload["visual_items"])
     payload["emitted_visual_count"] = len(payload["visual_items"])
@@ -223,10 +316,16 @@ def repair_index(path: Path) -> tuple[bool, list[str]]:
     payload["stale_reasons"] = []
     payload["ur5_runtime_repair_applied"] = True
     payload["ur5_runtime_repair_added_links"] = [spec["link"] for spec in missing]
-    payload["ur5_required_links"] = [spec["link"] for spec in REQUIRED_UR5_VISUALS]
+    payload["ur5_required_links"] = list(REQUIRED_UR5_LINKS)
     payload["repair_generated_at"] = datetime.now(timezone.utc).isoformat()
     blockers = payload.get("blockers") if isinstance(payload.get("blockers"), list) else []
-    payload["blockers"] = [b for b in blockers if "ur5" not in str(b).lower()]
+    stale_tokens = (
+        "missing_required_visible_ur5_links",
+        "ur5_final_viewport_links_missing",
+        "rendered_ur5_link_count_below_7",
+        "stale_retained_visual_rows_missing_warning",
+    )
+    payload["blockers"] = [b for b in blockers if not any(token in str(b) for token in stale_tokens)]
     warnings = payload.get("warnings") if isinstance(payload.get("warnings"), list) else []
     note = "ur5_runtime_visual_index_repair_applied"
     if note not in warnings:

--- a/tests/test_repair_ur5_scene3d_visual_index.py
+++ b/tests/test_repair_ur5_scene3d_visual_index.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.repair_ur5_scene3d_visual_index import REQUIRED_UR5_LINKS, repair_index
+
+
+def _write_index(tmp_path: Path, payload: dict) -> Path:
+    scene_dir = tmp_path / "scenes" / "suction_test" / "generated"
+    scene_dir.mkdir(parents=True)
+    path = scene_dir / "scene_visual_mesh_index.json"
+    path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+    return path
+
+
+def test_repair_replaces_stale_unrenderable_ur5_rows_and_preserves_non_ur5_rows(tmp_path):
+    path = _write_index(
+        tmp_path,
+        {
+            "scene_name": "suction_test",
+            "visual_items": [
+                {
+                    "id": "stale_shoulder",
+                    "link": "shoulder_link",
+                    "mesh_uri": "package://ur_description/meshes/ur5/visual/shoulder.dae",
+                    "resolved": False,
+                    "render_expected": True,
+                    "warning": "file_not_found",
+                },
+                {
+                    "id": "table",
+                    "display_name": "table",
+                    "geometry_type": "box",
+                    "render_expected": True,
+                    "resolved": True,
+                },
+            ],
+            "items": [],
+            "blockers": [
+                "ur5_final_viewport_links_missing",
+                "rendered_ur5_link_count_below_7",
+                "keep_non_ur5_blocker",
+            ],
+        },
+    )
+
+    changed, added = repair_index(path)
+
+    assert changed is True
+    assert set(added) == set(REQUIRED_UR5_LINKS)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    rows = payload["visual_items"]
+    assert payload["items"] == rows
+    assert any(row.get("id") == "table" for row in rows)
+    ur5_rows = [row for row in rows if row.get("robot_model") == "ur5"]
+    assert len(ur5_rows) == len(REQUIRED_UR5_LINKS)
+    assert {row["link"] for row in ur5_rows} == set(REQUIRED_UR5_LINKS)
+    assert all(row["category"] == "robot" for row in ur5_rows)
+    assert all(row["role"] == "robot" for row in ur5_rows)
+    assert all(row["has_mesh_metadata"] is True for row in ur5_rows)
+    assert all(row["source_layer"] == "locked_generated_urdf_visual" for row in ur5_rows)
+    assert all(row["final_render_identity"] == row["link"] for row in ur5_rows)
+    assert all(row["render_expected"] is True for row in ur5_rows)
+    assert "ur5_final_viewport_links_missing" not in payload["blockers"]
+    assert "rendered_ur5_link_count_below_7" not in payload["blockers"]
+    assert "keep_non_ur5_blocker" in payload["blockers"]
+
+
+def test_repair_skips_non_ur5_payload(tmp_path):
+    path = _write_index(
+        tmp_path,
+        {
+            "scene_name": "generic_scene",
+            "visual_items": [
+                {"id": "table", "display_name": "table", "geometry_type": "box", "resolved": True}
+            ],
+        },
+    )
+
+    changed, added = repair_index(path)
+
+    assert changed is False
+    assert added == []


### PR DESCRIPTION
## Current goal
Make the real supported UR5 scene path less fragile so Workcell Studio can move back toward real supported-scene readiness instead of more diagnostic loops.

## Immediate goal
Stop stale/non-renderable UR5 visual-index rows from being treated as valid renderable robot links, and emit stronger final-render identity metadata for repaired UR5 rows.

## Overall goal
Workcell Studio should reliably open/generate/validate/preview scene packages with fake-hardware-first safety before any guarded real-hardware path.

## Changes
- Hardened `scripts/repair_ur5_scene3d_visual_index.py` so required UR5 links only count as present when the row is renderable/resolved/not skipped and has mesh evidence.
- Broadened UR5 repair eligibility beyond scene names that start with `ur5_` when the index itself contains UR5 mesh/link evidence.
- Added stable robot-layer metadata on repaired rows: `item_id`, `category`, `role`, `robot_model`, `has_mesh_metadata`, `mesh_source`, final render identity fields, locked/generated flags, and preview editability flags.
- Kept non-UR5 rows intact and removed only specific stale UR5 blockers instead of removing every blocker that happens to mention UR5.
- Added regression tests proving stale unresolved UR5 rows are repaired and non-UR5 indexes are left alone.

## Safety
- No launch/runtime motion changes.
- No real robot execution paths added.
- Fake-hardware-first defaults remain untouched.

## Suggested validation in the real ROS Humble workspace
```bash
cd /home/user/workcell_ws/src/easy_manipulation_deployment
python3 -m pytest -q tests/test_repair_ur5_scene3d_visual_index.py tests/test_scene3d_gui_smoke_json_output_contract.py
python3 scripts/generate_scene_visual_mesh_index.py --scene ur5_2f_test --workspace-root /home/user/workcell_ws --use-fake-hardware true
python3 scripts/run_workcell_builder_scene3d_gui_smoke.py --repo-root "$PWD" --workspace-root /home/user/workcell_ws --scene ur5_2f_test --output "$PWD/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json" --screenshot "$PWD/scenes/ur5_2f_test/generated/scene3d_gui_smoke.png" --timeout-sec 30
```

## Notes
I intentionally did not weaken safety gates or add another validator-only loop. This is a product-path repair for the current broken UR5 Scene3D visual layer.