### PR TITLE
Clarify single-scene Scene3D repair output

### DIFF
--- a/scripts/generate_scene_visual_mesh_index.py
+++ b/scripts/generate_scene_visual_mesh_index.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -17,6 +18,28 @@ except Exception:  # pragma: no cover - optional post-processing safety net
     repair_index = None
 
 
+def _list_value(payload: dict, key: str) -> list:
+    value = payload.get(key)
+    return value if isinstance(value, list) else []
+
+
+def _repair_detail(index_path: Path, links: list[str]) -> str:
+    try:
+        payload = json.loads(index_path.read_text(encoding="utf-8"))
+    except Exception:
+        return ", ".join(links) if links else "visual rows normalized"
+    added_arm = links or _list_value(payload, "ur5_runtime_repair_added_links")
+    added_eef = _list_value(payload, "ur5_runtime_repair_added_end_effector_links")
+    reasons = _list_value(payload, "ur5_runtime_repair_reasons")
+    if added_arm:
+        return "ur5_links=" + ",".join(str(v) for v in added_arm)
+    if added_eef:
+        return "end_effector_links=" + ",".join(str(v) for v in added_eef)
+    if reasons:
+        return "reasons=" + ",".join(str(v) for v in reasons)
+    return "visual rows normalized"
+
+
 def _repair_existing_index(index_path: Path) -> int:
     if repair_index is None:
         print("visual mesh index repair helper unavailable", file=sys.stderr)
@@ -26,8 +49,7 @@ def _repair_existing_index(index_path: Path) -> int:
         return 2
     changed, links = repair_index(index_path)
     if changed:
-        detail = ", ".join(links) if links else "stale or implausible UR5 rows replaced"
-        print("[generate_scene_visual_mesh_index] UR5 repair applied: " + detail, flush=True)
+        print("[generate_scene_visual_mesh_index] UR5 repair applied: " + _repair_detail(index_path, links), flush=True)
     else:
         print("[generate_scene_visual_mesh_index] existing index already safe for preview", flush=True)
     return 0

--- a/tests/test_generate_scene_visual_mesh_index_repair_output.py
+++ b/tests/test_generate_scene_visual_mesh_index_repair_output.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+
+from scripts.generate_scene_visual_mesh_index import _repair_existing_index
+from scripts.repair_ur5_scene3d_visual_index import REQUIRED_UR5_LINKS
+
+
+def test_single_scene_repair_reports_missing_end_effector_links(tmp_path, capsys):
+    index_path = tmp_path / "scene_visual_mesh_index.json"
+    rows = [
+        {
+            "id": f"mesh_{link}",
+            "link": link,
+            "mesh_uri": f"package://ur_description/meshes/ur5/visual/{link}.dae",
+            "geometry_type": "mesh",
+            "resolved": True,
+            "render_expected": True,
+            "pose": {"xyz": [float(i) * 0.1, 0.0, 0.2], "rpy": [0.0, 0.0, 0.0]},
+        }
+        for i, link in enumerate(REQUIRED_UR5_LINKS)
+    ]
+    index_path.write_text(json.dumps({"scene_name": "ur5_2f_test", "visual_items": rows}) + "\n", encoding="utf-8")
+
+    assert _repair_existing_index(index_path) == 0
+
+    out = capsys.readouterr().out
+    assert "UR5 repair applied" in out
+    assert "end_effector_links=tool0,robotiq_85_base_link" in out
+
+
+def test_single_scene_repair_reports_already_safe(tmp_path, capsys):
+    index_path = tmp_path / "scene_visual_mesh_index.json"
+    index_path.write_text(json.dumps({"scene_name": "generic_scene", "visual_items": []}) + "\n", encoding="utf-8")
+
+    assert _repair_existing_index(index_path) == 0
+
+    out = capsys.readouterr().out
+    assert "existing index already safe for preview" in out


### PR DESCRIPTION
Improves the single-scene visual-index repair command output so it reports what was actually repaired.

Why:
- After the gripper-only repair path, `generate_scene_visual_mesh_index.py --repair-existing-only` could print the generic stale/implausible message even when the actual change was adding missing UR5 2F end-effector preview rows.
- That makes debugging the bare-wrist/gripper-missing case confusing.

Change:
- Reads repair metadata after repair.
- Reports `ur5_links=...`, `end_effector_links=...`, or repair reasons accurately.
- Adds regression coverage for the gripper-only output path.

Validation not run here. Please run:

```bash
python3 -m pytest tests/test_generate_scene_visual_mesh_index_repair_output.py
python3 scripts/generate_scene_visual_mesh_index.py --scene ur5_2f_test --repair-existing-only
```