### PR TITLE
Auto-frame viewer to rendered scene objects and add Reset View

### DIFF
--- a/workcell_studio_web/viewer/index.html
+++ b/workcell_studio_web/viewer/index.html
@@ -20,10 +20,13 @@
       <h1>Workcell Studio Web Scene Viewer</h1>
       <p>Static Phase 3 proof-of-life viewer for <code>web_scene.json</code>.</p>
     </div>
-    <label class="file-picker">
-      Load web_scene.json
-      <input id="scene-file" type="file" accept="application/json,.json" />
-    </label>
+    <div class="toolbar">
+      <label class="file-picker">
+        Load web_scene.json
+        <input id="scene-file" type="file" accept="application/json,.json" />
+      </label>
+      <button id="reset-view" class="toolbar-button" type="button" disabled>Reset View</button>
+    </div>
   </header>
 
   <main class="app-shell">

--- a/workcell_studio_web/viewer/style.css
+++ b/workcell_studio_web/viewer/style.css
@@ -31,6 +31,13 @@ body {
 }
 .topbar h1 { margin: 0; font-size: 1.1rem; }
 .topbar p { margin: 0.2rem 0 0; color: var(--muted); font-size: 0.85rem; }
+.toolbar {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
 .file-picker {
   display: inline-flex;
   align-items: center;
@@ -44,6 +51,17 @@ body {
   white-space: nowrap;
 }
 .file-picker input { max-width: 15rem; }
+.toolbar-button {
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: var(--panel-2);
+  color: var(--text);
+  cursor: pointer;
+  padding: 0.55rem 0.8rem;
+  white-space: nowrap;
+}
+.toolbar-button:not(:disabled):hover { border-color: var(--accent); background: #14364a; }
+.toolbar-button:disabled { cursor: not-allowed; opacity: 0.45; }
 
 .app-shell {
   display: grid;

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -2,9 +2,12 @@ let THREE;
 let OrbitControls;
 
 const SUPPORTED_SCHEMA_VERSION = 'workcell_studio_web_scene/v1';
-const state = { sceneJson: null, objects: [], selected: null, three: {}, animationId: null };
+const MIN_FRAME_RADIUS = 1.2;
+const FRAME_DISTANCE_MULTIPLIER = 2.7;
+const state = { sceneJson: null, objects: [], selected: null, three: {}, animationId: null, lastFrameBounds: null };
 const el = {
   file: document.getElementById('scene-file'),
+  resetView: document.getElementById('reset-view'),
   canvas: document.getElementById('scene-canvas'),
   empty: document.getElementById('empty-state'),
   error: document.getElementById('error-state'),
@@ -139,11 +142,48 @@ function animate() {
   controls.update();
   renderer.render(scene, camera);
 }
+
+function computeRenderedBounds() {
+  const bounds = new THREE.Box3();
+  for (const rendered of state.objects) {
+    if (!rendered.object3d) continue;
+    rendered.object3d.updateWorldMatrix(true, true);
+    bounds.expandByObject(rendered.object3d);
+  }
+  return bounds.isEmpty() ? null : bounds;
+}
+function frameScene(bounds) {
+  const { camera, controls } = state.three;
+  if (!camera || !controls || !bounds || bounds.isEmpty()) return false;
+  const center = new THREE.Vector3();
+  const sphere = new THREE.Sphere();
+  bounds.getCenter(center);
+  bounds.getBoundingSphere(sphere);
+  const radius = Math.max(sphere.radius, MIN_FRAME_RADIUS);
+  const direction = new THREE.Vector3(1.35, -1.65, 1.05).normalize();
+  const distance = Math.max(radius * FRAME_DISTANCE_MULTIPLIER, MIN_FRAME_RADIUS * FRAME_DISTANCE_MULTIPLIER);
+  camera.position.copy(center).addScaledVector(direction, distance);
+  camera.near = Math.max(0.01, radius / 100);
+  camera.far = Math.max(100, distance + radius * 6);
+  camera.updateProjectionMatrix();
+  controls.target.copy(center);
+  controls.update();
+  state.lastFrameBounds = bounds.clone();
+  if (el.resetView) el.resetView.disabled = false;
+  return true;
+}
+function resetView() {
+  const bounds = state.lastFrameBounds || computeRenderedBounds();
+  if (bounds) frameScene(bounds);
+}
+
 function clearSceneObjects() {
   const scene = state.three.scene;
   if (!scene) return;
   for (const rendered of state.objects) scene.remove(rendered.object3d);
   state.objects = [];
+  state.lastFrameBounds = null;
+  if (el.resetView) el.resetView.disabled = true;
 }
 function renderScene(items) {
   clearSceneObjects();
@@ -157,6 +197,8 @@ function renderScene(items) {
     state.objects.push({ item, object3d });
   }
   populateObjectList();
+  const bounds = computeRenderedBounds();
+  if (bounds) frameScene(bounds);
 }
 function populateObjectList() {
   el.list.innerHTML = '';
@@ -229,6 +271,8 @@ async function loadFile(file) {
     showError(err.message || String(err));
   }
 }
+
+if (el.resetView) el.resetView.addEventListener('click', resetView);
 
 el.file.addEventListener('change', event => {
   const file = event.target.files?.[0];


### PR DESCRIPTION
### Motivation
- Ensure the web scene viewer frames on physical rendered objects (robots/tools/assets) rather than helper overlays like grid/axes so Product View opens at a useful angle.
- Prevent extremely tight zoom on empty or tiny scenes by enforcing a minimum framing radius.
- Provide a simple, discoverable control to re-apply the last successful framing without adding editing or save-back UI.

### Description
- Added `computeRenderedBounds()`, `frameScene(bounds)`, and `resetView()` helpers and state fields (`lastFrameBounds`, `MIN_FRAME_RADIUS`, `FRAME_DISTANCE_MULTIPLIER`) to compute a `THREE.Box3` from rendered object roots and position the camera, `near`/`far` planes, and `OrbitControls.target` based on the computed center and radius.
- Updated `renderScene(items)` to run bounding calculation and frame the scene after all physical object roots are added, while leaving grid and axes helpers in the scene but excluded from the framing calculation.
- Added a `Reset View` toolbar button in `index.html` and compact toolbar styling in `style.css`, wired to re-run the last successful frame calculation and disabled until a frame is available.
- Kept mesh fallback behavior unchanged and did not introduce any editing or save-back controls.

### Testing
- Ran `node --check workcell_studio_web/viewer/viewer.js` which completed without errors.
- Ran `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py` and all tests passed (7 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4253cfdcf483319c8044969071c423)