### PR TITLE
viewer: add grouped object list and `viewerGroupFor` helper

### DIFF
--- a/workcell_studio_web/viewer/style.css
+++ b/workcell_studio_web/viewer/style.css
@@ -116,7 +116,33 @@ h2 { margin: 0 0 0.75rem; font-size: 0.95rem; color: var(--accent); }
   cursor: pointer;
 }
 .object-list li:hover, .object-list li.selected { border-color: var(--accent); background: #14364a; }
+.object-list .object-group-heading {
+  margin: 0.75rem 0 0.35rem;
+  padding: 0.2rem 0.1rem;
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  cursor: default;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.object-list .object-group-heading:hover { border-color: transparent; background: transparent; }
+.object-list .object-name { display: block; padding-right: 4.5rem; }
 .object-list .meta { display: block; color: var(--muted); font-size: 0.78rem; margin-top: 0.2rem; }
+.object-list .type-tag {
+  float: right;
+  max-width: 4.25rem;
+  overflow: hidden;
+  padding: 0.12rem 0.35rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: #c9f2ff;
+  font-size: 0.68rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .inspector-table { width: 100%; border-collapse: collapse; font-size: 0.86rem; }
 .inspector-table th, .inspector-table td { padding: 0.35rem 0.2rem; border-bottom: 1px solid var(--border); vertical-align: top; }
 .inspector-table th { width: 38%; text-align: left; color: var(--muted); font-weight: 600; }

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -98,8 +98,26 @@ function safeMeshUri(item) {
 }
 function itemType(item) { return item.type || item.category || item.role || item.source_kind || 'asset'; }
 function itemLabel(item) { return item.label || item.display_name || item.name || item.id || 'unnamed'; }
-function isZone(item) { return /zone|pick|place|spawn|safety/i.test(`${itemType(item)} ${item.id || ''} ${itemLabel(item)}`); }
-function isSensor(item) { return /camera|sensor|realsense/i.test(`${itemType(item)} ${item.id || ''} ${itemLabel(item)}`); }
+function viewerGroupIdentity(item) {
+  return [
+    item?.source_kind,
+    item?.type,
+    item?.category,
+    item?.role,
+    item?.id,
+    itemLabel(item || {}),
+  ].map(value => String(value || '').toLowerCase().replace(/[_-]+/g, ' ')).join(' ');
+}
+function viewerGroupFor(item) {
+  const identity = viewerGroupIdentity(item);
+  if (/\b(zone|pick zone|place zone|spawn zone|safety zone|work envelope|reachability|collision)\b/.test(identity)) return 'zones';
+  if (/\b(camera|sensor|realsense|depth camera|rgbd|lidar|vision)\b/.test(identity)) return 'sensors';
+  if (/\b(robot|arm|manipulator|ur3|ur5|ur10|tool|gripper|end effector|eef|suction|vacuum|robotiq|airpick|generated|generated preview|urdf|moveit)\b/.test(identity)) return 'robot/tool/generated';
+  if (/\b(environment|layout|asset|object|item|table|workbench|fixture|bin|tray|conveyor|shelf|rack|pallet|floor|wall|part|product)\b/.test(identity)) return 'environment/layout';
+  return 'unknown';
+}
+function isZone(item) { return viewerGroupFor(item) === 'zones'; }
+function isSensor(item) { return viewerGroupFor(item) === 'sensors'; }
 function materialFor(item) {
   if (isZone(item)) return new THREE.MeshBasicMaterial({ color: 0xffc857, transparent: true, opacity: 0.22, side: THREE.DoubleSide });
   if (isSensor(item)) return new THREE.MeshStandardMaterial({ color: 0x62d2ff, roughness: 0.65 });
@@ -323,16 +341,46 @@ function populateObjectList() {
     el.list.appendChild(li);
     return;
   }
+  const groupLabels = {
+    'robot/tool/generated': 'Robot, tool & generated',
+    'environment/layout': 'Environment & layout',
+    sensors: 'Sensors',
+    zones: 'Zones',
+    unknown: 'Unknown',
+  };
+  const grouped = new Map(Object.keys(groupLabels).map(group => [group, []]));
   for (const rendered of state.objects) {
-    const li = document.createElement('li');
-    li.dataset.id = rendered.item.id;
-    li.textContent = `${rendered.item.id} — ${itemLabel(rendered.item)}`;
-    const meta = document.createElement('span');
-    meta.className = 'meta';
-    meta.textContent = `${itemType(rendered.item)} · ${rendered.item.locked ? 'locked/generated' : 'editable/environment'}`;
-    li.appendChild(meta);
-    li.addEventListener('click', () => selectObject(rendered.item.id));
-    el.list.appendChild(li);
+    const group = viewerGroupFor(rendered.item);
+    if (!grouped.has(group)) grouped.set(group, []);
+    grouped.get(group).push(rendered);
+  }
+  for (const [group, renderedItems] of grouped.entries()) {
+    if (!renderedItems.length) continue;
+    const heading = document.createElement('li');
+    heading.className = 'object-group-heading';
+    heading.textContent = groupLabels[group] || group;
+    el.list.appendChild(heading);
+    for (const rendered of renderedItems) {
+      const li = document.createElement('li');
+      li.dataset.id = rendered.item.id;
+
+      const name = document.createElement('span');
+      name.className = 'object-name';
+      name.textContent = `${rendered.item.id} — ${itemLabel(rendered.item)}`;
+      li.appendChild(name);
+
+      const tag = document.createElement('span');
+      tag.className = 'type-tag';
+      tag.textContent = itemType(rendered.item);
+      li.appendChild(tag);
+
+      const meta = document.createElement('span');
+      meta.className = 'meta';
+      meta.textContent = `${group} · ${rendered.item.locked ? 'locked/generated' : 'editable/environment'}`;
+      li.appendChild(meta);
+      li.addEventListener('click', () => selectObject(rendered.item.id));
+      el.list.appendChild(li);
+    }
   }
 }
 function selectObject(id) {


### PR DESCRIPTION
### Motivation
- Improve the Scene3D/Product View object list so items are classified into logical groups (robot/tool/generated, environment/layout, sensors, zones, unknown) for easier navigation. 
- Use existing identity fields (`source_kind`, `type`, `category`, `role`, `id`, and label text) to produce a heuristic grouping without changing scene data or generation logic. 
- Surface per-item type tags and stable group headings while preserving the existing click-to-select behavior for each row.

### Description
- Added `viewerGroupIdentity(item)` and `viewerGroupFor(item)` helpers to classify objects from `source_kind`, `type`, `category`, `role`, `id`, and label text and normalize tokens for matching. (`workcell_studio_web/viewer/viewer.js`)
- Reworked `populateObjectList()` to build grouped lists with headings and per-item `type-tag` elements while keeping each item’s click handler that calls `selectObject(id)`. (`workcell_studio_web/viewer/viewer.js`)
- Replaced the previous `isZone`/`isSensor` checks to use the new grouping helpers so rendering/material decisions remain consistent with the classification. (`workcell_studio_web/viewer/viewer.js`)
- Added compact CSS rules for group headings, object name layout, and `type-tag` styling. (`workcell_studio_web/viewer/style.css`)

### Testing
- Performed a static JS check with `node --check workcell_studio_web/viewer/viewer.js`, which passed. 
- Ran the repository unit tests with `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py`, resulting in `7 passed`.
- Verified this is a UI-only change that does not modify ROS launch files, controllers, hardware parameters, or runtime behavior and therefore preserves fake-hardware defaults and guarded real-hardware paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a425cd1a6f48331baec7b8875ba7578)