### PR TITLE
Add Product View layer-default seam coverage

### DIFF
--- a/tests/test_workcell_builder_product_view_defaults.py
+++ b/tests/test_workcell_builder_product_view_defaults.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
@@ -9,84 +8,6 @@ SCENE3D_VIEWPORT_CPP = REPO / "workcell_builder/workcell_builder/gui/scene3d_vie
 SCENE3D_ASSEMBLY_CPP = REPO / "workcell_builder/workcell_builder/gui/scene3d_candidate_assembly.cpp"
 MAINWINDOW_CPP = REPO / "workcell_builder/workcell_builder/gui/mainwindow.cpp"
 UR5_SCENE = REPO / "scenes/ur5_2f_test"
-
-
-@dataclass
-class PreviewItem:
-    source_layer: str = ""
-    active_visual_source: str = ""
-    status: str = "ok"
-    warnings: list[str] = field(default_factory=list)
-    mesh_load_warning: str = ""
-    source_path_resolution_outcome: str = ""
-    id: str = ""
-    mesh_available: bool = False
-    has_mesh_metadata: bool = False
-
-
-def _token(value: str) -> str:
-    return value.strip().lower()
-
-
-def product_layer_defaults(items: list[PreviewItem]) -> dict[str, bool]:
-    primitive_fallback_count = 0
-    missing_mesh_count = 0
-    unresolved_package_uri_count = 0
-    unsupported_extension_count = 0
-    fallback_warning_count = 0
-    authoritative_generated_mesh_count = 0
-
-    for item in items:
-        source_layer = _token(item.source_layer)
-        visual_source = _token(item.active_visual_source)
-        combined = "|".join(
-            [
-                source_layer,
-                visual_source,
-                _token(item.status),
-                "|".join(w.lower() for w in item.warnings),
-                _token(item.mesh_load_warning),
-                _token(item.source_path_resolution_outcome),
-            ]
-        )
-        if source_layer == "primitive_fallback" or visual_source == "primitive_fallback":
-            primitive_fallback_count += 1
-        if any(
-            marker in combined
-            for marker in (
-                "missing mesh",
-                "missing_source_path",
-                "mesh unavailable",
-                "mesh unresolved",
-                "unresolved",
-            )
-        ):
-            missing_mesh_count += 1
-        if "unresolved_package_uri" in combined or "package uri unresolved" in combined:
-            unresolved_package_uri_count += 1
-        if "unsupported" in combined and ("extension" in combined or "format" in combined):
-            unsupported_extension_count += 1
-        if "fallback" in combined and any(marker in combined for marker in ("missing", "unavailable", "unresolved")):
-            fallback_warning_count += 1
-        if (
-            source_layer in ("locked_generated_urdf_visual", "generated_urdf_visual")
-            and (
-                item.mesh_available
-                or item.has_mesh_metadata
-                or item.id.startswith("generated_urdf_fallback::")
-                or item.id.startswith("urdf_visual_")
-            )
-        ):
-            authoritative_generated_mesh_count += 1
-
-    return {
-        "editable_layout": True,
-        "mesh_preview": True,
-        "locked_generated_urdf_visual": True,
-        "overlay": False,
-        "primitive_fallback": authoritative_generated_mesh_count == 0 and (primitive_fallback_count + missing_mesh_count) > 0,
-        "warning": False,
-    }
 
 
 def compact_warning_chip_state(mesh_index: dict[str, object], counters: dict[str, int]) -> tuple[bool, str]:
@@ -112,31 +33,18 @@ def compact_warning_chip_state(mesh_index: dict[str, object], counters: dict[str
     return True, "3D Preview Warnings · see Diagnostics"
 
 
-def test_loaded_scene_payload_product_defaults_suppress_empty_diagnostics_layers() -> None:
-    defaults = product_layer_defaults(
-        [
-            PreviewItem(source_layer="locked_generated_urdf_visual", mesh_available=True),
-            PreviewItem(active_visual_source="mesh_preview"),
-            PreviewItem(source_layer="editable_layout"),
-        ]
-    )
-
-    assert defaults == {
-        "locked_generated_urdf_visual": True,
-        "mesh_preview": True,
-        "editable_layout": True,
-        "primitive_fallback": False,
-        "overlay": False,
-        "warning": False,
-    }
-
+def test_product_view_defaults_are_wired_to_shared_scene3d_layer_helper() -> None:
     assembly_cpp = SCENE3D_ASSEMBLY_CPP.read_text()
-    assert "out.locked_generated_urdf_visual = true;" in assembly_cpp
-    assert "out.mesh_preview = true;" in assembly_cpp
-    assert "out.editable_layout = true;" in assembly_cpp
-    assert "out.primitive_fallback = authoritative_generated_mesh_count == 0" in assembly_cpp
-    assert "out.overlay = false;" in assembly_cpp
-    assert "out.warning = false;" in assembly_cpp
+    mainwindow_cpp = MAINWINDOW_CPP.read_text()
+    apply_defaults = mainwindow_cpp.split("void MainWindow::apply_scene3d_product_view_layer_defaults_and_commit()", 1)[1]
+    apply_defaults = apply_defaults.split("void MainWindow::apply_scene_preview_filter()", 1)[0]
+
+    assert "Scene3DLayerVisibilityDefaults compute_scene3d_default_layer_visibility" in assembly_cpp
+    assert "const auto defaults = workcell_builder::compute_scene3d_default_layer_visibility(all_scene_preview_items_);" in apply_defaults
+    assert "set_checked_blocked(preview_layer_generated_urdf_visual_box_, defaults.locked_generated_urdf_visual);" in apply_defaults
+    assert "set_checked_blocked(preview_layer_primitive_fallback_box_, defaults.primitive_fallback);" in apply_defaults
+    assert "set_checked_blocked(preview_layer_overlays_helpers_box_, defaults.overlay);" in apply_defaults
+    assert "set_checked_blocked(preview_layer_warnings_missing_assets_box_, defaults.warning);" in apply_defaults
 
 
 def test_scene_preview_widget_product_defaults_turn_off_viewport_helpers_and_warnings() -> None:

--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -374,6 +374,9 @@ if(BUILD_TESTING)
   ament_add_gtest(workcell_preview_item_suppression_test
     test/preview_item_suppression_test.cpp
     gui/preview_item_suppression.cpp)
+  ament_add_gtest(workcell_scene3d_product_view_layer_defaults_test
+    test/scene3d_product_view_layer_defaults_test.cpp
+    gui/scene3d_candidate_assembly.cpp)
   ament_add_gtest(workcell_layout_serialization_contract_test
     test/layout_serialization_contract_test.cpp)
   ament_add_gtest(workcell_studio_layout_editor_test
@@ -445,6 +448,11 @@ if(BUILD_TESTING)
   if(TARGET workcell_preview_item_suppression_test)
     target_link_libraries(workcell_preview_item_suppression_test Qt5::Widgets)
     target_include_directories(workcell_preview_item_suppression_test PRIVATE gui)
+  endif()
+
+  if(TARGET workcell_scene3d_product_view_layer_defaults_test)
+    target_link_libraries(workcell_scene3d_product_view_layer_defaults_test Qt5::Widgets)
+    target_include_directories(workcell_scene3d_product_view_layer_defaults_test PRIVATE gui)
   endif()
 
   if(TARGET workcell_studio_canvas_model_mesh_test)

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -494,7 +494,7 @@ void ScenePreviewWidget::apply_product_view_defaults()
   v->debug_overlays_mode = false;
   v->show_warnings = false;
   v->show_warning_labels = false;
-  v->show_safety = true;
+  v->show_safety = false;
   v->show_pick_place = false;
   v->show_reachability_heatmap = false;
   v->show_collision_warnings = false;

--- a/workcell_builder/workcell_builder/test/scene3d_product_view_layer_defaults_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_product_view_layer_defaults_test.cpp
@@ -1,0 +1,149 @@
+#include "scene3d_candidate_assembly.h"
+
+#include <gtest/gtest.h>
+
+namespace
+{
+ScenePreviewWidget::PreviewItem make_item(
+  const QString & source_layer,
+  const QString & active_visual_source = QString(),
+  const QString & id = QString())
+{
+  ScenePreviewWidget::PreviewItem item;
+  item.source_layer = source_layer;
+  item.active_visual_source = active_visual_source;
+  item.id = id;
+  item.status = QStringLiteral("ok");
+  return item;
+}
+
+ScenePreviewWidget::PreviewItem generated_robot_mesh()
+{
+  auto item = make_item(
+    QStringLiteral("locked_generated_urdf_visual"),
+    QStringLiteral("mesh_preview"),
+    QStringLiteral("generated_urdf::shoulder_link::visual_1::1"));
+  item.display_name = QStringLiteral("shoulder_link");
+  item.role = QStringLiteral("robot");
+  item.category = QStringLiteral("robot/ur5");
+  item.mesh_available = true;
+  item.has_mesh_metadata = true;
+  item.locked = true;
+  item.mesh_path = QStringLiteral("package://ur_description/meshes/ur5/visual/shoulder.dae");
+  item.package_uri = item.mesh_path;
+  item.visual_index_mesh_uri = item.mesh_path;
+  return item;
+}
+
+ScenePreviewWidget::PreviewItem stale_robot_primitive_box()
+{
+  auto item = make_item(
+    QStringLiteral("primitive_fallback"),
+    QStringLiteral("primitive_fallback"),
+    QStringLiteral("semantic_helper::shoulder_link::bounds_box"));
+  item.display_name = QStringLiteral("shoulder_link bounds box");
+  item.role = QStringLiteral("robot_link");
+  item.category = QStringLiteral("robot/ur5");
+  item.locked = true;
+  item.warnings = QStringList{QStringLiteral("mesh unavailable; using primitive fallback")};
+  return item;
+}
+
+ScenePreviewWidget::PreviewItem missing_mesh_without_authoritative_visual()
+{
+  auto item = make_item(
+    QStringLiteral("primitive_fallback"),
+    QStringLiteral("primitive_fallback"),
+    QStringLiteral("generated_primitive::tool0"));
+  item.display_name = QStringLiteral("tool0 fallback");
+  item.role = QStringLiteral("tool");
+  item.category = QStringLiteral("gripper");
+  item.mesh_load_warning = QStringLiteral("missing mesh");
+  return item;
+}
+
+ScenePreviewWidget::PreviewItem overlay_only_payload()
+{
+  auto item = make_item(
+    QStringLiteral("overlay"),
+    QStringLiteral("overlay"),
+    QStringLiteral("camera_fov::main"));
+  item.display_name = QStringLiteral("Camera FOV overlay");
+  item.role = QStringLiteral("camera_fov");
+  item.category = QStringLiteral("diagnostic overlay");
+  return item;
+}
+
+ScenePreviewWidget::PreviewItem editable_physical_item_with_helper_like_name()
+{
+  auto item = make_item(
+    QStringLiteral("editable_layout"),
+    QStringLiteral("mesh_preview"),
+    QStringLiteral("layout::helper_fixture_table"));
+  item.display_name = QStringLiteral("Helper Fixture Table");
+  item.role = QStringLiteral("workbench");
+  item.category = QStringLiteral("environment/table");
+  item.mesh_available = true;
+  item.has_mesh_metadata = true;
+  item.editable = true;
+  item.linked_to_editable_layout_state = true;
+  return item;
+}
+
+void expect_clean_product_layers(const workcell_builder::Scene3DLayerVisibilityDefaults & defaults)
+{
+  EXPECT_TRUE(defaults.locked_generated_urdf_visual);
+  EXPECT_TRUE(defaults.mesh_preview);
+  EXPECT_TRUE(defaults.editable_layout);
+  EXPECT_FALSE(defaults.overlay);
+  EXPECT_FALSE(defaults.warning);
+}
+}  // namespace
+
+TEST(Scene3DProductViewLayerDefaults, CleanGeneratedRobotMeshPayloadKeepsProductLayersAndHidesFallbacks)
+{
+  const auto defaults = workcell_builder::compute_scene3d_default_layer_visibility({generated_robot_mesh()});
+
+  expect_clean_product_layers(defaults);
+  EXPECT_FALSE(defaults.primitive_fallback);
+}
+
+TEST(Scene3DProductViewLayerDefaults, GeneratedMeshSuppressesStalePrimitiveRobotBoxesByDefault)
+{
+  const auto defaults = workcell_builder::compute_scene3d_default_layer_visibility(
+    {generated_robot_mesh(), stale_robot_primitive_box()});
+
+  expect_clean_product_layers(defaults);
+  EXPECT_FALSE(defaults.primitive_fallback);
+}
+
+TEST(Scene3DProductViewLayerDefaults, MissingMeshWithoutAuthoritativeGeneratedVisualEnablesPrimitiveFallback)
+{
+  const auto defaults = workcell_builder::compute_scene3d_default_layer_visibility(
+    {missing_mesh_without_authoritative_visual()});
+
+  expect_clean_product_layers(defaults);
+  EXPECT_TRUE(defaults.primitive_fallback);
+}
+
+TEST(Scene3DProductViewLayerDefaults, OverlayOnlyPayloadKeepsOverlayLayerExplicitOptIn)
+{
+  const auto defaults = workcell_builder::compute_scene3d_default_layer_visibility({overlay_only_payload()});
+
+  expect_clean_product_layers(defaults);
+  EXPECT_FALSE(defaults.primitive_fallback);
+}
+
+TEST(Scene3DProductViewLayerDefaults, EditablePhysicalItemWithHelperLikeNameRemainsDefaultVisible)
+{
+  const auto physical_item = editable_physical_item_with_helper_like_name();
+  const auto defaults = workcell_builder::compute_scene3d_default_layer_visibility({physical_item});
+  const QSet<QString> enabled_layers{
+    QStringLiteral("editable_layout"),
+    QStringLiteral("mesh_preview"),
+    QStringLiteral("locked_generated_urdf_visual")};
+
+  expect_clean_product_layers(defaults);
+  EXPECT_FALSE(defaults.primitive_fallback);
+  EXPECT_TRUE(workcell_builder::include_preview_item_for_scene3d(physical_item, enabled_layers));
+}


### PR DESCRIPTION
### Motivation
- Make Product View layer-default logic testable from C++ so Python tests can assert wiring instead of duplicating internal string-based formulas.
- Provide a small, focused test seam that exercises `compute_scene3d_default_layer_visibility(...)` and `include_preview_item_for_scene3d(...)` with synthetic `PreviewItem` fixtures for common payload cases.

### Description
- Add a C++ gtest `scene3d_product_view_layer_defaults_test.cpp` that creates synthetic `PreviewItem` fixtures for generated robot meshes, stale primitive robot boxes, missing meshes, overlay-only payloads, and editable physical items with helper-like display names and asserts expected layer defaults and inclusion behavior. (file: `workcell_builder/workcell_builder/test/scene3d_product_view_layer_defaults_test.cpp`)
- Register the new gtest target `workcell_scene3d_product_view_layer_defaults_test` in the Workcell Builder CMake test suite. (file: `workcell_builder/workcell_builder/CMakeLists.txt`)
- Reduce Python-side duplication by replacing internal-formula string assertions with wiring checks that verify the UI commits call the shared C++ helper. (file: `tests/test_workcell_builder_product_view_defaults.py`)
- Ensure Product View helper/safety overlays remain hidden by default by adjusting the ScenePreviewWidget product-view reset path (`v->show_safety` set to `false`). (file: `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp`)

### Testing
- Ran `python3 -m pytest tests/test_workcell_builder_product_view_defaults.py tests/test_scene3d_product_overlay_filtering.py` and all tests passed (7 passed).
- Verified `git diff --check` returned clean results in this workspace.
- Attempted CMake configure for in-repo gtests (`cd workcell_builder/workcell_builder && cmake -S . -B /tmp/workcell_builder_cmake -DBUILD_TESTING=ON`) but configure is blocked in this container due to missing ROS/`ament_cmake` CMake configuration, so the new C++ gtest was added but not compiled here; run full CMake/colcon build in a sourced ROS 2 Humble workspace to compile and run the gtest.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a410d70aba48331bed5ff63b4a7633f)