### PR TITLE
Protect UR5 generated visuals by canonical mesh identity

### DIFF
--- a/tests/test_scene3d_visual_loader_filtering.py
+++ b/tests/test_scene3d_visual_loader_filtering.py
@@ -59,7 +59,7 @@ def _normalized_ur5_link(item: dict) -> str:
 def _normalized_mesh_identity(item: dict) -> str:
     parts = [
         _token(str(item.get(key, "")))
-        for key in ("package_uri", "mesh_uri", "source_path", "mesh_path", "resolved_source_path", "resolved_path")
+        for key in ("package_uri", "mesh_uri", "source_path", "mesh_path", "resolved_source_path", "resolved_path", "filename")
         if str(item.get(key, "")).strip()
     ]
     return "__".join(parts) or "mesh_missing"
@@ -68,12 +68,15 @@ def _normalized_mesh_identity(item: dict) -> str:
 def _is_protected_ur5_generated_visual_row(item: dict) -> bool:
     link = _normalized_ur5_link(item)
     mesh_mix = "|".join(str(item.get(key, "")).lower() for key in (
-        "package_uri", "mesh_uri", "source_path", "mesh_path", "resolved_source_path", "resolved_path"
+        "package_uri", "mesh_uri", "source_path", "mesh_path", "resolved_path", "resolved_source_path", "filename"
     ))
+    mesh_token = _token(mesh_mix)
+    known_ur5_mesh_files = {"base_dae", "shoulder_dae", "upperarm_dae", "forearm_dae", "wrist1_dae", "wrist2_dae", "wrist3_dae"}
     return (
         bool(link)
         and _token(item.get("geometry_type") or item.get("type") or "") == "mesh"
-        and "ur_description/meshes/ur5/visual" in mesh_mix
+        and all(part in mesh_token for part in ("ur_description", "meshes", "ur5", "visual"))
+        and any(mesh_file in mesh_token for mesh_file in known_ur5_mesh_files)
     )
 
 
@@ -287,6 +290,73 @@ def _credible_physical_mesh_rows(items: list[dict]) -> list[dict]:
     return physical
 
 
+def _ur5_18_row_fixture_with_path_field(path_field: str, path_prefix: str) -> list[dict]:
+    ur5_meshes = {
+        "base_link_inertia": "base.dae",
+        "shoulder_link": "shoulder.dae",
+        "upper_arm_link": "upperarm.dae",
+        "forearm_link": "forearm.dae",
+        "wrist_1_link": "wrist1.dae",
+        "wrist_2_link": "wrist2.dae",
+        "wrist_3_link": "wrist3.dae",
+    }
+    rows = []
+    for index, (link, filename) in enumerate(ur5_meshes.items()):
+        rows.append(
+            {
+                "id": f"urdf_visual_{index}_{link}",
+                "source_row_index": index,
+                "link": link,
+                "visual_name": f"{link}_visual",
+                "source": "urdf_flattened",
+                "source_layer": "locked_generated_urdf_visual",
+                "active_visual_source": "mesh_preview",
+                "role": "robot",
+                "category": "locked_generated_urdf_visual",
+                "geometry_type": "mesh",
+                path_field: f"{path_prefix}/{filename}",
+                "filename": filename,
+            }
+        )
+    rows.extend(
+        [
+            {"id": "robot_base", "link": "robot_base", "visual_name": "robot_base_helper", "role": "robot", "category": "helper", "geometry_type": "box"},
+            {"id": "robot_reach", "link": "robot_reach", "visual_name": "robot_reach_helper", "role": "robot", "category": "robot_reach", "geometry_type": "sphere"},
+            {"id": "object_a", "link": "object_a", "visual_name": "object_a", "role": "object", "category": "pick_object", "geometry_type": "box"},
+            {"id": "conveyor", "link": "conveyor", "visual_name": "conveyor", "role": "environment", "category": "conveyor", "geometry_type": "box"},
+            {"id": "warning_anchor_1", "link": "warning", "visual_name": "warning_badge", "role": "warning", "category": "warning_anchor", "geometry_type": "box"},
+            {"id": "left_inner_finger", "link": "left_inner_finger", "visual_name": "left_inner_finger", "geometry_type": "mesh", "package_uri": "package://robotiq_85_description/meshes/visual/inner_finger.dae"},
+            {"id": "right_inner_finger", "link": "right_inner_finger", "visual_name": "right_inner_finger", "geometry_type": "mesh", "package_uri": "package://robotiq_85_description/meshes/visual/inner_finger.dae"},
+            {"id": "table", "link": "table", "visual_name": "table", "geometry_type": "mesh", "package_uri": "package://workbench_description/meshes/visual/table.stl"},
+            {"id": "camera_link", "link": "camera_link", "visual_name": "camera", "geometry_type": "mesh", "package_uri": "package://realsense2_description/meshes/d435.dae"},
+            {"id": "object_a_bounds_box", "link": "object_a", "visual_name": "object_a_bounds_box", "role": "helper", "category": "bounds_box", "geometry_type": "box"},
+            {"id": "conveyor_warning", "link": "conveyor", "visual_name": "warning", "role": "warning", "category": "warning", "geometry_type": "box"},
+        ]
+    )
+    assert len(rows) == 18
+    return rows
+
+
+def test_18_row_fixture_retains_all_ur5_rows_with_package_uri_paths() -> None:
+    items = _ur5_18_row_fixture_with_path_field("package_uri", "package://ur_description/meshes/ur5/visual")
+    retained = _filtered_links(items)
+
+    assert _PROTECTED_UR5_LINKS <= retained
+    assert all(_is_protected_ur5_generated_visual_row(item) for item in items[:7])
+    assert not any(_is_protected_ur5_generated_visual_row(item) for item in items[7:])
+
+
+def test_18_row_fixture_retains_all_ur5_rows_with_resolved_local_paths() -> None:
+    items = _ur5_18_row_fixture_with_path_field(
+        "resolved_path",
+        "/home/user/workcell_ws/install/ur_description/share/ur_description/meshes/ur5/visual",
+    )
+    retained = _filtered_links(items)
+
+    assert _PROTECTED_UR5_LINKS <= retained
+    assert all(_is_protected_ur5_generated_visual_row(item) for item in items[:7])
+    assert not any(_is_protected_ur5_generated_visual_row(item) for item in items[7:])
+
 def test_focused_m1_fixture_retains_physical_ur5_robotiq_table_and_camera_rows() -> None:
     items = _focused_m1_visual_items()
     retained_rows = _retained_rows(items)
@@ -397,10 +467,18 @@ def test_raw_ur5_mesh_rows_without_visual_source_metadata_are_protected() -> Non
             "link_name": link,
             "visual_name": f"visual_{index}",
             "type": "mesh",
-            "mesh_uri": f"package://ur_description/meshes/ur5/visual/{link}.dae",
+            "mesh_uri": f"package://ur_description/meshes/ur5/visual/{filename}",
         }
-        for index, link in enumerate(
-            ["base_link_inertia", "shoulder_link", "upper_arm_link", "forearm_link", "wrist_1_link", "wrist_2_link", "wrist_3_link"]
+        for index, (link, filename) in enumerate(
+            {
+                "base_link_inertia": "base.dae",
+                "shoulder_link": "shoulder.dae",
+                "upper_arm_link": "upperarm.dae",
+                "forearm_link": "forearm.dae",
+                "wrist_1_link": "wrist1.dae",
+                "wrist_2_link": "wrist2.dae",
+                "wrist_3_link": "wrist3.dae",
+            }.items()
         )
     ]
 

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -9367,10 +9367,32 @@ void MainWindow::populate_scene_hierarchy()
             visual_index_row_scalar_value(node, "source_path"),
             visual_index_row_scalar_value(node, "mesh_path"),
             visual_index_row_scalar_value(node, "resolved_path"),
-            visual_index_row_scalar_value(node, "resolved_source_path")
+            visual_index_row_scalar_value(node, "resolved_source_path"),
+            visual_index_row_scalar_value(node, "filename")
           }.join(QStringLiteral("|")).toLower();
-          return source_mix.contains(QStringLiteral("ur_description/meshes/ur5/visual")) ||
-                 source_mix.contains(QStringLiteral("package://ur_description/meshes/ur5/visual"));
+          const QString source_token = canonical_scene3d_token(source_mix);
+          static const QSet<QString> protected_ur5_mesh_files = {
+            QStringLiteral("base_dae"),
+            QStringLiteral("shoulder_dae"),
+            QStringLiteral("upperarm_dae"),
+            QStringLiteral("forearm_dae"),
+            QStringLiteral("wrist1_dae"),
+            QStringLiteral("wrist2_dae"),
+            QStringLiteral("wrist3_dae")
+          };
+          const bool has_ur_description_ur5_visual_path =
+            source_token.contains(QStringLiteral("ur_description")) &&
+            source_token.contains(QStringLiteral("meshes")) &&
+            source_token.contains(QStringLiteral("ur5")) &&
+            source_token.contains(QStringLiteral("visual"));
+          bool has_known_ur5_mesh_file = false;
+          for (const QString & mesh_file : protected_ur5_mesh_files) {
+            if (source_token.contains(mesh_file)) {
+              has_known_ur5_mesh_file = true;
+              break;
+            }
+          }
+          return has_ur_description_ur5_visual_path && has_known_ur5_mesh_file;
         };
         auto assert_scene3d_generated_urdf_identity_namespace_regression = [&]() {
           QSet<QString> regression_preview_ids;


### PR DESCRIPTION
### Motivation
- Ensure generated URDF UR5 visual rows are only protected when they are mesh-backed UR5 robot visuals and the mesh identity clearly belongs to the canonical `ur_description` UR5 visual assets.
- Avoid misclassifying semantic helper/overlay rows (e.g., `robot_base`, `robot_reach`, `object_a`, `conveyor`, `warning`) as protected robot geometry.

### Description
- Updated `populate_scene_hierarchy` local lambda `is_protected_ur5_generated_visual_row` in `workcell_builder/workcell_builder/gui/mainwindow.cpp` to inspect all available row fields (`package_uri`, `mesh_uri`, `source_path`, `mesh_path`, `resolved_path`, `resolved_source_path`, `filename`) and to use `canonical_scene3d_token` before testing path tokens. 
- Protection now requires: normalized UR5 link (from `normalized_protected_ur5_link`), `geometry == mesh`, presence of `ur_description` + `meshes` + `ur5` + `visual` in the tokenized path mix, and presence of a known UR5 mesh filename token (explicit canonical filenames such as `base_dae`, `shoulder_dae`, `upperarm_dae`, `forearm_dae`, `wrist1_dae`, `wrist2_dae`, `wrist3_dae`).
- Mirrored the new logic in tests by adding `filename` to normalized mesh identity and mesh-match checks, updating raw UR5 fixture filenames to canonical names, and adding an 18-row fixture plus two tests that assert the UR5 rows are retained when mesh paths are provided as `package://...` URIs or as resolved local paths.
- Changed files: `workcell_builder/workcell_builder/gui/mainwindow.cpp`, `tests/test_scene3d_visual_loader_filtering.py`.

### Testing
- Ran `python3 -m pytest tests/test_scene3d_visual_loader_filtering.py`; all tests passed (`13 passed`).
- Verified no whitespace/diff issues with `git diff --check`; no issues found.
- New/updated automated tests include `test_18_row_fixture_retains_all_ur5_rows_with_package_uri_paths` and `test_18_row_fixture_retains_all_ur5_rows_with_resolved_local_paths`, and updated raw UR5 mesh-row fixtures to use canonical UR5 asset filenames.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fc93ee2b083318b92894f9fe7fcb4)