### PR TITLE
Document Phase 3 static viewer readability improvements

### DIFF
--- a/workcell_studio_web/viewer/README.md
+++ b/workcell_studio_web/viewer/README.md
@@ -23,30 +23,51 @@ python3 scripts/export_workcell_studio_web_scene.py --scene scenes/ur5_2f_test -
 
 Because Three.js is loaded by CDN import map, the browser needs network access for the viewer to render. If the CDN modules cannot load, the page shows a clear Three.js/CDN load failure rather than silently pretending the scene rendered.
 
+## Phase 3 readability improvements
+
+Phase 3 focuses on making exported scenes easier to inspect in a browser without claiming that the static viewer is a full editor or simulator:
+
+- Scene auto-framing computes bounds from visible scene content and starts the camera at a useful overview angle instead of leaving the user to hunt for the cell manually.
+- **Reset View** restores the camera to the computed scene overview after orbiting, panning, or zooming.
+- Browser-safe mesh loading attempts are made for relative/local `.stl`, `.dae`, and `.obj` mesh references where the browser and Three.js loaders can support them from the selected/exported scene context.
+- Mesh loading remains best-effort. If a mesh URI cannot be fetched, parsed, or rendered safely in the browser, the viewer keeps the scene readable with a primitive or box fallback instead of hiding the object.
+- The inspector exposes `render_status` so users can distinguish loaded meshes, primitive fallbacks, and failed mesh attempts for the selected object.
+- Runtime mesh warnings are surfaced in the warnings panel and inspector context so missing, blocked, or unsupported assets are visible during review.
+- The object list is grouped to make robots, tools, environment items, cameras, zones, and other exported objects easier to scan.
+- Simple labels help identify important scene objects without requiring users to click every item.
+- Camera objects include lightweight frustum markers so sensor placement and approximate viewing direction are visible in the static scene.
+
 ## Current support
 
 - World grid and axes helper.
 - Orbit, pan, and zoom camera controls.
+- Scene auto-framing with **Reset View**.
 - Primitive objects from exported primitive/fallback data.
-- Box fallback for unknown assets and mesh-only assets.
+- Browser-safe relative/local `.stl`, `.dae`, and `.obj` mesh attempts where supported.
+- Box fallback for unknown assets, unsupported mesh URIs, blocked mesh access, and mesh-only assets that cannot be rendered by the browser.
 - Camera/sensor markers with simple frustum lines.
 - Pick, place, spawn, and safety zones as simple transparent geometry when present in the JSON.
 - Simple material/color differences between locked/generated preview items and editable/environment items.
-- Object list with IDs and labels.
+- Grouped object list with IDs and labels.
+- Simple in-scene labels for readable object identification.
 - Object selection from the list and basic canvas picking.
-- Inspector fields for ID, label, type, source, pose XYZ/RPY, scale, editable, locked, mesh URI, and primitive details.
-- JSON warnings rendered in a dedicated warnings panel.
+- Inspector fields for ID, label, type, source, pose XYZ/RPY, scale, editable, locked, mesh URI, `render_status`, and primitive details.
+- JSON warnings and runtime mesh warnings rendered in a dedicated warnings panel.
 
-## Intentional exclusions
+## Intentional exclusions and limitations
 
 This is not the final Web Studio editor. It intentionally excludes:
 
 - Editing transforms or scene data.
-- Saving JSON or writing source-of-truth scene files.
-- ROS launch, package generation, or backend action execution.
+- Saving JSON or writing source-of-truth scene files back to disk.
+- ROS launch, package generation, backend action execution, or runtime control.
+- RViz/MoveIt replacement; RViz/MoveIt remain the backend validation and simulation path for Workcell Studio.
+- Qt Scene3D fixes; this static browser viewer does not repair or replace the Workcell Builder Qt Scene3D canvas.
 - MoveIt planning or execution.
 - EPD live input or perception runtime streaming.
-- Mesh-perfect rendering and package URI mesh resolution.
+- Mesh-perfect rendering.
+- `package://` URI resolution in the browser.
+- Arbitrary local filesystem mesh access from the browser. Browser security rules only allow safe access to files made available through the selected file context, a local server, or other browser-permitted URLs.
 - Authentication, deployment packaging, and frontend framework scaffolding.
 
-RViz/MoveIt remain the backend validation and simulation path for Workcell Studio. This static viewer is only a lightweight browser proof-of-life for reviewing exported scene contract data.
+This static viewer is only a lightweight browser proof-of-life for reviewing exported scene contract data. It improves readability of exported scenes, but the source-of-truth editing, scene generation, validation, and fake-hardware simulation flows remain in Workcell Studio, generated packages, and RViz/MoveIt.


### PR DESCRIPTION
### Motivation

- Improve browser readability of exported `workcell_studio_web_scene/v1` files so users can inspect scenes quickly without claiming full editor or simulator capabilities. 
- Make mesh loading behavior and fallbacks explicit and surface runtime mesh warnings so missing or blocked assets are visible during review. 
- Clarify viewer limitations to avoid confusion about editing, ROS/MoveIt simulation, package URI resolution, and arbitrary local filesystem access from the browser.

### Description

- Add a `Phase 3 readability improvements` section documenting scene auto-framing, a `Reset View` action, browser-safe attempts to load relative/local `.stl`, `.dae`, and `.obj` meshes, and primitive/box fallbacks. 
- Document inspector `render_status`, runtime mesh warnings in the warnings panel, grouped object list, simple in-scene labels, and lightweight camera frustum markers. 
- Refresh the `Current support` list to include the new readability features and mesh fallback coverage. 
- Expand `Intentional exclusions and limitations` to explicitly state no editing/save-back, no ROS launch or runtime control, no RViz/MoveIt replacement, no Qt Scene3D fixes, no `package://` URI resolution, and no arbitrary local filesystem mesh access from the browser.

### Testing

- Ran `git diff --check` to validate whitespace and simple diff issues, which succeeded. 
- Verified repository status with `git status --short`, which reported no unstaged changes. 
- No automated runtime/viewer tests were run because this is a documentation-only change and does not modify executable viewer code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a425ee05a308331ad0cccf4b968783b)