### PR TITLE
Add safe Web 3D edit patch applicator

### DIFF
--- a/docs/WORKCELL_STUDIO_WEB_3D_EDIT_PATCH.md
+++ b/docs/WORKCELL_STUDIO_WEB_3D_EDIT_PATCH.md
@@ -1,6 +1,55 @@
 # Workcell Studio Web 3D edit patch contract
 
-This phase adds preview-only transform editing to the static Web 3D viewer. Web Studio can move editable layout/environment objects in the browser and export a JSON edit patch, but it does **not** apply patches to source files yet.
+This phase connects preview editing to a guarded backend persistence step. Web Studio can move editable layout/environment objects in the browser, export a `workcell_studio_web_scene_edit_patch/v1` JSON patch, validate it, and dry-run or apply it to the correct editable source YAML.
+
+## Workflow
+
+Export the current scene for the static viewer:
+
+```bash
+python3 scripts/export_workcell_studio_web_scene.py \
+  --scene scenes/ur5_2f_test \
+  --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json
+```
+
+Open `workcell_studio_web/viewer/index.html`, load the exported `web_scene.json`, edit one `editable=true` and `locked=false` item, then use **Export Edit Patch** to download an edit patch.
+
+Validate the patch before applying it:
+
+```bash
+python3 scripts/validate_workcell_studio_web_scene_edit_patch.py \
+  --web-scene build/workcell_studio_web_scene/ur5_2f_test.web_scene.json \
+  --patch build/workcell_studio_web_scene/ur5_2f_test.edit_patch.json
+```
+
+Dry-run the backend applicator. This is the default and writes nothing:
+
+```bash
+python3 scripts/apply_workcell_studio_web_scene_edit_patch.py \
+  --scene scenes/ur5_2f_test \
+  --web-scene build/workcell_studio_web_scene/ur5_2f_test.web_scene.json \
+  --patch build/workcell_studio_web_scene/ur5_2f_test.edit_patch.json
+```
+
+Apply only when you intentionally want to mutate editable source YAML:
+
+```bash
+python3 scripts/apply_workcell_studio_web_scene_edit_patch.py \
+  --scene scenes/ur5_2f_test \
+  --web-scene build/workcell_studio_web_scene/ur5_2f_test.web_scene.json \
+  --patch build/workcell_studio_web_scene/ur5_2f_test.edit_patch.json \
+  --write
+```
+
+Use `--backup` with `--write` to create timestamped `.bak` files next to edited YAML. Backups are optional and are never created for generated outputs.
+
+Re-export the web scene after applying a patch to confirm the persisted pose is reflected:
+
+```bash
+python3 scripts/export_workcell_studio_web_scene.py \
+  --scene scenes/ur5_2f_test \
+  --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json
+```
 
 ## Contract
 
@@ -15,34 +64,24 @@ Each patch records:
 
 Patch exports include only changed items. Exporting with no changed items is allowed and produces an empty `edits` array with a browser warning.
 
-## Safety and source of truth
+## Applicator safety rules
 
-The viewer is not the source of truth in this phase. It does not mutate:
+The applicator reuses the validator and then applies only safe editable updates:
 
-- `environment.yaml`
-- `layout/workcell_studio_layout.yaml`
-- `cell_definition.yaml`
-- `scene_manifest.yaml`
-- generated scene files
+- dry-run is default; `--write` is required for mutation;
+- only `update_transform` is supported;
+- item provenance must clearly map to `layout/workcell_studio_layout.yaml` or authored `environment.yaml` records;
+- ambiguous source mapping fails with a clear error;
+- locked items, `editable=false` items, and generated robot/tool visuals are rejected;
+- `generated/`, `cell_definition.yaml`, and `scene_manifest.yaml` are never mutated in this phase;
+- pose XYZ/RPY are updated; scale is updated only when the source record already has an obvious `scale` or `mesh_scale` field.
 
-Locked/generated robot and tool preview items are inspectable only. The viewer disables their transform inputs and tells the user to edit source layout/environment instead.
-
-## Validation
-
-Use the standalone validator before trusting an exported patch:
-
-```bash
-python3 scripts/validate_workcell_studio_web_scene_edit_patch.py \
-  --web-scene build/workcell_studio_web_scene/ur5_2f_test.web_scene.json \
-  --patch build/workcell_studio_web_scene/ur5_2f_test.edit_patch.json
-```
-
-The validator checks scene identity, item existence, editability, lock state, generated robot/tool guards, and finite transform numbers. It only reads JSON inputs and never writes source scene files.
+Dry-run output lists the scene id, item id, label, source, target file, old transform, new transform, and whether a write would occur. Write mode reports updated file paths, updated item counts, skipped/rejected edits, and the suggested re-export command.
 
 ## Relationship to RViz/MoveIt
 
-Web 3D editing is an authoring preview. RViz/MoveIt remains the planning and simulation truth, and fake hardware remains the default validation foundation. This change does not enable real robot motion and does not replace backend generation, validation, or safety gates.
+Web 3D editing is an authoring surface, not a planning or execution backend. No ROS launch is required for patch validation or application. RViz/MoveIt remains the planning and simulation truth, and fake hardware remains the default validation foundation. This workflow does not enable real robot motion, does not replace backend generation/validation/safety gates, and does not modify Qt Scene3D visuals.
 
 ## Next phase
 
-The next phase is a guarded backend application step that takes a validated patch and writes the appropriate layout/environment source files deterministically, with clear conflict handling and validation evidence.
+After persistence is proven, the next phase is improving browser transform UX/gizmos while preserving the same dry-run-first backend safety model.

--- a/scripts/apply_workcell_studio_web_scene_edit_patch.py
+++ b/scripts/apply_workcell_studio_web_scene_edit_patch.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Safely apply validated Workcell Studio Web 3D edit patches.
+
+Dry-run is the default. Source YAML is mutated only with --write, and only for
+clear editable layout/environment provenance. Generated files, manifests, and
+cell definitions are intentionally out of scope for this first persistence step.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+try:
+    import yaml  # type: ignore
+except ImportError:  # pragma: no cover
+    yaml = None  # type: ignore
+
+from validate_workcell_studio_web_scene_edit_patch import _items_by_id, _load_json, _scene_id, validate
+
+ALLOWED_SOURCES = {
+    "layout/workcell_studio_layout.yaml",
+    "environment.yaml",
+}
+FORBIDDEN_TARGET_PARTS = {"generated"}
+FORBIDDEN_TARGET_NAMES = {"cell_definition.yaml", "scene_manifest.yaml"}
+ENVIRONMENT_LIST_KEYS = ("support_surfaces", "assets", "sensors", "zones")
+
+
+@dataclass
+class PlannedUpdate:
+    item_id: str
+    label: str
+    source: str
+    target_file: Path
+    target_rel: str
+    item: dict[str, Any]
+    record: dict[str, Any]
+    old_transform: dict[str, Any]
+    new_transform: dict[str, Any]
+    update_scale: bool
+
+
+def _load_yaml(path: Path) -> Any:
+    if yaml is None:
+        raise ValueError("PyYAML is required to apply edit patches")
+    try:
+        return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError(f"{path}: unable to load YAML: {exc}") from exc
+
+
+def _write_yaml(path: Path, data: Any) -> None:
+    assert yaml is not None
+    path.write_text(yaml.safe_dump(data, sort_keys=False, default_flow_style=False), encoding="utf-8")
+
+
+def _as_list3(value: Any, field: str) -> list[float]:
+    if not isinstance(value, dict):
+        raise ValueError(f"new_transform.{field}: expected object with x/y/z")
+    return [float(value[k]) for k in ("x", "y", "z")]
+
+
+def _pose_lists(transform: dict[str, Any]) -> tuple[list[float], list[float]]:
+    pose = transform.get("pose")
+    if not isinstance(pose, dict):
+        raise ValueError("new_transform.pose: expected object")
+    return _as_list3(pose.get("xyz"), "pose.xyz"), _as_list3(pose.get("rpy"), "pose.rpy")
+
+
+def _scale_list(transform: dict[str, Any]) -> list[float] | None:
+    scale = transform.get("scale")
+    if scale is None:
+        return None
+    return _as_list3(scale, "scale")
+
+
+def _source_from_item(item: dict[str, Any]) -> str | None:
+    candidates: set[str] = set()
+    for key in ("source", "source_file", "source_path"):
+        value = item.get(key)
+        if isinstance(value, str) and value in ALLOWED_SOURCES:
+            candidates.add(value)
+    prov = item.get("provenance")
+    if isinstance(prov, dict):
+        for value in prov.values():
+            if isinstance(value, str) and value in ALLOWED_SOURCES:
+                candidates.add(value)
+    if len(candidates) == 1:
+        return next(iter(candidates))
+    return None
+
+
+def _safe_target(scene_dir: Path, rel: str) -> Path:
+    if rel not in ALLOWED_SOURCES:
+        raise ValueError(f"ambiguous or unsupported source mapping: {rel!r}")
+    path = (scene_dir / rel).resolve()
+    scene_root = scene_dir.resolve()
+    try:
+        relative_parts = path.relative_to(scene_root).parts
+    except ValueError as exc:
+        raise ValueError(f"target file escapes scene directory: {path}") from exc
+    if any(part in FORBIDDEN_TARGET_PARTS for part in relative_parts) or path.name in FORBIDDEN_TARGET_NAMES:
+        raise ValueError(f"refusing to update forbidden source file: {path}")
+    return path
+
+
+def _find_layout_record(data: Any, item_id: str) -> dict[str, Any] | None:
+    if not isinstance(data, dict):
+        return None
+    for record in data.get("items", []) if isinstance(data.get("items"), list) else []:
+        if isinstance(record, dict) and str(record.get("id")) == item_id:
+            return record
+    return None
+
+
+def _find_environment_record(data: Any, item_id: str) -> dict[str, Any] | None:
+    root = data.get("environment") if isinstance(data, dict) else None
+    if not isinstance(root, dict):
+        return None
+    matches: list[dict[str, Any]] = []
+    for key in ENVIRONMENT_LIST_KEYS:
+        for record in root.get(key, []) if isinstance(root.get(key), list) else []:
+            if isinstance(record, dict) and (str(record.get("id")) == item_id or str(record.get("layout_item_ref")) == item_id):
+                matches.append(record)
+    return matches[0] if len(matches) == 1 else None
+
+
+def _has_obvious_scale(record: dict[str, Any]) -> bool:
+    return isinstance(record.get("scale"), (list, dict)) or isinstance(record.get("mesh_scale"), (list, dict))
+
+
+def _plan(scene_dir: Path, web_scene: dict[str, Any], patch: dict[str, Any]) -> list[PlannedUpdate]:
+    errors = validate(web_scene, patch)
+    if errors:
+        raise ValueError("patch validation failed:\n" + "\n".join(f"- {e}" for e in errors))
+    items = _items_by_id(web_scene)
+    loaded_yaml: dict[str, Any] = {}
+    planned: list[PlannedUpdate] = []
+    for edit in patch.get("edits", []):
+        item_id = str(edit["item_id"])
+        item = items[item_id]
+        rel = _source_from_item(item)
+        if rel is None:
+            raise ValueError(f"{item_id}: ambiguous source mapping; item provenance must clearly identify layout/workcell_studio_layout.yaml or environment.yaml")
+        target = _safe_target(scene_dir, rel)
+        if rel not in loaded_yaml:
+            loaded_yaml[rel] = _load_yaml(target)
+        record = _find_layout_record(loaded_yaml[rel], item_id) if rel == "layout/workcell_studio_layout.yaml" else _find_environment_record(loaded_yaml[rel], item_id)
+        if record is None:
+            raise ValueError(f"{item_id}: source item not found exactly once in {rel}")
+        new_scale = _scale_list(edit["new_transform"])
+        old_scale = _scale_list(edit["old_transform"])
+        scale_changed = new_scale is not None and old_scale is not None and new_scale != old_scale
+        if scale_changed and not _has_obvious_scale(record):
+            raise ValueError(f"{item_id}: scale changed but {rel} has no obvious scale field; refusing to guess")
+        planned.append(PlannedUpdate(item_id, str(edit.get("label") or item.get("label") or item.get("display_name") or item_id), rel, target, rel, item, record, edit["old_transform"], edit["new_transform"], scale_changed))
+    return planned
+
+
+def _format_transform(transform: dict[str, Any]) -> str:
+    pose = transform.get("pose", {}) if isinstance(transform.get("pose"), dict) else {}
+    return f"xyz={pose.get('xyz')} rpy={pose.get('rpy')} scale={transform.get('scale')}"
+
+
+def _apply_update(update: PlannedUpdate) -> None:
+    xyz, rpy = _pose_lists(update.new_transform)
+    if update.target_rel == "layout/workcell_studio_layout.yaml":
+        pose = update.record.setdefault("pose", {})
+        if not isinstance(pose, dict):
+            raise ValueError(f"{update.item_id}: layout pose is not an object")
+        pose["xyz"] = xyz
+        pose["rpy"] = rpy
+    else:
+        update.record["pose_xyz"] = xyz
+        update.record["pose_rpy"] = rpy
+    if update.update_scale:
+        scale = _scale_list(update.new_transform)
+        if "scale" in update.record:
+            update.record["scale"] = scale
+        elif "mesh_scale" in update.record:
+            update.record["mesh_scale"] = scale
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Dry-run or apply a validated Workcell Studio web_scene_edit_patch/v1 patch.")
+    parser.add_argument("--scene", required=True, type=Path)
+    parser.add_argument("--web-scene", required=True, type=Path)
+    parser.add_argument("--patch", required=True, type=Path)
+    parser.add_argument("--write", action="store_true", help="Mutate editable source YAML. Omitted means dry-run only.")
+    parser.add_argument("--backup", action="store_true", help="In --write mode, create timestamped .bak files next to edited YAML.")
+    args = parser.parse_args(argv)
+    try:
+        scene_dir = args.scene.resolve()
+        web_scene = _load_json(args.web_scene)
+        patch = _load_json(args.patch)
+        planned = _plan(scene_dir, web_scene, patch)
+        print(f"scene id: {_scene_id(web_scene)}")
+        if not planned:
+            print("No edits to apply.")
+            return 0
+        for update in planned:
+            print(f"item id: {update.item_id}")
+            print(f"  label: {update.label}")
+            print(f"  source: {update.source}")
+            print(f"  target file: {update.target_file}")
+            print(f"  old transform: {_format_transform(update.old_transform)}")
+            print(f"  new transform: {_format_transform(update.new_transform)}")
+            print(f"  write would occur: {bool(args.write)}")
+        if not args.write:
+            print("Dry-run only; no files were modified. Pass --write to apply these safe editable updates.")
+            return 0
+        by_file: dict[Path, list[PlannedUpdate]] = {}
+        for update in planned:
+            by_file.setdefault(update.target_file, []).append(update)
+        for path, updates in by_file.items():
+            data = _load_yaml(path)
+            for update in updates:
+                update.record = _find_layout_record(data, update.item_id) if update.target_rel == "layout/workcell_studio_layout.yaml" else _find_environment_record(data, update.item_id)  # type: ignore[assignment]
+                if update.record is None:
+                    raise ValueError(f"{update.item_id}: source item disappeared from {update.target_rel}")
+                _apply_update(update)
+            if args.backup:
+                stamp = _dt.datetime.now(_dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+                shutil.copy2(path, path.with_name(f"{path.name}.{stamp}.bak"))
+            _write_yaml(path, data)
+            print(f"updated file path: {path}")
+            print(f"updated item count: {len(updates)}")
+        print("skipped/rejected edits: none")
+        print(f"next suggested command: python3 scripts/export_workcell_studio_web_scene.py --scene {args.scene} --output {args.web_scene}")
+        return 0
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_workcell_studio_web_scene_edit_patch_apply.py
+++ b/tests/test_workcell_studio_web_scene_edit_patch_apply.py
@@ -1,0 +1,150 @@
+import json
+import math
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APPLICATOR = REPO_ROOT / "scripts" / "apply_workcell_studio_web_scene_edit_patch.py"
+EXPORTER = REPO_ROOT / "scripts" / "export_workcell_studio_web_scene.py"
+
+
+def _transform(x=0.0, scale=1.0):
+    return {"pose": {"xyz": {"x": x, "y": 0.1, "z": 0.2}, "rpy": {"x": 0.0, "y": 0.0, "z": 0.3}}, "scale": {"x": scale, "y": scale, "z": scale}}
+
+
+def _web_scene(source="layout/workcell_studio_layout.yaml", editable=True, locked=False, source_kind="user_authored"):
+    return {
+        "schema_version": "workcell_studio_web_scene/v1",
+        "scene": {"id": "tiny_scene"},
+        "robots": [{"id": "ur5_visual", "label": "UR5", "type": "robot", "source_kind": "generated_preview", "source_layer": "generated_preview", "editable": False, "locked": True}],
+        "tools": [],
+        "assets": [{"id": "layout_bin", "label": "Bin", "type": "bin", "source_kind": source_kind, "editable": editable, "locked": locked, "provenance": {"pose": source, "id": source}}],
+        "sensors": [],
+        "zones": [],
+        "warnings": [],
+        "backend_actions": [],
+    }
+
+
+def _patch(item_id="layout_bin", new_x=0.4, scale=1.0):
+    return {
+        "schema_version": "workcell_studio_web_scene_edit_patch/v1",
+        "scene_id": "tiny_scene",
+        "source_scene_schema_version": "workcell_studio_web_scene/v1",
+        "created_at": "2026-06-29T00:00:00Z",
+        "created_by": "static_web_viewer",
+        "provenance": {"viewer_version": "test"},
+        "edits": [{
+            "item_id": item_id,
+            "label": "Bin",
+            "source": "user_authored",
+            "type": "bin",
+            "editable_required": True,
+            "locked_required": False,
+            "operation": "update_transform",
+            "old_transform": _transform(0.0),
+            "new_transform": _transform(new_x, scale),
+        }],
+    }
+
+
+def _scene(tmp_path):
+    scene = tmp_path / "scenes" / "tiny_scene"
+    (scene / "layout").mkdir(parents=True)
+    (scene / "layout" / "workcell_studio_layout.yaml").write_text(yaml.safe_dump({
+        "schema_version": "workcell_studio_layout/v1",
+        "items": [{"id": "layout_bin", "type": "bin", "display_name": "Bin", "pose": {"xyz": [0.0, 0.1, 0.2], "rpy": [0.0, 0.0, 0.3]}, "editable": True, "locked": False}],
+    }, sort_keys=False), encoding="utf-8")
+    (scene / "environment.yaml").write_text(yaml.safe_dump({
+        "schema_version": "workcell_scene/v1",
+        "scene": {"id": "tiny_scene", "name": "tiny_scene"},
+        "environment": {"assets": [{"id": "env_box", "type": "box", "pose_xyz": [0.0, 0.0, 0.0], "pose_rpy": [0.0, 0.0, 0.0]}]},
+    }, sort_keys=False), encoding="utf-8")
+    return scene
+
+
+def _run(tmp_path, scene, web_scene, patch, *extra):
+    web = tmp_path / "scene.web_scene.json"
+    patch_path = tmp_path / "scene.edit_patch.json"
+    web.write_text(json.dumps(web_scene), encoding="utf-8")
+    patch_path.write_text(json.dumps(patch), encoding="utf-8")
+    return subprocess.run([sys.executable, str(APPLICATOR), "--scene", str(scene), "--web-scene", str(web), "--patch", str(patch_path), *extra], cwd=REPO_ROOT, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def test_dry_run_does_not_mutate_files(tmp_path):
+    scene = _scene(tmp_path)
+    layout = scene / "layout" / "workcell_studio_layout.yaml"
+    before = layout.read_text(encoding="utf-8")
+    result = _run(tmp_path, scene, _web_scene(), _patch())
+    assert result.returncode == 0, result.stderr
+    assert "Dry-run only" in result.stdout
+    assert "write would occur: False" in result.stdout
+    assert layout.read_text(encoding="utf-8") == before
+
+
+def test_write_updates_editable_layout_item_pose(tmp_path):
+    scene = _scene(tmp_path)
+    result = _run(tmp_path, scene, _web_scene(), _patch(new_x=0.7), "--write")
+    assert result.returncode == 0, result.stderr
+    assert "updated item count: 1" in result.stdout
+    data = yaml.safe_load((scene / "layout" / "workcell_studio_layout.yaml").read_text(encoding="utf-8"))
+    assert data["items"][0]["pose"]["xyz"] == [0.7, 0.1, 0.2]
+
+
+def test_locked_generated_edit_is_rejected(tmp_path):
+    scene = _scene(tmp_path)
+    result = _run(tmp_path, scene, _web_scene(), _patch("ur5_visual"), "--write")
+    assert result.returncode == 1
+    assert "locked=true items cannot be edited" in result.stderr
+    assert "generated robot/tool preview items cannot be edited" in result.stderr
+
+
+def test_ambiguous_source_mapping_is_rejected(tmp_path):
+    scene = _scene(tmp_path)
+    web_scene = _web_scene(source="unknown.yaml")
+    result = _run(tmp_path, scene, web_scene, _patch(), "--write")
+    assert result.returncode == 1
+    assert "ambiguous source mapping" in result.stderr
+
+
+def test_missing_item_id_is_rejected(tmp_path):
+    scene = _scene(tmp_path)
+    result = _run(tmp_path, scene, _web_scene(), _patch("missing"))
+    assert result.returncode == 1
+    assert "item not found" in result.stderr
+
+
+def test_non_finite_transform_rejected_via_validator(tmp_path):
+    scene = _scene(tmp_path)
+    patch = _patch()
+    patch["edits"][0]["new_transform"]["pose"]["xyz"]["x"] = math.inf
+    result = _run(tmp_path, scene, _web_scene(), patch)
+    assert result.returncode == 1
+    assert "finite number" in result.stderr or "unable to load JSON" in result.stderr
+
+
+def test_generated_files_are_never_written(tmp_path):
+    scene = _scene(tmp_path)
+    (scene / "generated").mkdir()
+    generated = scene / "generated" / "scene_visual_mesh_index.json"
+    generated.write_text('{"items": []}', encoding="utf-8")
+    before = generated.read_text(encoding="utf-8")
+    web_scene = _web_scene(source="generated/scene_visual_mesh_index.json")
+    result = _run(tmp_path, scene, web_scene, _patch(), "--write")
+    assert result.returncode == 1
+    assert generated.read_text(encoding="utf-8") == before
+
+
+def test_reexport_after_apply_reflects_updated_pose(tmp_path):
+    scene = _scene(tmp_path)
+    result = _run(tmp_path, scene, _web_scene(), _patch(new_x=0.9), "--write")
+    assert result.returncode == 0, result.stderr
+    out = tmp_path / "reexport.web_scene.json"
+    export = subprocess.run([sys.executable, str(EXPORTER), "--scene", str(scene), "--output", str(out)], cwd=REPO_ROOT, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert export.returncode == 0, export.stderr
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    item = next(i for i in payload["assets"] if i["id"] == "layout_bin")
+    assert item["pose"]["xyz"] == [0.9, 0.1, 0.2]

--- a/workcell_studio_web/viewer/README.md
+++ b/workcell_studio_web/viewer/README.md
@@ -80,10 +80,31 @@ Locked or generated preview items, including generated robot/tool visuals, keep 
 
 Use **Export Edit Patch** to download a `workcell_studio_web_scene_edit_patch/v1` JSON file. The patch contains only changed items and does not modify `environment.yaml`, layout YAML, `cell_definition.yaml`, `scene_manifest.yaml`, or generated scene files. **Clear Preview Edits** resets all browser-only changes; **Reset Selected** restores the selected editable item to its original loaded transform.
 
-Validate exported patches separately before any future application step:
+Validate exported patches before application:
 
 ```bash
 python3 scripts/validate_workcell_studio_web_scene_edit_patch.py \
   --web-scene build/workcell_studio_web_scene/ur5_2f_test.web_scene.json \
   --patch build/workcell_studio_web_scene/ur5_2f_test.edit_patch.json
 ```
+
+Dry-run backend application. This is the default and writes nothing:
+
+```bash
+python3 scripts/apply_workcell_studio_web_scene_edit_patch.py \
+  --scene scenes/ur5_2f_test \
+  --web-scene build/workcell_studio_web_scene/ur5_2f_test.web_scene.json \
+  --patch build/workcell_studio_web_scene/ur5_2f_test.edit_patch.json
+```
+
+Apply only when you intentionally want to persist an editable layout/environment transform:
+
+```bash
+python3 scripts/apply_workcell_studio_web_scene_edit_patch.py \
+  --scene scenes/ur5_2f_test \
+  --web-scene build/workcell_studio_web_scene/ur5_2f_test.web_scene.json \
+  --patch build/workcell_studio_web_scene/ur5_2f_test.edit_patch.json \
+  --write
+```
+
+Re-export `web_scene.json` after `--write` to confirm the edited pose persists. The applicator does not launch ROS, does not mutate `generated/`, `cell_definition.yaml`, or `scene_manifest.yaml`, and does not replace RViz/MoveIt as the planning and fake-hardware simulation truth.


### PR DESCRIPTION
Summary:
- Added `scripts/apply_workcell_studio_web_scene_edit_patch.py` to safely apply validated Web 3D `web_scene_edit_patch/v1` transform edits to editable layout/environment YAML.
- Dry-run is the default; `--write` is required before any source file mutation, with optional `--backup` support.
- The applicator reuses the existing edit patch validator, rejects locked/generated robot/tool visuals, refuses ambiguous mappings, and does not mutate `generated/`, `cell_definition.yaml`, or `scene_manifest.yaml`.
- Added applicator tests covering dry-run, write persistence, generated/locked rejection, ambiguous/missing item rejection, non-finite validation, generated-file safety, and re-export persistence.
- Updated Web 3D edit patch docs and viewer README with export, validate, dry-run, write, and re-export workflow.

Validation:
- `python3 scripts/export_workcell_studio_web_scene.py --scene scenes/ur5_2f_test --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json` passed.
- `pytest -q tests/test_workcell_studio_web_scene_contract.py` passed.
- `pytest -q tests/test_workcell_studio_web_scene_edit_patch.py` passed.
- `pytest -q tests/test_workcell_studio_web_scene_edit_patch_apply.py` passed.
- `python3 scripts/run_workcell_studio_scene_readiness_matrix.py --supported-scenes scenes/supported_scenes.yaml --output-dir build/workcell_studio_scene_readiness` ran with PASS=0 FAIL=0 BLOCKED=8.
- `python3 scripts/validate_workcell_studio_web_scene_edit_patch.py --web-scene build/workcell_studio_web_scene/ur5_2f_test.web_scene.json --patch /tmp/ur5_2f_test.edit_patch.json` passed for a synthetic editable layout patch.
- `python3 scripts/apply_workcell_studio_web_scene_edit_patch.py --scene scenes/ur5_2f_test --web-scene build/workcell_studio_web_scene/ur5_2f_test.web_scene.json --patch /tmp/ur5_2f_test.edit_patch.json` dry-ran successfully and wrote nothing.
- `python3 -m py_compile scripts/apply_workcell_studio_web_scene_edit_patch.py scripts/validate_workcell_studio_web_scene_edit_patch.py scripts/export_workcell_studio_web_scene.py` passed.
- `colcon build --symlink-install --packages-select workcell_builder` was not run because `/opt/ros/humble/setup.bash` is not present in this container.

Safety:
- Fake hardware and ROS launch paths are untouched.
- Real-hardware execution was not enabled or exposed.
- Generated files are explicitly refused by the applicator and were not committed.
- Locked/generated robot/tool visuals remain rejected.
- RViz/MoveIt remains the planning and fake-hardware simulation truth; this does not replace it.
- Qt Scene3D was not touched.

Risks / rollback:
- This first applicator only supports `update_transform`; scale persists only when a source record already has an obvious `scale` or `mesh_scale` field.
- Ambiguous provenance intentionally blocks writes; exporter/source provenance can be improved in a later PR if needed.
- Roll back by reverting commit `f1a578e`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4269fffb088331bc21826449bfb5ea)