### PR TITLE
Add web-scene exporter contract tests and fix generated-item classification

### DIFF
--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -166,9 +166,15 @@ def _is_helper(item: Mapping[str, Any]) -> bool:
 
 def _section_from_item(item: Mapping[str, Any]) -> str:
     text = _identity_text(item)
-    if "robot" in text or item.get("category") == "robot":
+    category = str(item.get("category", "")).lower()
+    role = str(item.get("role", "")).lower()
+    if category == "robot" or role == "robot":
         return "robots"
-    if any(token in text for token in ("tool", "gripper", "end_effector", "robotiq", "suction")):
+    if (
+        category in {"tool", "gripper", "end_effector"}
+        or role in {"tool", "gripper", "end_effector"}
+        or any(token in text for token in ("tool", "gripper", "end_effector", "robotiq", "suction"))
+    ):
         return "tools"
     if "camera" in text or "realsense" in text:
         return "sensors"

--- a/tests/test_workcell_studio_web_scene_contract.py
+++ b/tests/test_workcell_studio_web_scene_contract.py
@@ -1,0 +1,155 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EXPORTER = REPO_ROOT / "scripts" / "export_workcell_studio_web_scene.py"
+SCHEMA = REPO_ROOT / "schemas" / "workcell_studio_web_scene_v1.schema.json"
+
+
+def _write_yaml(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, sort_keys=True), encoding="utf-8")
+
+
+def _tiny_scene_fixture(tmp_path: Path) -> Path:
+    scene = tmp_path / "tiny_scene"
+    (scene / "layout").mkdir(parents=True)
+    (scene / "generated").mkdir()
+
+    _write_yaml(
+        scene / "environment.yaml",
+        {
+            "scene": {"id": "tiny_scene", "name": "Tiny Scene"},
+            "environment": {
+                "assets": [
+                    {
+                        "id": "workbench",
+                        "type": "table",
+                        "role": "support_surface",
+                        "pose_xyz": [0.0, 0.0, 0.0],
+                        "dimensions": [1.0, 0.7, 0.05],
+                    }
+                ],
+                "sensors": [
+                    {
+                        "id": "inspection_camera",
+                        "category": "camera",
+                        "role": "camera",
+                        "pose_xyz": [0.4, -0.2, 1.1],
+                    }
+                ],
+            },
+        },
+    )
+    _write_yaml(
+        scene / "layout" / "workcell_studio_layout.yaml",
+        {
+            "schema_version": "workcell_studio_layout/v1",
+            "items": [
+                {
+                    "id": "layout_bin",
+                    "type": "target_bin",
+                    "category": "bin",
+                    "pose_xyz": [0.45, 0.25, 0.08],
+                    "mesh_path": str(scene / "meshes" / "bin.stl"),
+                }
+            ],
+        },
+    )
+    _write_json(
+        scene / "generated" / "scene_visual_mesh_index.json",
+        {
+            "visual_items": [
+                {
+                    "id": "ur5_visual",
+                    "category": "robot",
+                    "role": "robot",
+                    "mesh_path": str(scene / "meshes" / "ur5.dae"),
+                },
+                {
+                    "id": "robotiq_2f_visual",
+                    "category": "tool",
+                    "role": "gripper",
+                    "mesh_path": str(scene / "meshes" / "robotiq_2f.dae"),
+                },
+            ]
+        },
+    )
+    return scene
+
+
+def _export(scene: Path, output: Path) -> dict:
+    subprocess.run(
+        [sys.executable, str(EXPORTER), "--scene", str(scene), "--output", str(output)],
+        cwd=REPO_ROOT,
+        check=True,
+    )
+    return json.loads(output.read_text(encoding="utf-8"))
+
+
+def test_web_scene_schema_file_exists_and_is_valid_json():
+    assert SCHEMA.exists()
+    with SCHEMA.open(encoding="utf-8") as fh:
+        schema = json.load(fh)
+    assert schema["$id"].endswith("/workcell_studio_web_scene_v1.schema.json")
+    assert schema["properties"]["schema_version"]["const"] == "workcell_studio_web_scene/v1"
+
+
+def test_tiny_scene_exports_generated_and_authored_asset_contract(tmp_path):
+    scene = _tiny_scene_fixture(tmp_path)
+    out1 = tmp_path / "out" / "scene.web_scene.json"
+    out2 = tmp_path / "out" / "scene.again.web_scene.json"
+
+    payload1 = _export(scene, out1)
+    payload2 = _export(scene, out2)
+
+    assert out1.read_bytes() == out2.read_bytes()
+    assert payload1 == payload2
+    assert payload1["schema_version"] == "workcell_studio_web_scene/v1"
+    assert payload1["inputs"]["environment"]["present"] is True
+    assert payload1["inputs"]["layout"]["present"] is True
+    assert payload1["inputs"]["visual_mesh_index"]["present"] is True
+
+    robot = next(item for item in payload1["robots"] if item["id"] == "ur5_visual")
+    tool = next(item for item in payload1["tools"] if item["id"] == "robotiq_2f_visual")
+    for generated in (robot, tool):
+        assert generated["source_kind"] == "generated_preview"
+        assert generated["locked"] is True
+        assert generated["editable"] is False
+        assert generated["provenance"]["mesh_path"] == "generated/scene_visual_mesh_index.json"
+
+    layout_asset = next(item for item in payload1["assets"] if item["id"] == "layout_bin")
+    environment_asset = next(item for item in payload1["assets"] if item["id"] == "workbench")
+    environment_sensor = next(item for item in payload1["sensors"] if item["id"] == "inspection_camera")
+    for authored in (layout_asset, environment_asset, environment_sensor):
+        assert authored["source_kind"] == "user_authored"
+        assert authored["editable"] is True
+        assert authored["locked"] is False
+
+
+def test_missing_optional_inputs_warn_in_output_json_without_crashing(tmp_path):
+    scene = tmp_path / "missing_optional_inputs_scene"
+    scene.mkdir()
+
+    payload = _export(scene, tmp_path / "out" / "scene.web_scene.json")
+
+    assert payload["schema_version"] == "workcell_studio_web_scene/v1"
+    missing = [warning for warning in payload["warnings"] if warning["code"] == "optional_file_missing"]
+    assert {warning["source"] for warning in missing} == {
+        "scene_manifest.yaml",
+        "cell_definition.yaml",
+        "environment.yaml",
+        "layout/workcell_studio_layout.yaml",
+        "generated/scene_visual_mesh_index.json",
+    }
+    assert all(payload["inputs"][name]["present"] is False for name in payload["inputs"])


### PR DESCRIPTION
### Motivation
- Ensure the web Scene3D export path is deterministic and conforms to the web scene contract by adding a focused test suite that verifies schema parsing, authored vs generated asset semantics, warnings for missing optional inputs, and deterministic output.
- Prevent misclassification of generated preview items (e.g., Robotiq tools) as robots due to substring matching in identity fields, which caused incorrect section placement in the exporter output.

### Description
- Added `tests/test_workcell_studio_web_scene_contract.py` which creates a temporary tiny scene with `environment.yaml`, `layout/workcell_studio_layout.yaml`, and `generated/scene_visual_mesh_index.json` and validates exporter behavior including deterministic runs, `locked`/`editable` flags, provenance, and missing-file warnings.
- Adjusted exporter classification logic in `scripts/export_workcell_studio_web_scene.py` by updating `_section_from_item` to prefer explicit `category` and `role` values (lowercased) before falling back to substring matching, ensuring tools/grippers are routed to `tools` not `robots`.
- The tests and exporter remain dependency-light: they run the exporter as a Python script and do not require ROS, Qt, npm, or committed generated outputs.

### Testing
- Ran `python3 -m pytest tests/test_workcell_studio_web_scene_contract.py tests/test_export_workcell_studio_web_scene.py`, which executed 5 tests and all passed.
- Verified the schema file `schemas/workcell_studio_web_scene_v1.schema.json` parses as valid JSON as part of the tests.
- Confirmed deterministic export by running the exporter twice in the tests and asserting byte-identical and object-identical outputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a424b9a22088331ae5dd086d6aa1e35)