### PR TITLE
Fix Scene3D smoke runner blocker crash

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,1 +1,28 @@
-"""Local scripts package for tests."""
+"""Local scripts package for tests and script-side compatibility shims."""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+def _install_scene3d_smoke_legacy_blockers_guard() -> None:
+    """Protect the oversized Scene3D smoke runner from its legacy blocker bug.
+
+    ``run_workcell_builder_scene3d_gui_smoke.py`` still contains a large legacy
+    function body where ``_enforce_physical_render_evidence()`` references a
+    module-global ``blockers`` name before defining it.  The real fix is to wire
+    that runner fully through ``scripts.scene3d_smoke_payload`` and delete the
+    duplicate in-script helper.  Until that larger file is safely split, install
+    the missing global only when that script is the process entrypoint so the
+    wrapper reports ``scene_rendered_no_physical_items`` instead of crashing with
+    ``NameError`` and mislabeling the app JSON as unreadable.
+    """
+    main_module = sys.modules.get("__main__")
+    main_file = str(getattr(main_module, "__file__", "") or "")
+    if Path(main_file).name != "run_workcell_builder_scene3d_gui_smoke.py":
+        return
+    if main_module is not None and "blockers" not in vars(main_module):
+        setattr(main_module, "blockers", [])
+
+
+_install_scene3d_smoke_legacy_blockers_guard()

--- a/tests/test_scene3d_smoke_runner_blocker_regression.py
+++ b/tests/test_scene3d_smoke_runner_blocker_regression.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_scene3d_smoke_runner_reports_no_physical_items_instead_of_json_unreadable(tmp_path):
+    repo = Path(__file__).resolve().parents[1]
+    fake_builder = tmp_path / "fake_workcell_builder_no_physical.py"
+    fake_builder.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, pathlib, sys\n"
+        "out = pathlib.Path(sys.argv[sys.argv.index('--smoke-output') + 1])\n"
+        "out.parent.mkdir(parents=True, exist_ok=True)\n"
+        "out.write_text(json.dumps({\n"
+        "    'schema': 'workcell_studio_scene3d_gui_smoke/v1',\n"
+        "    'status': 'PASS',\n"
+        "    'counters': {'rendered_count': 1},\n"
+        "    'render_debug_counters': {'physical_mesh_items_rendered': 0, 'primitive_fallback_items_rendered': 0},\n"
+        "}) + '\\n', encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    fake_builder.chmod(0o755)
+
+    out = tmp_path / "smoke.json"
+    cmd = [
+        sys.executable,
+        str(repo / "scripts/run_workcell_builder_scene3d_gui_smoke.py"),
+        "--repo-root",
+        str(repo),
+        "--workspace-root",
+        str(tmp_path),
+        "--scene",
+        "ur5_2f_test",
+        "--output",
+        str(out),
+        "--executable",
+        str(fake_builder),
+        "--timeout-sec",
+        "2",
+    ]
+    env = os.environ.copy()
+    env["ROS_DISTRO"] = "humble"
+
+    proc = subprocess.run(cmd, text=True, capture_output=True, env=env)
+
+    assert proc.returncode != 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["status"] == "FAIL"
+    assert payload["wrapper_status"] == "FAIL"
+    assert "scene_rendered_no_physical_items" in payload["blockers"]
+    assert not any(str(blocker).startswith("app_smoke_json_unreadable") for blocker in payload["blockers"])
+    assert "APP_JSON_UNREADABLE" not in proc.stdout


### PR DESCRIPTION
## Goal
Fix the escaped Scene3D smoke wrapper bug while the oversized runner is still being split safely.

## Fix
- Adds a narrowly scoped compatibility guard that activates only when `run_workcell_builder_scene3d_gui_smoke.py` is the process entrypoint.
- Prevents the legacy `_enforce_physical_render_evidence()` path from raising `NameError: blockers is not defined`.
- Makes the wrapper report the real blocker: `scene_rendered_no_physical_items`, instead of treating a valid app smoke JSON as unreadable.

## Regression coverage
- Adds a subprocess regression where a fake builder writes a valid PASS smoke JSON with zero physical rendered items.
- Asserts the wrapper fails for the right reason and does not emit `APP_JSON_UNREADABLE` / `app_smoke_json_unreadable`.

## Notes
The direct cleanup remains to wire the large runner through `scripts.scene3d_smoke_payload` and remove duplicated helper logic. This PR fixes the runtime failure first with a tiny guarded shim and test.

## Suggested validation
```bash
cd /home/user/workcell_ws/src/easy_manipulation_deployment
python3 -m pytest -q \
  tests/test_scene3d_smoke_runner_blocker_regression.py \
  tests/test_scene3d_smoke_payload.py \
  tests/test_scene3d_gui_smoke_json_output_contract.py

cd /home/user/workcell_ws
source /opt/ros/humble/setup.bash
colcon build --symlink-install --packages-select workcell_builder
```