### PR TITLE
Add UR5 Scene3D spacing repair utility

### DIFF
--- a/scripts/repair_scene3d_ur5_spacing.py
+++ b/scripts/repair_scene3d_ur5_spacing.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Repair UR5 Scene3D visual index rows when adjacent links are too far apart."""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from scripts.scene3d_ur5_preview_rows import REQUIRED_UR5_LINKS, REQUIRED_UR5_VISUALS, make_ur5_preview_item
+
+MAX_ADJACENT_DISTANCE_M = 0.75
+POSE_FIELDS = ("baked_world_visual_pose", "expected_visual_pose", "link_world_pose", "world_pose", "pose")
+
+
+def _text(item: dict[str, Any]) -> str:
+    keys = ("link", "link_name", "canonical_link_name", "object_name", "visual_index_link", "visual_index_link_name", "id", "item_id")
+    return "|".join(str(item.get(key) or "") for key in keys).lower()
+
+
+def _xyz(item: dict[str, Any], field: str) -> list[float] | None:
+    pose = item.get(field)
+    raw = pose.get("xyz") if isinstance(pose, dict) else None
+    if not isinstance(raw, list) or len(raw) < 3:
+        return None
+    try:
+        xyz = [float(raw[i]) for i in range(3)]
+    except Exception:
+        return None
+    return xyz if all(math.isfinite(v) for v in xyz) else None
+
+
+def _positions(items: list[dict[str, Any]]) -> dict[str, list[float]]:
+    out: dict[str, list[float]] = {}
+    for item in items:
+        for link in REQUIRED_UR5_LINKS:
+            if link in out or link.lower() not in _text(item):
+                continue
+            for field in POSE_FIELDS:
+                xyz = _xyz(item, field)
+                if xyz is not None:
+                    out[link] = xyz
+                    break
+    return out
+
+
+def _distance(a: list[float], b: list[float]) -> float:
+    return math.sqrt(sum((a[i] - b[i]) ** 2 for i in range(3)))
+
+
+def spacing_reasons(items: list[dict[str, Any]]) -> list[str]:
+    pos = _positions(items)
+    reasons: list[str] = []
+    for prev, cur in zip(REQUIRED_UR5_LINKS, REQUIRED_UR5_LINKS[1:]):
+        if prev not in pos or cur not in pos:
+            continue
+        dist = _distance(pos[prev], pos[cur])
+        if dist > MAX_ADJACENT_DISTANCE_M:
+            reasons.append(f"{prev}->{cur}:{dist:.3f}m")
+    return reasons
+
+
+def repair_index(path: Path) -> tuple[bool, list[str]]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    items = data.get("visual_items") if isinstance(data.get("visual_items"), list) else []
+    items = [item for item in items if isinstance(item, dict)]
+    reasons = spacing_reasons(items)
+    if not reasons:
+        return False, []
+
+    replaced = set(REQUIRED_UR5_LINKS)
+    repaired = [make_ur5_preview_item(spec, idx) for idx, spec in enumerate(REQUIRED_UR5_VISUALS)]
+    kept = [item for item in items if not any(link.lower() in _text(item) for link in replaced)]
+    visual_items = repaired + kept
+
+    data["visual_items"] = visual_items
+    if isinstance(data.get("items"), list):
+        data["items"] = visual_items
+    data["visual_count"] = len(visual_items)
+    data["candidate_mesh_count"] = len(visual_items)
+    data["emitted_visual_count"] = len(visual_items)
+    data["safe_for_preview"] = True
+    data["stale_index"] = False
+    data["stale_reasons"] = []
+    data["ur5_runtime_repair_applied"] = True
+    data["ur5_runtime_repair_mode"] = "stable_primitive_builder_preview"
+    data["ur5_runtime_repair_added_links"] = list(REQUIRED_UR5_LINKS)
+    data["ur5_runtime_repair_reasons"] = ["implausible_adjacent_distance:" + reason for reason in reasons]
+    data["repair_generated_at"] = datetime.now(timezone.utc).isoformat()
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return True, reasons
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("index_path", type=Path)
+    args = parser.parse_args()
+    changed, reasons = repair_index(args.index_path.resolve())
+    if changed:
+        print("[repair_scene3d_ur5_spacing] repaired UR5 spacing: " + ";".join(reasons))
+    else:
+        print("[repair_scene3d_ur5_spacing] no UR5 spacing repair needed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Direct Scene3D repair utility for the robot spacing problem.

Changes:
- Adds `scripts/repair_scene3d_ur5_spacing.py`.
- Detects adjacent UR5 links that are too far apart in `scene_visual_mesh_index.json`.
- Replaces the bad UR5 arm rows with the stable connected preview rows.
- Preserves non-UR5 rows like table, camera, bins and zones.

Usage after merge:

```bash
python3 scripts/repair_scene3d_ur5_spacing.py scenes/ur5_2f_test/generated/scene_visual_mesh_index.json
```

Validation not run here.