### PR TITLE
Prefer final-rendered UR5 mesh bboxes for adjacency checks and export final bbox diagnostics

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke_impl.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke_impl.py
@@ -1316,15 +1316,28 @@ def _record_rendered_mesh_adjacency_fallback_warning(payload: dict[str, Any]) ->
     payload["warning_messages"] = messages
 
 
+def _bbox_mapping_from_record(record: dict[str, Any], *keys: str) -> dict[str, list[float]] | None:
+    for key in keys:
+        bbox = record.get(key)
+        if not isinstance(bbox, dict):
+            continue
+        mn = _finite_float_list(bbox.get("min"), 3)
+        mx = _finite_float_list(bbox.get("max"), 3)
+        if mn is not None and mx is not None:
+            return {"min": mn, "max": mx}
+    return None
+
+
 def _bbox_from_final_draw(record: dict[str, Any]) -> dict[str, list[float]] | None:
-    bbox = record.get("final_draw_bbox")
-    if not isinstance(bbox, dict):
-        return None
-    mn = _finite_float_list(bbox.get("min"), 3)
-    mx = _finite_float_list(bbox.get("max"), 3)
-    if mn is None or mx is None:
-        return None
-    return {"min": mn, "max": mx}
+    # Prefer bounds explicitly captured after final_mesh_transform_matrix(),
+    # because these are in the same coordinate basis used by the renderer.
+    return _bbox_mapping_from_record(
+        record,
+        "final_rendered_mesh_bbox",
+        "final_rendered_bbox",
+        "rendered_mesh_bbox",
+        "final_draw_bbox",
+    )
 
 
 def _item_id(record: dict[str, Any]) -> str | None:
@@ -1488,11 +1501,23 @@ def _checked_pair_record(
 
 
 def _final_draw_bbox_from_row(raw: dict[str, Any]) -> dict[str, list[float]] | None:
-    bbox = raw.get("final_draw_bbox")
-    if not isinstance(bbox, dict):
-        return None
-    bmin = _finite_float_list(bbox.get("min"), 3)
-    bmax = _finite_float_list(bbox.get("max"), 3)
+    bbox = _bbox_from_final_draw(raw)
+    if bbox is not None:
+        return bbox
+    bmin = _finite_float_list(
+        raw.get("final_rendered_mesh_bbox_min")
+        or raw.get("final_rendered_bbox_min")
+        or raw.get("rendered_mesh_bbox_min")
+        or raw.get("final_draw_bbox_min"),
+        3,
+    )
+    bmax = _finite_float_list(
+        raw.get("final_rendered_mesh_bbox_max")
+        or raw.get("final_rendered_bbox_max")
+        or raw.get("rendered_mesh_bbox_max")
+        or raw.get("final_draw_bbox_max"),
+        3,
+    )
     if bmin is None or bmax is None:
         return None
     return {"min": bmin, "max": bmax}
@@ -1593,14 +1618,6 @@ def _apply_ur5_rendered_mesh_adjacency(payload: dict[str, Any], *, repo_root: Pa
                     parent, child, parent_item, child_item, None, _rendered_mesh_adjacency_limit(parent, child), False
                 )
             )
-            continue
-        if _stable_metadata_proves_adjacency(parent, child, child_item):
-            checked.append(
-                _checked_pair_record(
-                    parent, child, parent_item, child_item, None, _rendered_mesh_adjacency_limit(parent, child), True
-                )
-            )
-            checked[-1]["evidence"] = "stable_metadata"
             continue
         if not isinstance(parent_item.get("bounds"), dict) or not isinstance(child_item.get("bounds"), dict):
             detail = parent_item.get("bbox_error") or child_item.get("bbox_error") or "bbox_missing"

--- a/tests/test_scene3d_gui_smoke_json_output_contract.py
+++ b/tests/test_scene3d_gui_smoke_json_output_contract.py
@@ -402,7 +402,42 @@ def test_ur5_rendered_mesh_adjacency_prefers_final_draw_bboxes():
     assert checked[-1]["ok"] is True
 
 
-def test_ur5_rendered_mesh_adjacency_passes_with_generated_urdf_ids_and_stable_metadata():
+def test_ur5_rendered_mesh_adjacency_prefers_final_rendered_mesh_bboxes_over_baked_pose_bounds():
+    import scripts.run_workcell_builder_scene3d_gui_smoke as smoke
+
+    def item(link: str, xmin: float, xmax: float) -> dict:
+        return {
+            "id": f"draw_{link}",
+            "link": link,
+            "mesh_path": f"meshes/{link}.dae",
+            "final_draw_world_pose": [100.0 + xmin, 0.0, 0.0],
+            "bounds": {"min": [100.0 + xmin, 0.0, 0.0], "max": [100.0 + xmax, 0.1, 0.1]},
+            "final_rendered_mesh_bbox": {"min": [xmin, 0.0, 0.0], "max": [xmax, 0.1, 0.1]},
+        }
+
+    payload = {
+        "status": "PASS",
+        "final_draw_visual_items": [
+            item("base_link_inertia", 0.0, 0.1),
+            item("shoulder_link", 0.1, 0.2),
+            item("upper_arm_link", 0.2, 0.3),
+            item("forearm_link", 0.3, 0.4),
+            item("wrist_1_link", 0.4, 0.5),
+            item("wrist_2_link", 0.5, 0.6),
+            item("wrist_3_link", 0.6, 0.7),
+            item("robotiq_arg2f_base_link", 0.7, 0.8),
+        ],
+    }
+
+    smoke._apply_ur5_rendered_mesh_adjacency(payload, repo_root=Path(__file__).resolve().parents[1], scene_name="ur5_2f_test", index_data={})
+
+    assert payload["rendered_mesh_adjacency_status"] == "PASS"
+    checked = payload["rendered_mesh_adjacency_checked_pairs"]
+    assert checked[0]["parent_bbox_min"] == [0.0, 0.0, 0.0]
+    assert all(pair["ok"] is True for pair in checked)
+
+
+def test_ur5_rendered_mesh_adjacency_rejects_metadata_only_nonfinite_bboxes():
     import scripts.run_workcell_builder_scene3d_gui_smoke as smoke
 
     chain = [
@@ -446,12 +481,13 @@ def test_ur5_rendered_mesh_adjacency_passes_with_generated_urdf_ids_and_stable_m
 
     smoke._apply_ur5_rendered_mesh_adjacency(payload, repo_root=Path(__file__).resolve().parents[1], scene_name="ur5_2f_test", index_data={})
 
-    assert payload["rendered_mesh_adjacency_status"] == "PASS"
-    assert "scene3d_rendered_mesh_adjacency_failed" not in payload.get("warnings", [])
+    assert payload["rendered_mesh_adjacency_status"] == "FAIL"
+    assert "scene3d_rendered_mesh_adjacency_failed" in payload.get("warnings", [])
     checked = payload["rendered_mesh_adjacency_checked_pairs"]
     assert len(checked) == 7
-    assert all(pair["ok"] is True for pair in checked)
-    assert all(pair.get("evidence") == "stable_metadata" for pair in checked)
+    arm_pairs = [pair for pair in checked if pair["child"] != "robotiq_base"]
+    assert all(pair["ok"] is False for pair in arm_pairs)
+    assert all(pair.get("evidence") != "stable_metadata" for pair in arm_pairs)
     assert checked[-1]["child"] == "robotiq_base"
     assert checked[-1]["child_item_id"] == "generated_urdf::gripper_base_link"
 

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -3990,6 +3990,11 @@ QJsonArray Scene3DViewportWidget::final_draw_visual_items_export() const
           row["final_draw_bbox_min"] = scene3d_vec_to_json(final_min);
           row["final_draw_bbox_max"] = scene3d_vec_to_json(final_max);
           row["final_draw_bbox_span"] = scene3d_vec_to_json(final_span);
+          row["final_draw_bbox_center"] = scene3d_vec_to_json((final_min + final_max) * 0.5f);
+          row["final_rendered_mesh_bbox"] = scene3d_bbox_to_json(final_min, final_max);
+          row["final_rendered_mesh_bbox_min"] = scene3d_vec_to_json(final_min);
+          row["final_rendered_mesh_bbox_max"] = scene3d_vec_to_json(final_max);
+          row["final_rendered_mesh_bbox_center"] = scene3d_vec_to_json((final_min + final_max) * 0.5f);
         }
       }
       out.append(row);
@@ -4008,6 +4013,11 @@ QJsonArray Scene3DViewportWidget::final_draw_visual_items_export() const
     row["final_draw_bbox_min"] = scene3d_vec_to_json(final_min);
     row["final_draw_bbox_max"] = scene3d_vec_to_json(final_max);
     row["final_draw_bbox_span"] = scene3d_vec_to_json(final_span);
+    row["final_draw_bbox_center"] = scene3d_vec_to_json((final_min + final_max) * 0.5f);
+    row["final_rendered_mesh_bbox"] = scene3d_bbox_to_json(final_min, final_max);
+    row["final_rendered_mesh_bbox_min"] = scene3d_vec_to_json(final_min);
+    row["final_rendered_mesh_bbox_max"] = scene3d_vec_to_json(final_max);
+    row["final_rendered_mesh_bbox_center"] = scene3d_vec_to_json((final_min + final_max) * 0.5f);
     row["final_draw_status"] = QStringLiteral("ok");
     out.append(row);
 


### PR DESCRIPTION
### Motivation
- Ensure UR5 adjacency smoke checks run against the actual final transformed mesh bounds used by the renderer rather than stale/baked pose positions or metadata-only link parentage. 
- Make diagnostics honest: the adjacency warning `scene3d_rendered_mesh_adjacency_failed` should disappear only when final transformed bboxes for the UR5 chain are present and adjacent in the renderer basis.

### Description
- Export final rendered mesh bbox min/max/center from the renderer after `final_mesh_transform_matrix()` by adding `final_rendered_mesh_bbox`, `final_rendered_mesh_bbox_min`, `final_rendered_mesh_bbox_max`, and `final_rendered_mesh_bbox_center`, and a `final_draw_bbox_center` helper in `final_draw_visual_items_export()` in `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp`.
- Populate those fields for both normal and required-UR5 fallback rows so consumers can prefer renderer-basis bounds where available in `final_draw_visual_items_export()`.
- Update the adjacency consumer in `scripts/run_workcell_builder_scene3d_gui_smoke_impl.py` to prefer final rendered mesh bounds by adding `_bbox_mapping_from_record()` and making `_bbox_from_final_draw()` / `_final_draw_bbox_from_row()` resolve `final_rendered_mesh_bbox*` (and related keys) before falling back to legacy `final_draw_bbox` or min/max aliases.
- Tighten adjacency logic so stable/index-only metadata no longer silences `scene3d_rendered_mesh_adjacency_failed`; required UR5 pairs must have finite final-rendered bbox evidence and pass the existing separation threshold to clear the warning.
- Update smoke contract tests in `tests/test_scene3d_gui_smoke_json_output_contract.py` to cover the expected precedence (final-rendered bbox preferred) and reject metadata-only/non-finite bbox cases.

### Testing
- Ran targeted smoke contract tests: `python3 -m pytest tests/test_scene3d_gui_smoke_json_output_contract.py -q -k "adjacency"` and `python3 -m pytest tests/test_scene3d_gui_smoke_json_output_contract.py -q -k "final_draw_bbox or adjacency or export"`, both passed.
- Ran final-draw regression tests: `python3 -m pytest tests/test_scene3d_final_draw_bbox_regression.py -q`, which passed.
- Static checks: `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke_impl.py scripts/run_workcell_builder_scene3d_gui_smoke.py` and `git diff --check` passed.
- Note: full wrapper smoke runs that exercise external runtime/ROS assumptions are environment-dependent and may be blocked in this CI/container; the changes intentionally tighten diagnostics so missing final-rendered bbox evidence will correctly surface `scene3d_rendered_mesh_adjacency_failed` until renderer-basis bboxes are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a402ec903b883319e496303c9872551)