### PR TITLE
Prioritize Scene3D transform gizmo picks

### DIFF
--- a/tests/test_3d_canvas_selection_transform_roundtrip.py
+++ b/tests/test_3d_canvas_selection_transform_roundtrip.py
@@ -50,7 +50,7 @@ def test_save_roundtrip_preserves_metadata_and_updates_task_zones_contract_prese
         'pose["xyz"]',
         'pose["rpy"]',
         'item["dimensions"]',
-        'environment["task_zones"]',
+        'root["task_zones"]',
     ]:
         assert token in MAIN_CPP
 
@@ -88,3 +88,17 @@ def test_escape_cancel_path_does_not_save_layout_or_commit_transform():
     assert 'save_layout_changes' not in esc_shortcut_block
     assert 'mark_layout_dirty' not in esc_shortcut_block
 
+
+
+def test_gizmo_handle_click_does_not_reselect_item_before_drag_contract_present():
+    viewport_cpp = (ROOT / 'workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp').read_text(encoding='utf-8')
+    body = viewport_cpp.split('void Scene3DViewportWidget::mousePressEvent(QMouseEvent * e) {', 1)[1].split('void Scene3DViewportWidget::mouseMoveEvent', 1)[0]
+    gizmo_block = body.split('if ((gizmo_mode == GizmoMode::Move || gizmo_mode == GizmoMode::Rotate) && !selected_id.isEmpty())', 1)[1].split('QString best_id, best_role;', 1)[0]
+
+    assert 'item_is_editable_for_gizmo(*selected_item)' in gizmo_block
+    assert 'pick_gizmo_axis_at_screen(e->pos(), axis, &score)' in gizmo_block
+    assert 'pick_gizmo_rotation_ring_at_screen(e->pos(), axis, &score)' in gizmo_block
+    assert 'drag_start_pose_.item_id = selected_item->id;' in gizmo_block
+    assert 'drag_in_progress_ = true;' in gizmo_block
+    assert 'return;' in gizmo_block
+    assert 'pick_item_at_screen' not in gizmo_block

--- a/tests/test_scene3d_transform_gizmos_static.py
+++ b/tests/test_scene3d_transform_gizmos_static.py
@@ -59,3 +59,21 @@ def test_scene3d_drag_uses_drag_start_screen_and_drag_start_pose_without_undefin
     assert "drag_start_pose_.roll + snapped" in viewport_cpp
     assert "drag_start_ =" not in viewport_cpp
     assert "drag_start_)" not in viewport_cpp
+
+def _mouse_press_event_body():
+    viewport_cpp = Path("workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp").read_text(encoding="utf-8")
+    start = viewport_cpp.index("void Scene3DViewportWidget::mousePressEvent(QMouseEvent * e) {")
+    end = viewport_cpp.index("void Scene3DViewportWidget::mouseMoveEvent", start)
+    return viewport_cpp[start:end]
+
+
+def test_mouse_press_prioritizes_editable_gizmo_handle_before_item_picking():
+    body = _mouse_press_event_body()
+    assert "if (e->button() != Qt::LeftButton) return;" in body
+    assert body.index("if (e->button() != Qt::LeftButton) return;") < body.index("pick_gizmo_axis_at_screen")
+    assert body.index("item_is_editable_for_gizmo(*selected_item)") < body.index("pick_gizmo_axis_at_screen")
+    assert body.index("item_is_editable_for_gizmo(*selected_item)") < body.index("pick_gizmo_rotation_ring_at_screen")
+    assert body.index("pick_gizmo_axis_at_screen") < body.index("pick_item_at_screen")
+    assert body.index("pick_gizmo_rotation_ring_at_screen") < body.index("pick_item_at_screen")
+    assert "if (picked && !axis.isEmpty())" in body
+    assert "return;" in body.split("if (picked && !axis.isEmpty())", 1)[1].split("QString best_id, best_role;", 1)[0]

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -5029,53 +5029,57 @@ bool Scene3DViewportWidget::pick_gizmo_rotation_ring_at_screen(const QPoint & po
 void Scene3DViewportWidget::mousePressEvent(QMouseEvent * e) {
   last_ = e->pos();
   if (e->button() != Qt::LeftButton) return;
-  QString best_id, best_role;
-  if (pick_item_at_screen(e->pos(), best_id, best_role) && !best_id.isEmpty() && select_cb) select_cb(best_id, best_role);
+
   drag_start_screen_ = e->pos();
   dragging_gizmo_ = false;
   drag_active_handle_ = GizmoHandle::None;
   drag_in_progress_ = false;
   drag_cancelled_ = false;
+  active_axis_.clear();
+
   if ((gizmo_mode == GizmoMode::Move || gizmo_mode == GizmoMode::Rotate) && !selected_id.isEmpty()) {
+    const ScenePreviewWidget::PreviewItem * selected_item = nullptr;
     for (const auto & it : items) {
-      if (it.id != selected_id) continue;
-      if (!item_is_editable_for_gizmo(it)) {
-        if (status_message_cb) status_message_cb(QStringLiteral("Locked: %1").arg(item_locked_reason(it)));
-        return;
+      if (it.id == selected_id) {
+        selected_item = &it;
+        break;
       }
-      dragging_gizmo_ = true;
-      break;
+    }
+
+    if (selected_item != nullptr) {
+      if (!item_is_editable_for_gizmo(*selected_item)) {
+        if (status_message_cb) status_message_cb(QStringLiteral("Locked: %1").arg(item_locked_reason(*selected_item)));
+      } else {
+        double score = std::numeric_limits<double>::max();
+        QString axis;
+        bool picked = false;
+        if (gizmo_mode == GizmoMode::Move) {
+          picked = pick_gizmo_axis_at_screen(e->pos(), axis, &score);
+          if (picked) drag_active_handle_ = (axis == "x") ? GizmoHandle::MoveX : (axis == "y" ? GizmoHandle::MoveY : GizmoHandle::MoveZ);
+        } else if (gizmo_mode == GizmoMode::Rotate) {
+          picked = pick_gizmo_rotation_ring_at_screen(e->pos(), axis, &score);
+          if (picked) drag_active_handle_ = (axis == "x") ? GizmoHandle::Roll : (axis == "y" ? GizmoHandle::Pitch : GizmoHandle::Yaw);
+        }
+
+        if (picked && !axis.isEmpty()) {
+          active_axis_ = axis;
+          dragging_gizmo_ = true;
+          drag_in_progress_ = true;
+          drag_start_pose_.item_id = selected_item->id;
+          drag_start_pose_.x = selected_item->x;
+          drag_start_pose_.y = selected_item->y;
+          drag_start_pose_.z = selected_item->z;
+          drag_start_pose_.roll = selected_item->roll;
+          drag_start_pose_.pitch = selected_item->pitch;
+          drag_start_pose_.yaw = selected_item->yaw;
+          return;
+        }
+      }
     }
   }
-  if (dragging_gizmo_) {
-    const int dx = qAbs(e->x() - width() / 2);
-    const int dy = qAbs(e->y() - height() / 2);
-    active_axis_ = (dx > dy) ? QStringLiteral("x") : QStringLiteral("y");
-    for (const auto & it : items) {
-      if (it.id != selected_id) continue;
-      drag_start_pose_.item_id = it.id;
-      drag_start_pose_.x = it.x;
-      drag_start_pose_.y = it.y;
-      drag_start_pose_.z = it.z;
-      drag_start_pose_.roll = it.roll;
-      drag_start_pose_.pitch = it.pitch;
-      drag_start_pose_.yaw = it.yaw;
-      break;
-    }
-    double score = std::numeric_limits<double>::max();
-    QString axis;
-    bool picked = false;
-    if (gizmo_mode == GizmoMode::Move) {
-      picked = pick_gizmo_axis_at_screen(e->pos(), axis, &score);
-      if (picked) drag_active_handle_ = (axis == "x") ? GizmoHandle::MoveX : (axis == "y" ? GizmoHandle::MoveY : GizmoHandle::MoveZ);
-    } else if (gizmo_mode == GizmoMode::Rotate) {
-      picked = pick_gizmo_rotation_ring_at_screen(e->pos(), axis, &score);
-      if (picked) drag_active_handle_ = (axis == "x") ? GizmoHandle::Roll : (axis == "y" ? GizmoHandle::Pitch : GizmoHandle::Yaw);
-    }
-    active_axis_ = axis;
-    dragging_gizmo_ = picked && !axis.isEmpty();
-    drag_in_progress_ = dragging_gizmo_;
-  }
+
+  QString best_id, best_role;
+  if (pick_item_at_screen(e->pos(), best_id, best_role) && !best_id.isEmpty() && select_cb) select_cb(best_id, best_role);
 }
 void Scene3DViewportWidget::mouseMoveEvent(QMouseEvent * e)
 {


### PR DESCRIPTION
### Motivation
- Prevent transform gizmo clicks from reselecting underlying scene items and ensure gizmo drags are initiated only when an editable gizmo handle is actually hit.
- Surface a clear "Locked:" status when a selected item is not editable for gizmo interaction while preserving the early non-left-click return.

### Description
- Reworked `Scene3DViewportWidget::mousePressEvent` to reset drag/gizmo state up-front and, when `gizmo_mode` is `Move` or `Rotate` and `selected_id` is set, locate the selected item and verify editability with `item_is_editable_for_gizmo` before any handle picking.
- Called `pick_gizmo_axis_at_screen` or `pick_gizmo_rotation_ring_at_screen` to detect handle hits, initialized `drag_start_pose_`, `drag_active_handle_`, `active_axis_`, and drag flags only when a handle was picked, and `return`ed early to avoid calling `pick_item_at_screen` when a gizmo handle was hit.
- Left the early non-left-click `return` in place and ensured `pick_item_at_screen(...)` is invoked only if no gizmo handle drag was started.
- Added/updated tests: `tests/test_scene3d_transform_gizmos_static.py` and `tests/test_3d_canvas_selection_transform_roundtrip.py` to assert the pick-order, editability checks, early-return behavior, and updated a contract token to reflect current root-level `task_zones` handling.

### Testing
- Ran `python3 -m pytest tests/test_scene3d_transform_gizmos_static.py tests/test_3d_canvas_selection_transform_roundtrip.py` and all tests passed (14 tests).
- Static test tokens verify presence of `pick_gizmo_axis_at_screen`, `pick_gizmo_rotation_ring_at_screen`, `item_is_editable_for_gizmo`, and the new mouse-press ordering assertions.
- No runtime/launch or hardware-related commands were changed and fake-hardware defaults remain unaffected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a410dde2c008331ba79a3b7c50fdc7c)