### PR TITLE
Add preview-only Web 3D edit patch export

### DIFF
--- a/docs/WORKCELL_STUDIO_WEB_3D_EDIT_PATCH.md
+++ b/docs/WORKCELL_STUDIO_WEB_3D_EDIT_PATCH.md
@@ -1,0 +1,48 @@
+# Workcell Studio Web 3D edit patch contract
+
+This phase adds preview-only transform editing to the static Web 3D viewer. Web Studio can move editable layout/environment objects in the browser and export a JSON edit patch, but it does **not** apply patches to source files yet.
+
+## Contract
+
+Patch files use `schemas/workcell_studio_web_scene_edit_patch_v1.schema.json` and `schema_version: workcell_studio_web_scene_edit_patch/v1`.
+
+Each patch records:
+
+- `scene_id` and the source web scene schema version;
+- `created_by: static_web_viewer`;
+- optional provenance such as the source `web_scene.json` file and viewer version;
+- an `edits` array of `update_transform` operations with old/new pose XYZ, RPY, and scale XYZ.
+
+Patch exports include only changed items. Exporting with no changed items is allowed and produces an empty `edits` array with a browser warning.
+
+## Safety and source of truth
+
+The viewer is not the source of truth in this phase. It does not mutate:
+
+- `environment.yaml`
+- `layout/workcell_studio_layout.yaml`
+- `cell_definition.yaml`
+- `scene_manifest.yaml`
+- generated scene files
+
+Locked/generated robot and tool preview items are inspectable only. The viewer disables their transform inputs and tells the user to edit source layout/environment instead.
+
+## Validation
+
+Use the standalone validator before trusting an exported patch:
+
+```bash
+python3 scripts/validate_workcell_studio_web_scene_edit_patch.py \
+  --web-scene build/workcell_studio_web_scene/ur5_2f_test.web_scene.json \
+  --patch build/workcell_studio_web_scene/ur5_2f_test.edit_patch.json
+```
+
+The validator checks scene identity, item existence, editability, lock state, generated robot/tool guards, and finite transform numbers. It only reads JSON inputs and never writes source scene files.
+
+## Relationship to RViz/MoveIt
+
+Web 3D editing is an authoring preview. RViz/MoveIt remains the planning and simulation truth, and fake hardware remains the default validation foundation. This change does not enable real robot motion and does not replace backend generation, validation, or safety gates.
+
+## Next phase
+
+The next phase is a guarded backend application step that takes a validated patch and writes the appropriate layout/environment source files deterministically, with clear conflict handling and validation evidence.

--- a/schemas/workcell_studio_web_scene_edit_patch_v1.schema.json
+++ b/schemas/workcell_studio_web_scene_edit_patch_v1.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://workcell-studio.local/schemas/workcell_studio_web_scene_edit_patch_v1.schema.json",
+  "title": "Workcell Studio Web Scene Edit Patch v1",
+  "description": "Preview-only transform edit patch exported by the static Workcell Studio web scene viewer. Patches are validated separately and do not mutate source scene files.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "scene_id", "source_scene_schema_version", "created_at", "created_by", "provenance", "edits"],
+  "properties": {
+    "schema_version": {"const": "workcell_studio_web_scene_edit_patch/v1"},
+    "scene_id": {"type": "string", "minLength": 1},
+    "source_scene_schema_version": {"type": "string", "minLength": 1},
+    "created_at": {"type": "string", "minLength": 1},
+    "created_by": {"const": "static_web_viewer"},
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "source_web_scene_file": {"type": "string", "minLength": 1},
+        "viewer_version": {"type": "string", "minLength": 1}
+      }
+    },
+    "edits": {"type": "array", "items": {"$ref": "#/$defs/edit"}}
+  },
+  "$defs": {
+    "edit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["item_id", "label", "source", "type", "editable_required", "locked_required", "operation", "old_transform", "new_transform"],
+      "properties": {
+        "item_id": {"type": "string", "minLength": 1},
+        "label": {"type": "string"},
+        "source": {"type": "string"},
+        "type": {"type": "string"},
+        "editable_required": {"const": true},
+        "locked_required": {"const": false},
+        "operation": {"const": "update_transform"},
+        "old_transform": {"$ref": "#/$defs/transform"},
+        "new_transform": {"$ref": "#/$defs/transform"},
+        "notes": {"type": "array", "items": {"type": "string"}},
+        "warnings": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "transform": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pose", "scale"],
+      "properties": {
+        "pose": {"$ref": "#/$defs/pose"},
+        "scale": {"$ref": "#/$defs/xyz"}
+      }
+    },
+    "pose": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["xyz", "rpy"],
+      "properties": {"xyz": {"$ref": "#/$defs/xyz"}, "rpy": {"$ref": "#/$defs/xyz"}}
+    },
+    "xyz": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["x", "y", "z"],
+      "properties": {"x": {"type": "number"}, "y": {"type": "number"}, "z": {"type": "number"}}
+    }
+  }
+}

--- a/scripts/validate_workcell_studio_web_scene_edit_patch.py
+++ b/scripts/validate_workcell_studio_web_scene_edit_patch.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Validate preview-only Workcell Studio web scene edit patches.
+
+This helper only reads web_scene.json and edit_patch.json. It never writes YAML,
+layout, cell definition, manifest, generated scene files, or patch outputs.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+PATCH_SCHEMA_VERSION = "workcell_studio_web_scene_edit_patch/v1"
+WEB_SCENE_SCHEMA_VERSION = "workcell_studio_web_scene/v1"
+GENERATED_SOURCES = {"generated_preview", "locked_generated_urdf_visual", "generated_urdf_visual"}
+GENERATED_GROUP_TOKENS = ("robot", "tool", "gripper", "suction", "urdf", "moveit", "generated")
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001 - CLI should report parse/open failures clearly.
+        raise ValueError(f"{path}: unable to load JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: expected a JSON object")
+    return data
+
+
+def _scene_id(web_scene: dict[str, Any]) -> str:
+    scene = web_scene.get("scene")
+    return str(scene.get("id", "")) if isinstance(scene, dict) else str(web_scene.get("scene_id", ""))
+
+
+def _items_by_id(web_scene: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    items: dict[str, dict[str, Any]] = {}
+    for bucket in ("robots", "tools", "assets", "sensors", "zones", "items", "objects"):
+        for item in web_scene.get(bucket, []) if isinstance(web_scene.get(bucket, []), list) else []:
+            if isinstance(item, dict) and item.get("id"):
+                items[str(item["id"])] = item
+    return items
+
+
+def _identity(item: dict[str, Any]) -> str:
+    parts = [item.get(k) for k in ("source_kind", "source_layer", "active_visual_source", "role", "category", "type", "id", "display_name", "label", "name")]
+    return " ".join(str(p or "").lower().replace("_", "-") for p in parts)
+
+
+def _is_generated_robot_or_tool(item: dict[str, Any]) -> bool:
+    identity = _identity(item)
+    if str(item.get("source_kind", "")).lower() in GENERATED_SOURCES:
+        return any(token in identity for token in GENERATED_GROUP_TOKENS)
+    if str(item.get("source_layer", "")).lower() in GENERATED_SOURCES:
+        return any(token in identity for token in GENERATED_GROUP_TOKENS)
+    return False
+
+
+def _walk_numbers(value: Any, path: str, errors: list[str]) -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            _walk_numbers(child, f"{path}.{key}", errors)
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _walk_numbers(child, f"{path}[{index}]", errors)
+    elif not isinstance(value, (int, float)) or isinstance(value, bool) or not math.isfinite(float(value)):
+        errors.append(f"{path}: expected finite number, got {value!r}")
+
+
+def validate(web_scene: dict[str, Any], patch: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if web_scene.get("schema_version") != WEB_SCENE_SCHEMA_VERSION:
+        errors.append(f"web scene schema_version must be {WEB_SCENE_SCHEMA_VERSION}")
+    if patch.get("schema_version") != PATCH_SCHEMA_VERSION:
+        errors.append(f"patch schema_version must be {PATCH_SCHEMA_VERSION}")
+    scene_id = _scene_id(web_scene)
+    if patch.get("scene_id") != scene_id:
+        errors.append(f"scene_id mismatch: patch={patch.get('scene_id')!r} web_scene={scene_id!r}")
+    if patch.get("created_by") != "static_web_viewer":
+        errors.append("created_by must be static_web_viewer")
+    items = _items_by_id(web_scene)
+    edits = patch.get("edits")
+    if not isinstance(edits, list):
+        errors.append("edits must be an array")
+        return errors
+    for index, edit in enumerate(edits):
+        prefix = f"edits[{index}]"
+        if not isinstance(edit, dict):
+            errors.append(f"{prefix}: expected object")
+            continue
+        item_id = edit.get("item_id")
+        if not item_id:
+            errors.append(f"{prefix}.item_id: required")
+            continue
+        item = items.get(str(item_id))
+        if item is None:
+            errors.append(f"{prefix}.item_id={item_id!r}: item not found in web scene")
+            continue
+        if item.get("locked") is True:
+            errors.append(f"{prefix}.item_id={item_id!r}: locked=true items cannot be edited")
+        if item.get("editable") is not True:
+            errors.append(f"{prefix}.item_id={item_id!r}: editable=false items cannot be edited")
+        if _is_generated_robot_or_tool(item):
+            errors.append(f"{prefix}.item_id={item_id!r}: generated robot/tool preview items cannot be edited")
+        if edit.get("editable_required") is not True:
+            errors.append(f"{prefix}.editable_required must be true")
+        if edit.get("locked_required") is not False:
+            errors.append(f"{prefix}.locked_required must be false")
+        if edit.get("operation") != "update_transform":
+            errors.append(f"{prefix}.operation must be update_transform")
+        for key in ("old_transform", "new_transform"):
+            transform = edit.get(key)
+            if not isinstance(transform, dict):
+                errors.append(f"{prefix}.{key}: required object")
+                continue
+            _walk_numbers(transform, f"{prefix}.{key}", errors)
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate a preview-only Workcell Studio web scene edit patch.")
+    parser.add_argument("--web-scene", required=True, type=Path)
+    parser.add_argument("--patch", required=True, type=Path)
+    args = parser.parse_args()
+    try:
+        errors = validate(_load_json(args.web_scene), _load_json(args.patch))
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print("Edit patch is valid for the supplied web_scene.json. No source scene files were modified.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_workcell_studio_web_scene_edit_patch.py
+++ b/tests/test_workcell_studio_web_scene_edit_patch.py
@@ -1,0 +1,117 @@
+import json
+import math
+import subprocess
+import sys
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = REPO_ROOT / "schemas" / "workcell_studio_web_scene_edit_patch_v1.schema.json"
+VALIDATOR = REPO_ROOT / "scripts" / "validate_workcell_studio_web_scene_edit_patch.py"
+VIEWER = REPO_ROOT / "workcell_studio_web" / "viewer" / "viewer.js"
+INDEX = REPO_ROOT / "workcell_studio_web" / "viewer" / "index.html"
+
+
+def _transform(x=0.0):
+    return {"pose": {"xyz": {"x": x, "y": 0.0, "z": 0.0}, "rpy": {"x": 0.0, "y": 0.0, "z": 0.0}}, "scale": {"x": 1.0, "y": 1.0, "z": 1.0}}
+
+
+def _web_scene():
+    return {
+        "schema_version": "workcell_studio_web_scene/v1",
+        "scene": {"id": "tiny_scene"},
+        "robots": [{"id": "ur5_visual", "label": "UR5", "type": "robot", "source_kind": "generated_preview", "editable": False, "locked": True}],
+        "tools": [{"id": "tool_visual", "label": "Tool", "type": "gripper", "source_kind": "generated_preview", "editable": False, "locked": True}],
+        "assets": [{"id": "layout_bin", "label": "Bin", "type": "bin", "source_kind": "user_authored", "editable": True, "locked": False}],
+        "sensors": [],
+        "zones": [],
+        "warnings": [],
+        "backend_actions": [],
+    }
+
+
+def _patch(item_id="layout_bin", new_x=0.2):
+    return {
+        "schema_version": "workcell_studio_web_scene_edit_patch/v1",
+        "scene_id": "tiny_scene",
+        "source_scene_schema_version": "workcell_studio_web_scene/v1",
+        "created_at": "2026-06-29T00:00:00Z",
+        "created_by": "static_web_viewer",
+        "provenance": {"viewer_version": "test"},
+        "edits": [{
+            "item_id": item_id,
+            "label": "Bin",
+            "source": "user_authored",
+            "type": "bin",
+            "editable_required": True,
+            "locked_required": False,
+            "operation": "update_transform",
+            "old_transform": _transform(0.0),
+            "new_transform": _transform(new_x),
+        }],
+    }
+
+
+def _run_validator(tmp_path, web_scene, patch):
+    web = tmp_path / "scene.web_scene.json"
+    patch_path = tmp_path / "scene.edit_patch.json"
+    web.write_text(json.dumps(web_scene), encoding="utf-8")
+    patch_path.write_text(json.dumps(patch), encoding="utf-8")
+    return subprocess.run([sys.executable, str(VALIDATOR), "--web-scene", str(web), "--patch", str(patch_path)], cwd=REPO_ROOT, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def test_edit_patch_schema_exists_and_is_valid_json():
+    assert SCHEMA.exists()
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    assert schema["properties"]["schema_version"]["const"] == "workcell_studio_web_scene_edit_patch/v1"
+    Draft202012Validator.check_schema(schema)
+
+
+def test_validator_accepts_valid_editable_item_transform_patch(tmp_path):
+    result = _run_validator(tmp_path, _web_scene(), _patch())
+    assert result.returncode == 0, result.stderr
+    assert "No source scene files were modified" in result.stdout
+
+
+def test_validator_rejects_locked_generated_item_patch(tmp_path):
+    result = _run_validator(tmp_path, _web_scene(), _patch("ur5_visual"))
+    assert result.returncode == 1
+    assert "locked=true items cannot be edited" in result.stderr
+    assert "generated robot/tool preview items cannot be edited" in result.stderr
+
+
+def test_validator_rejects_missing_item_id(tmp_path):
+    result = _run_validator(tmp_path, _web_scene(), _patch("missing_item"))
+    assert result.returncode == 1
+    assert "item not found" in result.stderr
+
+
+def test_validator_rejects_non_finite_transform_values(tmp_path):
+    patch = _patch()
+    patch["edits"][0]["new_transform"]["pose"]["xyz"]["x"] = math.inf
+    patch_path = tmp_path / "bad.edit_patch.json"
+    # JSON cannot portably encode infinity for strict parsers, so write the token explicitly.
+    text = json.dumps(patch).replace("Infinity", "1e999")
+    web = tmp_path / "scene.web_scene.json"
+    web.write_text(json.dumps(_web_scene()), encoding="utf-8")
+    patch_path.write_text(text, encoding="utf-8")
+    result = subprocess.run([sys.executable, str(VALIDATOR), "--web-scene", str(web), "--patch", str(patch_path)], cwd=REPO_ROOT, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert result.returncode != 0
+    assert "finite number" in result.stderr or "unable to load JSON" in result.stderr
+
+
+def test_viewer_files_contain_export_edit_patch_and_locked_editable_guards():
+    viewer = VIEWER.read_text(encoding="utf-8")
+    index = INDEX.read_text(encoding="utf-8")
+    assert "Export Edit Patch" in index
+    assert "Clear Preview Edits" in index
+    assert "Locked/generated preview item; edit source layout/environment instead." in viewer
+    assert "editable !== true" in viewer
+    assert "source.includes('generated')" in viewer
+    assert "schema_version: EDIT_PATCH_SCHEMA_VERSION" in viewer
+
+
+def test_no_generated_patch_json_committed():
+    tracked = subprocess.run(["git", "ls-files", "*.edit_patch.json", "*edit_patch.json"], cwd=REPO_ROOT, text=True, stdout=subprocess.PIPE, check=True).stdout.splitlines()
+    assert not tracked

--- a/workcell_studio_web/viewer/README.md
+++ b/workcell_studio_web/viewer/README.md
@@ -71,3 +71,19 @@ This is not the final Web Studio editor. It intentionally excludes:
 - Authentication, deployment packaging, and frontend framework scaffolding.
 
 This static viewer is only a lightweight browser proof-of-life for reviewing exported scene contract data. It improves readability of exported scenes, but the source-of-truth editing, scene generation, validation, and fake-hardware simulation flows remain in Workcell Studio, generated packages, and RViz/MoveIt.
+
+## Preview-only transform editing and edit patches
+
+The static viewer includes a first-pass safe editing surface for Web 3D. When a selected item is both `editable=true` and `locked=false`, the inspector shows XYZ, RPY, and scale inputs. Changing those inputs updates only the in-browser Three.js preview.
+
+Locked or generated preview items, including generated robot/tool visuals, keep the transform fields disabled with the reason: “Locked/generated preview item; edit source layout/environment instead.”
+
+Use **Export Edit Patch** to download a `workcell_studio_web_scene_edit_patch/v1` JSON file. The patch contains only changed items and does not modify `environment.yaml`, layout YAML, `cell_definition.yaml`, `scene_manifest.yaml`, or generated scene files. **Clear Preview Edits** resets all browser-only changes; **Reset Selected** restores the selected editable item to its original loaded transform.
+
+Validate exported patches separately before any future application step:
+
+```bash
+python3 scripts/validate_workcell_studio_web_scene_edit_patch.py \
+  --web-scene build/workcell_studio_web_scene/ur5_2f_test.web_scene.json \
+  --patch build/workcell_studio_web_scene/ur5_2f_test.edit_patch.json
+```

--- a/workcell_studio_web/viewer/index.html
+++ b/workcell_studio_web/viewer/index.html
@@ -26,6 +26,8 @@
         <input id="scene-file" type="file" accept="application/json,.json" />
       </label>
       <button id="reset-view" class="toolbar-button" type="button" disabled>Reset View</button>
+      <button id="clear-edits" class="toolbar-button" type="button" disabled>Clear Preview Edits</button>
+      <button id="export-edit-patch" class="toolbar-button" type="button" disabled>Export Edit Patch</button>
       <label class="toolbar-toggle" title="Show read-only object labels in the viewer">
         <input id="labels-toggle" type="checkbox" />
         Labels
@@ -42,6 +44,7 @@
 
     <section class="viewport-panel" aria-label="3D canvas area">
       <div id="error-state" class="state error" hidden></div>
+      <div id="dirty-state" class="state dirty" hidden>Unsaved preview edits</div>
       <canvas id="scene-canvas"></canvas>
       <div id="label-layer" class="label-layer" aria-hidden="true"></div>
     </section>

--- a/workcell_studio_web/viewer/style.css
+++ b/workcell_studio_web/viewer/style.css
@@ -203,3 +203,46 @@ code { color: #c9f2ff; }
   .viewport-panel { height: 55vh; }
   .topbar { align-items: flex-start; flex-direction: column; }
 }
+
+.dirty {
+  position: absolute;
+  z-index: 2;
+  right: 1rem;
+  top: 1rem;
+  border-color: var(--warn);
+  background: rgba(49, 41, 20, 0.94);
+  color: #ffe7a3;
+}
+.transform-editor {
+  margin-top: 0.85rem;
+  padding: 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: rgba(32, 43, 57, 0.72);
+}
+.transform-editor h3 { margin: 0 0 0.45rem; font-size: 0.9rem; color: var(--accent); }
+.edit-note, .edit-lock-reason { margin: 0 0 0.65rem; color: var(--muted); font-size: 0.8rem; }
+.edit-lock-reason { color: #ffe7a3; }
+.transform-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.45rem; }
+.transform-grid label { color: var(--muted); font-size: 0.75rem; }
+.transform-grid input {
+  display: block;
+  width: 100%;
+  margin-top: 0.18rem;
+  padding: 0.35rem;
+  border: 1px solid var(--border);
+  border-radius: 0.35rem;
+  background: #0b1018;
+  color: var(--text);
+}
+.transform-grid input:disabled { cursor: not-allowed; opacity: 0.55; }
+.editor-actions { margin-top: 0.65rem; }
+.editor-actions button {
+  border: 1px solid var(--border);
+  border-radius: 0.4rem;
+  background: var(--panel-2);
+  color: var(--text);
+  cursor: pointer;
+  padding: 0.45rem 0.65rem;
+}
+.editor-actions button:disabled { cursor: not-allowed; opacity: 0.45; }

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -5,13 +5,19 @@ let ColladaLoader;
 let OBJLoader;
 
 const SUPPORTED_SCHEMA_VERSION = 'workcell_studio_web_scene/v1';
+const EDIT_PATCH_SCHEMA_VERSION = 'workcell_studio_web_scene_edit_patch/v1';
+const VIEWER_VERSION = 'static_web_viewer_edit_patch_v1';
+const LOCKED_EDIT_REASON = 'Locked/generated preview item; edit source layout/environment instead.';
 const MIN_FRAME_RADIUS = 1.2;
 const EMPTY_SCENE_MESSAGE = 'Scene contains no renderable robots, tools, assets, sensors, zones, items, or objects.';
 const FRAME_DISTANCE_MULTIPLIER = 2.7;
-const state = { sceneJson: null, objects: [], selected: null, three: {}, animationId: null, lastFrameBounds: null, runtimeWarnings: [], labelsVisible: false };
+const state = { sceneJson: null, sourceWebSceneFile: '', objects: [], selected: null, three: {}, animationId: null, lastFrameBounds: null, runtimeWarnings: [], labelsVisible: false, dirtyTransforms: new Map() };
 const el = {
   file: document.getElementById('scene-file'),
   resetView: document.getElementById('reset-view'),
+  clearEdits: document.getElementById('clear-edits'),
+  exportEditPatch: document.getElementById('export-edit-patch'),
+  dirty: document.getElementById('dirty-state'),
   labelsToggle: document.getElementById('labels-toggle'),
   canvas: document.getElementById('scene-canvas'),
   labelLayer: document.getElementById('label-layer'),
@@ -43,6 +49,21 @@ function poseOf(item) {
 function scaleOf(item) {
   const scale = item.scale || item.mesh_scale || [1, 1, 1];
   return vector3(scale, [1, 1, 1]);
+}
+function transformOf(item) {
+  const pose = poseOf(item);
+  const scale = scaleOf(item);
+  return {
+    pose: { xyz: { x: pose.xyz.x, y: pose.xyz.y, z: pose.xyz.z }, rpy: { x: pose.rpy.x, y: pose.rpy.y, z: pose.rpy.z } },
+    scale: { x: scale.x, y: scale.y, z: scale.z },
+  };
+}
+function cloneTransform(transform) { return JSON.parse(JSON.stringify(transform)); }
+function sameTransform(a, b) { return JSON.stringify(a) === JSON.stringify(b); }
+function applyTransformToObject(object, transform) {
+  object.position.set(transform.pose.xyz.x, transform.pose.xyz.y, transform.pose.xyz.z);
+  object.rotation.set(transform.pose.rpy.x, transform.pose.rpy.y, transform.pose.rpy.z, 'XYZ');
+  object.scale.set(transform.scale.x, transform.scale.y, transform.scale.z);
 }
 function primitiveOf(item) {
   return item.primitive || item.primitive_details || item.dimensions || item.geometry || item.primitive_geometry || null;
@@ -165,7 +186,7 @@ function applyPose(object, item) {
   object.position.copy(pose.xyz);
   object.rotation.set(pose.rpy.x, pose.rpy.y, pose.rpy.z, 'XYZ');
   const s = scaleOf(item);
-  object.scale.multiply(s);
+  object.scale.set(s.x, s.y, s.z);
 }
 
 function assignItemUserData(object, item) {
@@ -318,6 +339,8 @@ function clearSceneObjects() {
 }
 function renderScene(items) {
   clearSceneObjects();
+  state.dirtyTransforms.clear();
+  updateDirtyState();
   const scene = state.three.scene;
   for (const item of items) {
     const object3d = new THREE.Group();
@@ -329,7 +352,7 @@ function renderScene(items) {
     applyPose(object3d, item);
     assignItemUserData(object3d, item);
     scene.add(object3d);
-    const rendered = { item, object3d, fallback, labelEl: createLabelElement(item) };
+    const rendered = { item, object3d, fallback, labelEl: createLabelElement(item), originalTransform: transformOf(item) };
     const fallbackStatus = primitive || isSensor(item) ? 'primitive_fallback' : 'box_fallback';
     const fallbackReason = primitive || isSensor(item) ? 'primitive geometry rendered while mesh loads or is unavailable' : 'no primitive geometry or mesh was provided; using box fallback';
     setRenderInfo(rendered, fallbackStatus, displayMeshUri(item), fallbackReason);
@@ -415,6 +438,7 @@ function populateObjectList() {
     for (const rendered of renderedItems) {
       const li = document.createElement('li');
       li.dataset.id = rendered.item.id;
+      if (state.selected === rendered.item.id) li.classList.add('selected');
 
       const name = document.createElement('span');
       name.className = 'object-name';
@@ -428,7 +452,7 @@ function populateObjectList() {
 
       const meta = document.createElement('span');
       meta.className = 'meta';
-      meta.textContent = `${group} · ${rendered.item.locked ? 'locked/generated' : 'editable/environment'}`;
+      meta.textContent = `${group} · ${rendered.item.locked ? 'locked/generated' : 'editable/environment'}${state.dirtyTransforms.has(rendered.item.id) ? ' · edited' : ''}`;
       li.appendChild(meta);
       li.addEventListener('click', () => selectObject(rendered.item.id));
       el.list.appendChild(li);
@@ -459,6 +483,98 @@ function pickObject(event) {
   const item = hit?.object?.userData?.item || hit?.object?.parent?.userData?.item;
   if (item?.id) selectObject(item.id);
 }
+
+function canEditItem(item) {
+  const source = String(item?.source_kind || item?.source_layer || item?.active_visual_source || '').toLowerCase();
+  if (item?.locked || item?.editable !== true || source.includes('generated')) return false;
+  return true;
+}
+function currentTransformFromInputs(container) {
+  const get = name => Number(container.querySelector(`[data-transform-field="${name}"]`)?.value);
+  return { pose: { xyz: { x: get('x'), y: get('y'), z: get('z') }, rpy: { x: get('roll'), y: get('pitch'), z: get('yaw') } }, scale: { x: get('scale_x'), y: get('scale_y'), z: get('scale_z') } };
+}
+function renderTransformInputs(rendered) {
+  const item = rendered.item;
+  const editable = canEditItem(item);
+  const transform = state.dirtyTransforms.get(item.id)?.newTransform || transformOf(item);
+  const fields = [
+    ['x', 'X', transform.pose.xyz.x], ['y', 'Y', transform.pose.xyz.y], ['z', 'Z', transform.pose.xyz.z],
+    ['roll', 'Roll', transform.pose.rpy.x], ['pitch', 'Pitch', transform.pose.rpy.y], ['yaw', 'Yaw', transform.pose.rpy.z],
+    ['scale_x', 'Scale X', transform.scale.x], ['scale_y', 'Scale Y', transform.scale.y], ['scale_z', 'Scale Z', transform.scale.z],
+  ];
+  const disabled = editable ? '' : 'disabled';
+  return `<section class="transform-editor"><h3>Preview transform editing</h3>${editable ? '<p class="edit-note">Browser preview only. Export Edit Patch to save a JSON patch; source YAML is not modified.</p>' : `<p class="edit-lock-reason">${LOCKED_EDIT_REASON}</p>`}<div class="transform-grid">${fields.map(([name, label, value]) => `<label>${label}<input type="number" step="0.001" data-transform-field="${name}" value="${Number(value).toFixed(6)}" ${disabled}></label>`).join('')}</div><div class="editor-actions"><button id="reset-selected" type="button" ${editable ? '' : 'disabled'}>Reset Selected</button></div></section>`;
+}
+function wireTransformInputs(rendered) {
+  const editor = el.inspector.querySelector('.transform-editor');
+  if (!editor) return;
+  editor.querySelectorAll('[data-transform-field]').forEach(input => input.addEventListener('input', () => {
+    if (!canEditItem(rendered.item)) return;
+    const next = currentTransformFromInputs(editor);
+    if (Object.values(next.pose.xyz).concat(Object.values(next.pose.rpy), Object.values(next.scale)).some(v => !Number.isFinite(v))) return;
+    applyTransformToObject(rendered.object3d, next);
+    if (sameTransform(rendered.originalTransform, next)) state.dirtyTransforms.delete(rendered.item.id);
+    else state.dirtyTransforms.set(rendered.item.id, { oldTransform: cloneTransform(rendered.originalTransform), newTransform: cloneTransform(next) });
+    updateDirtyState();
+    updateLabels();
+  }));
+  const reset = el.inspector.querySelector('#reset-selected');
+  if (reset) reset.addEventListener('click', () => resetSelectedTransform(rendered.item.id));
+}
+function resetSelectedTransform(id = state.selected) {
+  const rendered = state.objects.find(obj => obj.item.id === id);
+  if (!rendered || !canEditItem(rendered.item)) return;
+  state.dirtyTransforms.delete(rendered.item.id);
+  applyTransformToObject(rendered.object3d, rendered.originalTransform);
+  updateDirtyState();
+  populateInspector(rendered);
+  updateLabels();
+}
+function updateDirtyState() {
+  const dirty = state.dirtyTransforms.size > 0;
+  if (el.dirty) { el.dirty.hidden = !dirty; el.dirty.textContent = dirty ? `Unsaved preview edits (${state.dirtyTransforms.size})` : 'No preview edits'; }
+  if (el.clearEdits) el.clearEdits.disabled = !dirty;
+  if (el.exportEditPatch) el.exportEditPatch.disabled = !state.sceneJson;
+  populateObjectList();
+}
+function clearPreviewEdits() {
+  for (const rendered of state.objects) applyTransformToObject(rendered.object3d, rendered.originalTransform);
+  state.dirtyTransforms.clear();
+  updateDirtyState();
+  if (state.selected) { const rendered = state.objects.find(obj => obj.item.id === state.selected); if (rendered) populateInspector(rendered); }
+  updateLabels();
+}
+function sceneId() { return state.sceneJson?.scene?.id || state.sceneJson?.scene_id || ''; }
+function buildEditPatch() {
+  const edits = [];
+  for (const rendered of state.objects) {
+    const dirty = state.dirtyTransforms.get(rendered.item.id);
+    if (!dirty) continue;
+    edits.push({
+      item_id: rendered.item.id,
+      label: itemLabel(rendered.item),
+      source: rendered.item.source_kind || rendered.item.source || rendered.item.source_layer || '',
+      type: itemType(rendered.item),
+      editable_required: true,
+      locked_required: false,
+      operation: 'update_transform',
+      old_transform: dirty.oldTransform,
+      new_transform: dirty.newTransform,
+      notes: ['Preview-only browser transform edit. Source scene files were not modified.'],
+    });
+  }
+  return { schema_version: EDIT_PATCH_SCHEMA_VERSION, scene_id: sceneId(), source_scene_schema_version: state.sceneJson?.schema_version || '', created_at: new Date().toISOString(), created_by: 'static_web_viewer', provenance: { source_web_scene_file: state.sourceWebSceneFile || undefined, viewer_version: VIEWER_VERSION }, edits };
+}
+function exportEditPatch() {
+  if (!state.sceneJson) { showError('Load a web_scene.json before exporting an edit patch.'); return; }
+  if (state.dirtyTransforms.size === 0) showError('No changed items; exporting an empty edit patch.'); else clearError();
+  const blob = new Blob([JSON.stringify(buildEditPatch(), null, 2) + '\n'], { type: 'application/json' });
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = `${sceneId() || 'workcell_studio'}.edit_patch.json`;
+  document.body.appendChild(a); a.click(); a.remove(); URL.revokeObjectURL(a.href);
+}
+
 function firstPresent(item, keys) {
   for (const key of keys) {
     if (item?.[key] !== undefined && item?.[key] !== null && item?.[key] !== '') return item[key];
@@ -492,7 +608,8 @@ function populateInspector(renderedOrItem) {
     });
   }
   el.inspector.className = '';
-  el.inspector.innerHTML = `<table class="inspector-table"><tbody>${Object.entries(rows).map(([k,v]) => `<tr><th>${k}</th><td><code>${String(valueOrDash(v)).replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]))}</code></td></tr>`).join('')}</tbody></table>`;
+  el.inspector.innerHTML = `<table class="inspector-table"><tbody>${Object.entries(rows).map(([k,v]) => `<tr><th>${k}</th><td><code>${String(valueOrDash(v)).replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]))}</code></td></tr>`).join('')}</tbody></table>${rendered ? renderTransformInputs(rendered) : ''}`;
+  if (rendered) wireTransformInputs(rendered);
 }
 function refreshWarnings(sceneJson = state.sceneJson) {
   const warnings = asArray(sceneJson?.warnings).concat(asArray(sceneJson?.notes_warnings), asArray(state.runtimeWarnings));
@@ -514,7 +631,9 @@ async function loadFile(file) {
     try { json = JSON.parse(text); } catch (err) { throw new Error(`Invalid JSON in ${file.name}: ${err.message}`); }
     const items = validateSceneJson(json);
     state.sceneJson = json;
+    state.sourceWebSceneFile = file.name || '';
     state.runtimeWarnings = [];
+    state.dirtyTransforms.clear();
     el.empty.hidden = true;
     if (items.length) renderScene(items);
     else renderScene([]);
@@ -528,6 +647,8 @@ async function loadFile(file) {
 
 if (el.resetView) el.resetView.addEventListener('click', resetView);
 if (el.labelsToggle) el.labelsToggle.addEventListener('change', event => setLabelsVisible(event.target.checked));
+if (el.clearEdits) el.clearEdits.addEventListener('click', clearPreviewEdits);
+if (el.exportEditPatch) el.exportEditPatch.addEventListener('click', exportEditPatch);
 
 el.file.addEventListener('change', event => {
   const file = event.target.files?.[0];


### PR DESCRIPTION
Summary:
- Adds the `workcell_studio_web_scene_edit_patch/v1` schema and a standalone patch validator for Web 3D preview transform edits.
- Adds preview-only XYZ/RPY/scale editing, dirty-state handling, reset/clear controls, and edit patch export to the static viewer without introducing build tooling.
- Documents the preview-only edit flow and adds tests covering schema validity, validator acceptance/rejection cases, viewer guard strings, and no committed generated patch JSON.

Validation:
- `python3 -m pytest -q tests/test_workcell_studio_web_scene_edit_patch.py` — passed, 7 tests.
- `python3 -m pytest -q tests/test_workcell_studio_web_scene_contract.py tests/test_workcell_studio_web_scene_edit_patch.py` — passed, 10 tests.
- `python3 -m json.tool schemas/workcell_studio_web_scene_edit_patch_v1.schema.json > /dev/null` — passed.
- `python3 -m py_compile scripts/validate_workcell_studio_web_scene_edit_patch.py` — passed.
- `git diff --check` — passed.
- ROS/colcon, exporter against ur5_2f_test, readiness matrix, and manual browser checks were not run in this container.

Safety:
- This adds preview-only Web 3D transform editing and edit patch export.
- It does not apply patches to source YAML yet.
- It does not replace RViz/MoveIt planning truth.
- It does not modify Qt Scene3D.
- Fake-hardware-first safety remains unchanged; no ROS launch, controllers, runtime services, or real-hardware paths were modified.

Risks / rollback:
- Browser edit validation is intentionally limited to preview/export; applying patches to source layout/environment files is deferred.
- Manual browser verification is still recommended for object movement and locked/generated item UX.
- Roll back by reverting commit `dcc6925`.

Next phase:
- Apply validated patches safely to layout/environment source files with deterministic conflict handling and validation evidence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a426690c81083318ff877531401bb9d)