### PR TITLE
Reuse shared Scene3D repair helper

### DIFF
--- a/scripts/generate_scene_visual_mesh_index.py
+++ b/scripts/generate_scene_visual_mesh_index.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import subprocess
 import sys
 from pathlib import Path
@@ -12,44 +11,16 @@ from pathlib import Path
 if str(Path(__file__).resolve().parents[1]) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-try:
-    from scripts.repair_ur5_scene3d_visual_index import repair_index
-except Exception:  # pragma: no cover - optional post-processing safety net
-    repair_index = None
+from scripts.scene3d_visual_index_report import run_visual_index_postprocess  # noqa: E402
 
 
-def _list_value(payload: dict, key: str) -> list:
-    value = payload.get(key)
-    return value if isinstance(value, list) else []
-
-
-def _repair_detail(index_path: Path, links: list[str]) -> str:
-    try:
-        payload = json.loads(index_path.read_text(encoding="utf-8"))
-    except Exception:
-        return ", ".join(links) if links else "visual rows normalized"
-    added_arm = links or _list_value(payload, "ur5_runtime_repair_added_links")
-    added_eef = _list_value(payload, "ur5_runtime_repair_added_end_effector_links")
-    reasons = _list_value(payload, "ur5_runtime_repair_reasons")
-    if added_arm:
-        return "ur5_links=" + ",".join(str(v) for v in added_arm)
-    if added_eef:
-        return "end_effector_links=" + ",".join(str(v) for v in added_eef)
-    if reasons:
-        return "reasons=" + ",".join(str(v) for v in reasons)
-    return "visual rows normalized"
-
-
-def _repair_existing_index(index_path: Path) -> int:
-    if repair_index is None:
-        print("visual mesh index repair helper unavailable", file=sys.stderr)
+def _repair_scene_index(scene_dir: Path) -> int:
+    result = run_visual_index_postprocess(scene_dir)
+    if result.get("postprocess_error"):
+        print("visual mesh index repair failed: " + str(result["postprocess_error"]), file=sys.stderr)
         return 2
-    if not index_path.exists():
-        print(f"visual mesh index missing: {index_path}", file=sys.stderr)
-        return 2
-    changed, links = repair_index(index_path)
-    if changed:
-        print("[generate_scene_visual_mesh_index] UR5 repair applied: " + _repair_detail(index_path, links), flush=True)
+    if result.get("postprocess_changed"):
+        print("[generate_scene_visual_mesh_index] UR5 repair applied: " + str(result.get("postprocess_detail") or "visual rows normalized"), flush=True)
     else:
         print("[generate_scene_visual_mesh_index] existing index already safe for preview", flush=True)
     return 0
@@ -69,10 +40,10 @@ def main() -> int:
     args = parser.parse_args()
 
     repo_root = Path(args.repo_root).resolve()
-    index_path = repo_root / "scenes" / args.scene / "generated" / "scene_visual_mesh_index.json"
+    scene_dir = repo_root / "scenes" / args.scene
 
     if args.repair_existing_only:
-        return _repair_existing_index(index_path)
+        return _repair_scene_index(scene_dir)
 
     extractor = repo_root / "scripts" / "extract_scene_urdf_visual_mesh_index.py"
     if not extractor.exists():
@@ -94,7 +65,7 @@ def main() -> int:
     if result != 0:
         return result
 
-    return _repair_existing_index(index_path)
+    return _repair_scene_index(scene_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Cleanup PR.

Changes:
- Reuses `run_visual_index_postprocess()` in `generate_scene_visual_mesh_index.py`.
- Removes duplicated JSON parsing and repair-detail formatting.
- Reduces the file by 39 deleted lines.

Validation not run here. Existing checks:

```bash
python3 scripts/generate_scene_visual_mesh_index.py --scene ur5_2f_test --repair-existing-only
python3 scripts/regenerate_scene_visual_mesh_indexes.py --scene ur5_2f_test --repair-existing-only
```