### PR TITLE
Use baked URDF world matrix directly for Scene3D UR5 visuals

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -76,6 +76,7 @@
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QMap>
+#include <QMatrix4x4>
 #include <QHash>
 #include <QSplitter>
 #include <QScrollArea>
@@ -9749,7 +9750,20 @@ void MainWindow::populate_scene_hierarchy()
             p.pitch = normalize_angle_radians_with_guard(workcell_builder::yaml_seq_index(baked_world_visual_pose_rpy,1).as<double>(0.0), QStringLiteral("baked_world_visual_pose.rpy[1]"), &p.warnings);
             p.yaw = normalize_angle_radians_with_guard(workcell_builder::yaml_seq_index(baked_world_visual_pose_rpy,2).as<double>(0.0), QStringLiteral("baked_world_visual_pose.rpy[2]"), &p.warnings);
             p.has_baked_world_visual_transform = true;
-            p.baked_world_visual_transform_source = QStringLiteral("generated/scene_visual_mesh_index.json:baked_world_visual_pose");
+            {
+              QMatrix4x4 baked_pose_matrix;
+              baked_pose_matrix.translate(static_cast<float>(p.x), static_cast<float>(p.y), static_cast<float>(p.z));
+              baked_pose_matrix.rotate(static_cast<float>(qRadiansToDegrees(p.yaw)), 0.0f, 0.0f, 1.0f);
+              baked_pose_matrix.rotate(static_cast<float>(qRadiansToDegrees(p.pitch)), 0.0f, 1.0f, 0.0f);
+              baked_pose_matrix.rotate(static_cast<float>(qRadiansToDegrees(p.roll)), 1.0f, 0.0f, 0.0f);
+              for (int matrix_row = 0; matrix_row < 4; ++matrix_row) {
+                for (int matrix_col = 0; matrix_col < 4; ++matrix_col) {
+                  p.baked_world_visual_matrix[matrix_row * 4 + matrix_col] = baked_pose_matrix(matrix_row, matrix_col);
+                }
+              }
+            }
+            p.has_baked_world_visual_matrix = true;
+            p.baked_world_visual_transform_source = QStringLiteral("generated/scene_visual_mesh_index.json:baked_world_visual_pose_matrix");
             p.transform_chain_applied = false;
             p.visual_origin_applied = false;
           }
@@ -10610,7 +10624,22 @@ void MainWindow::populate_scene_hierarchy()
                 p.pitch = normalize_angle_radians_with_guard(workcell_builder::yaml_seq_index(baked_rpy, 1).as<double>(0.0), QStringLiteral("UR5_FINAL_APPEND.baked_world_visual_pose.rpy[1]"), &p.warnings);
                 p.yaw = normalize_angle_radians_with_guard(workcell_builder::yaml_seq_index(baked_rpy, 2).as<double>(0.0), QStringLiteral("UR5_FINAL_APPEND.baked_world_visual_pose.rpy[2]"), &p.warnings);
                 p.has_baked_world_visual_transform = true;
-                p.baked_world_visual_transform_source = QStringLiteral("generated/scene_visual_mesh_index.json:baked_world_visual_pose:final_append");
+                {
+                  QMatrix4x4 baked_pose_matrix;
+                  baked_pose_matrix.translate(static_cast<float>(p.x), static_cast<float>(p.y), static_cast<float>(p.z));
+                  baked_pose_matrix.rotate(static_cast<float>(qRadiansToDegrees(p.yaw)), 0.0f, 0.0f, 1.0f);
+                  baked_pose_matrix.rotate(static_cast<float>(qRadiansToDegrees(p.pitch)), 0.0f, 1.0f, 0.0f);
+                  baked_pose_matrix.rotate(static_cast<float>(qRadiansToDegrees(p.roll)), 1.0f, 0.0f, 0.0f);
+                  for (int matrix_row = 0; matrix_row < 4; ++matrix_row) {
+                    for (int matrix_col = 0; matrix_col < 4; ++matrix_col) {
+                      p.baked_world_visual_matrix[matrix_row * 4 + matrix_col] = baked_pose_matrix(matrix_row, matrix_col);
+                    }
+                  }
+                }
+                p.has_baked_world_visual_matrix = true;
+                p.baked_world_visual_transform_source = QStringLiteral("generated/scene_visual_mesh_index.json:baked_world_visual_pose_matrix:final_append");
+                append_studio_log(QStringLiteral("UR5_BAKED_MATRIX_APPLIED link=%1 source=%2")
+                  .arg(link, p.baked_world_visual_transform_source));
                 append_studio_log(QStringLiteral("UR5_BAKED_POSE_APPLIED link=%1 xyz=[%2,%3,%4] rpy=[%5,%6,%7]")
                   .arg(link)
                   .arg(p.x, 0, 'g', 8)
@@ -10621,13 +10650,33 @@ void MainWindow::populate_scene_hierarchy()
                   .arg(p.yaw, 0, 'g', 8));
               }
               const YAML::Node matrix = workcell_builder::yaml_map_key(row, "baked_world_visual_matrix");
-              if (matrix && matrix.IsSequence() && matrix.size() == 16) {
-                for (std::size_t i = 0; i < 16; ++i) {
-                  p.baked_world_visual_matrix[i] = workcell_builder::yaml_seq_index(matrix, i).as<double>(i % 5 == 0 ? 1.0 : 0.0);
+              if (matrix && matrix.IsSequence() && (matrix.size() == 16 || matrix.size() == 4)) {
+                bool matrix_loaded = false;
+                if (matrix.size() == 16) {
+                  for (std::size_t i = 0; i < 16; ++i) {
+                    p.baked_world_visual_matrix[i] = workcell_builder::yaml_seq_index(matrix, i).as<double>(i % 5 == 0 ? 1.0 : 0.0);
+                  }
+                  matrix_loaded = true;
+                } else {
+                  matrix_loaded = true;
+                  for (std::size_t matrix_row = 0; matrix_row < 4; ++matrix_row) {
+                    const YAML::Node matrix_row_node = workcell_builder::yaml_seq_index(matrix, matrix_row);
+                    if (!matrix_row_node || !matrix_row_node.IsSequence() || matrix_row_node.size() < 4) {
+                      matrix_loaded = false;
+                      break;
+                    }
+                    for (std::size_t matrix_col = 0; matrix_col < 4; ++matrix_col) {
+                      p.baked_world_visual_matrix[matrix_row * 4 + matrix_col] = workcell_builder::yaml_seq_index(matrix_row_node, matrix_col).as<double>(matrix_row == matrix_col ? 1.0 : 0.0);
+                    }
+                  }
                 }
-                p.has_baked_world_visual_transform = true;
-                p.has_baked_world_visual_matrix = true;
-                p.baked_world_visual_transform_source = QStringLiteral("generated/scene_visual_mesh_index.json:baked_world_visual_matrix:final_append");
+                if (matrix_loaded) {
+                  p.has_baked_world_visual_transform = true;
+                  p.has_baked_world_visual_matrix = true;
+                  p.baked_world_visual_transform_source = QStringLiteral("generated/scene_visual_mesh_index.json:baked_world_visual_matrix:final_append");
+                  append_studio_log(QStringLiteral("UR5_BAKED_MATRIX_APPLIED link=%1 source=%2")
+                    .arg(link, p.baked_world_visual_transform_source));
+                }
               }
               const YAML::Node mesh_scale = workcell_builder::yaml_map_key(row, "mesh_scale");
               const YAML::Node fallback_scale = workcell_builder::yaml_map_key(row, "scale");

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -139,12 +139,6 @@ void apply_urdf_rpy_gl(double roll, double pitch, double yaw)
   glRotated(qRadiansToDegrees(roll), 1.0, 0.0, 0.0);
 }
 
-void apply_urdf_pose_gl(double x, double y, double z, double roll, double pitch, double yaw)
-{
-  glTranslated(x, y, z);
-  apply_urdf_rpy_gl(roll, pitch, yaw);
-}
-
 void apply_urdf_rpy_matrix(QMatrix4x4 & transform, double roll, double pitch, double yaw)
 {
   // Keep Scene3D's CPU bounds path in the same URDF/RViz transform convention as rendering.
@@ -339,14 +333,6 @@ void apply_baked_mesh_asset_local_correction_matrix(QMatrix4x4 & transform, cons
   transform *= baked_mesh_asset_local_correction_matrix(item);
 }
 
-void apply_baked_mesh_asset_local_correction_gl(const ScenePreviewWidget::PreviewItem & item)
-{
-  if (!should_apply_baked_mesh_asset_local_correction(item)) return;
-
-  apply_urdf_rpy_gl(item.mesh_r, item.mesh_p, item.mesh_y);
-  if (item.has_origin_offset) glTranslated(item.origin_offset_x, item.origin_offset_y, item.origin_offset_z);
-}
-
 void apply_mesh_local_correction_matrix(QMatrix4x4 & transform, const ScenePreviewWidget::PreviewItem & item)
 {
   // Baked generated/locked URDF visuals already include the full URDF visual origin
@@ -384,34 +370,6 @@ QMatrix4x4 final_mesh_transform_matrix(const ScenePreviewWidget::PreviewItem & i
                   static_cast<float>(item.mesh_scale_y),
                   static_cast<float>(item.mesh_scale_z));
   return transform;
-}
-
-void apply_mesh_local_correction_gl(const ScenePreviewWidget::PreviewItem & item)
-{
-  // Mirror final_mesh_transform_matrix(): baked generated URDF visuals use the
-  // baked world visual pose directly and skip all legacy mesh-local correction
-  // hooks. Non-baked rows keep the existing mesh RPY/origin-offset path.
-  if (item.has_baked_world_visual_transform) return;
-
-  apply_urdf_rpy_gl(item.mesh_r, item.mesh_p, item.mesh_y);
-  if (item.has_origin_offset) glTranslated(item.origin_offset_x, item.origin_offset_y, item.origin_offset_z);
-}
-
-
-QJsonArray matrix_to_json_array(const QMatrix4x4 & matrix)
-{
-  QJsonArray out;
-  for (int row = 0; row < 4; ++row) {
-    for (int col = 0; col < 4; ++col) {
-      out.append(static_cast<double>(matrix(row, col)));
-    }
-  }
-  return out;
-}
-
-QJsonArray vector_to_json_array(const QVector3D & v)
-{
-  return QJsonArray{v.x(), v.y(), v.z()};
 }
 
 bool item_has_credible_mesh_handoff(const ScenePreviewWidget::PreviewItem & item)


### PR DESCRIPTION
Summary:
- Copies flat or nested `baked_world_visual_matrix` from `generated/scene_visual_mesh_index.json` into UR5 final-append PreviewItems.
- Converts `baked_world_visual_pose` to a matrix at handoff so generated URDF visual rows consistently use matrix-backed transforms.
- Emits `UR5_BAKED_MATRIX_APPLIED` logs for UR5 matrix-backed rows and removes unused legacy GL/JSON transform helpers from the viewport.

Validation:
- `git diff --check` passed.
- Full ROS/Workcell Studio smoke was not run in this container; the real VM `/home/user/workcell_ws` GUI/smoke environment is required for the acceptance run.

Safety:
- Did not touch launch files, controllers, runtime services, hardware parameters, or fake/real hardware configuration.
- No real-hardware path was enabled.

Risks / rollback:
- Risk: if upstream visual-index matrices use a different row/column convention than existing Scene3D diagnostics, UR5 placement could still need a matrix-order follow-up.
- Roll back by reverting commit `60e88a3`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a403175ad008331898dbc90430903a0)