### PR TITLE
Add Web 3D scene contract v1

### DIFF
--- a/docs/WORKCELL_STUDIO_WEB_3D_SCENE_CONTRACT.md
+++ b/docs/WORKCELL_STUDIO_WEB_3D_SCENE_CONTRACT.md
@@ -100,3 +100,17 @@ This contract PR does not:
 Fake-hardware-first behavior is unchanged. This contract is a data interchange format for scene review/editing and backend requests; it does not enable real robot motion, automatic runtime send, uncontrolled topic/service publishing, or real-hardware execution.
 
 Real-hardware operation remains explicitly guarded by existing backend safety gates and future guarded workflows. RViz/MoveIt fake-hardware validation remains the foundation for simulation and planning truth.
+
+## CLI exporter
+
+Use the dependency-light exporter to materialize the v1 contract for a scene directory:
+
+```bash
+python3 scripts/export_workcell_studio_web_scene.py \
+  --scene scenes/ur5_2f_test \
+  --output build/workcell_studio/ur5_2f_test.web_scene.json
+```
+
+The exporter reads only optional scene inputs (`scene_manifest.yaml`, `cell_definition.yaml`, `environment.yaml`, `layout/workcell_studio_layout.yaml`, and `generated/scene_visual_mesh_index.json`) and writes one deterministic JSON file. The payload includes `inputs` presence metadata, per-item provenance, editability/lock state, ROS world Z-up units, and backend action descriptors that are requests for backend workflows rather than frontend-side execution hooks.
+
+The `plan_simulate` action is intentionally exported as disabled in this first contract. It documents the intended guarded backend request path while avoiding any accidental real-hardware or runtime execution enablement from a static JSON export.

--- a/schemas/workcell_studio_web_scene_v1.schema.json
+++ b/schemas/workcell_studio_web_scene_v1.schema.json
@@ -2,259 +2,102 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://workcell-studio.local/schemas/workcell_studio_web_scene_v1.schema.json",
   "title": "Workcell Studio Web Scene v1",
-  "description": "JSON Schema for the workcell_studio_web_scene/v1 payload used by Workcell Studio web/Scene3D clients.",
+  "description": "Browser-facing, dependency-light scene JSON exported from Workcell Studio authored and generated scene inputs.",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "schema_version",
-    "scene_id",
-    "source_files",
-    "provenance",
-    "units",
-    "coordinate_system",
-    "robot",
-    "tool",
-    "assets",
-    "sensors",
-    "zones",
-    "warnings",
-    "backend_actions"
-  ],
+  "required": ["schema_version", "scene", "inputs", "robots", "tools", "assets", "sensors", "zones", "warnings", "backend_actions"],
   "properties": {
-    "schema_version": {
-      "const": "workcell_studio_web_scene/v1",
-      "description": "Schema contract identifier for this payload."
-    },
-    "scene_id": {
-      "type": "string",
-      "minLength": 1,
-      "description": "Stable scene identifier, normally matching the scene directory/package name."
-    },
-    "source_files": {
+    "schema_version": {"const": "workcell_studio_web_scene/v1"},
+    "scene": {"$ref": "#/$defs/scene"},
+    "inputs": {
       "type": "object",
-      "description": "Source files used to assemble this web scene payload.",
-      "additionalProperties": { "$ref": "#/$defs/sourceFile" },
-      "properties": {
-        "environment": { "$ref": "#/$defs/sourceFile" },
-        "layout": { "$ref": "#/$defs/sourceFile" },
-        "cell_definition": { "$ref": "#/$defs/sourceFile" },
-        "scene_manifest": { "$ref": "#/$defs/sourceFile" },
-        "visual_mesh_index": { "$ref": "#/$defs/sourceFile" }
-      }
-    },
-    "provenance": {
-      "type": "object",
-      "description": "Generation metadata for traceability and reproducibility.",
       "additionalProperties": false,
+      "required": ["cell_definition", "environment", "layout", "scene_manifest", "visual_mesh_index"],
       "properties": {
-        "generated_at": { "type": "string", "format": "date-time" },
-        "generated_by": { "type": "string" },
-        "generator_version": { "type": "string" },
-        "repository": { "type": "string" },
-        "commit": { "type": "string" }
+        "cell_definition": {"$ref": "#/$defs/input"},
+        "environment": {"$ref": "#/$defs/input"},
+        "layout": {"$ref": "#/$defs/input"},
+        "scene_manifest": {"$ref": "#/$defs/input"},
+        "visual_mesh_index": {"$ref": "#/$defs/input"}
       }
     },
-    "units": {
-      "type": "object",
-      "description": "Numeric units used by this scene payload. Distances are metres and angles are radians.",
-      "additionalProperties": false,
-      "required": ["distance", "angle"],
-      "properties": {
-        "distance": { "const": "metre", "description": "All XYZ positions and linear dimensions are expressed in metres." },
-        "angle": { "const": "radian", "description": "All RPY rotations are expressed in radians." }
-      }
-    },
-    "coordinate_system": {
-      "type": "object",
-      "description": "ROS world frame with a Z-up convention. Asset poses are expressed relative to the named world frame unless an item explicitly documents another frame.",
-      "additionalProperties": false,
-      "required": ["frame", "up_axis", "convention"],
-      "properties": {
-        "frame": { "const": "world", "description": "ROS world frame." },
-        "up_axis": { "const": "z", "description": "Z-up scene convention." },
-        "convention": { "const": "ros_world_z_up", "description": "ROS world frame / Z-up coordinate-system contract." },
-        "pose_reference": {
-          "type": "string",
-          "default": "asset poses are relative to world unless otherwise specified"
-        }
-      }
-    },
-    "robot": { "$ref": "#/$defs/component" },
-    "tool": { "$ref": "#/$defs/component" },
-    "assets": {
-      "type": "array",
-      "description": "Physical and generated visual assets available to web Scene3D/Product View clients.",
-      "items": { "$ref": "#/$defs/asset" }
-    },
-    "sensors": {
-      "type": "array",
-      "description": "Scene sensors such as cameras. Sensor bodies may also appear in assets with type camera.",
-      "items": { "$ref": "#/$defs/sensor" }
-    },
-    "zones": {
-      "type": "array",
-      "description": "Authored zones such as safety, pick, place, reach, or diagnostic areas. Product View clients should keep helper/diagnostic zones hidden unless explicitly enabled.",
-      "items": { "$ref": "#/$defs/zone" }
-    },
-    "warnings": {
-      "type": "array",
-      "description": "Non-fatal scene conversion warnings, including missing mesh, missing pose, unknown type, and unsupported field cases.",
-      "items": { "$ref": "#/$defs/warning" }
-    },
-    "backend_actions": {
-      "type": "array",
-      "description": "Backend actions exposed for this scene, such as validate, generate, plan/simulate, open logs, or export.",
-      "items": { "$ref": "#/$defs/backendAction" }
-    }
+    "robots": {"type": "array", "items": {"$ref": "#/$defs/item"}},
+    "tools": {"type": "array", "items": {"$ref": "#/$defs/item"}},
+    "assets": {"type": "array", "items": {"$ref": "#/$defs/item"}},
+    "sensors": {"type": "array", "items": {"$ref": "#/$defs/item"}},
+    "zones": {"type": "array", "items": {"$ref": "#/$defs/item"}},
+    "warnings": {"type": "array", "items": {"$ref": "#/$defs/warning"}},
+    "backend_actions": {"type": "array", "items": {"$ref": "#/$defs/backendAction"}}
   },
   "$defs": {
-    "sourceFile": {
+    "scene": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["path"],
+      "required": ["id", "name", "source_dir", "provenance", "units", "coordinate_system"],
       "properties": {
-        "path": { "type": "string", "minLength": 1 },
-        "exists": { "type": "boolean" },
-        "sha256": { "type": "string", "pattern": "^[A-Fa-f0-9]{64}$" },
-        "mtime": { "type": "string", "format": "date-time" }
-      }
-    },
-    "component": {
-      "type": "object",
-      "description": "Robot or tool metadata for the web scene.",
-      "additionalProperties": true,
-      "properties": {
-        "id": { "type": "string" },
-        "label": { "type": "string" },
-        "model": { "type": "string" },
-        "pose": { "$ref": "#/$defs/pose" },
-        "source": { "$ref": "#/$defs/assetSource" },
-        "visual_assets": {
-          "type": "array",
-          "items": { "type": "string" }
+        "id": {"type": "string", "minLength": 1},
+        "name": {"type": "string", "minLength": 1},
+        "source_dir": {"type": "string", "minLength": 1},
+        "provenance": {"$ref": "#/$defs/provenance"},
+        "units": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["distance", "angle"],
+          "properties": {"distance": {"const": "metre"}, "angle": {"const": "radian"}}
+        },
+        "coordinate_system": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["frame", "up_axis", "convention", "pose_reference"],
+          "properties": {
+            "frame": {"const": "world"},
+            "up_axis": {"const": "z"},
+            "convention": {"const": "ros_world_z_up"},
+            "pose_reference": {"type": "string"}
+          }
         }
       }
     },
-    "asset": {
+    "input": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "label", "type", "pose", "scale", "editable", "locked", "source"],
-      "properties": {
-        "id": { "type": "string", "minLength": 1 },
-        "label": { "type": "string" },
-        "type": {
-          "type": "string",
-          "enum": ["table", "bin", "conveyor", "camera", "zone", "object", "robot_visual", "tool_visual", "unknown"]
-        },
-        "pose": { "$ref": "#/$defs/pose" },
-        "scale": { "$ref": "#/$defs/scale" },
-        "mesh_uri": {
-          "type": ["string", "null"],
-          "description": "URI/path to a mesh visual when available. Null means no mesh is available for this asset."
-        },
-        "primitive": { "$ref": "#/$defs/primitive" },
-        "editable": { "type": "boolean" },
-        "locked": { "type": "boolean" },
-        "source": { "$ref": "#/$defs/assetSource" }
-      }
+      "required": ["path", "present"],
+      "properties": {"path": {"type": "string", "minLength": 1}, "present": {"type": "boolean"}}
     },
-    "pose": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["xyz", "rpy"],
-      "properties": {
-        "xyz": { "$ref": "#/$defs/vector3" },
-        "rpy": { "$ref": "#/$defs/vector3" }
-      }
-    },
-    "scale": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["xyz"],
-      "properties": {
-        "xyz": { "$ref": "#/$defs/vector3" }
-      }
-    },
-    "vector3": {
-      "type": "array",
-      "prefixItems": [
-        { "type": "number" },
-        { "type": "number" },
-        { "type": "number" }
-      ],
-      "minItems": 3,
-      "maxItems": 3
-    },
-    "primitive": {
-      "type": ["object", "null"],
-      "description": "Primitive fallback visual when no mesh is available or a simple shape is authoritative.",
-      "additionalProperties": false,
-      "properties": {
-        "shape": { "type": "string", "enum": ["box", "cylinder", "sphere", "plane", "unknown"] },
-        "dimensions": { "$ref": "#/$defs/vector3" },
-        "radius": { "type": "number", "minimum": 0 },
-        "height": { "type": "number", "minimum": 0 }
-      }
-    },
-    "assetSource": {
-      "type": "string",
-      "enum": ["environment", "layout", "visual_mesh_index", "generated"]
-    },
-    "sensor": {
+    "item": {
       "type": "object",
       "additionalProperties": true,
-      "required": ["id", "type", "pose"],
+      "required": ["id", "provenance"],
       "properties": {
-        "id": { "type": "string", "minLength": 1 },
-        "label": { "type": "string" },
-        "type": { "type": "string" },
-        "pose": { "$ref": "#/$defs/pose" },
-        "frame_id": { "type": "string" },
-        "asset_id": { "type": "string" },
-        "source": { "$ref": "#/$defs/assetSource" }
+        "id": {"type": "string", "minLength": 1},
+        "editable": {"type": "boolean"},
+        "locked": {"type": "boolean"},
+        "source_kind": {"enum": ["user_authored", "generated_preview"]},
+        "provenance": {"$ref": "#/$defs/provenance"}
       }
     },
-    "zone": {
-      "type": "object",
-      "additionalProperties": true,
-      "required": ["id", "type", "pose"],
-      "properties": {
-        "id": { "type": "string", "minLength": 1 },
-        "label": { "type": "string" },
-        "type": { "type": "string" },
-        "pose": { "$ref": "#/$defs/pose" },
-        "source": { "$ref": "#/$defs/assetSource" },
-        "visible_by_default": { "type": "boolean", "default": false }
-      }
-    },
+    "provenance": {"type": "object", "additionalProperties": {"type": "string"}},
     "warning": {
       "type": "object",
       "additionalProperties": false,
       "required": ["code", "message"],
       "properties": {
-        "code": {
-          "type": "string",
-          "enum": ["missing_mesh", "missing_pose", "unknown_type", "unsupported_field"]
-        },
-        "message": { "type": "string", "minLength": 1 },
-        "severity": { "type": "string", "enum": ["info", "warning", "error"], "default": "warning" },
-        "asset_id": { "type": "string" },
-        "field": { "type": "string" },
-        "source_file": { "type": "string" }
+        "code": {"type": "string", "minLength": 1},
+        "message": {"type": "string", "minLength": 1},
+        "source": {"type": "string", "minLength": 1}
       }
     },
     "backendAction": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "label", "enabled"],
+      "required": ["id", "label", "enabled", "request_kind"],
       "properties": {
-        "id": { "type": "string", "minLength": 1 },
-        "label": { "type": "string", "minLength": 1 },
-        "enabled": { "type": "boolean" },
-        "description": { "type": "string" },
-        "command": { "type": "string" },
-        "requires_ros_workspace": { "type": "boolean", "default": false },
-        "unavailable_reason": { "type": "string" }
+        "id": {"type": "string", "minLength": 1},
+        "label": {"type": "string", "minLength": 1},
+        "enabled": {"type": "boolean"},
+        "request_kind": {"enum": ["backend_request"]},
+        "description": {"type": "string"},
+        "safety_note": {"type": "string"}
       }
     }
   }

--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -249,8 +249,10 @@ def _authored_sections(data: Dict[str, Any], scene_dir: Path, warnings: List[Jso
     return sections
 
 
-def _entity(src: Mapping[str, Any], fields: Iterable[str], source: str) -> Json:
+def _entity(src: Mapping[str, Any], fields: Iterable[str], source: str, fallback_id: str) -> Json:
     item = {field: src[field] for field in fields if field in src}
+    if not item.get("id"):
+        item["id"] = str(_first_present(item.get("model"), item.get("profile"), item.get("type"), fallback_id))
     item["provenance"] = _provenance(item.keys(), source)
     return item
 
@@ -263,16 +265,16 @@ def _top_level_entities(data: Dict[str, Any], warnings: List[Json]) -> Tuple[Lis
         root = _as_map(data.get(key))
         robot = _as_map(root.get("robot"))
         if robot:
-            robots.append(_entity(robot, ("id", "model", "profile", "planning_group", "world_frame", "base_frame", "tool_link", "tool_mount_link", "home_named_target"), source))
+            robots.append(_entity(robot, ("id", "model", "profile", "planning_group", "world_frame", "base_frame", "tool_link", "tool_mount_link", "home_named_target"), source, "robot"))
         else:
             if data.get(key) is not None:
                 _warn(warnings, "robot_field_missing", f"{source} has no robot object.", source)
         tool = _as_map(root.get("tool") or root.get("end_effector"))
         if tool:
-            tools.append(_entity(tool, ("id", "type", "model", "profile", "mount_link", "grasp_frame", "allowed_touch_links"), source))
+            tools.append(_entity(tool, ("id", "type", "model", "profile", "mount_link", "grasp_frame", "allowed_touch_links"), source, "tool"))
         camera = _as_map(root.get("camera"))
         if camera:
-            sensors.append(_entity(camera, ("enabled", "camera_id", "frame_id", "pose", "rgb_topic", "depth_topic", "pointcloud_topic"), source))
+            sensors.append(_entity(camera, ("id", "enabled", "camera_id", "frame_id", "pose", "rgb_topic", "depth_topic", "pointcloud_topic"), source, "camera"))
     return robots, tools, sensors
 
 
@@ -311,6 +313,15 @@ def build_web_scene(scene_dir: Path) -> Json:
                 "id": "scene_manifest.yaml|cell_definition.yaml|environment.yaml|directory_name",
                 "name": "scene_manifest.yaml|cell_definition.yaml|environment.yaml|directory_name",
                 "source_dir": "cli:--scene",
+                "units": "contract",
+                "coordinate_system": "contract",
+            },
+            "units": {"distance": "metre", "angle": "radian"},
+            "coordinate_system": {
+                "frame": "world",
+                "up_axis": "z",
+                "convention": "ros_world_z_up",
+                "pose_reference": "item poses are relative to world unless their own frame field says otherwise",
             },
         },
         "inputs": {key: {"path": rel, "present": (scene_dir / rel).exists()} for key, rel in sorted(INPUTS.items())},
@@ -320,6 +331,32 @@ def build_web_scene(scene_dir: Path) -> Json:
         "sensors": _sort_items(sensors),
         "zones": _sort_items(zones),
         "warnings": sorted(warnings, key=lambda w: (str(w.get("source", "")), str(w.get("code", "")), str(w.get("message", "")))),
+        "backend_actions": [
+            {
+                "id": "validate",
+                "label": "Validate",
+                "enabled": True,
+                "request_kind": "backend_request",
+                "description": "Ask the Workcell Studio backend to validate the selected scene inputs.",
+                "safety_note": "Validation is offline metadata checking and does not command robot motion.",
+            },
+            {
+                "id": "generate_scene_package",
+                "label": "Generate Scene Package",
+                "enabled": True,
+                "request_kind": "backend_request",
+                "description": "Ask the backend to regenerate ROS 2 scene package artifacts from source-of-truth inputs.",
+                "safety_note": "Generation must preserve fake-hardware-first launch defaults.",
+            },
+            {
+                "id": "plan_simulate",
+                "label": "Plan / Simulate",
+                "enabled": False,
+                "request_kind": "backend_request",
+                "description": "Request RViz/MoveIt fake-hardware simulation through a guarded backend workflow.",
+                "safety_note": "Disabled in this exporter; real hardware execution is not exposed by the web scene contract.",
+            },
+        ],
     }
     return output
 

--- a/tests/test_workcell_studio_web_scene_contract.py
+++ b/tests/test_workcell_studio_web_scene_contract.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 
 import yaml
+from jsonschema import Draft202012Validator
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -103,6 +104,7 @@ def test_web_scene_schema_file_exists_and_is_valid_json():
         schema = json.load(fh)
     assert schema["$id"].endswith("/workcell_studio_web_scene_v1.schema.json")
     assert schema["properties"]["schema_version"]["const"] == "workcell_studio_web_scene/v1"
+    Draft202012Validator.check_schema(schema)
 
 
 def test_tiny_scene_exports_generated_and_authored_asset_contract(tmp_path):
@@ -115,7 +117,11 @@ def test_tiny_scene_exports_generated_and_authored_asset_contract(tmp_path):
 
     assert out1.read_bytes() == out2.read_bytes()
     assert payload1 == payload2
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    Draft202012Validator(schema).validate(payload1)
     assert payload1["schema_version"] == "workcell_studio_web_scene/v1"
+    assert payload1["scene"]["units"] == {"distance": "metre", "angle": "radian"}
+    assert payload1["scene"]["coordinate_system"]["convention"] == "ros_world_z_up"
     assert payload1["inputs"]["environment"]["present"] is True
     assert payload1["inputs"]["layout"]["present"] is True
     assert payload1["inputs"]["visual_mesh_index"]["present"] is True
@@ -136,6 +142,12 @@ def test_tiny_scene_exports_generated_and_authored_asset_contract(tmp_path):
         assert authored["editable"] is True
         assert authored["locked"] is False
 
+    actions = {action["id"]: action for action in payload1["backend_actions"]}
+    assert actions["validate"]["request_kind"] == "backend_request"
+    assert actions["generate_scene_package"]["enabled"] is True
+    assert actions["plan_simulate"]["enabled"] is False
+    assert "real hardware execution is not exposed" in actions["plan_simulate"]["safety_note"]
+
 
 def test_missing_optional_inputs_warn_in_output_json_without_crashing(tmp_path):
     scene = tmp_path / "missing_optional_inputs_scene"
@@ -143,6 +155,8 @@ def test_missing_optional_inputs_warn_in_output_json_without_crashing(tmp_path):
 
     payload = _export(scene, tmp_path / "out" / "scene.web_scene.json")
 
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    Draft202012Validator(schema).validate(payload)
     assert payload["schema_version"] == "workcell_studio_web_scene/v1"
     missing = [warning for warning in payload["warnings"] if warning["code"] == "optional_file_missing"]
     assert {warning["source"] for warning in missing} == {


### PR DESCRIPTION
### Motivation
- Provide a stable, dependency-light JSON contract for future browser-based 3D scene review/editing that is traceable to Workcell Studio source files.
- Make exported scene payloads deterministic and provenance-aware so web clients can distinguish authored layout items from locked generated preview items.
- Ensure the first contract is safe-by-default by documenting backend request actions and avoiding any accidental exposure of real-hardware execution.

### Description
- Added a JSON Schema at `schemas/workcell_studio_web_scene_v1.schema.json` that defines the v1 web scene payload shape, input presence metadata, provenance, units/coordinate conventions, item arrays, warnings, and backend action descriptors.
- Updated the exporter `scripts/export_workcell_studio_web_scene.py` to emit the v1 payload including explicit `units` (`metre`/`radian`), ROS world Z-up `coordinate_system`, stable fallback IDs for top-level robot/tool/camera entries, deterministic `inputs` presence reporting, and a `backend_actions` list with `plan_simulate` exported as disabled.
- Extended tests in `tests/test_workcell_studio_web_scene_contract.py` to validate the schema with `Draft202012Validator`, validate exported payloads against the schema, assert deterministic output and authored/generated editability semantics, and verify `backend_actions` safety defaults.
- Documented CLI usage and exporter behavior in `docs/WORKCELL_STUDIO_WEB_3D_SCENE_CONTRACT.md` showing the recommended `python3 scripts/export_workcell_studio_web_scene.py --scene <scene> --output <path>` invocation and noting safety constraints.

### Testing
- Ran `python3 -m pytest tests/test_workcell_studio_web_scene_contract.py` and the test file passed (schema checks and export validations succeeded).
- Ran `python3 -m pytest tests/test_workcell_studio_web_scene_contract.py tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py` and the combined set of tests (10 items) passed.
- Performed export smoke with `python3 scripts/export_workcell_studio_web_scene.py --scene scenes/ur5_2f_test --output build/workcell_studio/ur5_2f_test.web_scene.json` followed by `Draft202012Validator(...).validate(payload)` and the generated payload validated against the schema.
- All automated checks and schema validations completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a424d6fe858833187dd76e1522a1151)