### PR TITLE
Broaden Scene3D product helper tag filtering

### DIFF
--- a/tests/test_scene3d_product_overlay_filtering.py
+++ b/tests/test_scene3d_product_overlay_filtering.py
@@ -4,20 +4,31 @@ ROOT = Path(__file__).resolve().parents[1]
 ASSEMBLY_CPP = ROOT / "workcell_builder/workcell_builder/gui/scene3d_candidate_assembly.cpp"
 
 
-def test_product_view_treats_zone_rows_as_helper_overlays() -> None:
+def test_product_view_treats_helper_rows_as_overlay_only() -> None:
     source = ASSEMBLY_CPP.read_text(encoding="utf-8")
 
+    assert "bool contains_product_helper_overlay_token" in source
     assert "bool is_product_helper_overlay_role" in source
     assert "const bool is_overlay_or_helper = is_product_helper_overlay_role(role, category, combined);" in source
 
     for token in (
-        'role == QStringLiteral("pick_zone")',
-        'role == QStringLiteral("place_zone")',
-        'role == QStringLiteral("robot_reach")',
-        'role == QStringLiteral("warning_anchor")',
-        'role == QStringLiteral("warning_badge")',
-        'category == QStringLiteral("pick_zone")',
-        'category == QStringLiteral("place_zone")',
+        'QStringLiteral("safety_zone")',
+        'QStringLiteral("pick_zone")',
+        'QStringLiteral("place_zone")',
+        'QStringLiteral("robot_reach")',
+        'QStringLiteral("warning_anchor")',
+        'QStringLiteral("warning_badge")',
+        'QStringLiteral("camera_fov")',
+        'QStringLiteral("pick_coverage")',
+        'QStringLiteral("reachability")',
+        'QStringLiteral("collision")',
+        'QStringLiteral("work_envelope")',
+        'QStringLiteral("task_route")',
+        'QStringLiteral("approach_retreat")',
+        'QStringLiteral("epd_detection")',
+        'QStringLiteral("detection_label")',
+        'QStringLiteral("bounds_box")',
+        'QStringLiteral("bounding_box")',
     ):
         assert token in source
 

--- a/workcell_builder/workcell_builder/gui/scene3d_candidate_assembly.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_candidate_assembly.cpp
@@ -48,27 +48,50 @@ bool is_generated_robot_visual(const ScenePreviewWidget::PreviewItem & item)
                          combined.contains(QStringLiteral("robot_model")));
 }
 
+bool contains_product_helper_overlay_token(const QString & text)
+{
+  const QStringList helper_tokens = {
+    QStringLiteral("overlay"),
+    QStringLiteral("helper"),
+    QStringLiteral("guide"),
+    QStringLiteral("diagnostic"),
+    QStringLiteral("safety_zone"),
+    QStringLiteral("pick_zone"),
+    QStringLiteral("place_zone"),
+    QStringLiteral("robot_reach"),
+    QStringLiteral("warning_anchor"),
+    QStringLiteral("warning_badge"),
+    QStringLiteral("camera_fov"),
+    QStringLiteral("fov"),
+    QStringLiteral("pick_coverage"),
+    QStringLiteral("reachability"),
+    QStringLiteral("collision"),
+    QStringLiteral("work_envelope"),
+    QStringLiteral("task_route"),
+    QStringLiteral("approach_retreat"),
+    QStringLiteral("approach"),
+    QStringLiteral("retreat"),
+    QStringLiteral("epd_detection"),
+    QStringLiteral("detection_label"),
+    QStringLiteral("bounds_box"),
+    QStringLiteral("bounding_box")
+  };
+  for (const QString & helper_token : helper_tokens) {
+    if (text == helper_token || text.contains(helper_token)) return true;
+  }
+  return false;
+}
+
 bool is_product_helper_overlay_role(const QString & role, const QString & category, const QString & combined)
 {
   // token() normalises spaces and hyphens to underscores, so product-layer filtering
-  // must treat safety_zone/pick_zone/place_zone/etc. as helper overlays.  The old
-  // "safety zone" substring did not match canonical safety_zone rows, which let
-  // large zone boxes leak into the normal Product View even when the overlay layer
-  // was disabled.
-  return combined.contains(QStringLiteral("overlay")) ||
-         combined.contains(QStringLiteral("helper")) ||
-         role == QStringLiteral("safety_zone") ||
-         role == QStringLiteral("pick_zone") ||
-         role == QStringLiteral("place_zone") ||
-         role == QStringLiteral("robot_reach") ||
-         role == QStringLiteral("warning_anchor") ||
-         role == QStringLiteral("warning_badge") ||
-         category == QStringLiteral("safety_zone") ||
-         category == QStringLiteral("pick_zone") ||
-         category == QStringLiteral("place_zone") ||
-         category == QStringLiteral("overlay") ||
-         category == QStringLiteral("helper") ||
-         category == QStringLiteral("diagnostic");
+  // keeps canonical helper rows behind the overlay controls. Product View should
+  // load robot/tool/environment meshes first; FOV, reachability, zone, route,
+  // warning, coverage, detection, and bounds helper rows must not leak into the
+  // normal first view as large boxes.
+  return contains_product_helper_overlay_token(role) ||
+         contains_product_helper_overlay_token(category) ||
+         contains_product_helper_overlay_token(combined);
 }
 }
 


### PR DESCRIPTION
Summary:
- Broadened Scene3D Product View helper/overlay filtering so non-physical helper rows stay behind the overlay layer.
- Added a reusable helper-token check covering FOV, reachability, collision, work envelope, task route, approach/retreat, EPD detections, labels, and bounds boxes.
- Updated the regression test so it protects the broader helper-token list and the source-layer combined-token behavior from PR #2479.

Validation:
- Not run in this connector session; code and test updates were applied through GitHub only.
- Suggested command: `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py`.

Safety:
- No launch files, controllers, runtime execution, generated scene artifacts, or hardware parameters were changed.
- Fake-hardware defaults and real-hardware guards were not touched.

Risks / rollback:
- Risk is limited to Scene3D Product View item filtering.
- Roll back by reverting commits `fed376e` and `a85420d` if any physical item is incorrectly classified as helper content.