### PR TITLE
Harden Scene3D final draw UR5 diagnostics

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke_impl.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke_impl.py
@@ -687,6 +687,7 @@ UR5_RENDERED_MESH_LINK_ALIASES: dict[str, tuple[str, ...]] = {
     "robotiq_base": ("robotiq_base", "gripper_base_link", "robotiq_85_base_link", "robotiq base visual item"),
 }
 UR5_RENDERED_MESH_ADJACENT_PAIRS: tuple[tuple[str, str], ...] = (
+    ("base_link", "shoulder_link"),
     ("shoulder_link", "upper_arm_link"),
     ("upper_arm_link", "forearm_link"),
     ("forearm_link", "wrist_1_link"),
@@ -1505,8 +1506,6 @@ def _apply_ur5_rendered_mesh_adjacency(payload: dict[str, Any], *, repo_root: Pa
         return
 
     final_draw_items = payload.get("final_draw_visual_items")
-    if not isinstance(final_draw_items, list) or not final_draw_items:
-        final_draw_items = payload.get("final_draw_diagnostics")
     errors: list[str] = []
     source = "final_draw_visual_items"
     if not isinstance(final_draw_items, list) or not final_draw_items:
@@ -1514,7 +1513,7 @@ def _apply_ur5_rendered_mesh_adjacency(payload: dict[str, Any], *, repo_root: Pa
         if isinstance(index_items, list):
             payload["rendered_mesh_adjacency_visual_index_supplemental_count"] = len(index_items)
         errors.append(
-            "Final Scene3D viewport/renderable diagnostics are missing; "
+            "Final Scene3D final_draw_visual_items diagnostics are missing; "
             "visual-index metadata cannot prove UR5 arm visibility"
         )
         payload["rendered_mesh_adjacency_source"] = "missing_final_draw_diagnostics"

--- a/tests/test_scene3d_gui_smoke_json_output_contract.py
+++ b/tests/test_scene3d_gui_smoke_json_output_contract.py
@@ -637,7 +637,7 @@ def test_ur5_rendered_mesh_adjacency_rejects_index_fallback_when_final_draw_miss
     assert "rendered_mesh_adjacency_used_index_fallback" not in payload.get("warnings", [])
     assert "scene3d_rendered_mesh_adjacency_failed" in payload["warnings"]
     assert payload["rendered_mesh_adjacency_errors"] == [
-        "Final Scene3D viewport/renderable diagnostics are missing; visual-index metadata cannot prove UR5 arm visibility"
+        "Final Scene3D final_draw_visual_items diagnostics are missing; visual-index metadata cannot prove UR5 arm visibility"
     ]
 
 
@@ -1521,3 +1521,16 @@ def test_scene3d_final_draw_export_uses_generated_urdf_renderable_assembly():
     assert "generated_robot_items.push_back(&item);" in assembly_body
     assert "ordered_items.insert(ordered_items.end(), generated_robot_items.begin(), generated_robot_items.end());" in assembly_body
     assert "build_final_generated_urdf_robot_renderables(items, show_safety);" in export_body
+    assert 'row["canonical_link"] = canonical_link_name;' in export_body
+    assert 'row["canonical_link_name"] = canonical_link_name;' in export_body
+    assert 'row["frame_id"] = !item.frame_id.trimmed().isEmpty() ? item.frame_id.trimmed() : canonical_link_name;' in export_body
+    assert 'row["visual_index_link"] = !item.visual_index_link.trimmed().isEmpty() ? item.visual_index_link.trimmed() : link_name;' in export_body
+    assert 'row["mesh_uri"] = !item.visual_index_mesh_uri.trimmed().isEmpty() ? item.visual_index_mesh_uri.trimmed() : mesh_source;' in export_body
+    assert 'row["package_uri"] = !item.visual_index_package_uri.trimmed().isEmpty() ? item.visual_index_package_uri.trimmed() : item.package_uri;' in export_body
+    assert 'const QMatrix4x4 baked_transform = authoritative_world_visual_transform(item);' in export_body
+    assert 'const QMatrix4x4 viewport_root_transform = viewport_world_visual_transform(item);' in export_body
+    assert 'const QMatrix4x4 final_transform = final_mesh_transform_matrix(item);' in export_body
+    assert 'row["baked_world_visual_matrix"] = scene3d_matrix_to_json(baked_transform);' in export_body
+    assert 'row["viewport_world_visual_matrix"] = scene3d_matrix_to_json(viewport_root_transform);' in export_body
+    assert 'row["final_draw_model_matrix"] = scene3d_matrix_to_json(final_transform);' in export_body
+    assert 'scene3d_final_draw_bbox_for_mesh(cache.mesh, final_transform, final_min, final_max)' in export_body

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -3808,7 +3808,9 @@ QJsonArray Scene3DViewportWidget::final_draw_visual_items_export() const
     const QString canonical_link_name = scene3d_canonical_link_name_for_item(item);
     row["link"] = !item.visual_index_link.trimmed().isEmpty() ? item.visual_index_link.trimmed() : link_name;
     row["link_name"] = link_name;
+    row["canonical_link"] = canonical_link_name;
     row["canonical_link_name"] = canonical_link_name;
+    row["visual_index_link"] = !item.visual_index_link.trimmed().isEmpty() ? item.visual_index_link.trimmed() : link_name;
     if (!item.visual_index_object_name.trimmed().isEmpty()) row["object_name"] = item.visual_index_object_name.trimmed();
     const int visual_index = item.visual_index_value >= 0 ? item.visual_index_value : scene3d_visual_index_for_item(item);
     if (visual_index >= 0) row["visual_index"] = visual_index;
@@ -3824,7 +3826,7 @@ QJsonArray Scene3DViewportWidget::final_draw_visual_items_export() const
       row["link_chain"] = chain;
     }
     if (!item.visual_index_source.trimmed().isEmpty()) row["source"] = item.visual_index_source.trimmed();
-    row["frame_id"] = item.frame_id;
+    row["frame_id"] = !item.frame_id.trimmed().isEmpty() ? item.frame_id.trimmed() : canonical_link_name;
     row["source_layer"] = item.source_layer;
     row["category"] = item.category;
     row["role"] = item.role;
@@ -3861,6 +3863,15 @@ QJsonArray Scene3DViewportWidget::final_draw_visual_items_export() const
     row["canonical_mesh_source"] = canonical_mesh_source;
     row["path_resolved"] = path_resolved;
     row["resolve_failure_reason"] = resolve_failure_reason;
+
+    const QMatrix4x4 baked_transform = authoritative_world_visual_transform(item);
+    const QMatrix4x4 viewport_root_transform = viewport_world_visual_transform(item);
+    const QMatrix4x4 final_transform = final_mesh_transform_matrix(item);
+    row["baked_world_visual_matrix"] = scene3d_matrix_to_json(baked_transform);
+    row["ros_to_viewport_basis_matrix"] = scene3d_matrix_to_json(ros_to_viewport_basis_matrix());
+    row["viewport_world_visual_matrix"] = scene3d_matrix_to_json(viewport_root_transform);
+    row["final_draw_model_matrix"] = scene3d_matrix_to_json(final_transform);
+    row["final_draw_world_pose"] = scene3d_vec_to_json(final_transform.map(QVector3D(0.0f, 0.0f, 0.0f)));
     if (required_ur5_fallback) {
       row["source_type"] = QStringLiteral("generated_urdf_visual_fallback");
       row["final_draw_status"] = QStringLiteral("ur5_emergency_visible_fallback");
@@ -3928,6 +3939,7 @@ QJsonArray Scene3DViewportWidget::final_draw_visual_items_export() const
       ? ur5_baked_mesh_asset_local_correction_scope_reason(item)
       : QStringLiteral("none");
     row["resolved_source_path"] = item.resolved_source_path_original;
+
     const QString asset_local_correction_reason = baked_mesh_asset_local_correction_reason(item);
     const QMatrix4x4 asset_local_correction_transform = baked_mesh_asset_local_correction_matrix(item);
     row["baked_mesh_asset_local_correction_reason"] = asset_local_correction_reason;
@@ -3957,15 +3969,6 @@ QJsonArray Scene3DViewportWidget::final_draw_visual_items_export() const
     row["triangle_count"] = static_cast<int>(cache.mesh.triangles.size());
     row["local_min"] = scene3d_vec_to_json(cache.local_min);
     row["local_max"] = scene3d_vec_to_json(cache.local_max);
-
-    const QMatrix4x4 baked_transform = authoritative_world_visual_transform(item);
-    const QMatrix4x4 viewport_root_transform = viewport_world_visual_transform(item);
-    const QMatrix4x4 final_transform = final_mesh_transform_matrix(item);
-    row["baked_world_visual_matrix"] = scene3d_matrix_to_json(baked_transform);
-    row["ros_to_viewport_basis_matrix"] = scene3d_matrix_to_json(ros_to_viewport_basis_matrix());
-    row["viewport_world_visual_matrix"] = scene3d_matrix_to_json(viewport_root_transform);
-    row["final_draw_model_matrix"] = scene3d_matrix_to_json(final_transform);
-    row["final_draw_world_pose"] = scene3d_vec_to_json(final_transform.map(QVector3D(0.0f, 0.0f, 0.0f)));
 
     if (!cache.loaded || !cache.valid || !cache.has_bounds || cache.mesh.triangles.isEmpty()) {
       row["final_draw_status"] = is_required_ur5_viewport_link(item)


### PR DESCRIPTION
### Motivation
- Ensure final-draw export for generated/locked URDF visuals contains stable identity and transform data so UR5 rendered-mesh adjacency checks use baked geometry rather than fragile visual-index fallbacks.
- Make adjacency smoke checks stricter and evidence-driven so failures surface real final-draw geometry issues instead of being masked by weaker heuristics.

### Description
- Export stable identity fields for generated/locked URDF items in `final_draw_visual_items_export()`: `canonical_link`, `canonical_link_name`, `visual_index_link`, and a `frame_id` fallback when `item.frame_id` is empty, plus preserve `mesh_uri`/`package_uri` fields. (file: `scene3d_viewport_widget.cpp`)
- Compute and export final-draw transforms from the renderer path: `authoritative_world_visual_transform(item)`, `viewport_world_visual_transform(item)`, and `final_mesh_transform_matrix(item)`, and keep bbox computation using `scene3d_final_draw_bbox_for_mesh(cache.mesh, final_transform, ...)`. (file: `scene3d_viewport_widget.cpp`)
- Tighten the UR5 rendered-mesh adjacency logic in the smoke script to require `final_draw_visual_items` (no automatic fallback to visual-index/world-position data), enrich final rows from the visual index only when present, and add the base-link->shoulder adjacency pair to ensure root linkage is validated; thresholds are unchanged (no relaxation). (file: `scripts/run_workcell_builder_scene3d_gui_smoke_impl.py`)
- Updated smoke contract test expectations to reflect the new final-draw export fields and stricter missing-final-draw error text. (file: `tests/test_scene3d_gui_smoke_json_output_contract.py`)

### Testing
- Ran targeted smoke tests: `python3 -m pytest tests/test_scene3d_gui_smoke_json_output_contract.py::test_ur5_rendered_mesh_adjacency_prefers_final_draw_bboxes tests/test_scene3d_gui_smoke_json_output_contract.py::test_ur5_rendered_mesh_adjacency_final_draw_nonfinite_fails_without_index_fallback tests/test_scene3d_gui_smoke_json_output_contract.py::test_ur5_rendered_mesh_adjacency_passes_with_generated_urdf_ids_and_stable_metadata tests/test_scene3d_gui_smoke_json_output_contract.py::test_ur5_rendered_mesh_adjacency_rejects_index_fallback_when_final_draw_missing tests/test_scene3d_gui_smoke_json_output_contract.py::test_scene3d_final_draw_export_uses_generated_urdf_renderable_assembly` — passed.
- Verified Python smoke script syntax with `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke_impl.py` — passed.
- Ran `git diff --check` — passed.
- Ran broader Scene3D/product tests: `python3 -m pytest tests/test_scene3d_final_draw_bbox_regression.py tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py` — product-view-defaults assertions failed (existing unrelated expectations); these failures are not caused by the final-draw adjacency hardening and remain to be addressed separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a401f10abe48331ae99c0718eec9261)