### PR TITLE
Add toggleable labels to web scene viewer

### DIFF
--- a/workcell_studio_web/viewer/index.html
+++ b/workcell_studio_web/viewer/index.html
@@ -26,6 +26,10 @@
         <input id="scene-file" type="file" accept="application/json,.json" />
       </label>
       <button id="reset-view" class="toolbar-button" type="button" disabled>Reset View</button>
+      <label class="toolbar-toggle" title="Show read-only object labels in the viewer">
+        <input id="labels-toggle" type="checkbox" />
+        Labels
+      </label>
     </div>
   </header>
 
@@ -39,6 +43,7 @@
     <section class="viewport-panel" aria-label="3D canvas area">
       <div id="error-state" class="state error" hidden></div>
       <canvas id="scene-canvas"></canvas>
+      <div id="label-layer" class="label-layer" aria-hidden="true"></div>
     </section>
 
     <aside class="details-panel" aria-label="Inspector and warnings panel">

--- a/workcell_studio_web/viewer/style.css
+++ b/workcell_studio_web/viewer/style.css
@@ -63,6 +63,22 @@ body {
 .toolbar-button:not(:disabled):hover { border-color: var(--accent); background: #14364a; }
 .toolbar-button:disabled { cursor: not-allowed; opacity: 0.45; }
 
+.toolbar-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.65rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: rgba(32, 43, 57, 0.72);
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 0.86rem;
+  white-space: nowrap;
+}
+.toolbar-toggle:hover { border-color: var(--accent); color: var(--text); }
+.toolbar-toggle input { accent-color: var(--accent); }
+
 .app-shell {
   display: grid;
   grid-template-columns: minmax(13rem, 18rem) 1fr minmax(16rem, 22rem);
@@ -81,6 +97,39 @@ h2 { margin: 0 0 0.75rem; font-size: 0.95rem; color: var(--accent); }
 
 .viewport-panel { position: relative; min-width: 0; background: #0b1018; }
 #scene-canvas { width: 100%; height: 100%; display: block; }
+
+.label-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  overflow: hidden;
+  pointer-events: none;
+}
+.label-layer.labels-hidden { display: none; }
+.object-label {
+  position: absolute;
+  left: 0;
+  top: 0;
+  max-width: 10rem;
+  padding: 0.16rem 0.42rem;
+  border: 1px solid rgba(98, 210, 255, 0.45);
+  border-radius: 999px;
+  background: rgba(11, 16, 24, 0.68);
+  box-shadow: 0 0.2rem 0.8rem rgba(0, 0, 0, 0.22);
+  color: #d9f7ff;
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.8);
+  white-space: nowrap;
+}
+.object-label.selected {
+  border-color: var(--accent);
+  background: rgba(20, 54, 74, 0.82);
+  color: #ffffff;
+}
 .state {
   padding: 0.75rem;
   border-radius: 0.5rem;

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -8,11 +8,13 @@ const SUPPORTED_SCHEMA_VERSION = 'workcell_studio_web_scene/v1';
 const MIN_FRAME_RADIUS = 1.2;
 const EMPTY_SCENE_MESSAGE = 'Scene contains no renderable robots, tools, assets, sensors, zones, items, or objects.';
 const FRAME_DISTANCE_MULTIPLIER = 2.7;
-const state = { sceneJson: null, objects: [], selected: null, three: {}, animationId: null, lastFrameBounds: null, runtimeWarnings: [] };
+const state = { sceneJson: null, objects: [], selected: null, three: {}, animationId: null, lastFrameBounds: null, runtimeWarnings: [], labelsVisible: false };
 const el = {
   file: document.getElementById('scene-file'),
   resetView: document.getElementById('reset-view'),
+  labelsToggle: document.getElementById('labels-toggle'),
   canvas: document.getElementById('scene-canvas'),
+  labelLayer: document.getElementById('label-layer'),
   empty: document.getElementById('empty-state'),
   error: document.getElementById('error-state'),
   list: document.getElementById('object-list'),
@@ -118,6 +120,7 @@ function viewerGroupFor(item) {
 }
 function isZone(item) { return viewerGroupFor(item) === 'zones'; }
 function isSensor(item) { return viewerGroupFor(item) === 'sensors'; }
+function shouldLabelItem(item) { return viewerGroupFor(item) !== 'zones'; }
 function materialFor(item) {
   if (isZone(item)) return new THREE.MeshBasicMaterial({ color: 0xffc857, transparent: true, opacity: 0.22, side: THREE.DoubleSide });
   if (isSensor(item)) return new THREE.MeshStandardMaterial({ color: 0x62d2ff, roughness: 0.65 });
@@ -264,6 +267,7 @@ function animate() {
   state.animationId = requestAnimationFrame(animate);
   controls.update();
   renderer.render(scene, camera);
+  updateLabels();
 }
 
 function computeRenderedBounds() {
@@ -300,10 +304,14 @@ function resetView() {
   if (bounds) frameScene(bounds);
 }
 
+function clearLabels() {
+  if (el.labelLayer) el.labelLayer.innerHTML = '';
+}
 function clearSceneObjects() {
   const scene = state.three.scene;
   if (!scene) return;
   for (const rendered of state.objects) scene.remove(rendered.object3d);
+  clearLabels();
   state.objects = [];
   state.lastFrameBounds = null;
   if (el.resetView) el.resetView.disabled = true;
@@ -321,7 +329,7 @@ function renderScene(items) {
     applyPose(object3d, item);
     assignItemUserData(object3d, item);
     scene.add(object3d);
-    const rendered = { item, object3d, fallback };
+    const rendered = { item, object3d, fallback, labelEl: createLabelElement(item) };
     const fallbackStatus = primitive || isSensor(item) ? 'primitive_fallback' : 'box_fallback';
     const fallbackReason = primitive || isSensor(item) ? 'primitive geometry rendered while mesh loads or is unavailable' : 'no primitive geometry or mesh was provided; using box fallback';
     setRenderInfo(rendered, fallbackStatus, displayMeshUri(item), fallbackReason);
@@ -329,9 +337,53 @@ function renderScene(items) {
     tryLoadMesh(item, rendered, fallback);
   }
   populateObjectList();
+  updateLabels();
   const bounds = computeRenderedBounds();
   if (bounds) frameScene(bounds);
 }
+
+function createLabelElement(item) {
+  if (!el.labelLayer || !shouldLabelItem(item)) return null;
+  const label = document.createElement('div');
+  label.className = 'object-label';
+  label.textContent = itemLabel(item);
+  label.title = `${item.id || itemLabel(item)} — ${itemType(item)}`;
+  label.setAttribute('data-object-id', item.id || itemLabel(item));
+  el.labelLayer.appendChild(label);
+  return label;
+}
+function setLabelsVisible(visible) {
+  state.labelsVisible = Boolean(visible);
+  if (el.labelsToggle) el.labelsToggle.checked = state.labelsVisible;
+  if (el.labelLayer) el.labelLayer.classList.toggle('labels-hidden', !state.labelsVisible);
+  updateLabels();
+}
+function updateLabels() {
+  const { camera } = state.three;
+  if (!camera || !el.labelLayer) return;
+  const rect = el.canvas.getBoundingClientRect();
+  const center = new THREE.Vector3();
+  for (const rendered of state.objects) {
+    const label = rendered.labelEl;
+    if (!label) continue;
+    if (!state.labelsVisible || !rendered.object3d.visible) {
+      label.hidden = true;
+      continue;
+    }
+    rendered.object3d.updateWorldMatrix(true, true);
+    const bounds = new THREE.Box3().setFromObject(rendered.object3d);
+    if (bounds.isEmpty()) rendered.object3d.getWorldPosition(center);
+    else bounds.getCenter(center);
+    const screen = center.clone().project(camera);
+    const inFront = screen.z >= -1 && screen.z <= 1;
+    label.hidden = !inFront;
+    if (!inFront) continue;
+    const x = (screen.x * 0.5 + 0.5) * rect.width;
+    const y = (-screen.y * 0.5 + 0.5) * rect.height;
+    label.style.transform = `translate(-50%, -115%) translate(${x.toFixed(1)}px, ${y.toFixed(1)}px)`;
+  }
+}
+
 function populateObjectList() {
   el.list.innerHTML = '';
   if (!state.objects.length) {
@@ -391,7 +443,9 @@ function selectObject(id) {
     rendered.object3d.traverse(child => {
       if (child.material?.emissive) child.material.emissive.setHex(selected ? 0x1b6f8f : 0x000000);
     });
+    if (rendered.labelEl) rendered.labelEl.classList.toggle('selected', selected);
   }
+  updateLabels();
   const rendered = state.objects.find(obj => obj.item.id === id);
   if (rendered) populateInspector(rendered);
 }
@@ -454,6 +508,7 @@ async function loadFile(file) {
 }
 
 if (el.resetView) el.resetView.addEventListener('click', resetView);
+if (el.labelsToggle) el.labelsToggle.addEventListener('change', event => setLabelsVisible(event.target.checked));
 
 el.file.addEventListener('change', event => {
   const file = event.target.files?.[0];
@@ -473,6 +528,7 @@ async function boot() {
     ColladaLoader = colladaModule.ColladaLoader;
     OBJLoader = objModule.OBJLoader;
     initThree();
+    setLabelsVisible(el.labelsToggle?.checked || false);
   } catch (err) {
     showError(`Three.js/CDN load failure: ${err.message || err}`);
   }


### PR DESCRIPTION
### Motivation
- Provide a simple read-only labeling overlay so users can toggle visible object labels in the Product View for easier identification without editing scene data. 
- Keep the labels lightweight and non-dominating so the Product View remains focused on physical meshes and layout while allowing quick visual identification of important objects.

### Description
- Added a compact `Labels` checkbox in the viewer toolbar and an overlay container `<div id="label-layer">` to `workcell_studio_web/viewer/index.html` for screen-space labels. 
- Implemented DOM label support in `workcell_studio_web/viewer/viewer.js` including `state.labelsVisible`, `createLabelElement(item)`, `setLabelsVisible()`, `updateLabels()`, and `clearLabels()` to create, position, toggle, and clean up labels using `itemLabel(item)`; zones are excluded by default via `shouldLabelItem(item)`. 
- Wire label updates into the render loop and selection logic so labels are positioned each frame and the selected object’s label is highlighted without introducing any editing controls. 
- Added compact, pointer-events-free CSS for the toolbar toggle and label styling in `workcell_studio_web/viewer/style.css` so labels remain non-dominating and visually consistent.

### Testing
- Ran `node --check workcell_studio_web/viewer/viewer.js`, which passed. 
- Ran `git diff --check`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a425da53a8c8331bfb84234ada827c6)