### PR TITLE
Harden scene manifest reference checks

### DIFF
--- a/scripts/run_workcell_studio_scene_readiness_matrix.py
+++ b/scripts/run_workcell_studio_scene_readiness_matrix.py
@@ -187,8 +187,19 @@ def _iter_manifest_refs(value: Any, *, key_path: str = "") -> list[tuple[str, st
     return refs
 
 
+def _is_relative_to(candidate: Path, scene_root: Path) -> bool:
+    if hasattr(candidate, "is_relative_to"):
+        return candidate.is_relative_to(scene_root)
+    try:
+        candidate.relative_to(scene_root)
+    except ValueError:
+        return False
+    return True
+
+
 def _check_manifest_refs(scene_dir: Path) -> dict[str, Any]:
-    manifest = scene_dir / "scene_manifest.yaml"
+    scene_root = scene_dir.resolve()
+    manifest = scene_root / "scene_manifest.yaml"
     if not manifest.is_file():
         return _result(BLOCKED, "scene_manifest.yaml is missing; local-file references cannot be checked")
     payload, error = _load_yaml_file(manifest)
@@ -205,8 +216,11 @@ def _check_manifest_refs(scene_dir: Path) -> dict[str, Any]:
         if ref_path.is_absolute():
             missing.append({"field": key_path, "reference": ref, "reason": "absolute path is not a local scene-relative file"})
             continue
-        candidate = (scene_dir / ref_path).resolve()
+        candidate = (scene_root / ref_path).resolve()
         checked.append({"field": key_path, "reference": ref, "path": str(candidate)})
+        if candidate != scene_root and not _is_relative_to(candidate, scene_root):
+            missing.append({"field": key_path, "reference": ref, "reason": "referenced file resolves outside scene directory"})
+            continue
         if not candidate.exists():
             missing.append({"field": key_path, "reference": ref, "reason": "referenced file does not exist"})
     if missing:

--- a/tests/test_workcell_studio_scene_readiness_matrix.py
+++ b/tests/test_workcell_studio_scene_readiness_matrix.py
@@ -265,12 +265,17 @@ def test_bad_scene_manifest_local_reference_records_manifest_reference_failure(
         yaml.safe_dump(
             {
                 "scene": {"name": "bad_manifest_reference"},
-                "files": {"environment": "environment.yaml", "missing_urdf": "urdf/does_not_exist.xacro"},
+                "files": {
+                    "environment": "environment.yaml",
+                    "missing_urdf": "urdf/does_not_exist.xacro",
+                    "unsafe_outside": "../outside.txt",
+                },
             },
             sort_keys=False,
         ),
         encoding="utf-8",
     )
+    (scene_dir.parent / "outside.txt").write_text("exists but outside scene root\n", encoding="utf-8")
     catalog = _write_catalog(tmp_path, [entry])
 
     _write_valid_cell_definition(scene_dir, "bad_manifest_reference")
@@ -282,7 +287,42 @@ def test_bad_scene_manifest_local_reference_records_manifest_reference_failure(
     assert scene["categories"]["manifest_local_file_references"]["status"] == "FAIL"
     missing_refs = scene["categories"]["manifest_local_file_references"]["missing"]
     assert any(item["reference"] == "urdf/does_not_exist.xacro" for item in missing_refs)
+    unsafe_ref = next(item for item in missing_refs if item["reference"] == "../outside.txt")
+    assert unsafe_ref["reason"] == "referenced file resolves outside scene directory"
 
+
+
+def test_manifest_local_file_references_accepts_generated_scene3d_smoke_under_scene_root(tmp_path: Path) -> None:
+    scene_dir = tmp_path / "scenes" / "ur5_2f_test"
+    manifest_refs = {
+        "environment": "environment.yaml",
+        "cell_definition": "cell_definition.yaml",
+        "layout": "layout/workcell_studio_layout.yaml",
+        "demo_launch": "launch/demo.launch.py",
+        "scene_urdf": "urdf/scene.urdf.xacro",
+        "visual_mesh_index": "generated/scene_visual_mesh_index.json",
+        "scene3d_gui_smoke": "generated/scene3d_gui_smoke.json",
+    }
+    for rel_path in manifest_refs.values():
+        path = scene_dir / rel_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}\n", encoding="utf-8")
+    (scene_dir / "scene_manifest.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "scene": {"name": "ur5_2f_test"},
+                "files": manifest_refs,
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    result = matrix._check_manifest_refs(scene_dir)
+
+    assert result["status"] == "PASS"
+    assert len(result["checked"]) == len(manifest_refs)
+    assert any(item["reference"] == "generated/scene3d_gui_smoke.json" for item in result["checked"])
 
 def test_missing_visual_mesh_index_blocks_visual_evidence(tmp_path: Path, minimal_scene_factory: Any) -> None:
     report = _single_scene_report(


### PR DESCRIPTION
### Motivation
- Prevent manifest local-file references from resolving outside the intended scene directory and improve security of path resolution checks when validating scene manifests.
- Ensure generated artifacts like `generated/scene3d_gui_smoke.json` are accepted when they legitimately live under the scene folder.

### Description
- Canonicalize the scene root at the start of `_check_manifest_refs` using `scene_root = scene_dir.resolve()` and resolve manifest lookups against `scene_root`.
- Add `_is_relative_to(candidate, scene_root)` helper that uses `Path.is_relative_to` when available and falls back to `relative_to`/`try/except` for compatibility.
- For each relative manifest reference reject absolute paths and detect path traversal by resolving `candidate = (scene_root / ref_path).resolve()` and failing if `candidate` is not equal to or not inside `scene_root`, returning reason `referenced file resolves outside scene directory` before checking existence.
- Updated tests in `tests/test_workcell_studio_scene_readiness_matrix.py` to keep the existing negative case and add a path traversal case (`../outside.txt`) that must fail as unsafe, and add a positive regression test that creates a ur5_2f_test-style set of files (including `generated/scene3d_gui_smoke.json`) and asserts `manifest_local_file_references["status"] == "PASS"`.

### Testing
- Ran the test suite for the modified file: `pytest -q tests/test_workcell_studio_scene_readiness_matrix.py -q`, and all tests passed.
- Regression coverage added for both the unsafe outside-path case and the accepted `generated/scene3d_gui_smoke.json` under the scene root.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bac0439a0833190600f585b6134e6)