### PR TITLE
Protect raw UR5 visual mesh ingestion and normalize UR5 link/mesh identity

### DIFF
--- a/tests/test_scene3d_fresh_urdf_visual_ingestion_contract.py
+++ b/tests/test_scene3d_fresh_urdf_visual_ingestion_contract.py
@@ -21,7 +21,7 @@ def _final_draw_rows_from_fresh_visual_index_rows(visual_rows):
                 "link_name": link,
                 "canonical_link_name": link,
                 "source_layer": "locked_generated_urdf_visual",
-                "active_visual_source": "generated_urdf_visual",
+                "active_visual_source": "mesh_preview",
                 "visible": True,
                 "rendered": True,
             }
@@ -34,7 +34,7 @@ def test_fresh_urdf_visual_preview_items_preserve_visual_index_identity_fields()
     assert "p.visual_index_link_name = raw_visual_link_name.isEmpty() ? stable_visual_link_identity : raw_visual_link_name;" in MAIN
     assert "p.source_row_index = source_row_index;" in MAIN
     assert 'p.source_layer = QStringLiteral("locked_generated_urdf_visual");' in MAIN
-    assert 'p.active_visual_source = QStringLiteral("generated_urdf_visual");' in MAIN
+    assert 'p.active_visual_source = QStringLiteral("mesh_preview");' in MAIN
 
 
 def test_viewport_link_resolution_prefers_visual_index_fields_before_legacy_ids():
@@ -66,4 +66,4 @@ def test_fresh_ur5_urdf_visual_rows_survive_to_final_draw_visual_items():
     assert set(required_links) <= retained_links
     assert all(row["id"].startswith("urdf_visual_") for row in final_draw_visual_items)
     assert all(row["source_layer"] == "locked_generated_urdf_visual" for row in final_draw_visual_items)
-    assert all(row["active_visual_source"] == "generated_urdf_visual" for row in final_draw_visual_items)
+    assert all(row["active_visual_source"] == "mesh_preview" for row in final_draw_visual_items)

--- a/tests/test_scene3d_visual_loader_filtering.py
+++ b/tests/test_scene3d_visual_loader_filtering.py
@@ -33,16 +33,61 @@ def _mesh_identity(item: dict) -> str:
     )
 
 
+_PROTECTED_UR5_LINKS = {
+    "base_link_inertia",
+    "shoulder_link",
+    "upper_arm_link",
+    "forearm_link",
+    "wrist_1_link",
+    "wrist_2_link",
+    "wrist_3_link",
+}
+
+
+def _normalized_ur5_link(item: dict) -> str:
+    for key in ("link", "link_name", "canonical_link_name"):
+        link = _token(item.get(key, ""))
+        if link in _PROTECTED_UR5_LINKS:
+            return link
+    id_token = _token(item.get("id", ""))
+    for link in _PROTECTED_UR5_LINKS:
+        if id_token == link or f"_{link}_" in id_token or id_token.startswith(f"{link}_") or id_token.endswith(f"_{link}"):
+            return link
+    return ""
+
+
+def _normalized_mesh_identity(item: dict) -> str:
+    parts = [
+        _token(str(item.get(key, "")))
+        for key in ("package_uri", "mesh_uri", "source_path", "mesh_path", "resolved_source_path", "resolved_path")
+        if str(item.get(key, "")).strip()
+    ]
+    return "__".join(parts) or "mesh_missing"
+
+
+def _is_protected_ur5_generated_visual_row(item: dict) -> bool:
+    link = _normalized_ur5_link(item)
+    mesh_mix = "|".join(str(item.get(key, "")).lower() for key in (
+        "package_uri", "mesh_uri", "source_path", "mesh_path", "resolved_source_path", "resolved_path"
+    ))
+    return (
+        bool(link)
+        and _token(item.get("geometry_type") or item.get("type") or "") == "mesh"
+        and "ur_description/meshes/ur5/visual" in mesh_mix
+    )
+
+
 def _generated_row_key(item: dict, source_row_index: int) -> str:
     visual = item.get("visual_name") or item.get("visual") or item.get("id") or "visual_missing"
     row_index = item.get("source_row_index")
     if row_index in (None, ""):
         row_index = source_row_index
+    link = _normalized_ur5_link(item) if _is_protected_ur5_generated_visual_row(item) else ""
     return "generated_urdf_row::{}::{}::{}::{}".format(
-        _token(item.get("link_name") or item.get("link") or item.get("object_id") or item.get("object") or "link_missing"),
+        link or _token(item.get("link") or item.get("link_name") or item.get("canonical_link_name") or item.get("object_id") or item.get("object") or "link_missing"),
         _token(visual),
         _token(str(row_index)),
-        _token(_mesh_identity(item)),
+        _normalized_mesh_identity(item) if link else _token(_mesh_identity(item)),
     )
 
 
@@ -87,7 +132,7 @@ def _retained_rows(items: list[dict]) -> list[dict]:
 
 
 def _filtered_links(items: list[dict]) -> set[str]:
-    return {_token(item.get("link", "")) for item in _retained_rows(items)}
+    return {_normalized_ur5_link(item) or _token(item.get("link") or item.get("link_name") or item.get("canonical_link_name") or "") for item in _retained_rows(items)}
 
 
 def test_mainwindow_visual_loader_distinguishes_identity_fallback_and_shared_mesh_uri() -> None:
@@ -342,6 +387,84 @@ def test_fresh_real_xacro_style_urdf_visual_ids_retain_ur5_and_robotiq_rows() ->
     } <= retained
     assert "gripper_base_link" in retained
     assert any("finger" in link for link in retained)
+
+
+def test_raw_ur5_mesh_rows_without_visual_source_metadata_are_protected() -> None:
+    items = [
+        {
+            "id": f"urdf_visual_{index}_{link}",
+            "source_row_index": index,
+            "link_name": link,
+            "visual_name": f"visual_{index}",
+            "type": "mesh",
+            "mesh_uri": f"package://ur_description/meshes/ur5/visual/{link}.dae",
+        }
+        for index, link in enumerate(
+            ["base_link_inertia", "shoulder_link", "upper_arm_link", "forearm_link", "wrist_1_link", "wrist_2_link", "wrist_3_link"]
+        )
+    ]
+
+    retained = _filtered_links(items)
+
+    assert _PROTECTED_UR5_LINKS <= retained
+    assert all(_is_protected_ur5_generated_visual_row(item) for item in items)
+
+
+def test_ur5_link_can_be_recovered_from_raw_urdf_visual_id() -> None:
+    items = [
+        {
+            "id": "urdf_visual_12_shoulder_link_visual",
+            "source_row_index": 12,
+            "visual_name": "shoulder_visual",
+            "geometry_type": "mesh",
+            "resolved_path": "/tmp/ws/install/ur_description/share/ur_description/meshes/ur5/visual/shoulder.dae",
+        }
+    ]
+
+    retained_rows = _retained_rows(items)
+
+    assert len(retained_rows) == 1
+    assert _normalized_ur5_link(retained_rows[0]) == "shoulder_link"
+    assert _filtered_links(items) == {"shoulder_link"}
+
+
+def test_exact_duplicate_protected_ur5_rows_are_skipped_without_suppressing_other_visuals() -> None:
+    duplicate = {
+        "id": "urdf_visual_2_shoulder_link_visual",
+        "source_row_index": 2,
+        "link": "shoulder_link",
+        "visual_name": "shoulder_visual",
+        "geometry_type": "mesh",
+        "package_uri": "package://ur_description/meshes/ur5/visual/shoulder.dae",
+    }
+    distinct_same_link = {
+        **duplicate,
+        "id": "urdf_visual_3_shoulder_link_collision_visual",
+        "source_row_index": 3,
+        "visual_name": "shoulder_collision_visual",
+    }
+    robotiq = {
+        "id": "urdf_visual_30_left_inner_finger",
+        "source_row_index": 30,
+        "link": "left_inner_finger",
+        "visual_name": "left_inner_finger_visual",
+        "geometry_type": "mesh",
+        "package_uri": "package://robotiq_85_description/meshes/visual/inner_finger.dae",
+    }
+
+    retained_rows = _retained_rows([duplicate, dict(duplicate), distinct_same_link, robotiq])
+
+    assert len([row for row in retained_rows if _normalized_ur5_link(row) == "shoulder_link"]) == 2
+    assert len([row for row in retained_rows if row.get("link") == "left_inner_finger"]) == 1
+
+
+def test_mainwindow_logs_protected_ur5_ingestion_and_renderer_handoff_lines() -> None:
+    src = MAINWINDOW.read_text(encoding="utf-8")
+    assert "Scene3D preserved generated URDF robot mesh row before preview handoff" in src
+    assert "link=%2" in src
+    assert "Scene3D generated URDF robot mesh renderer handoff" in src
+    assert 'p.active_visual_source = QStringLiteral("mesh_preview");' in src
+    assert 'p.category = QStringLiteral("robot_arm");' in src
 
 
 def test_old_stale_generated_urdf_style_rows_still_retain_ur5_rows() -> None:

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -9293,7 +9293,7 @@ void MainWindow::populate_scene_hierarchy()
                  canonical_scene3d_token(row_index));
         };
         auto visual_item_canonical_link = [&](const YAML::Node & node) {
-          return canonical_scene3d_token(visual_index_first_scalar_value(node, {"link_name", "link", "object_id", "object"}));
+          return canonical_scene3d_token(visual_index_first_scalar_value(node, {"link", "link_name", "canonical_link_name", "object_id", "object"}));
         };
         auto visual_item_canonical_visual = [&](const YAML::Node & node) {
           return canonical_scene3d_token(visual_index_first_scalar_value(node, {"visual_name", "visual", "id"}));
@@ -9305,56 +9305,72 @@ void MainWindow::populate_scene_hierarchy()
         };
         auto visual_item_mesh_identity = [&](const YAML::Node & node) {
           return visual_index_first_scalar_value(node, {
-            "package_uri", "mesh_uri", "resolved_source_path", "resolved_path", "source_path", "mesh_path"});
+            "package_uri", "mesh_uri", "source_path", "mesh_path", "resolved_source_path", "resolved_path"});
+        };
+        auto visual_item_normalized_mesh_identity = [&](const YAML::Node & node) {
+          QStringList parts;
+          for (const char * field : {"package_uri", "mesh_uri", "source_path", "mesh_path", "resolved_source_path", "resolved_path"}) {
+            const QString value = visual_index_row_scalar_value(node, field).trimmed();
+            if (!value.isEmpty()) parts << canonical_scene3d_token(value);
+          }
+          return parts.isEmpty() ? QStringLiteral("mesh_missing") : parts.join(QStringLiteral("__"));
         };
         auto visual_item_generated_row_key = [&](const YAML::Node & node, int source_row_index) {
           const QString link = visual_item_canonical_link(node);
           const QString visual = visual_item_canonical_visual(node);
           const QString row_index = visual_item_source_row_token(node, source_row_index);
-          const QString mesh_identity = visual_item_mesh_identity(node);
+          const QString mesh_identity = visual_item_normalized_mesh_identity(node);
           return QStringLiteral("generated_urdf_row::%1::%2::%3::%4")
             .arg(link.isEmpty() ? QStringLiteral("link_missing") : link,
                  visual.isEmpty() ? QStringLiteral("visual_missing") : visual,
                  row_index.isEmpty() ? QStringLiteral("row_missing") : row_index,
                  mesh_identity.isEmpty() ? QStringLiteral("mesh_missing") : canonical_scene3d_token(mesh_identity));
         };
+        static const QSet<QString> protected_ur5_links = {
+          QStringLiteral("base_link_inertia"),
+          QStringLiteral("shoulder_link"),
+          QStringLiteral("upper_arm_link"),
+          QStringLiteral("forearm_link"),
+          QStringLiteral("wrist_1_link"),
+          QStringLiteral("wrist_2_link"),
+          QStringLiteral("wrist_3_link")
+        };
+        auto normalized_protected_ur5_link = [&](const YAML::Node & node) {
+          for (const char * field : {"link", "link_name", "canonical_link_name"}) {
+            const QString link = canonical_scene3d_token(visual_index_row_scalar_value(node, field));
+            if (protected_ur5_links.contains(link)) return link;
+          }
+          const QString id_token = canonical_scene3d_token(visual_index_row_scalar_value(node, "id"));
+          for (const QString & link : protected_ur5_links) {
+            if (id_token == link || id_token.contains(QStringLiteral("_%1_").arg(link)) ||
+                id_token.startsWith(QStringLiteral("%1_").arg(link)) ||
+                id_token.endsWith(QStringLiteral("_%1").arg(link))) {
+              return link;
+            }
+          }
+          return QString();
+        };
+        const bool processing_generated_scene_visual_mesh_index = true;
         auto is_protected_ur5_generated_visual_row = [&](const YAML::Node & node) {
-          const QString source_layer = canonical_scene3d_token(visual_index_first_scalar_value(node, {"source_layer", "layer"}));
-          const QString source = canonical_scene3d_token(visual_index_first_scalar_value(node, {"source", "visual_index_source"}));
-          const bool generated_urdf_source =
-            source_layer == QStringLiteral("locked_generated_urdf_visual") ||
-            source_layer == QStringLiteral("generated_urdf_visual") ||
-            source == QStringLiteral("urdf_flattened") ||
-            source.contains(QStringLiteral("generated_urdf")) ||
-            source.contains(QStringLiteral("flattened"));
-          if (!generated_urdf_source) return false;
-          const QString active_visual_source = canonical_scene3d_token(visual_index_first_scalar_value(node, {"active_visual_source", "visual_source"}));
-          const QString mesh_identity = visual_item_mesh_identity(node);
-          const bool credible_generated_mesh_metadata =
-            path_has_mesh_asset_extension(mesh_identity) ||
-            path_has_mesh_asset_extension(visual_index_first_scalar_value(node, {"filename"}));
-          if (active_visual_source != QStringLiteral("mesh_preview") && !credible_generated_mesh_metadata) return false;
+          const QString raw_id = visual_index_row_scalar_value(node, "id").trimmed();
+          const bool generated_visual_index_row =
+            raw_id.startsWith(QStringLiteral("urdf_visual_")) ||
+            processing_generated_scene_visual_mesh_index;
+          if (!generated_visual_index_row) return false;
+          const QString normalized_link = normalized_protected_ur5_link(node);
+          if (normalized_link.isEmpty()) return false;
           const QString geometry = canonical_scene3d_token(visual_index_first_scalar_value(node, {"geometry_type", "type"}));
           if (geometry != QStringLiteral("mesh")) return false;
           const QString source_mix = QStringList{
             visual_index_row_scalar_value(node, "package_uri"),
             visual_index_row_scalar_value(node, "mesh_uri"),
-            visual_index_row_scalar_value(node, "mesh_path"),
             visual_index_row_scalar_value(node, "source_path"),
+            visual_index_row_scalar_value(node, "mesh_path"),
             visual_index_row_scalar_value(node, "resolved_path"),
             visual_index_row_scalar_value(node, "resolved_source_path")
           }.join(QStringLiteral("|")).toLower();
-          if (!source_mix.contains(QStringLiteral("ur_description/meshes/ur5/visual"))) return false;
-          static const QSet<QString> protected_ur5_links = {
-            QStringLiteral("base_link_inertia"),
-            QStringLiteral("shoulder_link"),
-            QStringLiteral("upper_arm_link"),
-            QStringLiteral("forearm_link"),
-            QStringLiteral("wrist_1_link"),
-            QStringLiteral("wrist_2_link"),
-            QStringLiteral("wrist_3_link")
-          };
-          return protected_ur5_links.contains(visual_item_canonical_link(node));
+          return source_mix.contains(QStringLiteral("ur_description/meshes/ur5/visual")) ||
+                 source_mix.contains(QStringLiteral("package://ur_description/meshes/ur5/visual"));
         };
         auto assert_scene3d_generated_urdf_identity_namespace_regression = [&]() {
           QSet<QString> regression_preview_ids;
@@ -9464,21 +9480,31 @@ void MainWindow::populate_scene_hierarchy()
           generated_visual_row_key = visual_item_generated_row_key(v, source_row_index);
           generated_row_diagnostic = generated_visual_row_diagnostic(v, source_row_index, generated_visual_row_key, id);
           const bool protected_ur5_generated_mesh_row = is_protected_ur5_generated_visual_row(v);
+          const QString protected_ur5_link = protected_ur5_generated_mesh_row ? normalized_protected_ur5_link(v) : QString();
           if (protected_ur5_generated_mesh_row) {
+            const QString visual = visual_item_canonical_visual(v);
+            const QString row_index = visual_item_source_row_token(v, source_row_index);
+            const QString mesh_identity = visual_item_normalized_mesh_identity(v);
+            generated_visual_row_key = QStringLiteral("generated_urdf_row::%1::%2::%3::%4")
+              .arg(protected_ur5_link,
+                   visual.isEmpty() ? QStringLiteral("visual_missing") : visual,
+                   row_index.isEmpty() ? QStringLiteral("row_missing") : row_index,
+                   mesh_identity.isEmpty() ? QStringLiteral("mesh_missing") : mesh_identity);
+            generated_row_diagnostic = generated_visual_row_diagnostic(v, source_row_index, generated_visual_row_key, id);
             if (protected_ur5_generated_visual_row_keys.contains(generated_visual_row_key)) {
               ++skipped_true_duplicate_mesh_rows;
               const QString reason = add_skip_reason(QStringLiteral("duplicate_generated_visual_index_row"));
               append_generated_visual_row_diagnostic(generated_row_diagnostic, QStringLiteral("duplicate_generated_visual_index_row"), reason);
               append_visual_ingestion_diagnostic(v, raw_id, id, reason);
               append_studio_log(QStringLiteral("Scene3D skipped true duplicate generated URDF robot mesh row: key=%1 link=%2 visual=%3 mesh=%4")
-                .arg(generated_visual_row_key, visual_item_canonical_link(v), visual_item_canonical_visual(v), visual_item_mesh_identity(v)));
+                .arg(generated_visual_row_key, protected_ur5_link, visual_item_canonical_visual(v), visual_item_mesh_identity(v)));
               continue;
             }
             protected_ur5_generated_visual_row_keys.insert(generated_visual_row_key);
             generated_visual_row_keys.insert(generated_visual_row_key);
             ++preserved_generated_urdf_robot_mesh_rows;
-            append_studio_log(QStringLiteral("Scene3D preserved generated URDF robot mesh row before duplicate filtering: key=%1 link=%2 visual=%3 mesh=%4")
-              .arg(generated_visual_row_key, visual_item_canonical_link(v), visual_item_canonical_visual(v), visual_item_mesh_identity(v)));
+            append_studio_log(QStringLiteral("Scene3D preserved generated URDF robot mesh row before preview handoff: key=%1 link=%2 visual=%3 mesh=%4")
+              .arg(generated_visual_row_key, protected_ur5_link, visual_item_canonical_visual(v), visual_item_mesh_identity(v)));
           } else if (generated_visual_row_keys.contains(generated_visual_row_key)) {
             ++skipped_true_duplicate_mesh_rows;
             const QString reason = add_skip_reason(QStringLiteral("duplicate_generated_visual_index_row"));
@@ -9611,12 +9637,16 @@ void MainWindow::populate_scene_hierarchy()
           }
           ScenePreviewWidget::PreviewItem p;
           p.id = id;
-          const QString raw_visual_link = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "link")).trimmed();
-          const QString raw_visual_link_name = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "link_name")).trimmed();
+          const QString raw_visual_link_from_row = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "link")).trimmed();
+          const QString raw_visual_link_name_from_row = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "link_name")).trimmed();
+          const QString normalized_ur5_preview_link = protected_ur5_generated_mesh_row ? protected_ur5_link : QString();
+          const QString raw_visual_link = normalized_ur5_preview_link.isEmpty() ? raw_visual_link_from_row : normalized_ur5_preview_link;
+          const QString raw_visual_link_name = normalized_ur5_preview_link.isEmpty() ? raw_visual_link_name_from_row : normalized_ur5_preview_link;
           const QString stable_visual_link_identity = raw_visual_link_name.isEmpty() ? raw_visual_link : raw_visual_link_name;
           p.display_name = stable_visual_link_identity.isEmpty() ? id : stable_visual_link_identity;
           p.frame_id = p.display_name;
           p.category = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "category"));
+          if (protected_ur5_generated_mesh_row) p.category = QStringLiteral("robot_arm");
           if (p.category.trimmed().isEmpty()) p.category = "URDF Visual";
           p.role = p.category;
           p.status = "ready";
@@ -9836,6 +9866,19 @@ void MainWindow::populate_scene_hierarchy()
           p.selectable = true;
           if (geometry_type == QStringLiteral("mesh")) {
             p.active_visual_source = QStringLiteral("generated_urdf_visual");
+          }
+          if (protected_ur5_generated_mesh_row) {
+            p.source_layer = QStringLiteral("locked_generated_urdf_visual");
+            p.active_visual_source = QStringLiteral("mesh_preview");
+            p.category = QStringLiteral("robot_arm");
+            p.role = p.category;
+            p.visual_index_link = protected_ur5_link;
+            p.visual_index_link_name = protected_ur5_link;
+            p.display_name = protected_ur5_link;
+            p.frame_id = protected_ur5_link;
+            append_studio_log(QStringLiteral("Scene3D generated URDF robot mesh renderer handoff: item_id=%1 link=%2 source_layer=%3 active_visual_source=%4 mesh=%5")
+              .arg(p.id, protected_ur5_link, p.source_layer, p.active_visual_source,
+                   p.package_uri.trimmed().isEmpty() ? p.source_path : p.package_uri));
           }
           if (!p.visual_index_mesh_uri.trimmed().isEmpty() && p.package_uri.trimmed().isEmpty()) {
             p.package_uri = p.visual_index_mesh_uri.trimmed();


### PR DESCRIPTION
### Motivation
- The Scene3D visual mesh ingestion was missing some UR5 generated visuals when rows lacked `source_layer`/`active_visual_source`/`canonical_link_name`, causing product view drift for the canonical UR5 arm scene. 
- We need stable deduplication that only suppresses exact duplicates for the same UR5 link/visual/mesh identity and not drop distinct UR5 or tool meshes. 
- The renderer handoff must be authoritative for generated URDF visuals so protected UR5 meshes always present mesh-backed previews with clear metadata.

### Description
- Relaxed protected-UR5 detection so rows no longer require `source_layer`, `active_visual_source`, or `canonical_link_name`, and accept raw `urdf_visual_*` IDs and rows from `generated/scene_visual_mesh_index.json` as candidates for protection. (updated `mainwindow.cpp` ingestion block). 
- Added UR5 link normalization that checks `link`, `link_name`, `canonical_link_name`, and attempts to recover known UR5 link tokens from `id`. 
- Normalized mesh/source identity by combining `package_uri`, `mesh_uri`, `source_path`, `mesh_path`, `resolved_source_path`, and `resolved_path` into a canonical mesh token used for duplicate-scope decisions. 
- Scoped exact-duplicate suppression to protected UR5 rows using the normalized UR5 link + visual/row + normalized mesh identity, and preserved distinct visuals (e.g., Robotiq/tool/table/camera). 
- After a protected UR5 row survives duplicate suppression, force generated visual metadata prior to preview handoff: `source_layer = locked_generated_urdf_visual`, `active_visual_source = mesh_preview`, `category = robot_arm` (and `role`), and set `visual_index_link`/`visual_index_link_name` to the normalized UR5 link; also added preservation and renderer handoff log lines. 
- Preserved existing semantic/helper skipping behavior for rows such as `robot_base`, `robot_reach`, `conveyor`, `object_a`, `warning`, and non-credible `environment.yaml` entries. 
- Tests added/updated: `tests/test_scene3d_visual_loader_filtering.py` (added focused UR5 raw-row, link-recovery, duplicate-suppression, logging checks) and `tests/test_scene3d_fresh_urdf_visual_ingestion_contract.py` (updated to expect `mesh_preview` handoff). 

### Testing
- Ran the focused test suite: `python3 -m pytest tests/test_scene3d_visual_loader_filtering.py tests/test_scene3d_fresh_urdf_visual_ingestion_contract.py` and all collected tests passed: `14 passed in 0.80s`. 
- New/modified tests assert preservation of the six UR5 arm links from raw/generic visual rows, that exact protected duplicates are suppressed while other visuals remain, and that mainwindow logs include the preservation and renderer handoff lines (these checks passed). 
- No changes were made to launch files, controllers, runtime services, or hardware parameters and fake-hardware defaults remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e638dc3f48331b182cd10345d0d1e)