### PR TITLE
Log baked UR5 visual poses in Scene3D viewport

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -4140,6 +4140,15 @@ bool Scene3DViewportWidget::draw_mesh_preview_if_available(const ScenePreviewWid
 
   glPushMatrix();
   const QMatrix4x4 final_draw_transform = final_mesh_transform_matrix(it);
+  const QString canonical_link = scene3d_canonical_link_name_for_item(it);
+  if ((is_generated_urdf_visual_item(it) || is_locked_urdf_item(it)) &&
+      it.has_baked_world_visual_transform &&
+      is_required_ur5_viewport_link(it)) {
+    qInfo().noquote() << QStringLiteral("UR5_BAKED_POSE_APPLIED link=%1 xyz=[%2,%3,%4] rpy=[%5,%6,%7]")
+      .arg(canonical_link)
+      .arg(it.x, 0, 'g', 8).arg(it.y, 0, 'g', 8).arg(it.z, 0, 'g', 8)
+      .arg(it.roll, 0, 'g', 8).arg(it.pitch, 0, 'g', 8).arg(it.yaw, 0, 'g', 8);
+  }
   glMultMatrixf(final_draw_transform.constData());
 
   const MeshCacheEntry & cache = entry;  // ensure_mesh_cached(it, mesh_source) is intentionally upstream of final draw.


### PR DESCRIPTION
### Motivation
- Provide a targeted renderer diagnostic so generated/locked URDF visuals with baked world poses on UR5 links can be audited during Scene3D rendering.

### Description
- Added a `qInfo()` diagnostic immediately after computing `final_mesh_transform_matrix(it)` in `Scene3DViewportWidget::draw_mesh_preview_if_available` that emits `UR5_BAKED_POSE_APPLIED link=<canonical_link> xyz=[<it.x>,<it.y>,<it.z>] rpy=[<it.roll>,<it.pitch>,<it.yaw>]` for generated/locked URDF visuals with `has_baked_world_visual_transform` on required UR5 links.
- Preserved the existing transform application path by leaving `final_mesh_transform_matrix(it)` and `glMultMatrixf(final_draw_transform.constData())` unchanged so root pose from `baked_world_visual_pose`, the centralized ROS-to-viewport basis (applied exactly once), optional mesh-local correction, and `it.mesh_scale_x/y/z` remain unchanged.
- Did not reintroduce any legacy UR5 DAE special-case corrections for `source=urdf_flattened` or other generated rows; the change is strictly a diagnostic log and applies only when the item is a generated/locked URDF visual on required UR5 links.
- Affected file: `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp`.

### Testing
- Ran `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py` and observed 5 tests passed and 2 tests failed.
- The two failing tests are in `tests/test_workcell_builder_product_view_defaults.py` and assert existing Product View default strings that are not related to this diagnostic-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a401bcf0b988331b57bb47af55f8712)