### PR TITLE
Skip mesh-local corrections for baked Scene3D transforms

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -369,6 +369,16 @@ void apply_mesh_local_correction_matrix(QMatrix4x4 & transform, const ScenePrevi
 QMatrix4x4 final_mesh_transform_matrix(const ScenePreviewWidget::PreviewItem & item)
 {
   QMatrix4x4 transform = viewport_world_visual_transform(item);
+  if (item.has_baked_world_visual_transform) {
+    // Baked generated URDF rows already carry the authoritative world visual
+    // pose. Keep the final mesh path explicit: pose, scale, return. Do not let
+    // legacy mesh-local correction hooks re-enter for flattened/baked rows.
+    transform.scale(static_cast<float>(item.mesh_scale_x),
+                    static_cast<float>(item.mesh_scale_y),
+                    static_cast<float>(item.mesh_scale_z));
+    return transform;
+  }
+
   apply_mesh_local_correction_matrix(transform, item);
   transform.scale(static_cast<float>(item.mesh_scale_x),
                   static_cast<float>(item.mesh_scale_y),
@@ -378,13 +388,10 @@ QMatrix4x4 final_mesh_transform_matrix(const ScenePreviewWidget::PreviewItem & i
 
 void apply_mesh_local_correction_gl(const ScenePreviewWidget::PreviewItem & item)
 {
-  // See apply_mesh_local_correction_matrix(): baked URDF visuals use the baked
-  // world visual pose directly unless the explicit baked mesh-asset correction
-  // path opts in a known asset-local correction.
-  if (item.has_baked_world_visual_transform) {
-    apply_baked_mesh_asset_local_correction_gl(item);
-    return;
-  }
+  // Mirror final_mesh_transform_matrix(): baked generated URDF visuals use the
+  // baked world visual pose directly and skip all legacy mesh-local correction
+  // hooks. Non-baked rows keep the existing mesh RPY/origin-offset path.
+  if (item.has_baked_world_visual_transform) return;
 
   apply_urdf_rpy_gl(item.mesh_r, item.mesh_p, item.mesh_y);
   if (item.has_origin_offset) glTranslated(item.origin_offset_x, item.origin_offset_y, item.origin_offset_z);


### PR DESCRIPTION
### Motivation
- Generated/flattened URDF visuals provide an authoritative world-space pose and should not be double-corrected by legacy mesh-local RPY/origin-offset fixes, which cause incorrect final placement for baked rows.

### Description
- In `final_mesh_transform_matrix()` start from `viewport_world_visual_transform(item)` and add an explicit early path for `item.has_baked_world_visual_transform` that applies only mesh scaling and returns without invoking `apply_mesh_local_correction_matrix()`.
- Preserve the existing path for non-baked rows: `viewport_world_visual_transform(item)` → `apply_mesh_local_correction_matrix(transform, item)` → scale → return.
- Mirror the behavior in the GL path by making `apply_mesh_local_correction_gl()` return immediately for baked rows so legacy GL correction hooks (including the older UR5/DAE correction path) are skipped for baked previews while non-baked rows still apply RPY and origin-offset in GL.
- Affected file: `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp`.

### Testing
- A focused static assertion script verifying the baked matrix path and the GL helper behavior was executed and passed.
- Ran `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py` which resulted in 5 tests passing and 2 tests failing; the failing tests assert product-default strings in `scene3d_candidate_assembly.cpp` and `scene_preview_widget.cpp` and appear to reflect existing product-default drift rather than the Scene3D transform refactor.
- Performed `git diff --check` and basic repository sanity checks with no issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a402d44e3148331a601d8f743885ae9)