### PR TITLE
Keep RViz mesh rows in Scene3D repair

### DIFF
--- a/scripts/repair_ur5_scene3d_visual_index.py
+++ b/scripts/repair_ur5_scene3d_visual_index.py
@@ -3,7 +3,7 @@
 
 The extractor remains the source of truth for generated ROS/RViz packages.  The
 builder viewport also needs a safe preview layer: when required UR5 rows are
-missing, stale, seeded, collapsed, or geometrically implausible, this script
+missing, collapsed, unrenderable, or geometrically implausible, this script
 replaces the UR5 arm preview rows with a stable locked primitive preview.  For
 UR5 + Robotiq 2F scenes, it also adds a small locked gripper proxy so the builder
 canvas still shows an end-effector instead of a bare wrist when xacro expansion
@@ -33,7 +33,6 @@ UR5_VISUAL_TOKEN_HINTS = (
     "package://ur_description/meshes/ur5/visual/",
     "assets/robots/universal_robot/ur_description/meshes/ur5/visual/",
 )
-STALE_SEED_TOKENS = ("generated_urdf_identity_rviz_parity_seed", "identity_rviz_parity_seed", "rviz_parity_seed")
 MAX_ADJACENT_LINK_DISTANCE_M = 1.25
 COLLAPSED_LINK_EPSILON_M = 1e-6
 
@@ -172,8 +171,11 @@ def _ur5_link_positions(items: list[dict[str, Any]]) -> dict[str, list[float]]:
 
 def _existing_ur5_rows_need_repair(items: list[dict[str, Any]], present: set[str]) -> tuple[bool, list[str]]:
     reasons: list[str] = []
-    if any(any(token in _token_values(item) for token in STALE_SEED_TOKENS) for item in items):
-        reasons.append("stale_rviz_parity_seed_rows")
+    # RViz-level Scene3D must keep resolved, renderable mesh rows.  Older checked-in
+    # indexes can carry rviz-parity seed tokens even when their mesh paths and poses
+    # are valid; those tokens alone are not a reason to down-convert the robot to
+    # primitive boxes.  Repair only when the rows are missing, collapsed, or
+    # geometrically implausible.
     positions = _ur5_link_positions(items)
     if present and len(positions) < min(4, len(present)):
         reasons.append("insufficient_ur5_pose_data")

--- a/tests/test_repair_ur5_scene3d_visual_index.py
+++ b/tests/test_repair_ur5_scene3d_visual_index.py
@@ -122,7 +122,7 @@ def test_repair_adds_locked_2f_gripper_proxy_for_ur5_2f_scene(tmp_path):
     assert any(row.get("id") == "camera" for row in rows)
 
 
-def test_repair_adds_missing_2f_proxy_without_replacing_valid_ur5_rows(tmp_path):
+def test_repair_adds_missing_2f_proxy_without_replacing_valid_rviz_mesh_rows(tmp_path):
     valid_ur5_rows = [
         {
             "id": f"mesh_{link}",
@@ -131,6 +131,7 @@ def test_repair_adds_missing_2f_proxy_without_replacing_valid_ur5_rows(tmp_path)
             "geometry_type": "mesh",
             "resolved": True,
             "render_expected": True,
+            "baked_world_visual_transform_source": "generated_urdf_identity_rviz_parity_seed",
             "pose": {"xyz": [float(i) * 0.1, 0.0, 0.2], "rpy": [0.0, 0.0, 0.0]},
         }
         for i, link in enumerate(REQUIRED_UR5_LINKS)
@@ -163,7 +164,7 @@ def test_repair_adds_missing_2f_proxy_without_replacing_valid_ur5_rows(tmp_path)
     links = {row.get("link") for row in rows}
     assert set(REQUIRED_UR5_LINKS).issubset(links)
     assert set(STABLE_UR5_2F_LINKS).issubset(links)
-    assert all(any(row.get("id") == f"mesh_{link}" for row in rows) for link in REQUIRED_UR5_LINKS)
+    assert all(any(row.get("id") == f"mesh_{link}" and row.get("geometry_type") == "mesh" for row in rows) for link in REQUIRED_UR5_LINKS)
     assert payload["ur5_runtime_repair_reasons"] == ["missing_ur5_2f_end_effector_preview_rows"]
     assert any(row.get("id") == "table" for row in rows)
 


### PR DESCRIPTION
Scene3D visual fix.

Changes:
- Keeps valid resolved UR5 mesh rows instead of replacing them because of old parity marker text.
- Uses primitive fallback only when UR5 rows are missing, collapsed, unrenderable, or implausible.
- Still allows the missing 2F gripper proxy to be added without replacing the arm mesh rows.

Validation not run here.