### PR TITLE
Add Scene3D UR5 baked mesh transform test and scoped asset-local correction

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -336,6 +336,9 @@ if(BUILD_TESTING)
   ament_add_gtest(workcell_scene3d_render_role_classifier_test
     test/scene3d_render_role_classifier_test.cpp
     gui/scene3d_viewport_widget.cpp)
+  ament_add_gtest(workcell_scene3d_ur5_baked_transform_test
+    test/scene3d_ur5_baked_transform_test.cpp
+    gui/scene3d_viewport_widget.cpp)
 
   ament_add_gtest(workcell_command_builders_test
     test/command_builders_test.cpp
@@ -406,6 +409,15 @@ if(BUILD_TESTING)
       OpenGL::GL
     )
     target_include_directories(workcell_scene3d_render_role_classifier_test PRIVATE gui)
+  endif()
+
+  if(TARGET workcell_scene3d_ur5_baked_transform_test)
+    target_link_libraries(workcell_scene3d_ur5_baked_transform_test
+      Qt5::Widgets
+      Qt5::OpenGL
+      OpenGL::GL
+    )
+    target_include_directories(workcell_scene3d_ur5_baked_transform_test PRIVATE gui)
   endif()
 
   if(TARGET workcell_command_builders_test)

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -280,16 +280,19 @@ bool item_has_non_identity_mesh_asset_local_correction(const ScenePreviewWidget:
 bool should_apply_baked_mesh_asset_local_correction(const ScenePreviewWidget::PreviewItem & item)
 {
   // Generated visual mesh entries are already RViz/URDF-authored as
-  // world_T_link_or_object * visual_origin_T.  Do not reintroduce the old
-  // ad hoc UR5 DAE correction path; any asset-local correction must be part of
-  // the generated mesh-local transform, not a link-name/mesh-name special case.
+  // world_T_link_or_object * visual_origin_T. Most baked rows therefore must not
+  // re-apply legacy mesh RPY/origin fields.  The exception is the narrow UR5 DAE
+  // visual asset set where mesh_r/p/y and origin_offset describe asset-local
+  // corrections needed by Scene3D after the authoritative world_T_visual matrix.
   //
   // In particular, source=urdf_flattened entries from scene_visual_mesh_index.json
   // are raw ROS/RViz world-space poses. Scene3D applies only the centralized
   // ROS-to-viewport basis at viewport_world_visual_transform(); applying the
   // legacy UR5 mesh correction here would double-correct those locked previews.
   if (item_is_urdf_flattened_generated_preview(item)) return false;
-  return false;
+  if (!item.has_baked_world_visual_transform) return false;
+  if (!item_references_ur5_baked_mesh_asset_local_correction(item)) return false;
+  return item_has_non_identity_mesh_asset_local_correction(item);
 }
 
 QString baked_mesh_asset_local_correction_reason(const ScenePreviewWidget::PreviewItem & item)
@@ -365,10 +368,12 @@ QMatrix4x4 final_mesh_transform_matrix(const ScenePreviewWidget::PreviewItem & i
 
   if (item.has_baked_world_visual_transform && item.has_baked_world_visual_matrix) {
     // Matrix-baked generated URDF rows already carry world_T_visual from the
-    // visual mesh index (or the one-time pose-to-matrix handoff). Apply only
-    // the Scene3D ROS-to-viewport basis and mesh scale here; do not rebuild
-    // from xyz/rpy, reapply visual origin, or enter legacy local corrections.
+    // visual mesh index (or the one-time pose-to-matrix handoff). Apply the
+    // Scene3D ROS-to-viewport basis, then only the narrow asset-local correction
+    // path for known UR5 DAE visual meshes before mesh scale. Do not rebuild
+    // from xyz/rpy or reapply the URDF visual origin.
     QMatrix4x4 transform = ros_to_viewport_basis_matrix() * item.baked_world_visual_matrix;
+    apply_baked_mesh_asset_local_correction_matrix(transform, item);
     transform.scale(static_cast<float>(item.mesh_scale_x),
                     static_cast<float>(item.mesh_scale_y),
                     static_cast<float>(item.mesh_scale_z));
@@ -3215,6 +3220,16 @@ QColor Scene3DViewportWidget::material_color_for_test(const ScenePreviewWidget::
 bool Scene3DViewportWidget::is_raw_generated_bounds_only_for_test(const ScenePreviewWidget::PreviewItem & item)
 {
   return is_raw_generated_bounds_only_item(item);
+}
+
+QMatrix4x4 Scene3DViewportWidget::final_mesh_transform_matrix_for_test(const ScenePreviewWidget::PreviewItem & item)
+{
+  return final_mesh_transform_matrix(item);
+}
+
+QMatrix4x4 Scene3DViewportWidget::baked_mesh_asset_local_correction_matrix_for_test(const ScenePreviewWidget::PreviewItem & item)
+{
+  return baked_mesh_asset_local_correction_matrix(item);
 }
 
 bool Scene3DViewportWidget::try_resolve_canonical_mesh_path(const QString & path, QString & out_canonical,

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -163,6 +163,8 @@ public:
   static bool has_mesh_surface_candidate_for_test(const ScenePreviewWidget::PreviewItem & item);
   static QColor material_color_for_test(const ScenePreviewWidget::PreviewItem & item, bool diagnostic_transparency_mode = false);
   static bool is_raw_generated_bounds_only_for_test(const ScenePreviewWidget::PreviewItem & item);
+  static QMatrix4x4 final_mesh_transform_matrix_for_test(const ScenePreviewWidget::PreviewItem & item);
+  static QMatrix4x4 baked_mesh_asset_local_correction_matrix_for_test(const ScenePreviewWidget::PreviewItem & item);
 
 protected:
   void initializeGL() override;

--- a/workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp
@@ -272,7 +272,7 @@ TEST(Scene3DMeshPreviewRegression, SuppressesFallbackBoxesWhenMeshSurfaceLoads)
   EXPECT_NE(src.find("if (!editable_layout_preview && !scene3d_debug_fallback_boxes_enabled())"), std::string::npos);
 }
 
-TEST(Scene3DMeshPreviewRegression, BakedUrdfVisualsDoNotUseAdHocUr5MeshCorrections)
+TEST(Scene3DMeshPreviewRegression, BakedUrdfVisualsUseOnlyScopedUr5AssetCorrections)
 {
   const std::string src = load_file(std::string(WORKCELL_BUILDER_SOURCE_DIR) + "/gui/scene3d_viewport_widget.cpp");
   ASSERT_FALSE(src.empty());
@@ -286,8 +286,9 @@ TEST(Scene3DMeshPreviewRegression, BakedUrdfVisualsDoNotUseAdHocUr5MeshCorrectio
     << "flattened generated entries must be explicitly excluded from legacy UR5 correction";
   EXPECT_NE(body.find("item_is_urdf_flattened_generated_preview(item)"), std::string::npos);
   EXPECT_NE(body.find("return false;"), std::string::npos);
-  EXPECT_NE(body.find("Do not reintroduce the old"), std::string::npos);
-  EXPECT_EQ(body.find("item_references_ur5_baked_mesh_asset_local_correction(item)"), std::string::npos);
+  EXPECT_NE(body.find("narrow UR5 DAE"), std::string::npos);
+  EXPECT_NE(body.find("item_references_ur5_baked_mesh_asset_local_correction(item)"), std::string::npos);
+  EXPECT_NE(body.find("item_has_non_identity_mesh_asset_local_correction(item)"), std::string::npos);
 }
 
 TEST(Scene3DMeshPreviewRegression, FlattenedUrdfEntriesAreRawRosAndCorrectedOnce)
@@ -315,5 +316,7 @@ TEST(Scene3DMeshPreviewRegression, FlattenedUrdfEntriesAreRawRosAndCorrectedOnce
   ASSERT_NE(correction_helper_end, std::string::npos);
   const std::string correction_body = src.substr(correction_helper, correction_helper_end - correction_helper);
   EXPECT_NE(correction_body.find("if (item_is_urdf_flattened_generated_preview(item)) return false;"), std::string::npos)
-    << "source=urdf_flattened entries must not receive legacy UR5 mesh correction after basis conversion";
+    << "flattened locked previews must remain excluded from asset-local correction";
+  EXPECT_NE(correction_body.find("item_references_ur5_baked_mesh_asset_local_correction(item)"), std::string::npos)
+    << "non-flattened known UR5 DAE rows should retain the asset-local correction path";
 }

--- a/workcell_builder/workcell_builder/test/scene3d_ur5_baked_transform_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_ur5_baked_transform_test.cpp
@@ -1,0 +1,120 @@
+#include <gtest/gtest.h>
+
+#include <QMatrix4x4>
+#include <QString>
+#include <QVector>
+#include <cmath>
+
+#include "../gui/scene3d_viewport_widget.h"
+
+namespace {
+
+constexpr double kHalfPi = 1.57079632679489661923;
+
+ScenePreviewWidget::PreviewItem make_required_ur5_link(
+  const QString & link_name,
+  const QString & mesh_uri,
+  double mesh_r,
+  double mesh_p,
+  double mesh_y)
+{
+  ScenePreviewWidget::PreviewItem item;
+  item.id = QStringLiteral("ur5_%1_visual").arg(link_name);
+  item.display_name = link_name;
+  item.source_layer = QStringLiteral("locked_generated_urdf_visual");
+  item.active_visual_source = QStringLiteral("mesh_preview");
+  item.locked = true;
+  item.editable = false;
+  item.lock_reason = QStringLiteral("Generated URDF visual");
+  item.mesh_available = true;
+  item.has_mesh_metadata = true;
+  item.visual_index_link_name = link_name;
+  item.visual_index_mesh_uri = mesh_uri;
+  item.package_uri = mesh_uri;
+  item.mesh_path = mesh_uri;
+  item.has_baked_world_visual_transform = true;
+  item.baked_world_visual_transform_source = QStringLiteral("scene_visual_mesh_index");
+  item.has_baked_world_visual_matrix = true;
+  item.baked_world_visual_matrix.setToIdentity();
+  item.baked_world_visual_matrix.translate(0.42f, -0.13f, 0.77f);
+  item.baked_world_visual_matrix.rotate(17.0f, 0.0f, 0.0f, 1.0f);
+  item.mesh_r = mesh_r;
+  item.mesh_p = mesh_p;
+  item.mesh_y = mesh_y;
+  item.has_origin_offset = true;
+  item.origin_offset_x = 0.011;
+  item.origin_offset_y = -0.022;
+  item.origin_offset_z = 0.033;
+  item.mesh_scale_x = 1.0;
+  item.mesh_scale_y = 1.0;
+  item.mesh_scale_z = 1.0;
+  return item;
+}
+
+QMatrix4x4 ros_to_viewport_basis_matrix_for_expected()
+{
+  QMatrix4x4 basis;
+  basis.setToIdentity();
+  basis(1, 1) = 0.0f;
+  basis(1, 2) = 1.0f;
+  basis(2, 1) = -1.0f;
+  basis(2, 2) = 0.0f;
+  return basis;
+}
+
+void expect_matrix_near(const QMatrix4x4 & actual, const QMatrix4x4 & expected)
+{
+  for (int row = 0; row < 4; ++row) {
+    for (int col = 0; col < 4; ++col) {
+      EXPECT_NEAR(actual(row, col), expected(row, col), 1e-5)
+        << "matrix mismatch at (" << row << ", " << col << ")";
+    }
+  }
+}
+
+}  // namespace
+
+TEST(Scene3DUr5BakedTransform, MatrixBakedRequiredUr5LinksIncludeAssetLocalCorrection)
+{
+  const QVector<ScenePreviewWidget::PreviewItem> items = {
+    make_required_ur5_link(
+      QStringLiteral("upper_arm_link"),
+      QStringLiteral("package://ur_description/meshes/ur5/visual/upperarm.dae"),
+      kHalfPi, 0.0, 0.0),
+    make_required_ur5_link(
+      QStringLiteral("forearm_link"),
+      QStringLiteral("package://ur_description/meshes/ur5/visual/forearm.dae"),
+      0.0, kHalfPi, 0.0),
+    make_required_ur5_link(
+      QStringLiteral("wrist_1_link"),
+      QStringLiteral("package://ur_description/meshes/ur5/visual/wrist1.dae"),
+      0.0, 0.0, kHalfPi),
+  };
+
+  for (const ScenePreviewWidget::PreviewItem & item : items) {
+    const QMatrix4x4 correction =
+      Scene3DViewportWidget::baked_mesh_asset_local_correction_matrix_for_test(item);
+    ASSERT_FALSE(correction.isIdentity()) << item.visual_index_link_name.toStdString();
+
+    QMatrix4x4 expected = ros_to_viewport_basis_matrix_for_expected() * item.baked_world_visual_matrix;
+    expected *= correction;
+    expected.scale(static_cast<float>(item.mesh_scale_x),
+                   static_cast<float>(item.mesh_scale_y),
+                   static_cast<float>(item.mesh_scale_z));
+
+    const QMatrix4x4 actual = Scene3DViewportWidget::final_mesh_transform_matrix_for_test(item);
+    expect_matrix_near(actual, expected);
+
+    const QMatrix4x4 without_asset_local_correction =
+      ros_to_viewport_basis_matrix_for_expected() * item.baked_world_visual_matrix;
+    bool observed_correction = false;
+    for (int row = 0; row < 4; ++row) {
+      for (int col = 0; col < 4; ++col) {
+        if (std::abs(actual(row, col) - without_asset_local_correction(row, col)) > 1e-5) {
+          observed_correction = true;
+        }
+      }
+    }
+    EXPECT_TRUE(observed_correction) << item.visual_index_link_name.toStdString();
+  }
+}


### PR DESCRIPTION
### Motivation
- Ensure final CPU/GL mesh transform composition includes known UR5 asset-local corrections when a generated URDF visual row carries a baked world matrix so bounds/draws are correct.

### Description
- Added a focused unit test `test/scene3d_ur5_baked_transform_test.cpp` that constructs matrix-baked `ScenePreviewWidget::PreviewItem` rows for `upper_arm_link`, `forearm_link`, and `wrist_1_link` and asserts `final_mesh_transform_matrix()` contains the asset-local correction before scaling and bounds computation.
- Scoped the UR5 DAE asset-local correction path in `gui/scene3d_viewport_widget.cpp` so corrections apply only for non-`source=urdf_flattened` baked rows that reference the known UR5 visual mesh URIs and have non-identity mesh RPY/origin offsets, and applied the correction before mesh scaling in the baked-matrix branch.
- Exposed test-only wrappers `final_mesh_transform_matrix_for_test()` and `baked_mesh_asset_local_correction_matrix_for_test()` in `gui/scene3d_viewport_widget.h/.cpp` so the test can validate matrix composition without requiring GUI startup or mesh parsing.
- Registered the new `workcell_scene3d_ur5_baked_transform_test` target in `CMakeLists.txt` and updated a source-text regression test to reflect the scoped correction behavior.

### Testing
- Ran `git diff --check` which passed with no whitespace/merge errors.
- Ran Python unit smoke tests with `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py` where the scene3d product overlay filtering tests passed but two pre-existing assertions in `tests/test_workcell_builder_product_view_defaults.py` failed (5 passed, 2 failed); these failures are source-text assertions that appear unrelated to the new UR5 transform test.
- Attempted to run the CMake/ROS test target with `colcon` but could not because `/opt/ros/humble/setup.bash` was not present in the container, so `colcon test` for `workcell_builder` was not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a410894601083319a6c474da321e736)