### PR TITLE
Apply scoped UR5 correction for matrix-baked Scene3D visuals

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -369,6 +369,7 @@ QMatrix4x4 final_mesh_transform_matrix(const ScenePreviewWidget::PreviewItem & i
     // the Scene3D ROS-to-viewport basis and mesh scale here; do not rebuild
     // from xyz/rpy, reapply visual origin, or enter legacy local corrections.
     QMatrix4x4 transform = ros_to_viewport_basis_matrix() * item.baked_world_visual_matrix;
+    apply_baked_mesh_asset_local_correction_matrix(transform, item);
     transform.scale(static_cast<float>(item.mesh_scale_x),
                     static_cast<float>(item.mesh_scale_y),
                     static_cast<float>(item.mesh_scale_z));

--- a/workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp
@@ -255,10 +255,42 @@ TEST(Scene3DMeshPreviewRegression, CentralizesRosToViewportBasisForGeneratedVisu
   const auto final_mesh_end = src.find("void apply_mesh_local_correction_gl", final_mesh);
   ASSERT_NE(final_mesh_end, std::string::npos);
   const std::string final_body = src.substr(final_mesh, final_mesh_end - final_mesh);
-  EXPECT_EQ(final_body.find("ros_to_viewport_basis_matrix()"), std::string::npos) << "basis must not be duplicated inside mesh-local composition";
+  EXPECT_NE(final_body.find("QMatrix4x4 transform = ros_to_viewport_basis_matrix() * item.baked_world_visual_matrix;"), std::string::npos)
+    << "matrix-baked rows must use the raw ROS matrix plus the Scene3D viewport basis";
   EXPECT_NE(final_body.find("QMatrix4x4 transform = viewport_world_visual_transform(item);"), std::string::npos);
   EXPECT_NE(final_body.find("apply_mesh_local_correction_matrix(transform, item);"), std::string::npos);
   EXPECT_NE(final_body.find("transform.scale"), std::string::npos);
+}
+
+TEST(Scene3DMeshPreviewRegression, MatrixBakedUr5VisualsApplyScopedAssetCorrectionBeforeScale)
+{
+  const std::string src = load_file(std::string(WORKCELL_BUILDER_SOURCE_DIR) + "/gui/scene3d_viewport_widget.cpp");
+  ASSERT_FALSE(src.empty());
+
+  const auto final_mesh = src.find("QMatrix4x4 final_mesh_transform_matrix");
+  ASSERT_NE(final_mesh, std::string::npos);
+  const auto final_mesh_end = src.find("void apply_mesh_local_correction_gl", final_mesh);
+  ASSERT_NE(final_mesh_end, std::string::npos);
+  const std::string final_body = src.substr(final_mesh, final_mesh_end - final_mesh);
+
+  const auto baked_matrix_branch = final_body.find("if (item.has_baked_world_visual_transform && item.has_baked_world_visual_matrix)");
+  ASSERT_NE(baked_matrix_branch, std::string::npos);
+  const auto fallback_branch = final_body.find("if (item.has_baked_world_visual_transform)", baked_matrix_branch + 1);
+  ASSERT_NE(fallback_branch, std::string::npos);
+  const std::string baked_matrix_body = final_body.substr(baked_matrix_branch, fallback_branch - baked_matrix_branch);
+
+  const auto matrix = baked_matrix_body.find("QMatrix4x4 transform = ros_to_viewport_basis_matrix() * item.baked_world_visual_matrix;");
+  const auto scoped_correction = baked_matrix_body.find("apply_baked_mesh_asset_local_correction_matrix(transform, item);");
+  const auto legacy_correction = baked_matrix_body.find("apply_mesh_local_correction_matrix(transform, item);");
+  const auto scale = baked_matrix_body.find("transform.scale");
+  ASSERT_NE(matrix, std::string::npos);
+  ASSERT_NE(scoped_correction, std::string::npos);
+  ASSERT_NE(scale, std::string::npos);
+  EXPECT_LT(matrix, scoped_correction);
+  EXPECT_LT(scoped_correction, scale)
+    << "matrix-baked UR5 generated visual rows need asset-local correction before final draw bounds are exported";
+  EXPECT_EQ(legacy_correction, std::string::npos)
+    << "matrix-baked generated URDF visuals must not re-enter broad legacy mesh-local corrections";
 }
 
 TEST(Scene3DMeshPreviewRegression, SuppressesFallbackBoxesWhenMeshSurfaceLoads)


### PR DESCRIPTION
### Motivation
- Ensure matrix-baked generated URDF visuals keep the narrow UR5 asset-local mesh correction and apply it before mesh scaling so final CPU draw bounds and GL-exported bbox are correct. 
- Avoid re-introducing the broad legacy `apply_mesh_local_correction_matrix()` path for baked/locked generated URDF visuals while preserving the scoped correction for known UR5 assets.

### Description
- In `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp` updated `final_mesh_transform_matrix()` to call `apply_baked_mesh_asset_local_correction_matrix(transform, item);` immediately after constructing `QMatrix4x4 transform = ros_to_viewport_basis_matrix() * item.baked_world_visual_matrix;` and before `transform.scale(...)` for the matrix-baked branch. 
- Added a regression test `MatrixBakedUr5VisualsApplyScopedAssetCorrectionBeforeScale` to `workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp` that asserts the baked-matrix branch uses the raw ROS matrix + viewport basis, applies the scoped baked asset correction before scaling, and does not call the legacy `apply_mesh_local_correction_matrix()` in that branch. 
- Change is scoped to matrix-baked generated URDF visuals and does not re-enable broad legacy corrections for baked visuals.

### Testing
- Ran a static/source-order check that verified the new `apply_baked_mesh_asset_local_correction_matrix(transform, item);` call appears after `item.baked_world_visual_matrix` and before `transform.scale`, and that `apply_mesh_local_correction_matrix()` is not present in that branch (PASS). 
- Ran `python3 -m pytest tests/test_scene3d_final_draw_bbox_regression.py` which passed (2 tests passed). 
- Ran `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py` and observed 2 existing product-view default assertion failures that are unrelated to this scoped transform change (FAIL — pre-existing). 
- Ran `python3 -m pytest tests/test_scene3d_gui_smoke_json_output_contract.py` and observed multiple environment/runtime contract failures (ROS/Humble unavailable and related status drift) unrelated to this change (FAIL — environment-dependent). 
- Attempted `scripts/run_workcell_builder_scene3d_gui_smoke.py` against `ur5_2f_test` but the run was blocked because no built `workcell_builder` executable was found in the workspace search paths; smoke artifacts were not produced in this environment (BLOCKED). 

Safety: No launch files, controllers, runtime services, or hardware parameters were changed and fake-hardware defaults remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a410876d6a48331a90ada9a4c05fba7)