### PR TITLE
Fix Scene3D helper source layer filtering

### DIFF
--- a/tests/test_scene3d_product_overlay_filtering.py
+++ b/tests/test_scene3d_product_overlay_filtering.py
@@ -29,3 +29,21 @@ def test_product_view_keeps_helper_overlays_behind_overlay_layer() -> None:
 
     assert 'if (is_overlay_or_helper) return enabled_layers.contains("overlay");' in body
     assert "out.overlay = false;" in source
+
+
+def test_include_preview_item_combined_includes_source_identity() -> None:
+    source = ASSEMBLY_CPP.read_text(encoding="utf-8")
+    body = source.split("bool include_preview_item_for_scene3d", 1)[1]
+    body = body.split("Scene3DLayerVisibilityDefaults compute_scene3d_default_layer_visibility", 1)[0]
+
+    expected = (
+        'const QString combined = source_layer + "|" + visual_source + "|" + role + "|" '
+        '+ category + "|" + token(item.status) + "|" + item.warnings.join("|").toLower();'
+    )
+    assert expected in body
+    assert 'const QString source_layer = token(item.source_layer);' in body
+    assert 'const QString visual_source = token(item.active_visual_source);' in body
+    assert 'const QString role = token(item.role);' in body
+    assert 'const QString category = token(item.category);' in body
+    assert 'token(item.status)' in body
+    assert 'item.warnings.join("|").toLower()' in body

--- a/workcell_builder/workcell_builder/gui/scene3d_candidate_assembly.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_candidate_assembly.cpp
@@ -82,7 +82,7 @@ bool include_preview_item_for_scene3d(
   const QString visual_source = token(item.active_visual_source);
   const QString role = token(item.role);
   const QString category = token(item.category);
-  const QString combined = role + "|" + category + "|" + token(item.status) + "|" + item.warnings.join("|").toLower();
+  const QString combined = source_layer + "|" + visual_source + "|" + role + "|" + category + "|" + token(item.status) + "|" + item.warnings.join("|").toLower();
   const bool is_warning_or_missing = combined.contains("warning") || combined.contains("missing") || !item.mesh_load_warning.trimmed().isEmpty();
   const bool is_overlay_or_helper = is_product_helper_overlay_role(role, category, combined);
 


### PR DESCRIPTION
Summary:
- Updated `include_preview_item_for_scene3d()` so the helper/overlay combined token includes `source_layer` and `active_visual_source` before role/category/status/warnings.
- Added a small static regression test proving the combined expression includes source-layer identity fields.
- Affected files/packages: `workcell_builder/workcell_builder/gui/scene3d_candidate_assembly.cpp`, `tests/test_scene3d_product_overlay_filtering.py`.

Validation:
- Ran `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py`; new overlay filtering tests passed, but two existing assertions in `tests/test_workcell_builder_product_view_defaults.py` failed because expected source snippets are not present in the current checkout.
- ROS workspace build not run because `/home/user/workcell_ws` is not present in this container.

Safety:
- No launch files, controllers, runtime execution, generated scene artifacts, or hardware parameters were changed.
- Fake-hardware defaults and real-hardware guards were not touched.

Risks / rollback:
- Risk is limited to Product View layer filtering for Scene3D preview items.
- Roll back by reverting commit `d298923` if helper/source-layer filtering regresses.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d0c666f408331be191720a12604bc)