### PR TITLE
Account for baked world visual transforms in Scene3D smoke diagnostics

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke_impl.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke_impl.py
@@ -570,6 +570,10 @@ def _apply_runtime_transform_counter_mapping(payload: dict[str, Any]) -> None:
         "generated_visual_count",
         "generated_urdf_visual_count",
     )
+    baked_world_visual_transform_count = runtime_counter(
+        "baked_world_visual_transform_count",
+        "runtime_baked_world_visual_transform_count",
+    )
     baked_world_visual_pose_applied_count = runtime_counter(
         "runtime_baked_world_visual_pose_applied_count",
         "baked_world_visual_pose_count",
@@ -578,14 +582,15 @@ def _apply_runtime_transform_counter_mapping(payload: dict[str, Any]) -> None:
     payload["transform_chain_applied_count"] = transform_chain_applied_count
     payload["visual_origin_applied_count"] = visual_origin_applied_count
     payload["locked_generated_urdf_visual_count"] = generated_visual_count
+    payload["baked_world_visual_transform_count"] = baked_world_visual_transform_count
     payload["runtime_baked_world_visual_pose_applied_count"] = baked_world_visual_pose_applied_count
 
     warnings = payload.get("warnings")
     if not isinstance(warnings, list):
         warnings = []
-    if generated_visual_count > 0 and transform_chain_applied_count <= 0 and baked_world_visual_pose_applied_count <= 0:
+    if generated_visual_count > 0 and transform_chain_applied_count <= 0 and baked_world_visual_transform_count <= 0:
         _append_unique(warnings, "runtime_transform_chain_applied_count_zero_with_generated_visuals")
-    if generated_visual_count > 0 and visual_origin_applied_count <= 0 and baked_world_visual_pose_applied_count <= 0:
+    if generated_visual_count > 0 and visual_origin_applied_count <= 0 and baked_world_visual_transform_count <= 0:
         _append_unique(warnings, "runtime_visual_origin_applied_count_zero_with_generated_visuals")
     payload["warnings"] = warnings
 

--- a/tests/test_scene3d_gui_smoke_json_output_contract.py
+++ b/tests/test_scene3d_gui_smoke_json_output_contract.py
@@ -305,7 +305,7 @@ def test_static_headless_counts_remain_non_pass_evidence_when_runtime_unavailabl
     assert payload["non_runtime_static_headless_renderability_counts"]["runtime_available"] is False
 
 
-def test_baked_world_visual_pose_counter_suppresses_zero_transform_warnings():
+def test_baked_world_visual_transform_counter_suppresses_zero_transform_warnings():
     import scripts.run_workcell_builder_scene3d_gui_smoke as smoke
 
     payload = {
@@ -315,6 +315,7 @@ def test_baked_world_visual_pose_counter_suppresses_zero_transform_warnings():
             "locked_generated_urdf_visual_count": 4,
             "transform_chain_applied_count": 0,
             "visual_origin_applied_count": 0,
+            "baked_world_visual_transform_count": 4,
         },
         "runtime_scene3d_diagnostics": {
             "baked_world_visual_pose_count": 4,
@@ -326,6 +327,7 @@ def test_baked_world_visual_pose_counter_suppresses_zero_transform_warnings():
     assert payload["locked_generated_urdf_visual_count"] == 4
     assert payload["transform_chain_applied_count"] == 0
     assert payload["visual_origin_applied_count"] == 0
+    assert payload["baked_world_visual_transform_count"] == 4
     assert payload["runtime_baked_world_visual_pose_applied_count"] == 4
     assert "runtime_transform_chain_applied_count_zero_with_generated_visuals" not in payload.get("warnings", [])
     assert "runtime_visual_origin_applied_count_zero_with_generated_visuals" not in payload.get("warnings", [])
@@ -346,6 +348,7 @@ def test_zero_transform_warnings_preserved_when_all_transform_evidence_zero():
 
     smoke._apply_runtime_transform_counter_mapping(payload)
 
+    assert payload["baked_world_visual_transform_count"] == 0
     assert payload["runtime_baked_world_visual_pose_applied_count"] == 0
     assert "runtime_transform_chain_applied_count_zero_with_generated_visuals" in payload["warnings"]
     assert "runtime_visual_origin_applied_count_zero_with_generated_visuals" in payload["warnings"]
@@ -512,6 +515,7 @@ def test_reported_ur5_2f_smoke_json_generated_urdf_contract_passes():
         "render_debug_counters": {
             "physical_mesh_items_rendered": 31,
             "generated_urdf_visual_count": len(generated_rows),
+            "baked_world_visual_transform_count": 18,
         },
         "runtime_scene3d_diagnostics": {
             "baked_world_visual_pose_count": 18,
@@ -542,6 +546,7 @@ def test_reported_ur5_2f_smoke_json_generated_urdf_contract_passes():
     }
     assert payload["transform_chain_applied_count"] == 0
     assert payload["visual_origin_applied_count"] == 0
+    assert payload["baked_world_visual_transform_count"] == 18
     assert payload["runtime_baked_world_visual_pose_applied_count"] == 18
     assert "runtime_transform_chain_applied_count_zero_with_generated_visuals" not in payload.get("warnings", [])
     assert "runtime_visual_origin_applied_count_zero_with_generated_visuals" not in payload.get("warnings", [])

--- a/workcell_builder/workcell_builder/gui/main.cpp
+++ b/workcell_builder/workcell_builder/gui/main.cpp
@@ -658,6 +658,7 @@ private:
     copy_filter_counter("robot_base_frame");
     copy_filter_counter("transform_chain_applied_count");
     copy_filter_counter("visual_origin_applied_count");
+    copy_filter_counter("baked_world_visual_transform_count");
     copy_filter_counter("camera_fit_target");
     copy_filter_counter("robot_pose_source");
     auto * inspector = window_->findChild<QLabel *>("sceneBuilderInspectorLabel");
@@ -715,6 +716,7 @@ private:
       candidate_json["locked_generated_urdf_visual_count"] = candidate.counters.locked_generated_urdf_visual_count;
       candidate_json["transform_chain_applied_count"] = candidate.counters.transform_chain_applied_count;
       candidate_json["visual_origin_applied_count"] = candidate.counters.visual_origin_applied_count;
+      candidate_json["baked_world_visual_transform_count"] = candidate.counters.baked_world_visual_transform_count;
       candidate_json["placeholder_count"] = candidate.counters.placeholder_count;
       candidate_json["missing_geometry_count"] = candidate.counters.missing_geometry_count;
       candidate_json["wireframe_fallback_count"] = candidate.counters.wireframe_fallback_count;
@@ -823,6 +825,7 @@ private:
       counters["locked_generated_urdf_visual_count"] = rc.locked_generated_urdf_visual_count;
       counters["transform_chain_applied_count"] = rc.transform_chain_applied_count;
       counters["visual_origin_applied_count"] = rc.visual_origin_applied_count;
+      counters["baked_world_visual_transform_count"] = rc.baked_world_visual_transform_count;
       counters["overlay_count"] = rc.overlay_count;
       counters["selectable_count"] = qMax(0, rc.visible_count - rc.overlay_count);
       counters["hierarchy_rows_count"] = rc.hierarchy_child_row_count;


### PR DESCRIPTION
### Motivation
- Runtime smoke diagnostics were emitting warnings when generated URDF visuals existed but legacy runtime transform evidence counters were zero, despite baked URDF world transforms being present and valid.
- Treat baked (precomputed) world visual transforms as valid transform evidence so the smoke validator does not produce spurious zero-transform warnings when generated visuals already carry baked world poses.

### Description
- Normalize a `baked_world_visual_transform_count` runtime counter in the smoke wrapper and use it when gating the zero-transform warnings in `scripts/run_workcell_builder_scene3d_gui_smoke_impl.py`.
- Export `baked_world_visual_transform_count` through Workcell Builder JSON paths (copied filter counters, per-candidate JSON, and consolidated runtime `counters`) in `workcell_builder/workcell_builder/gui/main.cpp` so the smoke wrapper can observe baked transform evidence produced by `PreviewItem::has_baked_world_visual_transform`.
- Update smoke contract tests in `tests/test_scene3d_gui_smoke_json_output_contract.py` to assert that baked transform counts suppress the two warnings while preserving the original warning behavior when all transform evidence is zero.

### Testing
- Ran targeted unit tests: `python3 -m pytest tests/test_scene3d_gui_smoke_json_output_contract.py::test_baked_world_visual_transform_counter_suppresses_zero_transform_warnings tests/test_scene3d_gui_smoke_json_output_contract.py::test_zero_transform_warnings_preserved_when_all_transform_evidence_zero -q`, which passed.
- Verified the smoke wrapper implementation compiles: `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke_impl.py`, which passed.
- Ran the full smoke JSON contract file `python3 -m pytest tests/test_scene3d_gui_smoke_json_output_contract.py -q` in this container which produced unrelated failures (ROS Humble availability and several UR5 adjacency/final-viewport expectations) that are outside the scoped change and do not indicate regression for the updated transform accounting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a401d7e6a7c833194b90662aae484c9)