### PR TITLE
Tighten UR5 Robotiq rendered mesh adjacency gate and export topology diagnostics

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke_impl.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke_impl.py
@@ -1492,6 +1492,7 @@ def _checked_pair_record(
         "child_bbox_min": (child_item or {}).get("bounds", {}).get("min") if isinstance((child_item or {}).get("bounds"), dict) else None,
         "child_bbox_max": (child_item or {}).get("bounds", {}).get("max") if isinstance((child_item or {}).get("bounds"), dict) else None,
         "separation_m": sep,
+        "distance_m": sep,
         "bbox_gap_m": _bbox_gap(parent_item, child_item),
         "limit_m": limit_m,
         "threshold_m": limit_m,
@@ -1525,9 +1526,16 @@ def _final_draw_bbox_from_row(raw: dict[str, Any]) -> dict[str, list[float]] | N
 
 def _apply_ur5_rendered_mesh_adjacency(payload: dict[str, Any], *, repo_root: Path, scene_name: str | None, index_data: dict[str, Any]) -> None:
     if scene_name != "ur5_2f_test":
-        payload.setdefault("rendered_mesh_adjacency_status", "SKIPPED")
-        payload.setdefault("rendered_mesh_adjacency_errors", [])
-        payload.setdefault("rendered_mesh_adjacency_checked_pairs", [])
+        status = "SKIPPED"
+        errors: list[str] = []
+        checked: list[dict[str, Any]] = []
+        payload.setdefault("rendered_mesh_adjacency_status", status)
+        payload.setdefault("rendered_mesh_adjacency_errors", errors)
+        payload.setdefault("rendered_mesh_adjacency_checked_pairs", checked)
+        payload.setdefault(
+            "generated_robot_topology_diagnostics",
+            {"status": status, "source": "scene_not_ur5_2f_test", "checked_pairs": checked, "errors": errors},
+        )
         return
 
     final_draw_items = payload.get("final_draw_visual_items")
@@ -1545,6 +1553,12 @@ def _apply_ur5_rendered_mesh_adjacency(payload: dict[str, Any], *, repo_root: Pa
         payload["rendered_mesh_adjacency_status"] = "FAIL"
         payload["rendered_mesh_adjacency_errors"] = errors
         payload["rendered_mesh_adjacency_checked_pairs"] = []
+        payload["generated_robot_topology_diagnostics"] = {
+            "status": "FAIL",
+            "source": "missing_final_draw_diagnostics",
+            "checked_pairs": [],
+            "errors": errors,
+        }
         _record_rendered_mesh_adjacency_failure(payload, errors)
         return
 
@@ -1640,6 +1654,12 @@ def _apply_ur5_rendered_mesh_adjacency(payload: dict[str, Any], *, repo_root: Pa
     tool_parent = by_link.get("tool0") or by_link.get("wrist_3_link")
     tool_parent_name = "tool0" if by_link.get("tool0") is not None else "wrist_3_link"
     if robotiq_base is None or tool_parent is None:
+        missing_bits: list[str] = []
+        if tool_parent is None:
+            missing_bits.append("tool parent tool0/wrist_3_link")
+        if robotiq_base is None:
+            missing_bits.append("Robotiq base")
+        errors.append("Missing final draw rendered mesh topology row for " + " and ".join(missing_bits))
         checked.append(
             _checked_pair_record(
                 tool_parent_name,
@@ -1648,23 +1668,9 @@ def _apply_ur5_rendered_mesh_adjacency(payload: dict[str, Any], *, repo_root: Pa
                 robotiq_base,
                 None,
                 _rendered_mesh_adjacency_limit(tool_parent_name, "robotiq_base"),
-                True,
+                False,
             )
         )
-        checked[-1]["evidence"] = "m1_gripper_readiness_deferred"
-    elif _stable_metadata_proves_adjacency(tool_parent_name, "robotiq_base", robotiq_base) or _stable_metadata_proves_adjacency("wrist_3_link", "robotiq_base", robotiq_base):
-        checked.append(
-            _checked_pair_record(
-                tool_parent_name,
-                "robotiq_base",
-                tool_parent,
-                robotiq_base,
-                None,
-                _rendered_mesh_adjacency_limit(tool_parent_name, "robotiq_base"),
-                True,
-            )
-        )
-        checked[-1]["evidence"] = "stable_metadata"
     elif not isinstance(tool_parent.get("bounds"), dict) or not isinstance(robotiq_base.get("bounds"), dict):
         detail = tool_parent.get("bbox_error") or robotiq_base.get("bbox_error") or "bbox_missing"
         errors.append(f"Missing or non-finite final_draw_bbox diagnostics for Robotiq base association with wrist_3_link/tool0: {detail}")
@@ -1689,9 +1695,27 @@ def _apply_ur5_rendered_mesh_adjacency(payload: dict[str, Any], *, repo_root: Pa
                 f"Robotiq base final draw bbox separated from {tool_parent_name} by {sep:.3f} m; expected <= {limit_m:.3f} m"
             )
 
-    payload["rendered_mesh_adjacency_status"] = "PASS" if not errors else "FAIL"
+    # Stable parent/chain metadata is useful diagnostic evidence for topology,
+    # but the UR5 + Robotiq gate must be based on finite final draw bounds and a
+    # measured AABB separation so metadata-only rows cannot mask a detached or
+    # missing rendered gripper.
+    for pair in checked:
+        if pair.get("child") == "robotiq_base" and robotiq_base is not None:
+            pair["stable_metadata_adjacency"] = bool(
+                _stable_metadata_proves_adjacency(str(pair.get("parent") or tool_parent_name), "robotiq_base", robotiq_base)
+                or _stable_metadata_proves_adjacency("wrist_3_link", "robotiq_base", robotiq_base)
+            )
+
+    status = "PASS" if not errors else "FAIL"
+    payload["rendered_mesh_adjacency_status"] = status
     payload["rendered_mesh_adjacency_errors"] = errors
     payload["rendered_mesh_adjacency_checked_pairs"] = checked
+    payload["generated_robot_topology_diagnostics"] = {
+        "status": status,
+        "source": source,
+        "checked_pairs": checked,
+        "errors": errors,
+    }
     _record_rendered_mesh_adjacency_failure(payload, errors)
 
 

--- a/tests/test_scene3d_gui_smoke_json_output_contract.py
+++ b/tests/test_scene3d_gui_smoke_json_output_contract.py
@@ -517,9 +517,7 @@ def test_reported_ur5_2f_smoke_json_generated_urdf_contract_passes():
             "immediate_parent_link": parent,
             "link_chain": chain[: chain.index(link) + 1],
             "final_draw_status": "ok",
-            # Non-finite bboxes exercise the metadata-only adjacency path rather
-            # than accidentally passing because of fragile draw-order geometry.
-            "final_draw_bbox": {"min": [float("nan"), 0.0, 0.0], "max": [1.0, 1.0, 1.0]},
+            "final_draw_bbox": {"min": [float(chain.index(link)) * 0.1, 0.0, 0.0], "max": [float(chain.index(link)) * 0.1 + 0.1, 0.1, 0.1]},
             "generated_urdf_visual": True,
             "rendered": True,
         }
@@ -587,10 +585,111 @@ def test_reported_ur5_2f_smoke_json_generated_urdf_contract_passes():
     assert "runtime_transform_chain_applied_count_zero_with_generated_visuals" not in payload.get("warnings", [])
     assert "runtime_visual_origin_applied_count_zero_with_generated_visuals" not in payload.get("warnings", [])
     assert payload["rendered_mesh_adjacency_status"] == "PASS"
+    assert payload["generated_robot_topology_diagnostics"]["status"] == "PASS"
+    assert payload["generated_robot_topology_diagnostics"]["source"] == "final_draw_visual_items"
     assert "scene3d_rendered_mesh_adjacency_failed" not in payload.get("warnings", [])
     assert payload["warnings"] == ["scene3d_optional_ui_metadata_missing"]
-    assert all(pair.get("evidence") == "stable_metadata" for pair in payload["rendered_mesh_adjacency_checked_pairs"])
+    assert all(pair["separation_m"] == pytest.approx(0.0) for pair in payload["rendered_mesh_adjacency_checked_pairs"])
 
+
+
+def test_ur5_rendered_mesh_adjacency_missing_robotiq_base_fails_payload_status():
+    import scripts.run_workcell_builder_scene3d_gui_smoke as smoke
+
+    def item(link: str, xmin: float, xmax: float) -> dict:
+        return {
+            "id": f"draw_{link}",
+            "link": link,
+            "link_name": link,
+            "canonical_link_name": link,
+            "final_draw_bbox": {"min": [xmin, 0.0, 0.0], "max": [xmax, 0.1, 0.1]},
+        }
+
+    payload = {
+        "status": "PASS",
+        "final_draw_visual_items": [
+            item("base_link", 0.0, 0.1),
+            item("shoulder_link", 0.1, 0.2),
+            item("upper_arm_link", 0.2, 0.3),
+            item("forearm_link", 0.3, 0.4),
+            item("wrist_1_link", 0.4, 0.5),
+            item("wrist_2_link", 0.5, 0.6),
+            item("wrist_3_link", 0.6, 0.7),
+        ],
+    }
+
+    smoke._apply_ur5_rendered_mesh_adjacency(
+        payload, repo_root=Path(__file__).resolve().parents[1], scene_name="ur5_2f_test", index_data={}
+    )
+
+    assert payload["rendered_mesh_adjacency_status"] == "FAIL"
+    assert payload["status"] != "PASS"
+    topology = payload["generated_robot_topology_diagnostics"]
+    assert topology["status"] == "FAIL"
+    assert topology["source"] == "final_draw_visual_items"
+    robotiq_pair = topology["checked_pairs"][-1]
+    assert robotiq_pair["child"] == "robotiq_base"
+    assert robotiq_pair["ok"] is False
+    assert robotiq_pair["separation_m"] is None
+    assert robotiq_pair["distance_m"] is None
+    assert any("Robotiq base" in error for error in topology["errors"])
+
+
+def test_ur5_rendered_mesh_adjacency_far_robotiq_base_fails_despite_stable_metadata():
+    import scripts.run_workcell_builder_scene3d_gui_smoke as smoke
+
+    chain = [
+        "base_link_inertia",
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link",
+        "wrist_1_link",
+        "wrist_2_link",
+        "wrist_3_link",
+        "gripper_base_link",
+    ]
+
+    def item(link: str, xmin: float, xmax: float, parent: str | None = None) -> dict:
+        return {
+            "id": f"draw_{link}",
+            "link": link,
+            "link_name": link,
+            "canonical_link_name": link,
+            "parent_link": parent,
+            "immediate_parent_link": parent,
+            "link_chain": chain[: chain.index(link) + 1] if link in chain else [],
+            "final_draw_bbox": {"min": [xmin, 0.0, 0.0], "max": [xmax, 0.1, 0.1]},
+        }
+
+    payload = {
+        "status": "PASS",
+        "final_draw_visual_items": [
+            item("base_link_inertia", 0.0, 0.1),
+            item("shoulder_link", 0.1, 0.2, "base_link_inertia"),
+            item("upper_arm_link", 0.2, 0.3, "shoulder_link"),
+            item("forearm_link", 0.3, 0.4, "upper_arm_link"),
+            item("wrist_1_link", 0.4, 0.5, "forearm_link"),
+            item("wrist_2_link", 0.5, 0.6, "wrist_1_link"),
+            item("wrist_3_link", 0.6, 0.7, "wrist_2_link"),
+            item("gripper_base_link", 1.5, 1.6, "wrist_3_link"),
+        ],
+    }
+
+    smoke._apply_ur5_rendered_mesh_adjacency(
+        payload, repo_root=Path(__file__).resolve().parents[1], scene_name="ur5_2f_test", index_data={}
+    )
+
+    assert payload["rendered_mesh_adjacency_status"] == "FAIL"
+    assert payload["status"] != "PASS"
+    topology = payload["generated_robot_topology_diagnostics"]
+    robotiq_pair = topology["checked_pairs"][-1]
+    assert robotiq_pair["child"] == "robotiq_base"
+    assert robotiq_pair["stable_metadata_adjacency"] is True
+    assert robotiq_pair["separation_m"] == pytest.approx(0.8)
+    assert robotiq_pair["distance_m"] == pytest.approx(0.8)
+    assert robotiq_pair["limit_m"] <= smoke.RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M
+    assert robotiq_pair["ok"] is False
+    assert any("Robotiq base final draw bbox separated" in error for error in topology["errors"])
 
 def test_ur5_rendered_mesh_adjacency_keeps_upper_arm_forearm_gap_strict():
     import scripts.run_workcell_builder_scene3d_gui_smoke as smoke


### PR DESCRIPTION
### Motivation
- Make the UR5 M1 rendered-mesh adjacency gate stricter so missing or detached Robotiq gripper visuals cannot be bypassed by a deferred readiness path or metadata-only evidence.
- Surface explicit topology diagnostics for downstream consumers and CI so failures are actionable (which pair failed, measured separation, and why).

### Description
- Updated `_apply_ur5_rendered_mesh_adjacency()` in `scripts/run_workcell_builder_scene3d_gui_smoke_impl.py` to fail when either the tool parent (`tool0`/`wrist_3_link`) or Robotiq base is missing from `final_draw_visual_items` instead of using the previous `m1_gripper_readiness_deferred` path.
- Disabled metadata-only acceptance for the `tool0/wrist_3_link -> robotiq_base` check so `_stable_metadata_proves_adjacency(...)` is kept as diagnostic evidence only and no longer passes the gate by itself.
- Continued to use `_aabb_separation(...)` for the Robotiq base pair and enforce `RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M` (or a pair-specific tighter limit) to decide pass/fail; added `distance_m` alongside `separation_m` in checked pair records.
- Exported a new `generated_robot_topology_diagnostics` object in the payload containing `status`, `source`, `checked_pairs`, `errors`, and the measured `separation_m`/`distance_m` for consumers to inspect.
- Updated tests in `tests/test_scene3d_gui_smoke_json_output_contract.py` to assert that a missing Robotiq base or an over-separated Robotiq base produces `rendered_mesh_adjacency_status == "FAIL"` and a non-PASS payload topology status.

### Testing
- Ran `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke_impl.py` with success to validate syntax.
- Ran targeted tests with `pytest -q -k 'ur5_rendered_mesh_adjacency or reported_ur5_2f_smoke_json_generated_urdf_contract_passes'` and relevant smoke contract subsets, which passed in this environment.
- Ran the broader smoke JSON contract suite where unrelated environment-sensitive failures (ROS Humble availability and other pre-existing contract expectations) remained; these failures are external to the adjacency tightening and were documented as not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41765724848331bd0e83d0067f849b)