### PR TITLE
Align UR5 repair test with stable preview rows

### DIFF
--- a/tests/test_repair_ur5_scene3d_visual_index.py
+++ b/tests/test_repair_ur5_scene3d_visual_index.py
@@ -64,10 +64,14 @@ def test_repair_replaces_stale_unrenderable_ur5_rows_and_preserves_non_ur5_rows(
     assert {row["link"] for row in ur5_rows} == set(REQUIRED_UR5_LINKS)
     assert all(row["category"] == "robot" for row in ur5_rows)
     assert all(row["role"] == "robot" for row in ur5_rows)
-    assert all(row["has_mesh_metadata"] is True for row in ur5_rows)
+    assert all(row["has_mesh_metadata"] is False for row in ur5_rows)
+    assert all(row["geometry_type"] == "box" for row in ur5_rows)
+    assert all(row["primitive_geometry_type"] == "box" for row in ur5_rows)
+    assert all(row["active_visual_source"] == "primitive_fallback" for row in ur5_rows)
     assert all(row["source_layer"] == "locked_generated_urdf_visual" for row in ur5_rows)
     assert all(row["final_render_identity"] == row["link"] for row in ur5_rows)
     assert all(row["render_expected"] is True for row in ur5_rows)
+    assert payload["ur5_runtime_repair_mode"] == "stable_primitive_builder_preview"
     assert "ur5_final_viewport_links_missing" not in payload["blockers"]
     assert "rendered_ur5_link_count_below_7" not in payload["blockers"]
     assert "keep_non_ur5_blocker" in payload["blockers"]


### PR DESCRIPTION
Updates the UR5 visual-index repair regression test after the stable builder preview change.

The repair now intentionally emits locked primitive preview rows for the builder canvas, so the test should expect:

- box geometry
- primitive_fallback active source
- no mesh metadata on the stable preview rows
- the stable preview repair mode marker

This keeps the test aligned with the merged Scene3D preview behavior.