### PR TITLE
Accept valid empty web_scene.json and show explicit empty-state in viewer

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -46,3 +46,23 @@ def test_viewer_records_render_status_for_inspector():
         assert token in js
     assert "child.userData.renderInfo" in js
     assert "rendered.renderInfo" in js
+
+
+def test_viewer_allows_valid_empty_scene_with_empty_message():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    assert "EMPTY_SCENE_MESSAGE" in js
+    assert "Scene contains no renderable robots, tools, assets, sensors, zones, items, or objects." in js
+    validate_body = js.split("function validateSceneJson(json)", 1)[1].split("function initThree()", 1)[0]
+    assert "return items;" in validate_body
+    assert "!items.length" not in validate_body
+    assert "else renderScene([]);" in js
+    assert "li.textContent = EMPTY_SCENE_MESSAGE" in js
+    assert "items.length ? 'Select an object from the list or canvas.' : EMPTY_SCENE_MESSAGE" in js
+
+
+def test_viewer_keeps_invalid_json_and_schema_errors_clear():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    assert "Invalid web_scene.json: expected a JSON object." in js
+    assert "Invalid JSON in ${file.name}: ${err.message}" in js
+    assert "Unsupported schema_version" in js
+    assert "Expected ${SUPPORTED_SCHEMA_VERSION}" in js

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -6,6 +6,7 @@ let OBJLoader;
 
 const SUPPORTED_SCHEMA_VERSION = 'workcell_studio_web_scene/v1';
 const MIN_FRAME_RADIUS = 1.2;
+const EMPTY_SCENE_MESSAGE = 'Scene contains no renderable robots, tools, assets, sensors, zones, items, or objects.';
 const FRAME_DISTANCE_MULTIPLIER = 2.7;
 const state = { sceneJson: null, objects: [], selected: null, three: {}, animationId: null, lastFrameBounds: null, runtimeWarnings: [] };
 const el = {
@@ -205,7 +206,6 @@ function validateSceneJson(json) {
   if (!json || typeof json !== 'object' || Array.isArray(json)) throw new Error('Invalid web_scene.json: expected a JSON object.');
   if (json.schema_version !== SUPPORTED_SCHEMA_VERSION) throw new Error(`Unsupported schema_version "${valueOrDash(json.schema_version)}". Expected ${SUPPORTED_SCHEMA_VERSION}.`);
   const items = collectItems(json);
-  if (!items.length) throw new Error('Missing/empty assets: web_scene.json contains no robots, tools, assets, sensors, zones, items, or objects to render.');
   return items;
 }
 function initThree() {
@@ -316,6 +316,13 @@ function renderScene(items) {
 }
 function populateObjectList() {
   el.list.innerHTML = '';
+  if (!state.objects.length) {
+    const li = document.createElement('li');
+    li.className = 'state empty';
+    li.textContent = EMPTY_SCENE_MESSAGE;
+    el.list.appendChild(li);
+    return;
+  }
   for (const rendered of state.objects) {
     const li = document.createElement('li');
     li.dataset.id = rendered.item.id;
@@ -388,10 +395,11 @@ async function loadFile(file) {
     state.sceneJson = json;
     state.runtimeWarnings = [];
     el.empty.hidden = true;
-    renderScene(items);
+    if (items.length) renderScene(items);
+    else renderScene([]);
     refreshWarnings(json);
     el.inspector.className = 'state empty';
-    el.inspector.textContent = 'Select an object from the list or canvas.';
+    el.inspector.textContent = items.length ? 'Select an object from the list or canvas.' : EMPTY_SCENE_MESSAGE;
   } catch (err) {
     showError(err.message || String(err));
   }


### PR DESCRIPTION
### Motivation
- Valid scene JSON that conforms to the supported schema but contains zero renderable items should load as an empty scene instead of throwing, so the Product View remains usable and the grid/axes remain visible. 
- The viewer must still clearly surface invalid JSON and unsupported `schema_version` errors to avoid silently accepting malformed input.

### Description
- `validateSceneJson(json)` now returns the collected item list even when it is empty, while retaining existing checks that throw for non-object JSON and unsupported `schema_version` (file: `workcell_studio_web/viewer/viewer.js`).
- `loadFile()` now calls `renderScene([])` when a valid schema yields zero items, preserving Three.js helpers (grid/axes) and avoiding an error path for empty-but-valid scenes.
- Added a shared `EMPTY_SCENE_MESSAGE` constant and use it to populate the object list and inspector when no renderable objects exist so the UI shows: `Scene contains no renderable robots, tools, assets, sensors, zones, items, or objects.`
- Added static regression coverage to `tests/test_workcell_studio_web_viewer_static.py` for the empty-scene behaviour and to ensure invalid JSON and unsupported schema errors remain present.

### Testing
- Ran `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a425c2d250c8331b73b50ea74ecdf5e)