### PR TITLE
Mark Scene3D GUI smoke/screenshots as optional debug evidence in readiness docs

### DIFF
--- a/docs/manuals/WORKCELL_STUDIO_SCENE_READINESS.md
+++ b/docs/manuals/WORKCELL_STUDIO_SCENE_READINESS.md
@@ -4,11 +4,16 @@ Use the scene readiness matrix when you need a catalog-backed view of whether
 supported Workcell Studio scenes have enough evidence to proceed through the
 safe simulation-first readiness path.
 
-The matrix is broader than a visual screenshot audit. Scene3D visual-quality
-screenshots are only one readiness category. The matrix also checks package
-structure, generated artifacts, schema validation, manifest references,
-fake-hardware launch derivation, and whether ROS-dependent checks were skipped
-or evaluated in the current environment.
+The matrix is broader than a visual screenshot audit. Scene3D GUI smoke and
+screenshot outputs are optional debug/legacy evidence for Workcell Builder
+triage; they are not required to prove production 3D editor readiness and they
+must not introduce visual-topology or screenshot-quality gates. Production
+readiness remains grounded in package structure, generated artifacts, schema
+validation, manifest references, package build checks, generated-scene
+validation, fake-hardware RViz/MoveIt launch validation, and whether
+ROS-dependent checks were skipped or evaluated in the current environment.
+RViz/MoveIt remains the planning and visual truth for the simulation-first
+readiness path.
 
 ## Run the readiness matrix
 
@@ -39,31 +44,46 @@ source /opt/ros/humble/setup.bash
 colcon build --symlink-install --packages-select workcell_builder ur5_2f_test
 source install/setup.bash
 cd /home/user/workcell_ws/src/easy_manipulation_deployment
-python3 scripts/run_workcell_builder_scene3d_gui_smoke.py --repo-root "$PWD" --workspace-root /home/user/workcell_ws --scene ur5_2f_test --output /tmp/ur5_2f_scene3d_smoke.json --screenshot /tmp/ur5_2f_scene3d_smoke.png
 python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json
 python3 scripts/run_workcell_studio_scene_readiness_matrix.py --supported-scenes scenes/supported_scenes.yaml --output-dir build/workcell_studio_scene_readiness
 ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true
 ```
 
+If a PR explicitly needs optional Scene3D GUI debug/legacy evidence, collect it
+separately after the required validation commands:
+
+```bash
+cd /home/user/workcell_ws/src/easy_manipulation_deployment
+python3 scripts/run_workcell_builder_scene3d_gui_smoke.py --repo-root "$PWD" --workspace-root /home/user/workcell_ws --scene ur5_2f_test --output /tmp/ur5_2f_scene3d_smoke.json --screenshot /tmp/ur5_2f_scene3d_smoke.png
+```
+
 Canary status meanings:
 
 - **PASS** requires actual runtime evidence from a real ROS 2 Humble workspace:
-  successful package build, Scene3D smoke JSON/screenshot, generated-scene
-  validation output, readiness-matrix output, and a fake-hardware RViz/MoveIt
-  launch attempt for `ur5_2f_test`.
+  successful package build, generated-scene validation output,
+  readiness-matrix output, and a fake-hardware RViz/MoveIt launch attempt for
+  `ur5_2f_test`. Optional Scene3D GUI smoke JSON/screenshot artifacts may be
+  attached as debug/legacy evidence, but they are not PASS requirements and do
+  not replace generated scene validation, package build checks, or
+  fake-hardware RViz/MoveIt launch validation.
 - **BLOCKED** means required runtime or environment evidence is missing, such as
   ROS Humble not being sourced, the workspace not being built, the
-  `ur5_2f_test` package not being available, GUI/screenshot capture not being
-  possible, or the fake-hardware launch not being evaluated.
-- **FAIL** means the required evidence was collected but one or more commands
-  reported a real validation, build, smoke, readiness, or fake-hardware launch
-  failure.
+  `ur5_2f_test` package not being available, generated-scene validation not
+  being run, or the fake-hardware launch not being evaluated. Missing
+  GUI/screenshot capture alone should be reported as an optional debug evidence
+  limitation, not as a production-readiness blocker.
+- **FAIL** means the required evidence was collected but one or more required
+  commands reported a real validation, build, readiness, or fake-hardware launch
+  failure. Optional Scene3D GUI smoke failures should be recorded as debug
+  limitations unless the PR explicitly scoped that smoke path as the thing under
+  test.
 
-The repository copy of
-`scenes/ur5_2f_test/generated/scene3d_gui_smoke.json` must be regenerated from
-the real ROS 2 Humble workspace before it can serve as canary evidence. A stale
+When optional Scene3D GUI smoke artifacts are attached, the repository copy of
+`scenes/ur5_2f_test/generated/scene3d_gui_smoke.json` should be regenerated from
+the real ROS 2 Humble workspace before it is cited as debug evidence. A stale
 checked-in JSON file, a local non-ROS checkout run, or a hand-edited evidence
-file is not sufficient for PASS.
+file is not sufficient to claim current GUI smoke coverage, but these optional
+artifacts are not required for canary PASS.
 
 ## Output files
 
@@ -76,12 +96,14 @@ Use the JSON output for CI, dashboards, and machine-readable regression checks.
 Use the Markdown output for quick human triage in PRs, demo-readiness reviews,
 and scene owner handoffs.
 
-## `ur5_2f_test` real-workspace Scene3D GUI evidence
+## `ur5_2f_test` optional real-workspace Scene3D GUI debug evidence
 
-Use this focused smoke path when a PR needs real-workspace Workcell Builder
-Scene3D evidence for the supported `ur5_2f_test` scene. Run it from the ROS
-workspace layout used for Workcell Studio validation, not from an unrelated
-temporary checkout.
+Use this focused smoke path only when a PR needs optional real-workspace
+Workcell Builder Scene3D debug/legacy evidence for the supported `ur5_2f_test`
+scene. Run it from the ROS workspace layout used for Workcell Studio validation,
+not from an unrelated temporary checkout. This path is not a production 3D
+editor readiness gate and must not be treated as a visual-topology or
+screenshot-quality requirement.
 
 Build and source the builder package first:
 
@@ -99,25 +121,28 @@ cd /home/user/workcell_ws/src/easy_manipulation_deployment
 python3 scripts/run_workcell_builder_scene3d_gui_smoke.py --repo-root "$PWD" --workspace-root /home/user/workcell_ws --scene ur5_2f_test --output "$PWD/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json" --screenshot "$PWD/scenes/ur5_2f_test/generated/scene3d_gui_smoke.png" --timeout-sec 30
 ```
 
-Expected evidence files:
+Optional debug evidence files:
 
 - `scenes/ur5_2f_test/generated/scene3d_gui_smoke.json`
 - `scenes/ur5_2f_test/generated/scene3d_gui_smoke.png`
 - stdout and stderr tail log paths recorded in the JSON evidence file
 
-This evidence confirms that the Workcell Builder Scene3D GUI smoke path could
-open the selected scene and record visual/log artifacts in that workspace. It
-does **not** launch real hardware, does **not** enable real robot motion, and
-does **not** prove fake-hardware RViz/MoveIt readiness by itself. Treat it as
-Scene3D GUI evidence that complements, but does not replace, the fake-hardware
-RViz/MoveIt launch validation and broader scene readiness matrix.
+This optional evidence confirms only that the Workcell Builder Scene3D GUI smoke
+path could open the selected scene and record visual/log artifacts in that
+workspace. It does **not** launch real hardware, does **not** enable real robot
+motion, does **not** prove production 3D editor readiness, and does **not** prove
+fake-hardware RViz/MoveIt readiness by itself. Treat it as debug/legacy evidence
+that may complement, but never replace, generated scene validation, package build
+checks, the broader scene readiness matrix, or fake-hardware RViz/MoveIt launch
+validation. RViz/MoveIt remains the planning and visual truth.
 
 
 ## Local `ur5_2f_test` real-workspace evidence runner
 
 Use the local runner when you want one repeatable command to collect the
-`ur5_2f_test` Workcell Builder build log, Scene3D GUI smoke JSON/screenshot,
-and readiness-matrix logs from a real ROS 2 Humble workspace. The runner is
+`ur5_2f_test` Workcell Builder build log, optional Scene3D GUI smoke
+JSON/screenshot debug evidence, and readiness-matrix logs from a real ROS 2
+Humble workspace. The runner is
 fake-hardware-first: it sources ROS Humble when available, builds only
 `workcell_builder`, runs the existing Scene3D GUI smoke runner, runs the
 offline readiness matrix, and does **not** invoke `ros2 launch` or start real
@@ -133,7 +158,7 @@ bash scripts/run_local_ur5_2f_workcell_validation.sh \
   --output-dir build/workcell_studio/local_validation/ur5_2f_test
 ```
 
-Expected evidence files under the output directory are:
+Runner output files under the output directory include:
 
 - `build_workcell_builder.log`
 - `scene3d_gui_smoke.json`
@@ -144,9 +169,12 @@ Expected evidence files under the output directory are:
 - `validation_summary.md`
 
 The runner reports `BLOCKED` when ROS Humble or the built `workcell_builder`
-executable is unavailable, `FAIL` when the builder build or smoke command fails,
-and `PASS` only when the Scene3D smoke status is pass-like and both JSON and
-screenshot evidence are present. After a successful automated run, complete the
+executable is unavailable and `FAIL` when required builder build or readiness
+commands fail. `PASS` should be interpreted as the required build and
+readiness-matrix checks completing; Scene3D smoke JSON/screenshot artifacts
+remain optional debug/legacy evidence, and their absence should not be used as a
+production 3D editor readiness failure.
+After a successful automated run, complete the
 manual GUI persistence check printed by the script: open Workcell Builder, open
 `ur5_2f_test`, confirm the robot/gripper/environment are visible, create an
 editable layout from preview, move an editable item, save, close/reopen, and
@@ -159,7 +187,8 @@ The matrix uses these status values:
 - **PASS**: required evidence is present and valid.
 - **FAIL**: required evidence exists but is invalid or internally inconsistent.
 - **BLOCKED**: readiness cannot be evaluated because required inputs, generated
-  artifacts, ROS environment, or visual evidence are missing.
+  artifacts, ROS environment, generated-scene validation, package build checks,
+  or fake-hardware RViz/MoveIt launch evidence are missing.
 
 `BLOCKED` is intentionally distinct from `FAIL`: it means Workcell Studio cannot
 make a trustworthy readiness judgment yet because a prerequisite is absent or the
@@ -176,14 +205,18 @@ as ready based on one signal alone:
 - required authoring files and generated artifacts;
 - `cell_definition.yaml` schema validation;
 - `scene_manifest.yaml` references and internal consistency;
-- mesh, screenshot, and visual evidence needed for Scene3D quality review;
+- optional Scene3D GUI smoke/screenshot debug evidence when a PR explicitly
+  requests legacy visual triage artifacts;
 - fake-hardware RViz/MoveIt launch derivation from catalog/package metadata;
 - ROS skip/evaluation state, including whether ROS-dependent checks were
   actually evaluated or explicitly skipped because the environment was missing.
 
-Scene3D screenshots help demonstrate visual quality and layout fidelity, but
-they do not prove that the package contract, generated artifacts, manifest
-references, or fake-hardware launch path are ready.
+Scene3D screenshots can help with visual debugging and layout triage, but they
+are optional legacy/debug artifacts. They do not prove production 3D editor
+readiness, do not replace package contracts, generated artifacts, manifest
+references, generated-scene validation, package build checks, or fake-hardware
+RViz/MoveIt launch validation, and must not create new screenshot-quality or
+visual-topology gates. RViz/MoveIt remains the planning and visual truth.
 
 ## Recommended triage loop
 
@@ -194,9 +227,10 @@ straight to RViz/MoveIt launch debugging:
 2. Validate `cell_definition.yaml` and correct schema or consistency errors.
 3. Fix `scene_manifest.yaml` references so the package index points at real,
    current artifacts.
-4. Regenerate mesh, screenshot, and other visual evidence required for the
-   Scene3D visual-quality category.
-5. Only then evaluate fake-hardware RViz/MoveIt readiness.
+4. If a PR explicitly needs legacy Scene3D GUI triage, collect optional smoke
+   JSON/screenshot debug artifacts without treating them as production-readiness
+   gates.
+5. Evaluate fake-hardware RViz/MoveIt readiness as the planning and visual truth.
 
 This order keeps the earliest source-of-truth blockers visible and prevents ROS
 launch failures from masking simpler missing-file, schema, or manifest-reference


### PR DESCRIPTION
### Motivation
- The readiness matrix previously treated Scene3D screenshots/smoke output as required visual evidence, which can create brittle visual-topology or screenshot-quality gates for production readiness.
- Clarify that production 3D editor readiness must remain based on package and generated-scene validation and fake-hardware RViz/MoveIt checks rather than GUI screenshots.

### Description
- Updated `docs/manuals/WORKCELL_STUDIO_SCENE_READINESS.md` to state that Scene3D GUI smoke and screenshot outputs are optional debug/legacy evidence and must not introduce visual-topology or screenshot-quality gates. 
- Removed the Scene3D GUI smoke command from the primary `ur5_2f_test` canary command sequence and added it as a separate optional command to collect debug evidence when explicitly requested. 
- Clarified `PASS`/`BLOCKED`/`FAIL` semantics so that package build, generated-scene validation, readiness-matrix output, and fake-hardware RViz/MoveIt launch validation remain required; GUI smoke artifacts are optional and do not replace these checks. 

### Testing
- Ran an automated normalized-whitespace wording check that verified the new phrases are present and it passed. 
- Ran a content search (`rg`) to validate the updated terminology and it passed. 
- Ran `git diff --check` to ensure no lint issues and it passed. 
- This is a documentation-only change and no runtime or ROS integration tests were run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a423aff1890833184e29f0bfded1288)