### PR TITLE
Repair missing UR5 2F gripper independently

### DIFF
--- a/scripts/repair_ur5_scene3d_visual_index.py
+++ b/scripts/repair_ur5_scene3d_visual_index.py
@@ -307,18 +307,19 @@ def repair_index(path: Path) -> tuple[bool, list[str]]:
     present = _present_required_links(items)
     missing = [spec for spec in REQUIRED_UR5_VISUALS if spec["link"] not in present]
     stale_or_implausible, repair_reasons = _existing_ur5_rows_need_repair(items, present)
-    should_include_2f_proxy = _payload_uses_2f_gripper(payload, items, path) and (bool(missing) or stale_or_implausible)
+    repair_arm_rows = bool(missing) or stale_or_implausible
     present_2f_links = _present_links(items, STABLE_UR5_2F_LINKS)
     missing_2f_specs = [spec for spec in STABLE_UR5_2F_PREVIEW_VISUALS if spec["link"] not in present_2f_links]
+    should_include_2f_proxy = _payload_uses_2f_gripper(payload, items, path) and bool(missing_2f_specs)
     extra_specs = missing_2f_specs if should_include_2f_proxy else []
-    if not missing and not stale_or_implausible and not extra_specs:
+    if not repair_arm_rows and not extra_specs:
         return False, []
 
-    repaired_specs = list(REQUIRED_UR5_VISUALS) + list(extra_specs)
+    repaired_specs = (list(REQUIRED_UR5_VISUALS) if repair_arm_rows else []) + list(extra_specs)
     repaired = [_ur5_item(spec, index) for index, spec in enumerate(repaired_specs)]
-    replaced_links = set(REQUIRED_UR5_LINKS)
+    replaced_links: set[str] = set(REQUIRED_UR5_LINKS) if repair_arm_rows else set()
     if extra_specs:
-        replaced_links.update(STABLE_UR5_2F_LINKS)
+        replaced_links.update(spec["link"] for spec in extra_specs)
     kept = [
         item for item in items
         if isinstance(item, dict)
@@ -342,7 +343,12 @@ def repair_index(path: Path) -> tuple[bool, list[str]]:
     payload["ur5_runtime_repair_mode"] = "stable_primitive_builder_preview"
     payload["ur5_runtime_repair_added_links"] = [spec["link"] for spec in missing]
     payload["ur5_runtime_repair_added_end_effector_links"] = [spec["link"] for spec in extra_specs]
-    payload["ur5_runtime_repair_reasons"] = repair_reasons or ["missing_required_ur5_rows"]
+    if repair_reasons:
+        payload["ur5_runtime_repair_reasons"] = repair_reasons
+    elif repair_arm_rows:
+        payload["ur5_runtime_repair_reasons"] = ["missing_required_ur5_rows"]
+    else:
+        payload["ur5_runtime_repair_reasons"] = ["missing_ur5_2f_end_effector_preview_rows"]
     payload["ur5_required_links"] = list(REQUIRED_UR5_LINKS)
     if extra_specs:
         payload["ur5_2f_stable_preview_links"] = list(STABLE_UR5_2F_LINKS)

--- a/tests/test_repair_ur5_scene3d_visual_index.py
+++ b/tests/test_repair_ur5_scene3d_visual_index.py
@@ -122,6 +122,52 @@ def test_repair_adds_locked_2f_gripper_proxy_for_ur5_2f_scene(tmp_path):
     assert any(row.get("id") == "camera" for row in rows)
 
 
+def test_repair_adds_missing_2f_proxy_without_replacing_valid_ur5_rows(tmp_path):
+    valid_ur5_rows = [
+        {
+            "id": f"mesh_{link}",
+            "link": link,
+            "mesh_uri": f"package://ur_description/meshes/ur5/visual/{link}.dae",
+            "geometry_type": "mesh",
+            "resolved": True,
+            "render_expected": True,
+            "pose": {"xyz": [float(i) * 0.1, 0.0, 0.2], "rpy": [0.0, 0.0, 0.0]},
+        }
+        for i, link in enumerate(REQUIRED_UR5_LINKS)
+    ]
+    path = _write_index(
+        tmp_path,
+        {
+            "scene_name": "ur5_2f_test",
+            "visual_items": valid_ur5_rows + [
+                {
+                    "id": "table",
+                    "display_name": "table",
+                    "geometry_type": "box",
+                    "category": "table",
+                    "render_expected": True,
+                    "resolved": True,
+                }
+            ],
+            "items": [],
+            "blockers": [],
+        },
+    )
+
+    changed, added = repair_index(path)
+
+    assert changed is True
+    assert added == []
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    rows = payload["visual_items"]
+    links = {row.get("link") for row in rows}
+    assert set(REQUIRED_UR5_LINKS).issubset(links)
+    assert set(STABLE_UR5_2F_LINKS).issubset(links)
+    assert all(any(row.get("id") == f"mesh_{link}" for row in rows) for link in REQUIRED_UR5_LINKS)
+    assert payload["ur5_runtime_repair_reasons"] == ["missing_ur5_2f_end_effector_preview_rows"]
+    assert any(row.get("id") == "table" for row in rows)
+
+
 def test_repair_skips_non_ur5_payload(tmp_path):
     path = _write_index(
         tmp_path,


### PR DESCRIPTION
Fixes the stable UR5 2F preview repair path so a missing Robotiq 2F proxy is repaired even when the UR5 arm rows are already valid.

Why:
- The previous repair only added the 2F proxy when the arm rows were also being replaced.
- A scene can have valid UR5 arm rows but still be missing tool0 / Robotiq rows, leaving the builder preview as a bare wrist.

Change:
- Separates arm-row repair from gripper-proxy repair.
- Preserves valid existing UR5 arm mesh rows during gripper-only repair.
- Adds regression coverage for gripper-only repair.

Validation not run here. Please run:

```bash
python3 -m pytest tests/test_repair_ur5_scene3d_visual_index.py
```