### PR TITLE
Gate Scene3D preview index repairs behind explicit debug flags/env

### DIFF
--- a/scripts/repair_all_scene3d_ur5_spacing.py
+++ b/scripts/repair_all_scene3d_ur5_spacing.py
@@ -11,6 +11,11 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo-root", default=str(Path(__file__).resolve().parents[1]))
     parser.add_argument("--scene", action="append", default=[])
+    parser.add_argument(
+        "--write-debug-repair",
+        action="store_true",
+        help="Rewrite generated Scene3D preview indexes. Default is read-only diagnostics.",
+    )
     args = parser.parse_args()
 
     repo_root = Path(args.repo_root).resolve()
@@ -26,15 +31,17 @@ def main() -> int:
             missing += 1
             print(f"{scene_name}: missing scene_visual_mesh_index.json")
             continue
-        changed, reasons = repair_index(index_path)
+        changed, reasons = repair_index(index_path, write_debug_repair=args.write_debug_repair)
         if changed:
             repaired += 1
-            print(f"{scene_name}: repaired {';'.join(reasons)}")
+            action = "wrote Debug 3D Preview repair" if args.write_debug_repair else "diagnostic only"
+            print(f"{scene_name}: {action} {';'.join(reasons)} (source-of-truth layout/planning artifacts unchanged)")
         else:
             unchanged += 1
             print(f"{scene_name}: already safe")
 
-    print(f"summary: repaired={repaired} unchanged={unchanged} missing={missing}")
+    label = "repaired" if args.write_debug_repair else "would_repair"
+    print(f"summary: {label}={repaired} unchanged={unchanged} missing={missing}")
     return 0
 
 

--- a/scripts/repair_scene3d_ur5_spacing.py
+++ b/scripts/repair_scene3d_ur5_spacing.py
@@ -62,7 +62,7 @@ def spacing_reasons(items: list[dict[str, Any]]) -> list[str]:
     return reasons
 
 
-def repair_index(path: Path) -> tuple[bool, list[str]]:
+def repair_index(path: Path, *, write_debug_repair: bool = False) -> tuple[bool, list[str]]:
     data = json.loads(path.read_text(encoding="utf-8"))
     items = data.get("visual_items") if isinstance(data.get("visual_items"), list) else []
     items = [item for item in items if isinstance(item, dict)]
@@ -89,6 +89,11 @@ def repair_index(path: Path) -> tuple[bool, list[str]]:
     data["ur5_runtime_repair_added_links"] = list(REQUIRED_UR5_LINKS)
     data["ur5_runtime_repair_reasons"] = ["implausible_adjacent_distance:" + reason for reason in reasons]
     data["repair_generated_at"] = datetime.now(timezone.utc).isoformat()
+    if not write_debug_repair:
+        return True, reasons
+    # Debug 3D Preview exception: this rewrites only the generated Scene3D
+    # preview index for local diagnostics. It does not modify source-of-truth
+    # layout, cell-definition, URDF/xacro, launch, or planning artifacts.
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     return True, reasons
 
@@ -96,10 +101,19 @@ def repair_index(path: Path) -> tuple[bool, list[str]]:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("index_path", type=Path)
+    parser.add_argument(
+        "--write-debug-repair",
+        action="store_true",
+        help=(
+            "Rewrite generated/scene_visual_mesh_index.json for Debug 3D Preview only. "
+            "Default is read-only diagnostics."
+        ),
+    )
     args = parser.parse_args()
-    changed, reasons = repair_index(args.index_path.resolve())
+    changed, reasons = repair_index(args.index_path.resolve(), write_debug_repair=args.write_debug_repair)
     if changed:
-        print("[repair_scene3d_ur5_spacing] repaired UR5 spacing: " + ";".join(reasons))
+        action = "wrote Debug 3D Preview repair" if args.write_debug_repair else "diagnostic only; rerun with --write-debug-repair to mutate generated preview index"
+        print("[repair_scene3d_ur5_spacing] UR5 spacing issue: " + ";".join(reasons) + f" ({action}; source-of-truth layout/planning artifacts unchanged)")
     else:
         print("[repair_scene3d_ur5_spacing] no UR5 spacing repair needed")
     return 0

--- a/scripts/run_workcell_builder_scene3d_gui_smoke_impl.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke_impl.py
@@ -292,7 +292,7 @@ def _check_and_refresh_visual_index(
 
     regenerated = False
     command: list[str] = []
-    if stale_reasons and scene_name:
+    if stale_reasons and scene_name and getattr(args, "repair_preview_index", False):
         command = [
             "python3",
             "scripts/extract_scene_urdf_visual_mesh_index.py",
@@ -300,6 +300,10 @@ def _check_and_refresh_visual_index(
             scene_name,
             "--prefer-xacro",
         ]
+        # Debug 3D Preview exception: this command rewrites only generated/
+        # scene_visual_mesh_index.json so the GUI smoke can compare against a
+        # refreshed preview index. It does not modify source-of-truth layout,
+        # URDF/xacro, launch, or planning artifacts.
         if workspace_root is not None:
             command += ["--workspace-root", str(workspace_root)]
         if getattr(args, "require_xacro", False) or (workspace_root is not None and xacro_available):
@@ -323,10 +327,18 @@ def _check_and_refresh_visual_index(
     elif regenerated:
         status = "regenerated"
     else:
-        status = "stale"
+        status = "stale_diagnostic_read_only"
     return {
         "index_freshness_status": status,
         "visual_index_regenerated_before_smoke": regenerated,
+        "visual_index_repair_preview_index_requested": bool(getattr(args, "repair_preview_index", False)),
+        "visual_index_read_only_diagnostic": bool(stale_reasons and not regenerated),
+        "visual_index_debug_repair_note": (
+            "Debug 3D Preview repair only; generated preview index was refreshed without modifying source-of-truth layout/planning artifacts"
+            if regenerated else
+            "Read-only diagnostics; pass --repair-preview-index to refresh generated Debug 3D Preview index"
+            if stale_reasons else ""
+        ),
         "visual_index_regeneration_command": " ".join(shlex.quote(part) for part in command) if command else "",
         "visual_index_before_visual_count": before_count,
         "visual_index_after_visual_count": after_count,
@@ -2304,6 +2316,14 @@ def main() -> int:
     ap.add_argument("--timeout-sec", type=float, default=30.0)
     ap.add_argument("--xvfb", action="store_true")
     ap.add_argument("--require-xacro", action="store_true")
+    ap.add_argument(
+        "--repair-preview-index",
+        action="store_true",
+        help=(
+            "Refresh generated/scene_visual_mesh_index.json before GUI smoke for Debug 3D Preview only. "
+            "Default is read-only diagnostics."
+        ),
+    )
     args = ap.parse_args()
 
     if args.all_scenes and args.scene:

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -8647,6 +8647,14 @@ void MainWindow::populate_scene_hierarchy()
   };
 
   auto run_visual_index_refresh = [&]() -> bool {
+    const bool debug_repair_enabled =
+      qEnvironmentVariableIntValue("WORKCELL_STUDIO_DEBUG_REPAIR_PREVIEW_INDEX") == 1;
+    if (!debug_repair_enabled) {
+      visual_index_refresh_blocker = QStringLiteral(
+        "read-only diagnostics by default; set WORKCELL_STUDIO_DEBUG_REPAIR_PREVIEW_INDEX=1 "
+        "to rewrite generated/scene_visual_mesh_index.json for Debug 3D Preview only");
+      return false;
+    }
     QString script;
     if (!helper_script_exists("extract_scene_urdf_visual_mesh_index.py", &script)) {
       visual_index_refresh_blocker = QStringLiteral("extractor script not found in helper script search paths");
@@ -8682,7 +8690,10 @@ void MainWindow::populate_scene_hierarchy()
     env.insert(QStringLiteral("VISUAL_INDEX_WORKSPACE_ROOT"), workspace_root);
     process.setProcessEnvironment(env);
     const QString command = command_parts.join(QStringLiteral(" && "));
-    append_studio_log(QString("Visual mesh index refresh: preview-only metadata command for scene '%1' at %2 (no RViz/MoveIt/controllers/real hardware launched).")
+    // Debug 3D Preview exception: this helper rewrites only the generated
+    // Scene3D preview index. It never edits source-of-truth layout,
+    // cell-definition, URDF/xacro, launch, controller, or planning artifacts.
+    append_studio_log(QString("Visual mesh index refresh: Debug 3D Preview repair command for scene '%1' at %2 (no source-of-truth layout/planning artifacts, RViz/MoveIt/controllers, or real hardware touched).")
       .arg(scene_name, QString::fromStdString(urdf_visual_index.string())));
     process.start(QStringLiteral("/bin/bash"), QStringList() << QStringLiteral("-lc") << command);
     if (!process.waitForFinished(120000)) {
@@ -8724,7 +8735,7 @@ void MainWindow::populate_scene_hierarchy()
       }
     } else {
       append_studio_log(
-        QString("Visual mesh index %1 for scene '%2' at %3 (workspace root: %4). Automatic preview-only refresh could not run: %5. Run python3 scripts/extract_scene_urdf_visual_mesh_index.py --scene %2 --workspace-root %4 from a ROS/workspace environment to refresh this generated artifact.")
+        QString("Visual mesh index %1 for scene '%2' at %3 (workspace root: %4). Workcell Builder kept this path read-only during scene open/save/generate/validate: %5. For Debug 3D Preview only, run python3 scripts/extract_scene_urdf_visual_mesh_index.py --scene %2 --workspace-root %4 from a ROS/workspace environment, or set WORKCELL_STUDIO_DEBUG_REPAIR_PREVIEW_INDEX=1 before opening the scene. Source-of-truth layout and planning artifacts are not modified by the debug preview repair.")
         .arg(original_reason, scene_name, QString::fromStdString(urdf_visual_index.string()), workspace_root, visual_index_refresh_blocker));
       append_studio_log("Visual mesh index unsafe/best-effort; preview may show placeholders");
     }


### PR DESCRIPTION
### Motivation
- Prevent automatic repair mutations of generated Scene3D preview indexes during normal Workcell Builder flows by default, so preview-only fixes do not alter source-of-truth layout, URDF/xacro, launch, or planning artifacts. 
- Make preview repair actions explicit and auditable for developers running debug/diagnostic workflows. 

### Description
- Made `repair_index()` in `scripts/repair_scene3d_ur5_spacing.py` read-only by default and added a `--write-debug-repair` flag to opt in to rewriting `generated/scene_visual_mesh_index.json`, with code comments clarifying this is a Debug 3D Preview-only exception and does not touch source-of-truth artifacts. 
- Updated `scripts/repair_all_scene3d_ur5_spacing.py` to accept `--write-debug-repair` and to report `would_repair` when run without the flag. 
- Changed the Scene3D GUI smoke helper `scripts/run_workcell_builder_scene3d_gui_smoke_impl.py` to default to read-only diagnostics and added `--repair-preview-index` to allow regenerating the preview index for smoke runs. 
- Prevented the Workcell Builder GUI auto-refresh from rewriting preview indexes during normal scene open/save/generate/validate flows unless the explicit environment variable `WORKCELL_STUDIO_DEBUG_REPAIR_PREVIEW_INDEX=1` is set, and improved logging to state the repair is debug-only; modified `workcell_builder/workcell_builder/gui/mainwindow.cpp` accordingly. 

### Testing
- Ran `PYTHONPATH=. python3 -m pytest tests/test_workcell_builder_product_view_defaults.py tests/test_scene3d_product_overlay_filtering.py` and both test modules passed. 
- Verified Python compile of modified scripts with `PYTHONPATH=. python3 -m py_compile scripts/repair_scene3d_ur5_spacing.py scripts/repair_all_scene3d_ur5_spacing.py scripts/run_workcell_builder_scene3d_gui_smoke_impl.py scripts/extract_scene_urdf_visual_mesh_index.py`, which succeeded. 
- Confirmed new CLI help flags and presence with `python3 scripts/repair_scene3d_ur5_spacing.py --help` and `python3 scripts/run_workcell_builder_scene3d_gui_smoke_impl.py --help`, which show `--write-debug-repair` and `--repair-preview-index`. 
- Ran a broader test set `PYTHONPATH=. python3 -m pytest tests/test_scene_urdf_visual_mesh_index.py tests/test_expanded_urdf_visual_preview_pipeline.py tests/test_workcell_builder_product_view_defaults.py` which failed (4 tests) due to extractor `extraction_mode` assertion drift unrelated to the gating changes; these failures were observed and noted but the repair-gating changes were isolated and did not introduce the extractor drift.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4241ca2ae8833187a811acb7c99142)