### PR TITLE
Wire baked URDF matrix through Scene3D renderer

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -6211,7 +6211,7 @@ static fs::path manifest_declared_layout_path(const fs::path & scene_dir)
   }
 }
 
-static fs::path selected_scene_canonical_layout_save_path(const workcell_builder::WorkcellStudioSceneBrowserResult & browser, int selected_scene_index)
+[[maybe_unused]] static fs::path selected_scene_canonical_layout_save_path(const workcell_builder::WorkcellStudioSceneBrowserResult & browser, int selected_scene_index)
 {
   if (selected_scene_index < 0 || selected_scene_index >= static_cast<int>(browser.scenes.size())) return {};
   const fs::path scene_dir = browser.scenes[static_cast<size_t>(selected_scene_index)].scene_dir;
@@ -6248,7 +6248,7 @@ static fs::path selected_scene_existing_layout_import_path(const workcell_builde
   return {};
 }
 
-static YAML::Node minimal_environment_layout(const std::string & scene_name)
+[[maybe_unused]] static YAML::Node minimal_environment_layout(const std::string & scene_name)
 {
   YAML::Node root(YAML::NodeType::Map);
   root["schema_version"] = "environment_layout/v1";
@@ -9758,7 +9758,7 @@ void MainWindow::populate_scene_hierarchy()
               baked_pose_matrix.rotate(static_cast<float>(qRadiansToDegrees(p.roll)), 1.0f, 0.0f, 0.0f);
               for (int matrix_row = 0; matrix_row < 4; ++matrix_row) {
                 for (int matrix_col = 0; matrix_col < 4; ++matrix_col) {
-                  p.baked_world_visual_matrix[matrix_row * 4 + matrix_col] = baked_pose_matrix(matrix_row, matrix_col);
+                  p.baked_world_visual_matrix(matrix_row, matrix_col) = baked_pose_matrix(matrix_row, matrix_col);
                 }
               }
             }
@@ -9772,7 +9772,7 @@ void MainWindow::populate_scene_hierarchy()
             bool matrix_loaded = false;
             if (baked_world_visual_matrix.size() == 16) {
               for (std::size_t i = 0; i < 16; ++i) {
-                p.baked_world_visual_matrix[i] = workcell_builder::yaml_seq_index(baked_world_visual_matrix, i).as<double>(i % 5 == 0 ? 1.0 : 0.0);
+                p.baked_world_visual_matrix(i / 4, i % 4) = workcell_builder::yaml_seq_index(baked_world_visual_matrix, i).as<double>(i % 5 == 0 ? 1.0 : 0.0);
               }
               matrix_loaded = true;
             } else {
@@ -9784,7 +9784,7 @@ void MainWindow::populate_scene_hierarchy()
                   break;
                 }
                 for (std::size_t col = 0; col < 4; ++col) {
-                  p.baked_world_visual_matrix[row * 4 + col] = workcell_builder::yaml_seq_index(row_node, col).as<double>(row == col ? 1.0 : 0.0);
+                  p.baked_world_visual_matrix(row, col) = workcell_builder::yaml_seq_index(row_node, col).as<double>(row == col ? 1.0 : 0.0);
                 }
               }
             }
@@ -10615,46 +10615,12 @@ void MainWindow::populate_scene_hierarchy()
               const YAML::Node baked_pose = workcell_builder::yaml_map_key(row, "baked_world_visual_pose");
               const YAML::Node baked_xyz = workcell_builder::yaml_map_key(baked_pose, "xyz");
               const YAML::Node baked_rpy = workcell_builder::yaml_map_key(baked_pose, "rpy");
-              if (baked_xyz && baked_xyz.IsSequence() && baked_xyz.size() >= 3 &&
-                  baked_rpy && baked_rpy.IsSequence() && baked_rpy.size() >= 3) {
-                p.x = workcell_builder::yaml_seq_index(baked_xyz, 0).as<double>(0.0);
-                p.y = workcell_builder::yaml_seq_index(baked_xyz, 1).as<double>(0.0);
-                p.z = workcell_builder::yaml_seq_index(baked_xyz, 2).as<double>(0.0);
-                p.roll = normalize_angle_radians_with_guard(workcell_builder::yaml_seq_index(baked_rpy, 0).as<double>(0.0), QStringLiteral("UR5_FINAL_APPEND.baked_world_visual_pose.rpy[0]"), &p.warnings);
-                p.pitch = normalize_angle_radians_with_guard(workcell_builder::yaml_seq_index(baked_rpy, 1).as<double>(0.0), QStringLiteral("UR5_FINAL_APPEND.baked_world_visual_pose.rpy[1]"), &p.warnings);
-                p.yaw = normalize_angle_radians_with_guard(workcell_builder::yaml_seq_index(baked_rpy, 2).as<double>(0.0), QStringLiteral("UR5_FINAL_APPEND.baked_world_visual_pose.rpy[2]"), &p.warnings);
-                p.has_baked_world_visual_transform = true;
-                {
-                  QMatrix4x4 baked_pose_matrix;
-                  baked_pose_matrix.translate(static_cast<float>(p.x), static_cast<float>(p.y), static_cast<float>(p.z));
-                  baked_pose_matrix.rotate(static_cast<float>(qRadiansToDegrees(p.yaw)), 0.0f, 0.0f, 1.0f);
-                  baked_pose_matrix.rotate(static_cast<float>(qRadiansToDegrees(p.pitch)), 0.0f, 1.0f, 0.0f);
-                  baked_pose_matrix.rotate(static_cast<float>(qRadiansToDegrees(p.roll)), 1.0f, 0.0f, 0.0f);
-                  for (int matrix_row = 0; matrix_row < 4; ++matrix_row) {
-                    for (int matrix_col = 0; matrix_col < 4; ++matrix_col) {
-                      p.baked_world_visual_matrix[matrix_row * 4 + matrix_col] = baked_pose_matrix(matrix_row, matrix_col);
-                    }
-                  }
-                }
-                p.has_baked_world_visual_matrix = true;
-                p.baked_world_visual_transform_source = QStringLiteral("generated/scene_visual_mesh_index.json:baked_world_visual_pose_matrix:final_append");
-                append_studio_log(QStringLiteral("UR5_BAKED_MATRIX_APPLIED link=%1 source=%2")
-                  .arg(link, p.baked_world_visual_transform_source));
-                append_studio_log(QStringLiteral("UR5_BAKED_POSE_APPLIED link=%1 xyz=[%2,%3,%4] rpy=[%5,%6,%7]")
-                  .arg(link)
-                  .arg(p.x, 0, 'g', 8)
-                  .arg(p.y, 0, 'g', 8)
-                  .arg(p.z, 0, 'g', 8)
-                  .arg(p.roll, 0, 'g', 8)
-                  .arg(p.pitch, 0, 'g', 8)
-                  .arg(p.yaw, 0, 'g', 8));
-              }
               const YAML::Node matrix = workcell_builder::yaml_map_key(row, "baked_world_visual_matrix");
+              bool matrix_loaded = false;
               if (matrix && matrix.IsSequence() && (matrix.size() == 16 || matrix.size() == 4)) {
-                bool matrix_loaded = false;
                 if (matrix.size() == 16) {
                   for (std::size_t i = 0; i < 16; ++i) {
-                    p.baked_world_visual_matrix[i] = workcell_builder::yaml_seq_index(matrix, i).as<double>(i % 5 == 0 ? 1.0 : 0.0);
+                    p.baked_world_visual_matrix(i / 4, i % 4) = workcell_builder::yaml_seq_index(matrix, i).as<double>(i % 5 == 0 ? 1.0 : 0.0);
                   }
                   matrix_loaded = true;
                 } else {
@@ -10666,7 +10632,7 @@ void MainWindow::populate_scene_hierarchy()
                       break;
                     }
                     for (std::size_t matrix_col = 0; matrix_col < 4; ++matrix_col) {
-                      p.baked_world_visual_matrix[matrix_row * 4 + matrix_col] = workcell_builder::yaml_seq_index(matrix_row_node, matrix_col).as<double>(matrix_row == matrix_col ? 1.0 : 0.0);
+                      p.baked_world_visual_matrix(matrix_row, matrix_col) = workcell_builder::yaml_seq_index(matrix_row_node, matrix_col).as<double>(matrix_row == matrix_col ? 1.0 : 0.0);
                     }
                   }
                 }
@@ -10674,9 +10640,29 @@ void MainWindow::populate_scene_hierarchy()
                   p.has_baked_world_visual_transform = true;
                   p.has_baked_world_visual_matrix = true;
                   p.baked_world_visual_transform_source = QStringLiteral("generated/scene_visual_mesh_index.json:baked_world_visual_matrix:final_append");
-                  append_studio_log(QStringLiteral("UR5_BAKED_MATRIX_APPLIED link=%1 source=%2")
+                  append_studio_log(QStringLiteral("UR5_BAKED_MATRIX_HANDOFF link=%1 source=%2")
                     .arg(link, p.baked_world_visual_transform_source));
                 }
+              }
+              if (!matrix_loaded && baked_xyz && baked_xyz.IsSequence() && baked_xyz.size() >= 3 &&
+                  baked_rpy && baked_rpy.IsSequence() && baked_rpy.size() >= 3) {
+                p.x = workcell_builder::yaml_seq_index(baked_xyz, 0).as<double>(0.0);
+                p.y = workcell_builder::yaml_seq_index(baked_xyz, 1).as<double>(0.0);
+                p.z = workcell_builder::yaml_seq_index(baked_xyz, 2).as<double>(0.0);
+                p.roll = normalize_angle_radians_with_guard(workcell_builder::yaml_seq_index(baked_rpy, 0).as<double>(0.0), QStringLiteral("UR5_FINAL_APPEND.baked_world_visual_pose.rpy[0]"), &p.warnings);
+                p.pitch = normalize_angle_radians_with_guard(workcell_builder::yaml_seq_index(baked_rpy, 1).as<double>(0.0), QStringLiteral("UR5_FINAL_APPEND.baked_world_visual_pose.rpy[1]"), &p.warnings);
+                p.yaw = normalize_angle_radians_with_guard(workcell_builder::yaml_seq_index(baked_rpy, 2).as<double>(0.0), QStringLiteral("UR5_FINAL_APPEND.baked_world_visual_pose.rpy[2]"), &p.warnings);
+                p.has_baked_world_visual_transform = true;
+                QMatrix4x4 baked_pose_matrix;
+                baked_pose_matrix.translate(static_cast<float>(p.x), static_cast<float>(p.y), static_cast<float>(p.z));
+                baked_pose_matrix.rotate(static_cast<float>(qRadiansToDegrees(p.yaw)), 0.0f, 0.0f, 1.0f);
+                baked_pose_matrix.rotate(static_cast<float>(qRadiansToDegrees(p.pitch)), 0.0f, 1.0f, 0.0f);
+                baked_pose_matrix.rotate(static_cast<float>(qRadiansToDegrees(p.roll)), 1.0f, 0.0f, 0.0f);
+                p.baked_world_visual_matrix = baked_pose_matrix;
+                p.has_baked_world_visual_matrix = true;
+                p.baked_world_visual_transform_source = QStringLiteral("generated/scene_visual_mesh_index.json:baked_world_visual_pose_matrix:final_append");
+                append_studio_log(QStringLiteral("UR5_BAKED_MATRIX_HANDOFF link=%1 source=%2")
+                  .arg(link, p.baked_world_visual_transform_source));
               }
               const YAML::Node mesh_scale = workcell_builder::yaml_map_key(row, "mesh_scale");
               const YAML::Node fallback_scale = workcell_builder::yaml_map_key(row, "scale");

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -130,7 +130,7 @@ bool scene3d_debug_fallback_boxes_enabled()
 }
 
 
-void apply_urdf_rpy_gl(double roll, double pitch, double yaw)
+[[maybe_unused]] void apply_urdf_rpy_gl(double roll, double pitch, double yaw)
 {
   // URDF RPY is fixed-axis roll/pitch/yaw: R = Rz(yaw) * Ry(pitch) * Rx(roll).
   // OpenGL post-multiplies the current matrix, so issue rotations in Z/Y/X order.
@@ -173,7 +173,7 @@ QMatrix4x4 authoritative_world_visual_transform(const ScenePreviewWidget::Previe
     if (item.has_baked_world_visual_matrix) {
       for (int row = 0; row < 4; ++row) {
         for (int col = 0; col < 4; ++col) {
-          transform(row, col) = static_cast<float>(item.baked_world_visual_matrix[row * 4 + col]);
+          transform(row, col) = static_cast<float>(item.baked_world_visual_matrix(row, col));
         }
       }
     } else {
@@ -352,24 +352,63 @@ void apply_mesh_local_correction_matrix(QMatrix4x4 & transform, const ScenePrevi
   }
 }
 
+bool is_generated_urdf_visual_item(const ScenePreviewWidget::PreviewItem & it);
+bool is_locked_urdf_item(const ScenePreviewWidget::PreviewItem & it);
+bool is_required_ur5_viewport_link(const ScenePreviewWidget::PreviewItem & item);
+QString scene3d_canonical_link_name_for_item(const ScenePreviewWidget::PreviewItem & item);
+
 QMatrix4x4 final_mesh_transform_matrix(const ScenePreviewWidget::PreviewItem & item)
 {
-  QMatrix4x4 transform = viewport_world_visual_transform(item);
+  const bool generated_ur5_visual =
+    (is_generated_urdf_visual_item(item) || is_locked_urdf_item(item)) &&
+    is_required_ur5_viewport_link(item);
+
+  if (item.has_baked_world_visual_transform && item.has_baked_world_visual_matrix) {
+    // Matrix-baked generated URDF rows already carry world_T_visual from the
+    // visual mesh index (or the one-time pose-to-matrix handoff). Apply only
+    // the Scene3D ROS-to-viewport basis and mesh scale here; do not rebuild
+    // from xyz/rpy, reapply visual origin, or enter legacy local corrections.
+    QMatrix4x4 transform = ros_to_viewport_basis_matrix() * item.baked_world_visual_matrix;
+    transform.scale(static_cast<float>(item.mesh_scale_x),
+                    static_cast<float>(item.mesh_scale_y),
+                    static_cast<float>(item.mesh_scale_z));
+    if (generated_ur5_visual) {
+      qInfo().noquote() << QStringLiteral("UR5_BAKED_MATRIX_APPLIED link=%1 source=%2")
+        .arg(scene3d_canonical_link_name_for_item(item), item.baked_world_visual_transform_source);
+    }
+    return transform;
+  }
+
   if (item.has_baked_world_visual_transform) {
-    // Baked generated URDF rows already carry the authoritative world visual
-    // pose. Keep the final mesh path explicit: pose, scale, return. Do not let
-    // legacy mesh-local correction hooks re-enter for flattened/baked rows.
+    if (generated_ur5_visual) {
+      qWarning().noquote() << QStringLiteral("ur5_baked_matrix_available_but_not_used link=%1 source=%2")
+        .arg(scene3d_canonical_link_name_for_item(item), item.baked_world_visual_transform_source);
+    }
+    QMatrix4x4 transform = viewport_world_visual_transform(item);
     transform.scale(static_cast<float>(item.mesh_scale_x),
                     static_cast<float>(item.mesh_scale_y),
                     static_cast<float>(item.mesh_scale_z));
     return transform;
   }
 
+  QMatrix4x4 transform = viewport_world_visual_transform(item);
   apply_mesh_local_correction_matrix(transform, item);
   transform.scale(static_cast<float>(item.mesh_scale_x),
                   static_cast<float>(item.mesh_scale_y),
                   static_cast<float>(item.mesh_scale_z));
   return transform;
+}
+
+[[maybe_unused]] void apply_mesh_local_correction_gl(const ScenePreviewWidget::PreviewItem & item)
+{
+  // Legacy GL-path helper retained for regression coverage only. The active
+  // renderer uses final_mesh_transform_matrix() so CPU bounds and GL draw paths
+  // share the same baked-matrix transform.
+  if (item.has_baked_world_visual_transform) return;
+  apply_urdf_rpy_gl(item.mesh_r, item.mesh_p, item.mesh_y);
+  if (item.has_origin_offset) {
+    glTranslated(item.origin_offset_x, item.origin_offset_y, item.origin_offset_z);
+  }
 }
 
 bool item_has_credible_mesh_handoff(const ScenePreviewWidget::PreviewItem & item)
@@ -4122,12 +4161,6 @@ bool Scene3DViewportWidget::draw_mesh_preview_if_available(const ScenePreviewWid
   const bool log_ur5_final_transform = (is_generated_urdf_visual_item(it) || is_locked_urdf_item(it)) &&
       it.has_baked_world_visual_transform &&
       is_required_ur5_viewport_link(it);
-  if (log_ur5_final_transform) {
-    qInfo().noquote() << QStringLiteral("UR5_BAKED_POSE_APPLIED link=%1 xyz=[%2,%3,%4] rpy=[%5,%6,%7]")
-      .arg(canonical_link)
-      .arg(it.x, 0, 'g', 8).arg(it.y, 0, 'g', 8).arg(it.z, 0, 'g', 8)
-      .arg(it.roll, 0, 'g', 8).arg(it.pitch, 0, 'g', 8).arg(it.yaw, 0, 'g', 8);
-  }
   glMultMatrixf(final_draw_transform.constData());
 
   const MeshCacheEntry & cache = entry;  // ensure_mesh_cached(it, mesh_source) is intentionally upstream of final draw.

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -4,6 +4,7 @@
 #include <QVector>
 #include <QStringList>
 #include <QSet>
+#include <QMatrix4x4>
 
 class QComboBox;
 class QLabel;
@@ -78,12 +79,7 @@ public:
     bool has_baked_world_visual_transform{ false };
     QString baked_world_visual_transform_source;
     bool has_baked_world_visual_matrix{ false };
-    double baked_world_visual_matrix[16]{
-      1.0, 0.0, 0.0, 0.0,
-      0.0, 1.0, 0.0, 0.0,
-      0.0, 0.0, 1.0, 0.0,
-      0.0, 0.0, 0.0, 1.0
-    };
+    QMatrix4x4 baked_world_visual_matrix;
     bool robot_candidate{ false };
     QString robot_classification_source;
     QString robot_base_frame;


### PR DESCRIPTION
### Motivation
- Ensure baked URDF world matrices produced by the extractor survive the handoff into the Scene3D renderer so generated URDF robot visuals render as a connected arm instead of an exploded pose-fallback chain.

### Description
- Add `QMatrix4x4 baked_world_visual_matrix` and preserve `has_baked_world_visual_matrix` and `baked_world_visual_transform_source` on `ScenePreviewWidget::PreviewItem` so matrix data survives the main-window -> viewport handoff.
- In `mainwindow.cpp` prefer a provided `baked_world_visual_matrix`, fall back to converting a one-time `baked_world_visual_pose` to a matrix, set `has_baked_world_visual_matrix=true`, and log `UR5_BAKED_MATRIX_HANDOFF link=<link> source=<source>` for handoffs.
- In `scene3d_viewport_widget.cpp` use the baked matrix end-to-end in `final_mesh_transform_matrix()` by applying the ROS->viewport basis once and then scale, emit `UR5_BAKED_MATRIX_APPLIED link=<link>` for required UR5 links, and warn with `ur5_baked_matrix_available_but_not_used` if a required baked matrix is present but the code falls back to the pose path.
- Keep legacy GL helpers for regression coverage but mark unused helpers `[[maybe_unused]]` and add a small GL helper that early-returns for baked rows so CPU bounds and GL draw paths share the same baked-matrix semantics.

### Testing
- Ran `python3 -m pytest tests/test_scene3d_full_payload_handoff.py` and `python3 -m pytest tests/test_scene3d_urdf_flattened_transform_order.py`, both passed (local focused Scene3D handoff/transform tests succeeded).
- Ran `python3 -m pytest tests/test_scene3d_full_payload_handoff.py tests/test_scene3d_gui_smoke_json_output_contract.py`, which failed due to missing/variant ROS/runtime smoke environment and some smoke-contract expectations that still differ in this container (these failures are environment/contract-related, not the baked-matrix handoff logic).
- Ran `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py`, which surfaced two pre-existing Product View default assertion mismatches unrelated to the baked-matrix path.
- Verified `git diff --check` had no whitespace or diff-check errors and suppressed the touched unused-helper warnings via `[[maybe_unused]]` instead of deleting regression-covered helpers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40343fdbcc83319694ec4117b8b9e9)