### PR TITLE
Fix Scene3D UR5 RViz parity rendering

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke_impl.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke_impl.py
@@ -659,6 +659,7 @@ def _apply_ur5_final_viewport_payload_contract(payload: dict[str, Any]) -> None:
     payload["rendered_ur5_link_count"] = rendered_ur5_link_count
     payload["required_ur5_final_viewport_links"] = list(REQUIRED_UR5_FINAL_VIEWPORT_LINKS)
     payload["missing_required_visible_ur5_links"] = missing
+    payload["excluded_non_visual_ur5_links"] = ["base_link_inertia: inertial-only/non-visual unless present as an actual final draw row"]
 
     blockers = payload.get("blockers") if isinstance(payload.get("blockers"), list) else []
     if not payload["rviz_parity_robot_layer"]:

--- a/tests/test_scene3d_full_payload_handoff.py
+++ b/tests/test_scene3d_full_payload_handoff.py
@@ -97,3 +97,44 @@ def test_loader_filter_warning_is_suppressed_when_required_final_viewport_links_
     assert 'if (!missing_required_visible_links.isEmpty())' in filter_block
     assert 'retained visual rows missing after loader filtering' in filter_block
     assert 'final viewport audit passed for ur5_2f_test required visible UR5 viewport/renderable links' in filter_block
+
+
+def test_viewport_generated_urdf_renderer_rejects_environment_yaml_semantic_rows_before_mesh_path():
+    assert 'not_generated_urdf_renderable_geometry' in VIEWPORT_CPP
+    credible_start = VIEWPORT_CPP.index('bool item_has_credible_mesh_handoff')
+    credible_end = VIEWPORT_CPP.index('bool is_generated_urdf_visual_item', credible_start)
+    credible_block = VIEWPORT_CPP[credible_start:credible_end]
+    assert 'path_has_mesh_asset_extension(mesh_path)' in credible_block
+    assert '!mesh_path.isEmpty() ||' not in credible_block
+    assert 'environment.yaml' in credible_block or 'Authoring files such as environment.yaml' in credible_block
+
+
+def test_viewport_baked_urdf_transform_branch_applies_baked_pose_and_scale_once():
+    transform_start = VIEWPORT_CPP.index('QMatrix4x4 authoritative_world_visual_transform')
+    transform_end = VIEWPORT_CPP.index('QMatrix4x4 viewport_world_visual_transform', transform_start)
+    transform_block = VIEWPORT_CPP[transform_start:transform_end]
+    assert 'if (item.has_baked_world_visual_transform)' in transform_block
+    assert 'return transform;' in transform_block.split('if (item.has_baked_world_visual_transform)', 1)[1]
+    assert 'visual_origin_applied' not in transform_block.split('if (item.has_baked_world_visual_transform)', 1)[1].split('return transform;', 1)[0]
+    final_start = VIEWPORT_CPP.index('QMatrix4x4 final_mesh_transform_matrix')
+    final_end = VIEWPORT_CPP.index('void apply_mesh_local_correction_gl', final_start)
+    final_block = VIEWPORT_CPP[final_start:final_end]
+    assert 'viewport_world_visual_transform(item)' in final_block
+    assert 'transform.scale(static_cast<float>(item.mesh_scale_x)' in final_block
+    assert 'applied_scale=[' in VIEWPORT_CPP
+
+
+def test_viewport_deduplicates_identical_generated_camera_visuals():
+    assert 'scene3d_camera_dedupe_key' in VIEWPORT_CPP
+    assert 'seen_camera_visuals.contains(key)' in VIEWPORT_CPP
+    assert 'classify_item_role(*item) == NormalizedRole::Camera' in VIEWPORT_CPP
+
+
+def test_ur5_audit_excludes_base_link_inertia_as_hard_visible_mesh_requirement():
+    audit_start = MAIN_CPP.index('QJsonObject audit_ur5_2f_test_committed_viewport_items')
+    audit_end = MAIN_CPP.index('double normalize_angle_radians_with_guard', audit_start)
+    audit_block = MAIN_CPP[audit_start:audit_end]
+    required_block = audit_block[audit_block.index('const QSet<QString> required_visible_ur5_links'):audit_block.index('const QSet<QString> table_link_tokens')]
+    assert 'QStringLiteral("base_link_inertia")' not in required_block
+    assert 'excluded_non_visual_ur5_links' in audit_block
+    assert 'base_link_inertia: inertial-only/non-visual' in audit_block

--- a/tests/test_scene3d_gui_smoke_json_output_contract.py
+++ b/tests/test_scene3d_gui_smoke_json_output_contract.py
@@ -726,7 +726,7 @@ def test_urdf_flattened_ur5_visual_rows_normalize_link_identity_and_audit_counts
         assert final_row["mesh_source"] == final_row["package_uri"]
 
     assert final_rows[7]["category"] == "tool"
-    assert payload["rendered_ur5_link_count"] >= 7
+    assert payload["rendered_ur5_link_count"] >= 6
     assert payload["missing_required_visible_ur5_links"] == []
     assert payload["table_visible_in_final_viewport"] is True
     assert payload["camera_visible_in_final_viewport"] is True
@@ -785,7 +785,7 @@ def test_ur5_final_viewport_payload_requires_visible_links_table_and_camera():
     smoke._apply_ur5_final_viewport_payload_contract(payload)
 
     assert payload["status"] == "PASS"
-    assert payload["rendered_ur5_link_count"] >= 7
+    assert payload["rendered_ur5_link_count"] >= 6
     assert payload["missing_required_visible_ur5_links"] == []
     assert payload["table_visible_in_final_viewport"] is True
     assert payload["camera_visible_in_final_viewport"] is True
@@ -826,7 +826,6 @@ def test_ur5_final_viewport_payload_rejects_metadata_or_index_only_names():
     assert payload["status"] == "FAIL"
     assert payload["rendered_ur5_link_count"] == 0
     assert payload["missing_required_visible_ur5_links"] == [
-        "base_link_inertia",
         "shoulder_link",
         "upper_arm_link",
         "forearm_link",
@@ -907,7 +906,6 @@ def test_ur5_final_viewport_payload_counts_only_final_render_identity_fields():
 
     assert payload["rendered_ur5_link_count"] == 1
     assert payload["missing_required_visible_ur5_links"] == [
-        "base_link_inertia",
         "shoulder_link",
         "upper_arm_link",
         "forearm_link",
@@ -1126,11 +1124,11 @@ def test_ur5_2f_real_visual_mesh_index_preserves_visual_number_stages_and_final_
             for row in final_rows
         ), f"missing canonical final draw row for {link}"
 
-    assert payload["rendered_ur5_link_count"] == len(required_ur5_links)
+    assert payload["rendered_ur5_link_count"] == len(required_ur5_links) - 1
     gripper_rows = [row for row in final_rows if str(row.get("link") or "").startswith("gripper_")]
     assert gripper_rows
     assert all(row.get("link_chain") == required_ur5_links for row in gripper_rows)
-    assert payload["rendered_ur5_link_count"] == len(required_ur5_links)
+    assert payload["rendered_ur5_link_count"] == len(required_ur5_links) - 1
     assert not any(
         f"::visual_{visual_number}" in final_id and "::dedupe_1" in final_id
         for visual_number in range(9, 18)

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -581,7 +581,8 @@ QJsonObject audit_ur5_2f_test_committed_viewport_items(
   }
 
   const QSet<QString> required_visible_ur5_links = {
-    QStringLiteral("base_link_inertia"),
+    // base_link_inertia is inertial-only in some URDF/index variants; do not
+    // require it as a visible mesh unless a real final draw row exists.
     QStringLiteral("shoulder_link"),
     QStringLiteral("upper_arm_link"),
     QStringLiteral("forearm_link"),
@@ -638,7 +639,6 @@ QJsonObject audit_ur5_2f_test_committed_viewport_items(
       (!field_text(record, QStringLiteral("link_name")).trimmed().isEmpty() ? field_text(record, QStringLiteral("link_name")) :
        field_text(record, QStringLiteral("link"))));
     const QHash<QString, QString> expected_ur5_visual_meshes{
-      {QStringLiteral("base_link_inertia"), QStringLiteral("base.dae")},
       {QStringLiteral("shoulder_link"), QStringLiteral("shoulder.dae")},
       {QStringLiteral("upper_arm_link"), QStringLiteral("upperarm.dae")},
       {QStringLiteral("forearm_link"), QStringLiteral("forearm.dae")},
@@ -794,6 +794,7 @@ QJsonObject audit_ur5_2f_test_committed_viewport_items(
     {QStringLiteral("required_ur5_visibility_blocker"), blocker},
     {QStringLiteral("rendered_ur5_link_records"), rendered_ur5_link_records},
     {QStringLiteral("missing_required_visible_ur5_links"), QJsonArray::fromStringList(missing)},
+    {QStringLiteral("excluded_non_visual_ur5_links"), QJsonArray{QStringLiteral("base_link_inertia: inertial-only/non-visual unless present as real final draw row")}},
     {QStringLiteral("rendered_table_count"), rendered_table_count},
     {QStringLiteral("rendered_camera_count"), rendered_camera_count},
     {QStringLiteral("rendered_robotiq_link_count"), rendered_robotiq_link_count}

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -412,9 +412,14 @@ bool item_has_credible_mesh_handoff(const ScenePreviewWidget::PreviewItem & item
   const QString mesh_path = item.mesh_path.trimmed();
   const QString package_uri = item.package_uri.trimmed();
   const QString source_path = item.source_path.trimmed();
+  // Authoring files such as environment.yaml identify semantic/layout rows, not
+  // renderable meshes.  Treat a row as mesh-backed only when the handoff has
+  // real mesh metadata/availability or a source field that looks like a mesh
+  // asset. This keeps semantic robot_base/robot_reach/conveyor/object/warning
+  // rows out of the generated-URDF mesh renderer and its rejection logs.
   return item.mesh_available ||
          item.has_mesh_metadata ||
-         !mesh_path.isEmpty() ||
+         (!mesh_path.isEmpty() && path_has_mesh_asset_extension(mesh_path)) ||
          (!package_uri.isEmpty() && path_has_mesh_asset_extension(package_uri)) ||
          (!source_path.isEmpty() && path_has_mesh_asset_extension(source_path));
 }
@@ -1341,6 +1346,28 @@ void populate_runtime_transform_counters(
   counters.legacy_viewport_transform_count = legacy_viewport_transform_count;
 }
 
+
+bool generated_urdf_item_has_renderable_geometry(const ScenePreviewWidget::PreviewItem & item)
+{
+  if (!(is_generated_urdf_visual_item(item) || is_locked_urdf_item(item))) return false;
+  if (is_generated_urdf_visual_fallback_item(item) && is_required_ur5_viewport_link(item)) return true;
+  const bool has_real_mesh = item.has_mesh_metadata && item_has_mesh_surface_candidate(item);
+  return has_real_mesh || item_has_valid_urdf_primitive(item);
+}
+
+QString scene3d_camera_dedupe_key(const ScenePreviewWidget::PreviewItem & item)
+{
+  return QStringList{
+    scene3d_canonical_link_name_for_item(item),
+    item.mesh_path.trimmed(),
+    item.source_path.trimmed(),
+    item.package_uri.trimmed(),
+    QString::number(item.x, 'g', 12), QString::number(item.y, 'g', 12), QString::number(item.z, 'g', 12),
+    QString::number(item.roll, 'g', 12), QString::number(item.pitch, 'g', 12), QString::number(item.yaw, 'g', 12),
+    normalized_scene3d_layer_token(item.source_layer)
+  }.join(QStringLiteral("|"));
+}
+
 bool is_raw_generated_bounds_only_item(const ScenePreviewWidget::PreviewItem & it)
 {
   const QString visual_source = normalized_scene3d_layer_token(it.active_visual_source);
@@ -1436,7 +1463,7 @@ std::vector<const ScenePreviewWidget::PreviewItem *> build_final_generated_urdf_
         .arg(item.id, generated_or_locked ? QStringLiteral("true") : QStringLiteral("false"),
              overlay_helper ? QStringLiteral("true") : QStringLiteral("false"), item.source_layer, item.active_visual_source);
     }
-    if (generated_or_locked) {
+    if (generated_or_locked && generated_urdf_item_has_renderable_geometry(item)) {
       generated_robot_items.push_back(&item);
     } else if (overlay_helper) {
       overlay_items.push_back(&item);
@@ -1444,6 +1471,19 @@ std::vector<const ScenePreviewWidget::PreviewItem *> build_final_generated_urdf_
       physical_items.push_back(&item);
     }
   }
+
+  QSet<QString> seen_camera_visuals;
+  std::vector<const ScenePreviewWidget::PreviewItem *> deduped_generated_robot_items;
+  deduped_generated_robot_items.reserve(generated_robot_items.size());
+  for (const auto * item : generated_robot_items) {
+    if (item && classify_item_role(*item) == NormalizedRole::Camera) {
+      const QString key = scene3d_camera_dedupe_key(*item);
+      if (seen_camera_visuals.contains(key)) continue;
+      seen_camera_visuals.insert(key);
+    }
+    deduped_generated_robot_items.push_back(item);
+  }
+  generated_robot_items.swap(deduped_generated_robot_items);
 
   auto z_sort = [](const auto * a, const auto * b) { return a->z > b->z; };
   std::sort(generated_robot_items.begin(), generated_robot_items.end(), z_sort);
@@ -3667,7 +3707,8 @@ QJsonArray Scene3DViewportWidget::final_draw_visual_items_export() const
     if (!item_ptr) continue;
     const ScenePreviewWidget::PreviewItem & item = *item_ptr;
     if (!is_generated_urdf_visual_item(item) && !is_locked_urdf_item(item)) continue;
-    if (!item.has_mesh_metadata) continue;
+    if (!generated_urdf_item_has_renderable_geometry(item)) continue;
+    if (!item.has_mesh_metadata && !is_generated_urdf_visual_fallback_item(item) && !item_has_valid_urdf_primitive(item)) continue;
 
     const QString mesh_source = !item.mesh_path.trimmed().isEmpty() ? item.mesh_path : item.source_path;
     const bool required_ur5_fallback = is_generated_urdf_visual_fallback_item(item) && is_required_ur5_viewport_link(item);
@@ -3907,7 +3948,7 @@ bool Scene3DViewportWidget::draw_mesh_preview_if_available(const ScenePreviewWid
                                       const QString & mesh_source = QString(), const QString & canonical_source = QString()) {
     if (!(is_generated_urdf_visual_item(it) || is_locked_urdf_item(it))) return;
     qInfo().noquote() << QStringLiteral(
-      "Scene3D renderer generated_urdf draw: id=%1 link=%2 canonical_link=%3 source_layer=%4 active_visual_source=%5 type=%6 category=%7 mesh_path=%8 canonical_mesh=%9 cache=%10 submitted_to_draw=%11 skip_reason=%12")
+      "Scene3D renderer generated_urdf draw: id=%1 link=%2 canonical_link=%3 source_layer=%4 active_visual_source=%5 type=%6 category=%7 mesh_path=%8 canonical_mesh=%9 cache=%10 submitted_to_draw=%11 skip_reason=%12 applied_scale=[%13,%14,%15]")
       .arg(it.id,
            scene3d_link_name_for_item(it),
            scene3d_canonical_link_name_for_item(it),
@@ -3919,7 +3960,8 @@ bool Scene3DViewportWidget::draw_mesh_preview_if_available(const ScenePreviewWid
            canonical_source.trimmed().isEmpty() ? QStringLiteral("<none>") : canonical_source.trimmed(),
            cache_result,
            submitted,
-           skip_reason);
+           skip_reason)
+      .arg(it.mesh_scale_x, 0, 'g', 8).arg(it.mesh_scale_y, 0, 'g', 8).arg(it.mesh_scale_z, 0, 'g', 8);
   };
 
   if (mesh_preview_mode == ScenePreviewWidget::MeshPreviewMode::Primitives) {
@@ -3938,6 +3980,11 @@ bool Scene3DViewportWidget::draw_mesh_preview_if_available(const ScenePreviewWid
     remember_mesh_rejection_reason(it.id, reason);
     if (meshes_only_mode || always_surface_mesh_warning || scene3d_debug_logs_enabled()) warn_mesh_fallback_once(it.id, reason, path);
   };
+
+  if ((is_generated_urdf_visual_item(it) || is_locked_urdf_item(it)) && !generated_urdf_item_has_renderable_geometry(it)) {
+    log_generated_draw(QStringLiteral("not_attempted"), QStringLiteral("no"), QStringLiteral("not_generated_urdf_renderable_geometry"));
+    return false;
+  }
 
   if (!it.has_mesh_metadata) {
     const QString detail = mesh_rejection_diagnostic_detail(it, it.source_path);


### PR DESCRIPTION
Summary:
- Tightened generated-URDF mesh render eligibility so semantic/environment rows such as robot_base, robot_reach, conveyor, object_a, and warning with environment.yaml sources do not enter the generated mesh renderer.
- Kept baked generated URDF visual transform handling explicit: baked rows use the baked world visual pose path and mesh scale is applied in the final mesh transform, with generated draw diagnostics now reporting applied scale.
- Updated final UR5 viewport audit/smoke contract to require the six visible UR5 arm links while explicitly excluding base_link_inertia as inertial/non-visual unless it is present as a real final draw row.
- Added generated camera visual deduplication by canonical link, mesh source, pose, and source layer so identical camera bodies draw once.

Validation:
- `python3 -m pytest tests/test_scene3d_full_payload_handoff.py -q` — passed, 10 passed.
- `python3 -m pytest tests/test_scene3d_full_payload_handoff.py tests/test_scene3d_gui_smoke_json_output_contract.py tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py` — failed in this container; 33 passed and 12 failed. Remaining failures are ROS-Humble/environment-contract and existing product-default/static fixture expectations not fully satisfiable in this stripped container.
- `git diff --check` — passed.
- ROS workspace build and GUI smoke were not run because `/home/ubuntu/workcell_ws` is not present in this container.

Safety:
- No launch, controller, hardware, runtime execution, or real robot path changes.
- Fake hardware defaults were not modified.

Risks / rollback:
- Renderer classification changes could suppress a generated row if future handoff metadata lacks both mesh metadata and mesh-like source extensions; rollback by reverting commit `c928d9e` if a supported generated visual disappears.
- Audit contract now treats `base_link_inertia` as non-visual by default; revert the audit/smoke contract portions if a later visual index makes it a required visible mesh again.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d973d493083318fee1c6cd3f4d96c)