### PR TITLE
Add Scene3D Robotiq topology smoke checks

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke_impl.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke_impl.py
@@ -684,7 +684,7 @@ UR5_RENDERED_MESH_LINK_ALIASES: dict[str, tuple[str, ...]] = {
     "wrist_2_link": ("wrist_2_link",),
     "wrist_3_link": ("wrist_3_link",),
     "tool0": ("tool0",),
-    "robotiq_base": ("robotiq_base", "gripper_base_link", "robotiq_85_base_link", "robotiq base visual item"),
+    "robotiq_base": ("robotiq_base", "gripper_base_link", "robotiq_85_base_link", "robotiq_arg2f_base_link", "robotiq base visual item"),
 }
 UR5_RENDERED_MESH_ADJACENT_PAIRS: tuple[tuple[str, str], ...] = (
     ("base_link", "shoulder_link"),
@@ -695,7 +695,13 @@ UR5_RENDERED_MESH_ADJACENT_PAIRS: tuple[tuple[str, str], ...] = (
     ("wrist_2_link", "wrist_3_link"),
 )
 RENDERED_MESH_ADJACENCY_MAX_SEPARATION_M = 0.20
-RENDERED_MESH_ADJACENCY_PAIR_LIMITS_M: dict[tuple[str, str], float] = {}
+RENDERED_MESH_ADJACENCY_PAIR_LIMITS_M: dict[tuple[str, str], float] = {
+    ("wrist_3_link", "tool0"): 0.20,
+    ("tool0", "robotiq_base"): 0.20,
+    ("wrist_3_link", "robotiq_base"): 0.20,
+    ("robotiq_base", "robotiq_knuckle_or_finger"): 0.25,
+    ("robotiq_knuckle_or_finger", "robotiq_finger_tip"): 0.25,
+}
 REQUIRED_UR5_FINAL_VIEWPORT_LINKS: tuple[str, ...] = (
     "shoulder_link",
     "upper_arm_link",
@@ -1358,7 +1364,7 @@ def _mesh_path(record: dict[str, Any]) -> str | None:
 
 def _is_robotiq_base_record(record: dict[str, Any]) -> bool:
     canonical = str(record.get("canonical_link_name") or record.get("link_name") or record.get("link") or "").strip().lower()
-    if canonical in {"gripper_base_link", "robotiq_85_base_link", "robotiq_base"}:
+    if canonical in {"gripper_base_link", "robotiq_85_base_link", "robotiq_arg2f_base_link", "robotiq_base"}:
         return True
     haystack = " ".join(
         str(record.get(key) or "")
@@ -1441,6 +1447,50 @@ def _stable_metadata_candidates(record: dict[str, Any]) -> list[str]:
         if canonical and canonical not in candidates:
             candidates.append(canonical)
     return candidates
+
+
+def _raw_link_name(record: dict[str, Any]) -> str | None:
+    for key in ("canonical_link_name", "link_name", "link", "frame_id"):
+        value = record.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _robotiq_tip_key(link_name: str) -> str:
+    text = link_name.lower()
+    for suffix in (
+        "_inner_knuckle_link",
+        "_outer_knuckle_link",
+        "_knuckle_link",
+        "_finger_link",
+        "_inner_finger_link",
+        "_finger_tip_link",
+        "_tip_link",
+    ):
+        if text.endswith(suffix):
+            return text[: -len(suffix)]
+    return text
+
+
+def _is_robotiq_knuckle_or_finger_link(link_name: str) -> bool:
+    text = link_name.lower()
+    return (
+        "gripper_finger" in text
+        and not ("tip_link" in text or "finger_tip" in text)
+        and (
+            text.endswith("_knuckle_link")
+            or text.endswith("_inner_knuckle_link")
+            or text.endswith("_outer_knuckle_link")
+            or text.endswith("_finger_link")
+            or text.endswith("_inner_finger_link")
+        )
+    )
+
+
+def _is_robotiq_tip_link(link_name: str) -> bool:
+    text = link_name.lower()
+    return "gripper_finger" in text and (text.endswith("_tip_link") or text.endswith("_finger_tip_link"))
 
 
 def _bbox_gap(parent_item: dict[str, Any] | None, child_item: dict[str, Any] | None) -> list[float] | None:
@@ -1591,6 +1641,7 @@ def _apply_ur5_rendered_mesh_adjacency(payload: dict[str, Any], *, repo_root: Pa
     alias_to_canonical["tool0"] = "tool0"
 
     by_link: dict[str, dict[str, Any]] = {}
+    by_raw_link: dict[str, dict[str, Any]] = {}
     robotiq_base: dict[str, Any] | None = None
     for raw in final_draw_items:
         if not isinstance(raw, dict):
@@ -1604,6 +1655,10 @@ def _apply_ur5_rendered_mesh_adjacency(payload: dict[str, Any], *, repo_root: Pa
             normalized["bbox_error"] = "final_draw_bbox_missing_or_non_finite"
         if _is_robotiq_base_record(raw) and robotiq_base is None:
             robotiq_base = normalized
+        raw_link = _raw_link_name(raw)
+        if raw_link:
+            by_raw_link.setdefault(raw_link, normalized)
+            by_raw_link.setdefault(raw_link.lower(), normalized)
         # Prefer stable generated-URDF metadata over runtime/display ids such as
         # generated_urdf::...; ids are only used as a last-resort diagnostic
         # fallback when metadata is absent.
@@ -1622,6 +1677,27 @@ def _apply_ur5_rendered_mesh_adjacency(payload: dict[str, Any], *, repo_root: Pa
                     by_link[canonical] = normalized
 
     checked: list[dict[str, Any]] = []
+    tool0_item = by_link.get("tool0")
+    wrist3_item = by_link.get("wrist_3_link")
+    if tool0_item is not None:
+        parent, child = "wrist_3_link", "tool0"
+        parent_item = wrist3_item
+        child_item = tool0_item
+        if parent_item is None or child_item is None:
+            errors.append(f"Missing final draw rendered mesh topology link for required pair {parent}->{child}")
+            checked.append(_checked_pair_record(parent, child, parent_item, child_item, None, _rendered_mesh_adjacency_limit(parent, child), False))
+        elif not isinstance(parent_item.get("bounds"), dict) or not isinstance(child_item.get("bounds"), dict):
+            detail = parent_item.get("bbox_error") or child_item.get("bbox_error") or "bbox_missing"
+            errors.append(f"Missing or non-finite final_draw_bbox diagnostics for generated topology pair {parent}->{child}: {detail}")
+            checked.append(_checked_pair_record(parent, child, parent_item, child_item, None, _rendered_mesh_adjacency_limit(parent, child), False))
+        else:
+            sep = _aabb_separation(parent_item["bounds"], child_item["bounds"])
+            limit_m = _rendered_mesh_adjacency_limit(parent, child)
+            ok = math.isfinite(sep) and sep <= limit_m
+            checked.append(_checked_pair_record(parent, child, parent_item, child_item, sep, limit_m, ok))
+            if not ok:
+                errors.append(f"UR wrist/tool mount final draw bbox adjacency {parent}->{child} separated by {sep:.3f} m; expected <= {limit_m:.3f} m")
+
     for parent, child in UR5_RENDERED_MESH_ADJACENT_PAIRS:
         parent_item = by_link.get(parent)
         child_item = by_link.get(child)
@@ -1694,6 +1770,42 @@ def _apply_ur5_rendered_mesh_adjacency(payload: dict[str, Any], *, repo_root: Pa
             errors.append(
                 f"Robotiq base final draw bbox separated from {tool_parent_name} by {sep:.3f} m; expected <= {limit_m:.3f} m"
             )
+
+    robotiq_link_rows: list[tuple[str, dict[str, Any]]] = []
+    for link_name, row in by_raw_link.items():
+        if link_name != link_name.lower():
+            continue
+        if "gripper_finger" in link_name:
+            robotiq_link_rows.append((link_name, row))
+    knuckle_rows = [(link, row) for link, row in robotiq_link_rows if _is_robotiq_knuckle_or_finger_link(link)]
+    tip_by_key: dict[str, tuple[str, dict[str, Any]]] = {}
+    for link, row in robotiq_link_rows:
+        if _is_robotiq_tip_link(link):
+            tip_by_key.setdefault(_robotiq_tip_key(link), (link, row))
+
+    def check_topology_pair(parent: str, child: str, parent_item: dict[str, Any] | None, child_item: dict[str, Any] | None, limit_key: tuple[str, str]) -> None:
+        limit_m = _rendered_mesh_adjacency_limit(*limit_key)
+        if parent_item is None or child_item is None:
+            errors.append(f"Missing final draw rendered mesh topology link for required pair {parent}->{child}")
+            checked.append(_checked_pair_record(parent, child, parent_item, child_item, None, limit_m, False))
+            return
+        if not isinstance(parent_item.get("bounds"), dict) or not isinstance(child_item.get("bounds"), dict):
+            detail = parent_item.get("bbox_error") or child_item.get("bbox_error") or "bbox_missing"
+            errors.append(f"Missing or non-finite final_draw_bbox diagnostics for generated topology pair {parent}->{child}: {detail}")
+            checked.append(_checked_pair_record(parent, child, parent_item, child_item, None, limit_m, False))
+            return
+        sep = _aabb_separation(parent_item["bounds"], child_item["bounds"])
+        ok = math.isfinite(sep) and sep <= limit_m
+        checked.append(_checked_pair_record(parent, child, parent_item, child_item, sep, limit_m, ok))
+        if not ok:
+            errors.append(f"Generated Robotiq topology final draw bbox adjacency {parent}->{child} separated by {sep:.3f} m; expected <= {limit_m:.3f} m")
+
+    for link, row in sorted(knuckle_rows):
+        check_topology_pair("robotiq_base", link, robotiq_base, row, ("robotiq_base", "robotiq_knuckle_or_finger"))
+        tip = tip_by_key.get(_robotiq_tip_key(link))
+        if tip is not None:
+            tip_link, tip_row = tip
+            check_topology_pair(link, tip_link, row, tip_row, ("robotiq_knuckle_or_finger", "robotiq_finger_tip"))
 
     # Stable parent/chain metadata is useful diagnostic evidence for topology,
     # but the UR5 + Robotiq gate must be based on finite final draw bounds and a

--- a/tests/test_scene3d_gui_smoke_json_output_contract.py
+++ b/tests/test_scene3d_gui_smoke_json_output_contract.py
@@ -691,6 +691,61 @@ def test_ur5_rendered_mesh_adjacency_far_robotiq_base_fails_despite_stable_metad
     assert robotiq_pair["ok"] is False
     assert any("Robotiq base final draw bbox separated" in error for error in topology["errors"])
 
+
+def test_ur5_rendered_mesh_adjacency_exploded_robotiq_finger_fails():
+    import scripts.run_workcell_builder_scene3d_gui_smoke as smoke
+
+    def item(link: str, xmin: float, xmax: float) -> dict:
+        return {
+            "id": f"draw_{link}",
+            "link": link,
+            "link_name": link,
+            "canonical_link_name": link,
+            "final_draw_status": "ok",
+            "final_draw_bbox": {"min": [xmin, 0.0, 0.0], "max": [xmax, 0.1, 0.1]},
+        }
+
+    payload = {
+        "status": "PASS",
+        "final_draw_visual_items": [
+            item("base_link_inertia", 0.0, 0.1),
+            item("shoulder_link", 0.1, 0.2),
+            item("upper_arm_link", 0.2, 0.3),
+            item("forearm_link", 0.3, 0.4),
+            item("wrist_1_link", 0.4, 0.5),
+            item("wrist_2_link", 0.5, 0.6),
+            item("wrist_3_link", 0.6, 0.7),
+            item("tool0", 0.7, 0.75),
+            item("robotiq_85_base_link", 0.75, 0.85),
+            item("gripper_finger1_knuckle_link", 1.30, 1.40),
+            item("gripper_finger1_finger_tip_link", 1.40, 1.50),
+        ],
+    }
+
+    smoke._apply_ur5_rendered_mesh_adjacency(
+        payload, repo_root=Path(__file__).resolve().parents[1], scene_name="ur5_2f_test", index_data={}
+    )
+
+    assert payload["rendered_mesh_adjacency_status"] == "FAIL"
+    assert payload["status"] != "PASS"
+    topology = payload["generated_robot_topology_diagnostics"]
+    assert topology["status"] == "FAIL"
+    assert topology["source"] == "final_draw_visual_items"
+    checked = topology["checked_pairs"]
+    wrist_tool = next(pair for pair in checked if pair["parent"] == "wrist_3_link" and pair["child"] == "tool0")
+    tool_base = next(pair for pair in checked if pair["parent"] == "tool0" and pair["child"] == "robotiq_base")
+    exploded_finger = next(pair for pair in checked if pair["parent"] == "robotiq_base" and pair["child"] == "gripper_finger1_knuckle_link")
+    finger_tip = next(pair for pair in checked if pair["parent"] == "gripper_finger1_knuckle_link" and pair["child"] == "gripper_finger1_finger_tip_link")
+    assert wrist_tool["separation_m"] == pytest.approx(0.0)
+    assert tool_base["separation_m"] == pytest.approx(0.0)
+    assert exploded_finger["limit_m"] == pytest.approx(0.25)
+    assert exploded_finger["separation_m"] == pytest.approx(0.45)
+    assert exploded_finger["ok"] is False
+    assert finger_tip["separation_m"] == pytest.approx(0.0)
+    assert finger_tip["ok"] is True
+    assert any("robotiq_base->gripper_finger1_knuckle_link" in error for error in topology["errors"])
+
+
 def test_ur5_rendered_mesh_adjacency_keeps_upper_arm_forearm_gap_strict():
     import scripts.run_workcell_builder_scene3d_gui_smoke as smoke
 


### PR DESCRIPTION
### Motivation

- Improve Scene3D/Product View smoke diagnostics by verifying that generated gripper topology is actually rendered and colocated, not only present in visual-index metadata.

### Description

- Added final-draw AABB-based topology checks into `scripts/run_workcell_builder_scene3d_gui_smoke_impl.py` for `wrist_3_link -> tool0` (if `tool0` exists), `tool0 -> robotiq_base` (and nearest Robotiq base alias), `robotiq_base -> gripper_finger*_knuckle_link`, `gripper_finger*_knuckle_link -> gripper_finger*_finger_tip_link`, and finger/tip pairs when both rows are exported.
- Use final draw bbox data and measured AABB separation via `_aabb_separation` rather than relying on visual-index identity alone, with pair-specific thresholds and defaults (`<= 0.20 m` for wrist/tool and tool->base, `<= 0.25 m` for Robotiq knuckle/finger/tip checks).
- Normalized Robotiq base aliases to include `gripper_base_link`, `robotiq_85_base_link`, and `robotiq_arg2f_base_link` so rows are reliably recognized across variants.
- Added helpers to normalize raw link names, detect knuckle/finger and tip link naming patterns, and to key finger tip rows so knuckle->tip relationships are checked where present.
- Export all measured topology records into `generated_robot_topology_diagnostics.checked_pairs` (each record contains parent/child ids, canonical names, parent/child bbox mins/maxs, measured separation/distance, limit/threshold, and pass/fail flags).
- Added a regression test `test_ur5_rendered_mesh_adjacency_exploded_robotiq_finger_fails` in `tests/test_scene3d_gui_smoke_json_output_contract.py` which asserts that an exploded Robotiq finger row causes the topology diagnostics to fail while wrist/tool and tool/base remain OK.

### Testing

- Ran static compile check with `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke_impl.py tests/test_scene3d_gui_smoke_json_output_contract.py`, which succeeded.
- Ran a focused test selection that exercises the new Robotiq topology checks with `python3 -m pytest tests/test_scene3d_gui_smoke_json_output_contract.py -q -k 'exploded_robotiq_finger or rendered_mesh_adjacency_prefers_final_draw_bboxes or missing_robotiq_base or far_robotiq_base'` and observed 4 passed / 34 deselected.
- Ran the full contract test suite `python3 -m pytest tests/test_scene3d_gui_smoke_json_output_contract.py -q` and observed unrelated environment-sensitive failures (11 failures) that are pre-existing or depend on ROS Humble availability / PATH / local fixture expectations and did not relate to the Robotiq topology logic added here; the new regression passed in the targeted run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41784dd74083318703c7a9d54b34ee)