### PR TITLE
Tighten Scene3D final-draw diagnostics and require final_draw_bbox for topology smoke

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke_impl.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke_impl.py
@@ -1335,15 +1335,11 @@ def _bbox_mapping_from_record(record: dict[str, Any], *keys: str) -> dict[str, l
 
 
 def _bbox_from_final_draw(record: dict[str, Any]) -> dict[str, list[float]] | None:
-    # Prefer bounds explicitly captured after final_mesh_transform_matrix(),
-    # because these are in the same coordinate basis used by the renderer.
-    return _bbox_mapping_from_record(
-        record,
-        "final_rendered_mesh_bbox",
-        "final_rendered_bbox",
-        "rendered_mesh_bbox",
-        "final_draw_bbox",
-    )
+    # Smoke topology PASS decisions must use only bounds exported from the
+    # renderer's final draw rows.  Earlier visual-index/world-pose fields are
+    # useful diagnostics, but they can be plausible while the rendered mesh is
+    # detached or exploded.
+    return _bbox_mapping_from_record(record, "final_draw_bbox")
 
 
 def _item_id(record: dict[str, Any]) -> str | None:
@@ -1555,23 +1551,14 @@ def _final_draw_bbox_from_row(raw: dict[str, Any]) -> dict[str, list[float]] | N
     bbox = _bbox_from_final_draw(raw)
     if bbox is not None:
         return bbox
-    bmin = _finite_float_list(
-        raw.get("final_rendered_mesh_bbox_min")
-        or raw.get("final_rendered_bbox_min")
-        or raw.get("rendered_mesh_bbox_min")
-        or raw.get("final_draw_bbox_min"),
-        3,
-    )
-    bmax = _finite_float_list(
-        raw.get("final_rendered_mesh_bbox_max")
-        or raw.get("final_rendered_bbox_max")
-        or raw.get("rendered_mesh_bbox_max")
-        or raw.get("final_draw_bbox_max"),
-        3,
-    )
-    if bmin is None or bmax is None:
+    bmin = _finite_float_list(raw.get("final_draw_bbox_min"), 3)
+    bmax = _finite_float_list(raw.get("final_draw_bbox_max"), 3)
+    if bmin is not None and bmax is not None:
+        return {"min": bmin, "max": bmax}
+    center = _finite_float_list(raw.get("final_draw_bbox_center"), 3)
+    if center is None:
         return None
-    return {"min": bmin, "max": bmax}
+    return {"min": center, "max": center}
 
 
 def _apply_ur5_rendered_mesh_adjacency(payload: dict[str, Any], *, repo_root: Path, scene_name: str | None, index_data: dict[str, Any]) -> None:
@@ -1615,11 +1602,7 @@ def _apply_ur5_rendered_mesh_adjacency(payload: dict[str, Any], *, repo_root: Pa
     payload["rendered_mesh_adjacency_source"] = source
     alias_to_canonical: dict[str, str] = {}
     if source == "final_draw_visual_items":
-        final_rows = [
-            _enrich_final_row_from_visual_index(row, payload)
-            for row in final_draw_items
-            if isinstance(row, dict)
-        ]
+        final_rows = [row for row in final_draw_items if isinstance(row, dict)]
         expected_links = set(REQUIRED_UR5_FINAL_VIEWPORT_LINKS)
         final_links = {str(row.get("link") or row.get("link_name") or "").strip() for row in final_rows}
         final_canonical_links = {
@@ -1646,9 +1629,9 @@ def _apply_ur5_rendered_mesh_adjacency(payload: dict[str, Any], *, repo_root: Pa
     for raw in final_draw_items:
         if not isinstance(raw, dict):
             continue
-        raw = _enrich_final_row_from_visual_index(raw, payload)
-        bounds = _bbox_from_final_draw(raw) or _final_draw_bbox_from_row(raw)
+        bounds = _final_draw_bbox_from_row(raw)
         normalized = dict(raw)
+        normalized.pop("bounds", None)
         if bounds is not None:
             normalized["bounds"] = bounds
         elif str(raw.get("final_draw_status") or "") == "ok":

--- a/tests/test_scene3d_gui_smoke_json_output_contract.py
+++ b/tests/test_scene3d_gui_smoke_json_output_contract.py
@@ -402,7 +402,7 @@ def test_ur5_rendered_mesh_adjacency_prefers_final_draw_bboxes():
     assert checked[-1]["ok"] is True
 
 
-def test_ur5_rendered_mesh_adjacency_prefers_final_rendered_mesh_bboxes_over_baked_pose_bounds():
+def test_ur5_rendered_mesh_adjacency_ignores_legacy_rendered_mesh_bbox_aliases():
     import scripts.run_workcell_builder_scene3d_gui_smoke as smoke
 
     def item(link: str, xmin: float, xmax: float) -> dict:
@@ -431,11 +431,72 @@ def test_ur5_rendered_mesh_adjacency_prefers_final_rendered_mesh_bboxes_over_bak
 
     smoke._apply_ur5_rendered_mesh_adjacency(payload, repo_root=Path(__file__).resolve().parents[1], scene_name="ur5_2f_test", index_data={})
 
-    assert payload["rendered_mesh_adjacency_status"] == "PASS"
+    assert payload["rendered_mesh_adjacency_status"] == "FAIL"
     checked = payload["rendered_mesh_adjacency_checked_pairs"]
-    assert checked[0]["parent_bbox_min"] == [0.0, 0.0, 0.0]
-    assert all(pair["ok"] is True for pair in checked)
+    assert checked[0]["parent_bbox_min"] is None
+    assert all(pair["ok"] is False for pair in checked)
+    assert any("final_draw_bbox" in error for error in payload["rendered_mesh_adjacency_errors"])
 
+
+
+def test_ur5_rendered_mesh_adjacency_fails_when_final_draw_bboxes_far_despite_plausible_visual_index():
+    import scripts.run_workcell_builder_scene3d_gui_smoke as smoke
+
+    chain = [
+        "base_link_inertia",
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link",
+        "wrist_1_link",
+        "wrist_2_link",
+        "wrist_3_link",
+        "gripper_base_link",
+    ]
+
+    def index_row(link: str, i: int) -> dict:
+        return {
+            "source_row_index": i,
+            "link": link,
+            "link_name": link,
+            "baked_world_visual_pose": {"xyz": [i * 0.05, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]},
+            "visual_origin": {"xyz": [0.0, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]},
+            "link_world_pose": {"xyz": [i * 0.05, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]},
+        }
+
+    def final_row(link: str, i: int) -> dict:
+        x = i * 2.0
+        return {
+            "id": f"draw_{link}",
+            "source_row_index": i,
+            "link": link,
+            "link_name": link,
+            "canonical_link_name": link,
+            "final_draw_status": "ok",
+            "final_draw_bbox": {"min": [x, 0.0, 0.0], "max": [x + 0.1, 0.1, 0.1]},
+            "final_draw_bbox_center": [x + 0.05, 0.05, 0.05],
+        }
+
+    payload = {
+        "status": "PASS",
+        "visual_index": {"items": [index_row(link, i) for i, link in enumerate(chain)]},
+        "scene_visual_mesh_index": {"items": [index_row(link, i) for i, link in enumerate(chain)]},
+        "final_draw_visual_items": [final_row(link, i) for i, link in enumerate(chain)],
+    }
+
+    smoke._apply_ur5_rendered_mesh_adjacency(
+        payload, repo_root=Path(__file__).resolve().parents[1], scene_name="ur5_2f_test", index_data=payload["visual_index"]
+    )
+
+    assert payload["rendered_mesh_adjacency_source"] == "final_draw_visual_items"
+    assert payload["rendered_mesh_adjacency_status"] == "FAIL"
+    assert payload["generated_robot_topology_diagnostics"]["source"] == "final_draw_visual_items"
+    first_pair = payload["rendered_mesh_adjacency_checked_pairs"][0]
+    assert first_pair["parent"] == "base_link"
+    assert first_pair["child"] == "shoulder_link"
+    assert first_pair["separation_m"] == pytest.approx(1.9)
+    assert first_pair["ok"] is False
+    assert any("final draw bbox adjacency" in error for error in payload["rendered_mesh_adjacency_errors"])
+    assert "rendered_mesh_adjacency_used_index_fallback" not in payload.get("warnings", [])
 
 def test_ur5_rendered_mesh_adjacency_rejects_metadata_only_nonfinite_bboxes():
     import scripts.run_workcell_builder_scene3d_gui_smoke as smoke

--- a/workcell_builder/workcell_builder/gui/scene3d_diagnostics.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_diagnostics.cpp
@@ -364,17 +364,34 @@ QJsonArray Scene3DViewportWidget::final_draw_visual_items_export() const
     row["ros_to_viewport_basis_matrix"] = scene3d_matrix_to_json(ros_to_viewport_basis_matrix());
     row["viewport_world_visual_matrix"] = scene3d_matrix_to_json(viewport_root_transform);
     row["final_draw_model_matrix"] = scene3d_matrix_to_json(final_transform);
-    row["final_draw_world_pose"] = scene3d_vec_to_json(final_transform.map(QVector3D(0.0f, 0.0f, 0.0f)));
+    const QVector3D final_draw_origin = final_transform.map(QVector3D(0.0f, 0.0f, 0.0f));
+    row["final_draw_world_pose"] = scene3d_vec_to_json(final_draw_origin);
+    const QVector3D diagnostic_fallback_span(
+      static_cast<float>(qMax(0.08, item.sx)),
+      static_cast<float>(qMax(0.08, item.sy)),
+      static_cast<float>(qMax(0.08, item.sz)));
+    const QVector3D diagnostic_fallback_half = diagnostic_fallback_span * 0.5f;
+    const QVector3D diagnostic_fallback_min = final_draw_origin - diagnostic_fallback_half;
+    const QVector3D diagnostic_fallback_max = final_draw_origin + diagnostic_fallback_half;
+    row["final_draw_bbox"] = scene3d_bbox_to_json(diagnostic_fallback_min, diagnostic_fallback_max);
+    row["final_draw_bbox_min"] = scene3d_vec_to_json(diagnostic_fallback_min);
+    row["final_draw_bbox_max"] = scene3d_vec_to_json(diagnostic_fallback_max);
+    row["final_draw_bbox_span"] = scene3d_vec_to_json(diagnostic_fallback_span);
+    row["final_draw_bbox_center"] = scene3d_vec_to_json(final_draw_origin);
+    row["final_draw_bbox_source"] = QStringLiteral("diagnostic_primitive_fallback");
+    row["has_baked_world_visual_transform"] = item.has_baked_world_visual_transform;
+    row["has_baked_world_visual_matrix"] = item.has_baked_world_visual_matrix;
+    row["visual_origin_applied"] = item.visual_origin_applied;
+    row["baked_world_visual_pose"] = scene3d_pose_to_json(item.x, item.y, item.z, item.roll, item.pitch, item.yaw);
+    const bool early_baked_mesh_asset_correction_applied = should_apply_baked_mesh_asset_local_correction(item);
+    row["final_draw_asset_local_correction_applied"] = early_baked_mesh_asset_correction_applied;
     if (required_ur5_fallback) {
       row["source_type"] = QStringLiteral("generated_urdf_visual_fallback");
       row["final_draw_status"] = QStringLiteral("ur5_emergency_visible_fallback");
       row["fallback_visible_primitive"] = true;
       row["path_resolved"] = true;
       row["resolve_failure_reason"] = QStringLiteral("mesh_submission_failed_visible_fallback_submitted");
-      row["final_draw_bbox_span"] = scene3d_vec_to_json(QVector3D(
-        static_cast<float>(qMax(0.08, item.sx)),
-        static_cast<float>(qMax(0.08, item.sy)),
-        static_cast<float>(qMax(0.08, item.sz))));
+      row["final_draw_bbox_source"] = QStringLiteral("ur5_emergency_visible_fallback_primitive");
       out.append(row);
       continue;
     }
@@ -469,6 +486,7 @@ QJsonArray Scene3DViewportWidget::final_draw_visual_items_export() const
           row["final_draw_bbox_max"] = scene3d_vec_to_json(final_max);
           row["final_draw_bbox_span"] = scene3d_vec_to_json(final_span);
           row["final_draw_bbox_center"] = scene3d_vec_to_json((final_min + final_max) * 0.5f);
+          row["final_draw_bbox_source"] = QStringLiteral("mesh_final_draw");
           row["final_rendered_mesh_bbox"] = scene3d_bbox_to_json(final_min, final_max);
           row["final_rendered_mesh_bbox_min"] = scene3d_vec_to_json(final_min);
           row["final_rendered_mesh_bbox_max"] = scene3d_vec_to_json(final_max);
@@ -492,6 +510,7 @@ QJsonArray Scene3DViewportWidget::final_draw_visual_items_export() const
     row["final_draw_bbox_max"] = scene3d_vec_to_json(final_max);
     row["final_draw_bbox_span"] = scene3d_vec_to_json(final_span);
     row["final_draw_bbox_center"] = scene3d_vec_to_json((final_min + final_max) * 0.5f);
+    row["final_draw_bbox_source"] = QStringLiteral("mesh_final_draw");
     row["final_rendered_mesh_bbox"] = scene3d_bbox_to_json(final_min, final_max);
     row["final_rendered_mesh_bbox_min"] = scene3d_vec_to_json(final_min);
     row["final_rendered_mesh_bbox_max"] = scene3d_vec_to_json(final_max);


### PR DESCRIPTION
### Motivation
- Ensure the smoke/diagnostics use authoritative renderer final-draw evidence to prevent plausible visual-index/world-pose values from masking exploded or detached rendered meshes. 
- Make every generated URDF visual diagnostic row export a consistent set of final-draw fields so downstream smoke logic has the required evidence. 
- Treat visual-index/legacy fields as supplemental diagnostics only and fail the UR5 smoke when final-draw rows are missing for `ur5_2f_test`.

### Description
- Export additional final-draw fields for every generated URDF visual row in `final_draw_visual_items_export()`: `final_draw_model_matrix`, `final_draw_world_pose`, `final_draw_bbox`, `final_draw_bbox_min`, `final_draw_bbox_max`, `final_draw_bbox_center`, `has_baked_world_visual_transform`, `has_baked_world_visual_matrix`, `visual_origin_applied`, and `final_draw_asset_local_correction_applied` (implemented in `workcell_builder/workcell_builder/gui/scene3d_diagnostics.cpp`).
- Add a small diagnostic primitive fallback bbox and explicit `final_draw_bbox_source` tags so fallback rows still surface deterministic diagnostics while real mesh-computed bboxes remain authoritative.
- Tighten smoke topology logic in `scripts/run_workcell_builder_scene3d_gui_smoke_impl.py` so PASS decisions use only `final_draw_bbox` / `final_draw_bbox_min` / `final_draw_bbox_max` / `final_draw_bbox_center` exported from final-draw rows, and avoid falling back to `baked_world_visual_pose`, `visual_origin`, `link_world_pose`, legacy `final_rendered_mesh_bbox` aliases, or `scene_visual_mesh_index.json` for topology PASS evidence.
- Keep visual-index and other pre-final fields as supplemental diagnostic counts only; missing final-draw rows now cause the `ur5_2f_test` topology check to fail rather than pass on index-only evidence.
- Add a regression test that constructs plausible visual-index poses but intentionally spaced/far final-draw bboxes to assert the smoke fails in that case (updated `tests/test_scene3d_gui_smoke_json_output_contract.py`).

### Testing
- Ran targeted rendered-mesh adjacency smoke tests with `python3 -m pytest tests/test_scene3d_gui_smoke_json_output_contract.py -q -k "rendered_mesh_adjacency"` and observed success: 10 passed, 29 deselected.
- Verified Python module compiles with `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke_impl.py` with no syntax errors.
- Ran broader test suite partially; some unrelated environment-sensitive tests failed in this container due to ROS Humble availability / subprocess PATH issues, not because of the topology changes, so only the targeted topology tests are asserted as passing in this validation.
- Confirmed these changes only affect diagnostics/smoke validation evidence and do not change runtime/fake-hardware defaults or enable any real-hardware motion paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41949fd8708331911d3941e4bab52c)