### PR TITLE
Add static Workcell Studio web scene viewer (no-build Phase‑3 proof‑of‑life)

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VIEWER = ROOT / "workcell_studio_web" / "viewer"
+
+
+def test_static_viewer_files_exist():
+    assert (VIEWER / "index.html").is_file()
+    assert (VIEWER / "viewer.js").is_file()
+    assert (VIEWER / "style.css").is_file()
+    assert (VIEWER / "README.md").is_file()
+
+
+def test_index_references_static_assets():
+    index = (VIEWER / "index.html").read_text(encoding="utf-8")
+    assert 'href="style.css"' in index
+    assert 'src="viewer.js"' in index
+    assert 'id="scene-file"' in index
+    assert 'web_scene.json' in index
+
+
+def test_viewer_js_schema_and_inspector_hooks():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    assert "SUPPORTED_SCHEMA_VERSION" in js
+    assert "workcell_studio_web_scene/v1" in js
+    assert "schema_version" in js
+    assert "populateInspector" in js
+    assert "mesh_uri" in js
+    assert "primitive" in js
+    assert "editable" in js
+    assert "locked" in js

--- a/workcell_studio_web/viewer/README.md
+++ b/workcell_studio_web/viewer/README.md
@@ -1,0 +1,52 @@
+# Workcell Studio static web scene viewer
+
+This directory contains a **Phase 3 proof-of-life** browser viewer for the Workcell Studio `workcell_studio_web_scene/v1` JSON contract. It is intentionally tiny: static HTML, CSS, and JavaScript only, with no npm package, no bundler, no generated scene outputs committed to the repository, and no replacement of the existing Workcell Builder or RViz/MoveIt validation flow.
+
+The viewer uses an isolated browser import map that loads Three.js and OrbitControls from a CDN at runtime. That keeps this proof-of-life self-contained while avoiding a committed frontend build system.
+
+## Export a scene JSON
+
+From the repository root, export a browser-readable scene file into `build/`:
+
+```bash
+python3 scripts/export_workcell_studio_web_scene.py --scene scenes/ur5_2f_test --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json
+```
+
+`build/` outputs are local artifacts and should not be committed.
+
+## Open the viewer
+
+1. Open `workcell_studio_web/viewer/index.html` directly in a browser.
+2. Use the **Load web_scene.json** file picker.
+3. Select the exported JSON, for example:
+   `build/workcell_studio_web_scene/ur5_2f_test.web_scene.json`.
+
+Because Three.js is loaded by CDN import map, the browser needs network access for the viewer to render. If the CDN modules cannot load, the page shows a clear Three.js/CDN load failure rather than silently pretending the scene rendered.
+
+## Current support
+
+- World grid and axes helper.
+- Orbit, pan, and zoom camera controls.
+- Primitive objects from exported primitive/fallback data.
+- Box fallback for unknown assets and mesh-only assets.
+- Camera/sensor markers with simple frustum lines.
+- Pick, place, spawn, and safety zones as simple transparent geometry when present in the JSON.
+- Simple material/color differences between locked/generated preview items and editable/environment items.
+- Object list with IDs and labels.
+- Object selection from the list and basic canvas picking.
+- Inspector fields for ID, label, type, source, pose XYZ/RPY, scale, editable, locked, mesh URI, and primitive details.
+- JSON warnings rendered in a dedicated warnings panel.
+
+## Intentional exclusions
+
+This is not the final Web Studio editor. It intentionally excludes:
+
+- Editing transforms or scene data.
+- Saving JSON or writing source-of-truth scene files.
+- ROS launch, package generation, or backend action execution.
+- MoveIt planning or execution.
+- EPD live input or perception runtime streaming.
+- Mesh-perfect rendering and package URI mesh resolution.
+- Authentication, deployment packaging, and frontend framework scaffolding.
+
+RViz/MoveIt remain the backend validation and simulation path for Workcell Studio. This static viewer is only a lightweight browser proof-of-life for reviewing exported scene contract data.

--- a/workcell_studio_web/viewer/index.html
+++ b/workcell_studio_web/viewer/index.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Workcell Studio Web Scene Viewer</title>
+  <link rel="stylesheet" href="style.css" />
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+        "three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/"
+      }
+    }
+  </script>
+</head>
+<body>
+  <header class="topbar">
+    <div>
+      <h1>Workcell Studio Web Scene Viewer</h1>
+      <p>Static Phase 3 proof-of-life viewer for <code>web_scene.json</code>.</p>
+    </div>
+    <label class="file-picker">
+      Load web_scene.json
+      <input id="scene-file" type="file" accept="application/json,.json" />
+    </label>
+  </header>
+
+  <main class="app-shell">
+    <aside class="object-panel" aria-label="Object list panel">
+      <h2>Objects</h2>
+      <div id="empty-state" class="state empty">Choose an exported <code>web_scene.json</code> file to begin.</div>
+      <ul id="object-list" class="object-list"></ul>
+    </aside>
+
+    <section class="viewport-panel" aria-label="3D canvas area">
+      <div id="error-state" class="state error" hidden></div>
+      <canvas id="scene-canvas"></canvas>
+    </section>
+
+    <aside class="details-panel" aria-label="Inspector and warnings panel">
+      <section>
+        <h2>Inspector</h2>
+        <div id="inspector" class="state empty">Select an object from the list or canvas.</div>
+      </section>
+      <section>
+        <h2>Warnings</h2>
+        <div id="warnings" class="warnings state empty">No scene loaded.</div>
+      </section>
+    </aside>
+  </main>
+
+  <script type="module" src="viewer.js"></script>
+</body>
+</html>

--- a/workcell_studio_web/viewer/style.css
+++ b/workcell_studio_web/viewer/style.css
@@ -1,0 +1,112 @@
+:root {
+  color-scheme: dark;
+  --bg: #10151d;
+  --panel: #18212d;
+  --panel-2: #202b39;
+  --text: #eef5ff;
+  --muted: #aeb9c8;
+  --accent: #62d2ff;
+  --warn: #ffc857;
+  --error: #ff6b6b;
+  --border: #334256;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--panel);
+}
+.topbar h1 { margin: 0; font-size: 1.1rem; }
+.topbar p { margin: 0.2rem 0 0; color: var(--muted); font-size: 0.85rem; }
+.file-picker {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.55rem 0.8rem;
+  border: 1px solid var(--accent);
+  border-radius: 0.5rem;
+  background: #123040;
+  color: var(--text);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.file-picker input { max-width: 15rem; }
+
+.app-shell {
+  display: grid;
+  grid-template-columns: minmax(13rem, 18rem) 1fr minmax(16rem, 22rem);
+  height: calc(100vh - 74px);
+  min-height: 34rem;
+}
+.object-panel, .details-panel {
+  overflow: auto;
+  padding: 1rem;
+  background: var(--panel);
+  border-color: var(--border);
+}
+.object-panel { border-right: 1px solid var(--border); }
+.details-panel { border-left: 1px solid var(--border); }
+h2 { margin: 0 0 0.75rem; font-size: 0.95rem; color: var(--accent); }
+
+.viewport-panel { position: relative; min-width: 0; background: #0b1018; }
+#scene-canvas { width: 100%; height: 100%; display: block; }
+.state {
+  padding: 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border);
+  background: var(--panel-2);
+  color: var(--muted);
+}
+.empty { border-style: dashed; }
+.error {
+  position: absolute;
+  z-index: 2;
+  top: 1rem;
+  left: 1rem;
+  right: 1rem;
+  color: #fff;
+  border-color: var(--error);
+  background: rgba(106, 26, 35, 0.94);
+}
+.warning-item {
+  margin: 0 0 0.5rem;
+  padding: 0.55rem;
+  border-left: 3px solid var(--warn);
+  background: #312914;
+  color: #ffe7a3;
+}
+.object-list { list-style: none; margin: 0; padding: 0; }
+.object-list li {
+  margin-bottom: 0.4rem;
+  padding: 0.55rem;
+  border: 1px solid var(--border);
+  border-radius: 0.45rem;
+  background: var(--panel-2);
+  cursor: pointer;
+}
+.object-list li:hover, .object-list li.selected { border-color: var(--accent); background: #14364a; }
+.object-list .meta { display: block; color: var(--muted); font-size: 0.78rem; margin-top: 0.2rem; }
+.inspector-table { width: 100%; border-collapse: collapse; font-size: 0.86rem; }
+.inspector-table th, .inspector-table td { padding: 0.35rem 0.2rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+.inspector-table th { width: 38%; text-align: left; color: var(--muted); font-weight: 600; }
+code { color: #c9f2ff; }
+
+@media (max-width: 900px) {
+  .app-shell { grid-template-columns: 1fr; grid-template-rows: auto minmax(24rem, 1fr) auto; height: auto; }
+  .object-panel, .details-panel { border: 0; border-bottom: 1px solid var(--border); max-height: 18rem; }
+  .viewport-panel { height: 55vh; }
+  .topbar { align-items: flex-start; flex-direction: column; }
+}

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -1,0 +1,250 @@
+let THREE;
+let OrbitControls;
+
+const SUPPORTED_SCHEMA_VERSION = 'workcell_studio_web_scene/v1';
+const state = { sceneJson: null, objects: [], selected: null, three: {}, animationId: null };
+const el = {
+  file: document.getElementById('scene-file'),
+  canvas: document.getElementById('scene-canvas'),
+  empty: document.getElementById('empty-state'),
+  error: document.getElementById('error-state'),
+  list: document.getElementById('object-list'),
+  inspector: document.getElementById('inspector'),
+  warnings: document.getElementById('warnings'),
+};
+
+function showError(message) {
+  el.error.textContent = message;
+  el.error.hidden = false;
+}
+function clearError() { el.error.hidden = true; el.error.textContent = ''; }
+function valueOrDash(value) { return value === undefined || value === null || value === '' ? '—' : value; }
+function asArray(value) { return Array.isArray(value) ? value : []; }
+function vector3(value, fallback = [0, 0, 0]) {
+  const arr = Array.isArray(value) ? value : fallback;
+  return new THREE.Vector3(Number(arr[0] || 0), Number(arr[1] || 0), Number(arr[2] || 0));
+}
+function poseOf(item) {
+  const pose = item.pose || item.world_pose || item.baked_world_visual_pose || {};
+  const xyz = item.pose_xyz || pose.xyz || pose.position || pose.translation || (Array.isArray(pose) ? pose.slice(0, 3) : [0, 0, 0]);
+  const rpy = item.pose_rpy || pose.rpy || pose.rotation_rpy || (Array.isArray(pose) ? pose.slice(3, 6) : [0, 0, 0]);
+  return { xyz: vector3(xyz), rpy: vector3(rpy) };
+}
+function scaleOf(item) {
+  const scale = item.scale || item.mesh_scale || [1, 1, 1];
+  return vector3(scale, [1, 1, 1]);
+}
+function primitiveOf(item) {
+  return item.primitive || item.primitive_details || item.dimensions || item.geometry || item.primitive_geometry || null;
+}
+function itemType(item) { return item.type || item.category || item.role || item.source_kind || 'asset'; }
+function itemLabel(item) { return item.label || item.display_name || item.name || item.id || 'unnamed'; }
+function isZone(item) { return /zone|pick|place|spawn|safety/i.test(`${itemType(item)} ${item.id || ''} ${itemLabel(item)}`); }
+function isSensor(item) { return /camera|sensor|realsense/i.test(`${itemType(item)} ${item.id || ''} ${itemLabel(item)}`); }
+function materialFor(item) {
+  if (isZone(item)) return new THREE.MeshBasicMaterial({ color: 0xffc857, transparent: true, opacity: 0.22, side: THREE.DoubleSide });
+  if (isSensor(item)) return new THREE.MeshStandardMaterial({ color: 0x62d2ff, roughness: 0.65 });
+  if (item.locked || item.source_kind === 'generated_preview') return new THREE.MeshStandardMaterial({ color: 0x8794aa, roughness: 0.78, metalness: 0.05 });
+  return new THREE.MeshStandardMaterial({ color: 0x7bd88f, roughness: 0.72 });
+}
+function dimensionsFromPrimitive(primitive) {
+  if (!primitive) return [0.25, 0.25, 0.25];
+  if (Array.isArray(primitive)) return primitive.slice(0, 3);
+  return primitive.size || primitive.dimensions || primitive.extents || [primitive.x || primitive.width || 0.25, primitive.y || primitive.depth || 0.25, primitive.z || primitive.height || 0.25];
+}
+function makePrimitiveMesh(item) {
+  const primitive = primitiveOf(item);
+  const kind = String(item.geometry_type || item.primitive_geometry_type || primitive?.type || primitive?.shape || '').toLowerCase();
+  const material = materialFor(item);
+  let geometry;
+  if (kind.includes('sphere')) geometry = new THREE.SphereGeometry(Number(primitive?.radius || 0.12), 24, 16);
+  else if (kind.includes('cylinder')) geometry = new THREE.CylinderGeometry(Number(primitive?.radius || 0.08), Number(primitive?.radius || 0.08), Number(primitive?.height || 0.25), 24);
+  else {
+    const dims = dimensionsFromPrimitive(primitive);
+    geometry = new THREE.BoxGeometry(Number(dims[0] || 0.25), Number(dims[1] || 0.25), Number(dims[2] || 0.25));
+  }
+  return new THREE.Mesh(geometry, material);
+}
+function makeSensorMarker(item) {
+  const group = new THREE.Group();
+  group.add(new THREE.Mesh(new THREE.BoxGeometry(0.16, 0.08, 0.08), materialFor(item)));
+  const frustum = new THREE.LineSegments(
+    new THREE.BufferGeometry().setFromPoints([
+      new THREE.Vector3(0,0,0), new THREE.Vector3(0.35,0.22,-0.18), new THREE.Vector3(0,0,0), new THREE.Vector3(0.35,-0.22,-0.18),
+      new THREE.Vector3(0,0,0), new THREE.Vector3(0.35,0.22,0.18), new THREE.Vector3(0,0,0), new THREE.Vector3(0.35,-0.22,0.18),
+      new THREE.Vector3(0.35,0.22,-0.18), new THREE.Vector3(0.35,-0.22,-0.18), new THREE.Vector3(0.35,-0.22,-0.18), new THREE.Vector3(0.35,-0.22,0.18),
+      new THREE.Vector3(0.35,-0.22,0.18), new THREE.Vector3(0.35,0.22,0.18), new THREE.Vector3(0.35,0.22,0.18), new THREE.Vector3(0.35,0.22,-0.18),
+    ]),
+    new THREE.LineBasicMaterial({ color: 0x62d2ff })
+  );
+  group.add(frustum);
+  return group;
+}
+function applyPose(object, item) {
+  const pose = poseOf(item);
+  object.position.copy(pose.xyz);
+  object.rotation.set(pose.rpy.x, pose.rpy.y, pose.rpy.z, 'XYZ');
+  const s = scaleOf(item);
+  object.scale.multiply(s);
+}
+function collectItems(sceneJson) {
+  const buckets = ['robots', 'tools', 'assets', 'sensors', 'zones', 'items', 'objects'];
+  const byId = new Map();
+  for (const bucket of buckets) for (const item of asArray(sceneJson[bucket])) if (item && typeof item === 'object') byId.set(item.id || `${bucket}_${byId.size}`, { ...item, id: item.id || `${bucket}_${byId.size}` });
+  return Array.from(byId.values());
+}
+function validateSceneJson(json) {
+  if (!json || typeof json !== 'object' || Array.isArray(json)) throw new Error('Invalid web_scene.json: expected a JSON object.');
+  if (json.schema_version !== SUPPORTED_SCHEMA_VERSION) throw new Error(`Unsupported schema_version "${valueOrDash(json.schema_version)}". Expected ${SUPPORTED_SCHEMA_VERSION}.`);
+  const items = collectItems(json);
+  if (!items.length) throw new Error('Missing/empty assets: web_scene.json contains no robots, tools, assets, sensors, zones, items, or objects to render.');
+  return items;
+}
+function initThree() {
+  try {
+    if (!THREE?.Scene || !OrbitControls) throw new Error('Three.js modules were not available.');
+    const renderer = new THREE.WebGLRenderer({ canvas: el.canvas, antialias: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x0b1018);
+    const camera = new THREE.PerspectiveCamera(55, 1, 0.01, 100);
+    camera.position.set(2.4, -2.8, 1.8);
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enableDamping = true;
+    scene.add(new THREE.GridHelper(5, 20, 0x3a4a5e, 0x263445));
+    scene.add(new THREE.AxesHelper(0.75));
+    scene.add(new THREE.HemisphereLight(0xffffff, 0x223344, 1.2));
+    const light = new THREE.DirectionalLight(0xffffff, 1.5); light.position.set(2, -3, 4); scene.add(light);
+    state.three = { renderer, scene, camera, controls, raycaster: new THREE.Raycaster(), pointer: new THREE.Vector2() };
+    resize();
+    window.addEventListener('resize', resize);
+    el.canvas.addEventListener('pointerdown', pickObject);
+    animate();
+  } catch (err) {
+    showError(`Three.js/CDN load failure: ${err.message || err}`);
+  }
+}
+function resize() {
+  const { renderer, camera } = state.three;
+  if (!renderer || !camera) return;
+  const rect = el.canvas.getBoundingClientRect();
+  renderer.setSize(rect.width, rect.height, false);
+  camera.aspect = rect.width / Math.max(rect.height, 1);
+  camera.updateProjectionMatrix();
+}
+function animate() {
+  const { renderer, scene, camera, controls } = state.three;
+  if (!renderer) return;
+  state.animationId = requestAnimationFrame(animate);
+  controls.update();
+  renderer.render(scene, camera);
+}
+function clearSceneObjects() {
+  const scene = state.three.scene;
+  if (!scene) return;
+  for (const rendered of state.objects) scene.remove(rendered.object3d);
+  state.objects = [];
+}
+function renderScene(items) {
+  clearSceneObjects();
+  const scene = state.three.scene;
+  for (const item of items) {
+    let object3d = isSensor(item) ? makeSensorMarker(item) : makePrimitiveMesh(item);
+    if (!primitiveOf(item) && item.mesh_uri) object3d.userData.viewerWarning = 'Mesh loading is intentionally excluded; showing box fallback.';
+    applyPose(object3d, item);
+    object3d.userData.item = item;
+    scene.add(object3d);
+    state.objects.push({ item, object3d });
+  }
+  populateObjectList();
+}
+function populateObjectList() {
+  el.list.innerHTML = '';
+  for (const rendered of state.objects) {
+    const li = document.createElement('li');
+    li.dataset.id = rendered.item.id;
+    li.textContent = `${rendered.item.id} — ${itemLabel(rendered.item)}`;
+    const meta = document.createElement('span');
+    meta.className = 'meta';
+    meta.textContent = `${itemType(rendered.item)} · ${rendered.item.locked ? 'locked/generated' : 'editable/environment'}`;
+    li.appendChild(meta);
+    li.addEventListener('click', () => selectObject(rendered.item.id));
+    el.list.appendChild(li);
+  }
+}
+function selectObject(id) {
+  state.selected = id;
+  document.querySelectorAll('.object-list li').forEach(li => li.classList.toggle('selected', li.dataset.id === id));
+  for (const rendered of state.objects) {
+    const selected = rendered.item.id === id;
+    rendered.object3d.traverse(child => {
+      if (child.material?.emissive) child.material.emissive.setHex(selected ? 0x1b6f8f : 0x000000);
+    });
+  }
+  const rendered = state.objects.find(obj => obj.item.id === id);
+  if (rendered) populateInspector(rendered.item);
+}
+function pickObject(event) {
+  const rect = el.canvas.getBoundingClientRect();
+  state.three.pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+  state.three.pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+  state.three.raycaster.setFromCamera(state.three.pointer, state.three.camera);
+  const hits = state.three.raycaster.intersectObjects(state.objects.map(o => o.object3d), true);
+  const hit = hits.find(h => h.object?.parent || h.object);
+  const item = hit?.object?.userData?.item || hit?.object?.parent?.userData?.item;
+  if (item?.id) selectObject(item.id);
+}
+function populateInspector(item) {
+  const pose = poseOf(item);
+  const rows = {
+    id: item.id, label: itemLabel(item), type: itemType(item), source: item.source_kind || item.source || valueOrDash(item.provenance && Object.values(item.provenance)[0]),
+    'pose xyz': [pose.xyz.x, pose.xyz.y, pose.xyz.z].map(n => n.toFixed(3)).join(', '),
+    'pose rpy': [pose.rpy.x, pose.rpy.y, pose.rpy.z].map(n => n.toFixed(3)).join(', '),
+    scale: JSON.stringify(item.scale || item.mesh_scale || [1, 1, 1]), editable: String(Boolean(item.editable)), locked: String(Boolean(item.locked)),
+    mesh_uri: item.mesh_uri || item.package_uri || item.mesh_path || item.source_path, primitive: JSON.stringify(primitiveOf(item) || 'box fallback'),
+  };
+  el.inspector.className = '';
+  el.inspector.innerHTML = `<table class="inspector-table"><tbody>${Object.entries(rows).map(([k,v]) => `<tr><th>${k}</th><td><code>${String(valueOrDash(v)).replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]))}</code></td></tr>`).join('')}</tbody></table>`;
+}
+function populateWarnings(sceneJson) {
+  const warnings = asArray(sceneJson.warnings).concat(asArray(sceneJson.notes_warnings));
+  if (!warnings.length) { el.warnings.className = 'warnings state empty'; el.warnings.textContent = 'No warnings in JSON.'; return; }
+  el.warnings.className = 'warnings';
+  el.warnings.innerHTML = warnings.map(w => `<div class="warning-item"><strong>${valueOrDash(w.code || w.source || 'warning')}</strong><br>${valueOrDash(w.message || JSON.stringify(w))}</div>`).join('');
+}
+async function loadFile(file) {
+  clearError();
+  try {
+    const text = await file.text();
+    let json;
+    try { json = JSON.parse(text); } catch (err) { throw new Error(`Invalid JSON in ${file.name}: ${err.message}`); }
+    const items = validateSceneJson(json);
+    state.sceneJson = json;
+    el.empty.hidden = true;
+    renderScene(items);
+    populateWarnings(json);
+    el.inspector.className = 'state empty';
+    el.inspector.textContent = 'Select an object from the list or canvas.';
+  } catch (err) {
+    showError(err.message || String(err));
+  }
+}
+
+el.file.addEventListener('change', event => {
+  const file = event.target.files?.[0];
+  if (file) loadFile(file);
+});
+
+async function boot() {
+  try {
+    const threeModule = await import('three');
+    const controlsModule = await import('three/addons/controls/OrbitControls.js');
+    THREE = threeModule;
+    OrbitControls = controlsModule.OrbitControls;
+    initThree();
+  } catch (err) {
+    showError(`Three.js/CDN load failure: ${err.message || err}`);
+  }
+}
+
+boot();


### PR DESCRIPTION
### Motivation
- Provide a tiny, dependency-light static browser viewer for the exported `workcell_studio_web_scene/v1` JSON contract as a Phase‑3 proof‑of‑life before a full Web Studio editor. 

### Description
- Add a no-build CDN/import-map Three.js viewer shell with `index.html`, `viewer.js`, `style.css`, and a `README.md` that documents export and usage, and intentionally excludes editing/saving/ROS execution. 
- Implement `viewer.js` to load a chosen JSON file, validate `schema_version` against `workcell_studio_web_scene/v1`, show clear errors for invalid JSON/unsupported schema/missing assets/CDN load failure, render grid/axes, primitive fallbacks and box fallbacks, sensor markers/frustums, zone geometry, and visually distinguish locked/generated items from editable/environment items. 
- Add UI features: local file picker, empty/error/warnings states, object list, inspector panel populated with id/label/type/source/pose xyz/rpy/scale/editable/locked/mesh_uri/primitive details, orbit/pan/zoom controls, and object selection via list or canvas picking. 
- Include a lightweight CI-safe test `tests/test_workcell_studio_web_viewer_static.py` that verifies the viewer files exist, `index.html` references `viewer.js` and `style.css` and the file picker, and that `viewer.js` contains schema handling and inspector hooks. 

### Testing
- Ran `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py`, which passed (3 tests, 0 failures). 
- Performed a static JavaScript syntax check (`node --check workcell_studio_web/viewer/viewer.js`), which passed. 
- Viewer is static/browser-run only and does not perform ROS/MoveIt launches or enable any real-hardware paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42515d53e883318be44e10194ee417)