### PR TITLE
Add UR5 final-draw candidate diagnostics and smoke-wrapper mapping

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke_impl.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke_impl.py
@@ -990,6 +990,25 @@ def _apply_ur5_final_viewport_payload_contract(payload: dict[str, Any]) -> None:
         payload["status"] = "FAIL"
 
 
+def _apply_ur5_candidate_drop_diagnostics(payload: dict[str, Any]) -> None:
+    rows = payload.get("ur5_final_draw_candidate_diagnostics")
+    if not isinstance(rows, list):
+        return
+    dropped_ids: list[str] = []
+    first_stage: dict[str, str] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        row_id = str(row.get("id") or row.get("item_id") or "").strip()
+        stage = str(row.get("first_rejection_stage") or row.get("first_drop_stage") or "").strip()
+        if not row_id or not stage or stage == "accepted":
+            continue
+        dropped_ids.append(row_id)
+        first_stage[row_id] = stage
+    payload["dropped_ur5_row_ids"] = dropped_ids
+    payload["dropped_ur5_first_stage"] = first_stage
+
+
 def _finite_float_list(value: Any, length: int) -> list[float] | None:
     if not isinstance(value, (list, tuple)) or len(value) < length:
         return None
@@ -2353,6 +2372,7 @@ def main() -> int:
             screenshot_path=diag.get("screenshot_path"),
             screenshot_available=diag.get("screenshot_available"),
         )
+        _apply_ur5_candidate_drop_diagnostics(payload)
         if any(key in payload for key in ("final_draw_visual_items", "final_draw_diagnostics", "viewport_visible_items")):
             _apply_ur5_final_viewport_payload_contract(payload)
         _apply_generated_urdf_visual_first_drop_smoke_stage(payload)

--- a/tests/test_scene3d_gui_smoke_json_output_contract.py
+++ b/tests/test_scene3d_gui_smoke_json_output_contract.py
@@ -732,6 +732,70 @@ def test_urdf_flattened_ur5_visual_rows_normalize_link_identity_and_audit_counts
     assert payload["camera_visible_in_final_viewport"] is True
     assert "ur5_final_viewport_links_missing" not in payload.get("blockers", [])
 
+
+def test_ur5_candidate_drop_diagnostics_populates_exact_first_rejection_stage():
+    import scripts.run_workcell_builder_scene3d_gui_smoke as smoke
+
+    payload = {
+        "scene": "ur5_2f_test",
+        "ur5_final_draw_candidate_diagnostics": [
+            {
+                "id": "urdf_visual_missing_metadata",
+                "source_row_index": 4,
+                "link": "shoulder_link",
+                "link_name": "shoulder_link",
+                "canonical_link_name": "shoulder_link",
+                "source_layer": "locked_generated_urdf_visual",
+                "active_visual_source": "generated_urdf_visual",
+                "role": "robot",
+                "category": "robot",
+                "mesh_path": "",
+                "source_path": "",
+                "package_uri": "package://ur_description/meshes/ur5/visual/shoulder.dae",
+                "first_rejection_stage": "missing_mesh_metadata",
+            },
+            {
+                "id": "urdf_visual_missing_cache",
+                "source_row_index": 5,
+                "link": "upper_arm_link",
+                "link_name": "upper_arm_link",
+                "canonical_link_name": "upper_arm_link",
+                "source_layer": "locked_generated_urdf_visual",
+                "active_visual_source": "generated_urdf_visual",
+                "role": "robot",
+                "category": "robot",
+                "mesh_path": "package://ur_description/meshes/ur5/visual/upperarm.dae",
+                "source_path": "",
+                "package_uri": "package://ur_description/meshes/ur5/visual/upperarm.dae",
+                "first_rejection_stage": "missing_mesh_cache",
+            },
+            {
+                "id": "urdf_visual_ok",
+                "source_row_index": 6,
+                "link": "forearm_link",
+                "link_name": "forearm_link",
+                "canonical_link_name": "forearm_link",
+                "source_layer": "locked_generated_urdf_visual",
+                "active_visual_source": "generated_urdf_visual",
+                "role": "robot",
+                "category": "robot",
+                "mesh_path": "package://ur_description/meshes/ur5/visual/forearm.dae",
+                "source_path": "",
+                "package_uri": "package://ur_description/meshes/ur5/visual/forearm.dae",
+                "first_rejection_stage": "accepted",
+            },
+        ],
+    }
+
+    smoke._apply_ur5_candidate_drop_diagnostics(payload)
+
+    assert payload["dropped_ur5_row_ids"] == ["urdf_visual_missing_metadata", "urdf_visual_missing_cache"]
+    assert payload["dropped_ur5_first_stage"] == {
+        "urdf_visual_missing_metadata": "missing_mesh_metadata",
+        "urdf_visual_missing_cache": "missing_mesh_cache",
+    }
+
+
 def test_ur5_final_viewport_payload_requires_visible_links_table_and_camera():
     import scripts.run_workcell_builder_scene3d_gui_smoke as smoke
 

--- a/workcell_builder/workcell_builder/gui/main.cpp
+++ b/workcell_builder/workcell_builder/gui/main.cpp
@@ -790,6 +790,7 @@ private:
         viewport->render_smoke_fallback_frame();
       }
       const auto rc = viewport ? viewport->render_debug_counters() : Scene3DViewportWidget::RenderDebugCounters{};
+      root["ur5_final_draw_candidate_diagnostics"] = viewport->ur5_final_draw_candidate_diagnostics_export();
       const QJsonArray final_draw_diagnostics = viewport->final_draw_diagnostics_export();
       root["final_draw_diagnostics"] = final_draw_diagnostics;
       root["final_draw_visual_items"] = final_draw_diagnostics;

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -1915,6 +1915,7 @@ void Scene3DViewportWidget::ingest_preview_items(const QVector<ScenePreviewWidge
         root["robot_aabb_max"] = QJsonArray{last_robot_aabb_max_.x(), last_robot_aabb_max_.y(), last_robot_aabb_max_.z()};
       }
       root["mesh_diagnostics"] = mesh_diagnostics_export();
+      root["ur5_final_draw_candidate_diagnostics"] = ur5_final_draw_candidate_diagnostics_export();
       root["final_draw_visual_items"] = final_draw_visual_items_export();
       QJsonObject render_debug;
       const auto counters = render_debug_counters();
@@ -3692,6 +3693,85 @@ QJsonArray Scene3DViewportWidget::mesh_diagnostics_export() const
       guard_details.append(gd);
     }
     row["guard_decision_details"] = guard_details;
+    out.append(row);
+  }
+  return out;
+}
+
+QJsonArray Scene3DViewportWidget::ur5_final_draw_candidate_diagnostics_export() const
+{
+  QJsonArray out;
+  QSet<QString> seen_candidate_keys;
+  for (const auto & item : items) {
+    const QString joined_identity = QStringList{
+      item.id, item.display_name, item.category, item.role, item.source_layer, item.active_visual_source,
+      item.mesh_path, item.source_path, item.package_uri, item.visual_index_mesh_uri,
+      scene3d_link_name_for_item(item), scene3d_canonical_link_name_for_item(item), item.metadata_tags
+    }.join(QStringLiteral("|")).toLower();
+    if (!is_required_ur5_viewport_link(item) &&
+        !joined_identity.contains(QStringLiteral("ur5")) &&
+        !joined_identity.contains(QStringLiteral("universal_robot")) &&
+        !joined_identity.contains(QStringLiteral("ur_description"))) {
+      continue;
+    }
+
+    const NormalizedRole role = classify_item_role(item);
+    const bool generated_or_locked = is_generated_urdf_visual_item(item) || is_locked_urdf_item(item);
+    const bool overlay_helper = !generated_or_locked && (is_overlay_only_item(item) || is_overlay_visual_role(role));
+    const QString mesh_source = !item.mesh_path.trimmed().isEmpty() ? item.mesh_path.trimmed() : item.source_path.trimmed();
+
+    QString first_stage;
+    if (!generated_or_locked) {
+      first_stage = QStringLiteral("not_generated_locked_urdf_visual");
+    } else if (overlay_helper) {
+      first_stage = QStringLiteral("classified_helper_overlay");
+    } else if (!generated_urdf_item_has_renderable_geometry(item)) {
+      first_stage = QStringLiteral("missing_renderable_geometry");
+    } else if (!item.has_mesh_metadata && !is_generated_urdf_visual_fallback_item(item) && !item_has_valid_urdf_primitive(item)) {
+      first_stage = QStringLiteral("missing_mesh_metadata");
+    } else if (mesh_source.isEmpty() && !(is_generated_urdf_visual_fallback_item(item) && is_required_ur5_viewport_link(item))) {
+      first_stage = QStringLiteral("missing_mesh_source");
+    } else {
+      const QString duplicate_key = QStringList{
+        scene3d_canonical_link_name_for_item(item), mesh_source, item.source_path.trimmed(), item.package_uri.trimmed(),
+        QString::number(item.x, 'g', 12), QString::number(item.y, 'g', 12), QString::number(item.z, 'g', 12)
+      }.join(QStringLiteral("|"));
+      if (seen_candidate_keys.contains(duplicate_key)) {
+        first_stage = QStringLiteral("duplicate_suppression");
+      } else {
+        seen_candidate_keys.insert(duplicate_key);
+        QString canonical_mesh_source;
+        if (!mesh_source.isEmpty() && !try_resolve_canonical_mesh_path(mesh_source, canonical_mesh_source, &item)) {
+          canonical_mesh_source = QFileInfo(mesh_source).absoluteFilePath();
+        }
+        const auto cache_it = mesh_cache_.constFind(canonical_mesh_source);
+        if (!mesh_source.isEmpty() && cache_it == mesh_cache_.constEnd()) {
+          first_stage = QStringLiteral("missing_mesh_cache");
+        } else if (!mesh_source.isEmpty()) {
+          const MeshCacheEntry & cache = cache_it.value();
+          if (!cache.loaded || !cache.valid || !cache.has_bounds || cache.mesh.triangles.isEmpty()) {
+            first_stage = QStringLiteral("invalid_mesh_bounds");
+          }
+        }
+      }
+    }
+    if (first_stage.isEmpty()) first_stage = QStringLiteral("accepted");
+
+    QJsonObject row;
+    row["id"] = item.id;
+    if (item.source_row_index >= 0) row["source_row_index"] = item.source_row_index;
+    row["link"] = !item.visual_index_link.trimmed().isEmpty() ? item.visual_index_link.trimmed() : scene3d_link_name_for_item(item);
+    row["link_name"] = scene3d_link_name_for_item(item);
+    row["canonical_link_name"] = scene3d_canonical_link_name_for_item(item);
+    row["source_layer"] = item.source_layer;
+    row["active_visual_source"] = item.active_visual_source;
+    row["role"] = item.role;
+    row["category"] = item.category;
+    row["mesh_path"] = item.mesh_path;
+    row["source_path"] = item.source_path;
+    row["package_uri"] = !item.visual_index_package_uri.trimmed().isEmpty() ? item.visual_index_package_uri.trimmed() : item.package_uri;
+    row["first_rejection_stage"] = first_stage;
+    row["first_drop_stage"] = first_stage;
     out.append(row);
   }
   return out;

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -135,6 +135,7 @@ public:
   QString last_camera_fit_target() const;
   bool render_smoke_fallback_frame(QImage * out_image = nullptr);
   QJsonArray mesh_diagnostics_export() const;
+  QJsonArray ur5_final_draw_candidate_diagnostics_export() const;
   QJsonArray final_draw_visual_items_export() const;
   QJsonArray final_draw_diagnostics_export() const;
 


### PR DESCRIPTION
### Motivation

- Surface why generated UR5 visual rows are rejected by the viewport so smoke reports can show exact first-failure reasons for investigation. 
- Provide structured evidence for UR5 candidate rows before final draw assembly to help diagnose missing mesh metadata, missing cache, invalid bounds, duplicates, and overlay classification. 
- Keep the change read-only from a rendering/ordering perspective and avoid touching runtime/hardware paths or defaults.

### Description

- Added `ur5_final_draw_candidate_diagnostics_export()` to `Scene3DViewportWidget` to scan the raw `items` vector and emit candidate rows with fields `id`, `source_row_index`, `link`, `link_name`, `canonical_link_name`, `source_layer`, `active_visual_source`, `role`, `category`, `mesh_path`, `source_path`, `package_uri`, and `first_rejection_stage`/`first_drop_stage` (see `scene3d_viewport_widget.cpp`).
- Mapped internal rejection stages to the requested categories: `not_generated_locked_urdf_visual`, `classified_helper_overlay`, `missing_renderable_geometry`, `missing_mesh_metadata`, `missing_mesh_source`, `duplicate_suppression`, `missing_mesh_cache`, and `invalid_mesh_bounds` (exported as the first rejection stage).
- Surface the diagnostic array in smoke/diagnostic JSON output (`ur5_final_draw_candidate_diagnostics`) prior to final-draw diagnostics and also emit it in the diagnostics file path when `SCENE3D_MESH_DIAGNOSTICS_JSON` is used (changes in `scene3d_viewport_widget.cpp` and `main.cpp`).
- Updated the smoke wrapper implementation in `scripts/run_workcell_builder_scene3d_gui_smoke_impl.py` to consume the new array and populate `dropped_ur5_row_ids` and `dropped_ur5_first_stage` from the diagnostic rows.
- Added/extended a Python contract test `test_ur5_candidate_drop_diagnostics_populates_exact_first_rejection_stage` that builds a sample payload of UR5-style `urdf_visual_*` rows and asserts rejected rows expose the exact rejection reason (test in `tests/test_scene3d_gui_smoke_json_output_contract.py`).

### Testing

- Ran the focused contract test with `python3 -m pytest tests/test_scene3d_gui_smoke_json_output_contract.py::test_ur5_candidate_drop_diagnostics_populates_exact_first_rejection_stage -q` and it passed. 
- Verified Python modules compile with `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke_impl.py scripts/run_workcell_builder_scene3d_gui_smoke.py` which completed without errors. 
- Ran the broader smoke JSON contract test file with `python3 -m pytest tests/test_scene3d_gui_smoke_json_output_contract.py -q`; the new focused test passed but the full file fails in this environment due to pre-existing/environment-sensitive issues (ROS Humble unavailable and some UR5 final-viewport expectation drift) and are unrelated to the new diagnostic export.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e5a3cb94c8331bb3ddf3f9d7cfbad)