### PR TITLE
Verify Web 3D edit persistence loop

### DIFF
--- a/docs/WORKCELL_STUDIO_WEB_3D_EDIT_PATCH.md
+++ b/docs/WORKCELL_STUDIO_WEB_3D_EDIT_PATCH.md
@@ -51,6 +51,52 @@ python3 scripts/export_workcell_studio_web_scene.py \
   --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json
 ```
 
+## Persistence verification loop
+
+Use a copied/temp scene for write testing when you are proving the loop manually; do not mutate checked-in scenes or commit generated `web_scene.json` / `edit_patch.json` outputs. The full loop is:
+
+1. Export a before snapshot:
+
+   ```bash
+   python3 scripts/export_workcell_studio_web_scene.py \
+     --scene scenes/ur5_2f_test \
+     --output build/workcell_studio_web_scene/ur5_2f_test.before.web_scene.json
+   ```
+
+2. Edit only an `editable=true`, `locked=false` source layout/environment item in the viewer.
+3. Export `edit_patch.json` from the viewer.
+4. Validate the patch:
+
+   ```bash
+   python3 scripts/validate_workcell_studio_web_scene_edit_patch.py \
+     --web-scene build/workcell_studio_web_scene/ur5_2f_test.before.web_scene.json \
+     --patch build/workcell_studio_web_scene/ur5_2f_test.edit_patch.json
+   ```
+
+5. Dry-run the backend applicator; this must write nothing.
+6. Apply with `--write` only on the copied/temp scene. The applicator persists source layout/environment YAML only through safe provenance mapping.
+7. Re-export an after snapshot:
+
+   ```bash
+   python3 scripts/export_workcell_studio_web_scene.py \
+     --scene scenes/ur5_2f_test \
+     --output build/workcell_studio_web_scene/ur5_2f_test.after.web_scene.json
+   ```
+
+8. Verify persistence:
+
+   ```bash
+   python3 scripts/verify_workcell_studio_web_scene_edit_persistence.py \
+     --scene scenes/ur5_2f_test \
+     --web-scene-before build/workcell_studio_web_scene/ur5_2f_test.before.web_scene.json \
+     --patch build/workcell_studio_web_scene/ur5_2f_test.edit_patch.json \
+     --web-scene-after build/workcell_studio_web_scene/ur5_2f_test.after.web_scene.json
+   ```
+
+9. Only after the verifier passes should you regenerate and validate the ROS scene package. Generated files are not edited directly by the web viewer or applicator. RViz/MoveIt remains the planning truth, and real hardware remains disabled/default-safe.
+
+The verifier checks that `scene_id` matches, each edited item existed before and after, `old_transform` matched the before export, `new_transform` persisted in the after export, locked/generated robot/tool visuals stayed unchanged, and unrelated items stayed unchanged except allowed provenance/timestamp/export metadata.
+
 ## Contract
 
 Patch files use `schemas/workcell_studio_web_scene_edit_patch_v1.schema.json` and `schema_version: workcell_studio_web_scene_edit_patch/v1`.

--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -213,7 +213,7 @@ def _authored_item(raw: Mapping[str, Any], source: str, index: int, scene_dir: P
     fields = (
         "id", "type", "role", "category", "display_name", "frame", "pose", "pose_xyz", "pose_rpy", "dimensions",
         "geometry_type", "primitive_geometry_type", "mesh_uri", "package_uri", "source_path", "mesh_path", "material",
-        "layout_item_ref", "support_surface_ref", "task_zone_ref", "perception_mode", "runtime_enforced", "runtime_commanded",
+        "layout_item_ref", "support_surface_ref", "task_zone_ref", "scale", "mesh_scale", "perception_mode", "runtime_enforced", "runtime_commanded",
     )
     item = _copy_fields(raw, fields, source, scene_dir)
     item.setdefault("id", _stable_id("authored", index))

--- a/scripts/verify_workcell_studio_web_scene_edit_persistence.py
+++ b/scripts/verify_workcell_studio_web_scene_edit_persistence.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Verify the full Workcell Studio Web 3D edit persistence loop.
+
+This checker compares a before web_scene.json, a viewer edit_patch.json, and an
+after web_scene.json re-exported after the backend applicator was run with
+--write. It never writes scene files; it only proves that intended editable
+source edits persisted and that unrelated/generated preview items stayed stable.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+from validate_workcell_studio_web_scene_edit_patch import _is_generated_robot_or_tool, _items_by_id, _load_json, _scene_id, validate
+
+_ALLOWED_ITEM_METADATA = {
+    "provenance",
+    "exported_at",
+    "updated_at",
+    "created_at",
+    "timestamp",
+    "export_metadata",
+    "metadata",
+}
+
+
+def _as_xyz(value: Any) -> dict[str, float] | None:
+    if isinstance(value, dict) and all(k in value for k in ("x", "y", "z")):
+        return {k: float(value[k]) for k in ("x", "y", "z")}
+    if isinstance(value, list) and len(value) >= 3:
+        return {k: float(value[i]) for i, k in enumerate(("x", "y", "z"))}
+    return None
+
+
+def _item_transform(item: dict[str, Any]) -> dict[str, Any]:
+    pose = item.get("pose") if isinstance(item.get("pose"), dict) else {}
+    xyz = _as_xyz(pose.get("xyz")) or _as_xyz(item.get("pose_xyz"))
+    rpy = _as_xyz(pose.get("rpy")) or _as_xyz(item.get("pose_rpy"))
+    transform: dict[str, Any] = {"pose": {}}
+    if xyz is not None:
+        transform["pose"]["xyz"] = xyz
+    if rpy is not None:
+        transform["pose"]["rpy"] = rpy
+    scale = _as_xyz(item.get("scale")) or _as_xyz(item.get("mesh_scale"))
+    if scale is not None:
+        transform["scale"] = scale
+    return transform
+
+
+def _numbers_close(a: Any, b: Any, path: str = "transform") -> list[str]:
+    errors: list[str] = []
+    if isinstance(a, dict) and isinstance(b, dict):
+        for key in sorted(set(a) | set(b)):
+            if key not in a or key not in b:
+                errors.append(f"{path}.{key}: missing in {'after' if key not in b else 'expected'}")
+            else:
+                errors.extend(_numbers_close(a[key], b[key], f"{path}.{key}"))
+    elif isinstance(a, (int, float)) and isinstance(b, (int, float)):
+        if not (math.isfinite(float(a)) and math.isfinite(float(b))) or not math.isclose(float(a), float(b), rel_tol=1e-9, abs_tol=1e-9):
+            errors.append(f"{path}: expected {a!r}, got {b!r}")
+    else:
+        errors.append(f"{path}: expected {a!r}, got {b!r}")
+    return errors
+
+
+def _strip_allowed_metadata(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {k: _strip_allowed_metadata(v) for k, v in value.items() if k not in _ALLOWED_ITEM_METADATA}
+    if isinstance(value, list):
+        return [_strip_allowed_metadata(v) for v in value]
+    return value
+
+
+def verify(before: dict[str, Any], patch: dict[str, Any], after: dict[str, Any]) -> tuple[bool, list[str], list[str]]:
+    details: list[str] = []
+    errors: list[str] = []
+
+    before_scene_id = _scene_id(before)
+    after_scene_id = _scene_id(after)
+    patch_scene_id = str(patch.get("scene_id", ""))
+    if before_scene_id != patch_scene_id or after_scene_id != patch_scene_id:
+        errors.append(f"scene_id mismatch: before={before_scene_id!r} patch={patch_scene_id!r} after={after_scene_id!r}")
+
+    validation_errors = validate(before, patch)
+    errors.extend(f"patch invalid against before web_scene: {error}" for error in validation_errors)
+
+    before_items = _items_by_id(before)
+    after_items = _items_by_id(after)
+    edited_ids: set[str] = set()
+
+    for index, edit in enumerate(patch.get("edits", []) if isinstance(patch.get("edits"), list) else []):
+        item_id = str(edit.get("item_id", ""))
+        prefix = f"edits[{index}] item {item_id!r}"
+        edited_ids.add(item_id)
+        before_item = before_items.get(item_id)
+        after_item = after_items.get(item_id)
+        if before_item is None:
+            errors.append(f"{prefix}: edited item missing from before web_scene")
+            continue
+        if after_item is None:
+            errors.append(f"{prefix}: edited item missing from after web_scene")
+            continue
+        old_transform = edit.get("old_transform")
+        new_transform = edit.get("new_transform")
+        if not isinstance(old_transform, dict) or not isinstance(new_transform, dict):
+            errors.append(f"{prefix}: old_transform and new_transform must be objects")
+            continue
+        old_errors = _numbers_close(old_transform, _item_transform(before_item), f"{prefix} old_transform")
+        if old_errors:
+            errors.extend(old_errors)
+        new_errors = _numbers_close(new_transform, _item_transform(after_item), f"{prefix} new_transform")
+        if new_errors:
+            errors.extend(new_errors)
+        if not new_errors:
+            details.append(f"PASS edited item {item_id}: new_transform persisted")
+
+    for item_id, before_item in sorted(before_items.items()):
+        after_item = after_items.get(item_id)
+        if after_item is None:
+            errors.append(f"item {item_id!r}: missing from after web_scene")
+            continue
+        if item_id in edited_ids:
+            continue
+        if before_item.get("locked") is True or _is_generated_robot_or_tool(before_item):
+            label = "locked/generated"
+        else:
+            label = "unrelated"
+        if _strip_allowed_metadata(before_item) != _strip_allowed_metadata(after_item):
+            errors.append(f"item {item_id!r}: {label} item changed unexpectedly")
+        else:
+            details.append(f"PASS {label} item {item_id}: unchanged")
+
+    return not errors, details, errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Verify Workcell Studio Web 3D edit persistence after apply --write and re-export.")
+    parser.add_argument("--scene", required=True, type=Path, help="Scene directory used for operator context; not modified.")
+    parser.add_argument("--web-scene-before", required=True, type=Path)
+    parser.add_argument("--patch", required=True, type=Path)
+    parser.add_argument("--web-scene-after", required=True, type=Path)
+    args = parser.parse_args(argv)
+    try:
+        before = _load_json(args.web_scene_before)
+        patch = _load_json(args.patch)
+        after = _load_json(args.web_scene_after)
+    except ValueError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 2
+    ok, details, errors = verify(before, patch, after)
+    print(f"scene: {args.scene}")
+    for detail in details:
+        print(detail)
+    if ok:
+        print("PASS: Web 3D edit persistence verified; generated/locked and unrelated items stayed unchanged.")
+        return 0
+    for error in errors:
+        print(f"FAIL: {error}", file=sys.stderr)
+    print("FAIL: Web 3D edit persistence verification failed.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_workcell_studio_web_scene_edit_persistence.py
+++ b/tests/test_workcell_studio_web_scene_edit_persistence.py
@@ -1,0 +1,168 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APPLICATOR = REPO_ROOT / "scripts" / "apply_workcell_studio_web_scene_edit_patch.py"
+EXPORTER = REPO_ROOT / "scripts" / "export_workcell_studio_web_scene.py"
+VERIFIER = REPO_ROOT / "scripts" / "verify_workcell_studio_web_scene_edit_persistence.py"
+
+
+def _transform(x=0.0, y=0.1, z=0.2, yaw=0.3, scale=None):
+    data = {"pose": {"xyz": {"x": x, "y": y, "z": z}, "rpy": {"x": 0.0, "y": 0.0, "z": yaw}}}
+    if scale is not None:
+        data["scale"] = {"x": scale, "y": scale, "z": scale}
+    return data
+
+
+def _patch(item_id="layout_bin", new_x=0.4, old_x=0.0, scale=None, old_scale=None):
+    return {
+        "schema_version": "workcell_studio_web_scene_edit_patch/v1",
+        "scene_id": "tiny_scene",
+        "source_scene_schema_version": "workcell_studio_web_scene/v1",
+        "created_at": "2026-06-29T00:00:00Z",
+        "created_by": "static_web_viewer",
+        "provenance": {"viewer_version": "test"},
+        "edits": [{
+            "item_id": item_id,
+            "label": item_id,
+            "source": "user_authored",
+            "type": "box",
+            "editable_required": True,
+            "locked_required": False,
+            "operation": "update_transform",
+            "old_transform": _transform(old_x, scale=old_scale),
+            "new_transform": _transform(new_x, scale=scale),
+        }],
+    }
+
+
+def _scene(tmp_path):
+    scene = tmp_path / "scenes" / "tiny_scene"
+    (scene / "layout").mkdir(parents=True)
+    (scene / "generated").mkdir()
+    (scene / "scene_manifest.yaml").write_text(yaml.safe_dump({"scene": {"id": "tiny_scene", "name": "tiny_scene"}}, sort_keys=False), encoding="utf-8")
+    (scene / "cell_definition.yaml").write_text(yaml.safe_dump({"cell": {"id": "tiny_scene", "name": "tiny_scene"}}, sort_keys=False), encoding="utf-8")
+    (scene / "layout" / "workcell_studio_layout.yaml").write_text(yaml.safe_dump({
+        "schema_version": "workcell_studio_layout/v1",
+        "items": [
+            {"id": "layout_bin", "type": "bin", "display_name": "Bin", "pose": {"xyz": [0.0, 0.1, 0.2], "rpy": [0.0, 0.0, 0.3]}, "editable": True, "locked": False},
+            {"id": "other_box", "type": "box", "display_name": "Other", "pose": {"xyz": [1.0, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]}, "editable": True, "locked": False},
+            {"id": "scaled_box", "type": "box", "display_name": "Scaled", "pose": {"xyz": [0.0, 0.1, 0.2], "rpy": [0.0, 0.0, 0.3]}, "scale": [1.0, 1.0, 1.0], "editable": True, "locked": False},
+        ],
+    }, sort_keys=False), encoding="utf-8")
+    (scene / "environment.yaml").write_text(yaml.safe_dump({"schema_version": "workcell_scene/v1", "scene": {"id": "tiny_scene", "name": "tiny_scene"}, "environment": {"assets": []}}, sort_keys=False), encoding="utf-8")
+    (scene / "generated" / "scene_visual_mesh_index.json").write_text(json.dumps({"items": [{"id": "ur5_visual", "role": "robot", "type": "robot", "pose": {"xyz": [0, 0, 0], "rpy": [0, 0, 0]}}]}), encoding="utf-8")
+    return scene
+
+
+def _run(cmd, **kwargs):
+    return subprocess.run([sys.executable, *map(str, cmd)], cwd=REPO_ROOT, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs)
+
+
+def _export(scene, output):
+    result = _run([EXPORTER, "--scene", scene, "--output", output])
+    assert result.returncode == 0, result.stderr
+    return json.loads(Path(output).read_text(encoding="utf-8"))
+
+
+def _write_json(path, data):
+    Path(path).write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def _full_loop(tmp_path, patch):
+    scene = _scene(tmp_path)
+    before_path = tmp_path / "before.json"
+    patch_path = tmp_path / "patch.json"
+    after_path = tmp_path / "after.json"
+    before = _export(scene, before_path)
+    _write_json(patch_path, patch)
+    dry = _run([APPLICATOR, "--scene", scene, "--web-scene", before_path, "--patch", patch_path])
+    assert dry.returncode == 0, dry.stderr
+    write = _run([APPLICATOR, "--scene", scene, "--web-scene", before_path, "--patch", patch_path, "--write"])
+    assert write.returncode == 0, write.stderr
+    after = _export(scene, after_path)
+    verify = _run([VERIFIER, "--scene", scene, "--web-scene-before", before_path, "--patch", patch_path, "--web-scene-after", after_path])
+    return scene, before, after, verify, before_path, patch_path, after_path
+
+
+def test_edited_layout_pose_persists_after_apply_and_reexport(tmp_path):
+    _, _, after, verify, *_ = _full_loop(tmp_path, _patch(new_x=0.7))
+    assert verify.returncode == 0, verify.stderr
+    assert "PASS edited item layout_bin" in verify.stdout
+    item = next(i for i in after["assets"] if i["id"] == "layout_bin")
+    assert item["pose"]["xyz"] == [0.7, 0.1, 0.2]
+
+
+def test_scale_persists_when_supported_by_source_mapping(tmp_path):
+    _, _, after, verify, *_ = _full_loop(tmp_path, _patch("scaled_box", new_x=0.2, scale=1.5, old_scale=1.0))
+    assert verify.returncode == 0, verify.stderr
+    item = next(i for i in after["assets"] if i["id"] == "scaled_box")
+    assert item["scale"] == [1.5, 1.5, 1.5]
+
+
+def test_unrelated_editable_and_locked_generated_items_remain_unchanged(tmp_path):
+    _, before, after, verify, *_ = _full_loop(tmp_path, _patch(new_x=0.8))
+    assert verify.returncode == 0, verify.stderr
+    assert next(i for i in before["assets"] if i["id"] == "other_box") == next(i for i in after["assets"] if i["id"] == "other_box")
+    assert next(i for i in before["robots"] if i["id"] == "ur5_visual") == next(i for i in after["robots"] if i["id"] == "ur5_visual")
+
+
+def test_dry_run_still_writes_nothing(tmp_path):
+    scene = _scene(tmp_path)
+    before_path = tmp_path / "before.json"
+    patch_path = tmp_path / "patch.json"
+    _export(scene, before_path)
+    _write_json(patch_path, _patch(new_x=0.9))
+    layout = scene / "layout" / "workcell_studio_layout.yaml"
+    before_text = layout.read_text(encoding="utf-8")
+    result = _run([APPLICATOR, "--scene", scene, "--web-scene", before_path, "--patch", patch_path])
+    assert result.returncode == 0, result.stderr
+    assert layout.read_text(encoding="utf-8") == before_text
+
+
+def test_verifier_rejects_after_scene_where_edited_item_did_not_change(tmp_path):
+    scene = _scene(tmp_path)
+    before_path = tmp_path / "before.json"
+    patch_path = tmp_path / "patch.json"
+    _export(scene, before_path)
+    _write_json(patch_path, _patch(new_x=0.6))
+    result = _run([VERIFIER, "--scene", scene, "--web-scene-before", before_path, "--patch", patch_path, "--web-scene-after", before_path])
+    assert result.returncode == 1
+    assert "new_transform" in result.stderr
+
+
+def test_verifier_rejects_after_scene_where_unrelated_item_changed(tmp_path):
+    scene, _, after, _, before_path, patch_path, after_path = _full_loop(tmp_path, _patch(new_x=0.6))
+    for item in after["assets"]:
+        if item["id"] == "other_box":
+            item["pose"]["xyz"] = [9, 9, 9]
+    _write_json(after_path, after)
+    result = _run([VERIFIER, "--scene", scene, "--web-scene-before", before_path, "--patch", patch_path, "--web-scene-after", after_path])
+    assert result.returncode == 1
+    assert "unrelated item changed unexpectedly" in result.stderr
+
+
+def test_verifier_rejects_scene_id_mismatch(tmp_path):
+    scene, _, after, _, before_path, patch_path, after_path = _full_loop(tmp_path, _patch(new_x=0.6))
+    after["scene"]["id"] = "wrong_scene"
+    _write_json(after_path, after)
+    result = _run([VERIFIER, "--scene", scene, "--web-scene-before", before_path, "--patch", patch_path, "--web-scene-after", after_path])
+    assert result.returncode == 1
+    assert "scene_id mismatch" in result.stderr
+
+
+def test_verifier_prints_useful_failure_messages(tmp_path):
+    scene = _scene(tmp_path)
+    before_path = tmp_path / "before.json"
+    patch_path = tmp_path / "patch.json"
+    _export(scene, before_path)
+    bad_patch = _patch("missing_item", new_x=0.6)
+    _write_json(patch_path, bad_patch)
+    result = _run([VERIFIER, "--scene", scene, "--web-scene-before", before_path, "--patch", patch_path, "--web-scene-after", before_path])
+    assert result.returncode == 1
+    assert "missing_item" in result.stderr
+    assert "edited item missing" in result.stderr or "item not found" in result.stderr

--- a/workcell_studio_web/viewer/README.md
+++ b/workcell_studio_web/viewer/README.md
@@ -72,6 +72,36 @@ This is not the final Web Studio editor. It intentionally excludes:
 
 This static viewer is only a lightweight browser proof-of-life for reviewing exported scene contract data. It improves readability of exported scenes, but the source-of-truth editing, scene generation, validation, and fake-hardware simulation flows remain in Workcell Studio, generated packages, and RViz/MoveIt.
 
+## Persistence verification loop
+
+The viewer edits are persisted only through the backend applicator; the viewer never writes source YAML, generated files, `cell_definition.yaml`, or `scene_manifest.yaml` directly. For manual verification, use a copied/temp scene rather than a checked-in real scene:
+
+1. Export before `web_scene.json`:
+
+   ```bash
+   python3 scripts/export_workcell_studio_web_scene.py \
+     --scene scenes/ur5_2f_test \
+     --output build/workcell_studio_web_scene/ur5_2f_test.before.web_scene.json
+   ```
+
+2. Open the viewer and edit one `editable=true`, `locked=false` layout/environment item.
+3. Export `edit_patch.json`.
+4. Validate the patch.
+5. Run the applicator dry-run and confirm it writes nothing.
+6. Run the applicator with `--write` on the temp scene only.
+7. Re-export after `web_scene.json`.
+8. Run the persistence verifier:
+
+   ```bash
+   python3 scripts/verify_workcell_studio_web_scene_edit_persistence.py \
+     --scene scenes/ur5_2f_test \
+     --web-scene-before build/workcell_studio_web_scene/ur5_2f_test.before.web_scene.json \
+     --patch build/workcell_studio_web_scene/ur5_2f_test.edit_patch.json \
+     --web-scene-after build/workcell_studio_web_scene/ur5_2f_test.after.web_scene.json
+   ```
+
+9. Only then regenerate and validate the scene package through Workcell Studio backend tooling. RViz/MoveIt remains the fake-hardware planning/simulation truth; this static viewer does not replace it and does not enable real-hardware execution.
+
 ## Preview-only transform editing and edit patches
 
 The static viewer includes a first-pass safe editing surface for Web 3D. When a selected item is both `editable=true` and `locked=false`, the inspector shows XYZ, RPY, and scale inputs. Changing those inputs updates only the in-browser Three.js preview.


### PR DESCRIPTION
### Motivation

- Prove that browser Web 3D edits persist through the full backend loop (export → edit_patch → apply --write → re-export) instead of remaining preview-only.  
- Provide a clear, scriptable, read-only verifier to detect accidental changes to generated/locked items or unrelated data during persistence tests.  
- Preserve safety constraints by using temp-scene fixtures for write tests and keeping fake-hardware-first defaults and generated outputs untouched.

### Description

- Add `scripts/verify_workcell_studio_web_scene_edit_persistence.py`, a read-only verifier that compares before web_scene, edit_patch, and after web_scene and reports item-level PASS/FAIL for transformed items and unchanged locked/generated/unrelated items.  
- Add `tests/test_workcell_studio_web_scene_edit_persistence.py`, a temp-fixture test suite that exercises dry-run, `--write` apply + re-export, scale persistence when supported, locked/generated protection, unrelated-change detection, scene_id mismatch, and helpful failure messages.  
- Update `scripts/export_workcell_studio_web_scene.py` to include authored `scale`/`mesh_scale` fields in exported authored items so scale persistence can be verified when the source mapping supports it.  
- Document the manual/scripted persistence verification loop in `docs/WORKCELL_STUDIO_WEB_3D_EDIT_PATCH.md` and the static viewer README so operators know to use a copied/temp scene and to validate/ dry-run before `--write`.

### Testing

- Ran unit/integration tests: `pytest -q tests/test_workcell_studio_web_scene_contract.py tests/test_workcell_studio_web_scene_edit_patch.py tests/test_workcell_studio_web_scene_edit_patch_apply.py tests/test_workcell_studio_web_scene_edit_persistence.py` and all tests passed.  
- Executed exporter smoke: `python3 scripts/export_workcell_studio_web_scene.py --scene scenes/ur5_2f_test --output build/workcell_studio_web_scene/ur5_2f_test.before.web_scene.json` and it succeeded.  
- Ran readiness matrix: `python3 scripts/run_workcell_studio_scene_readiness_matrix.py --supported-scenes scenes/supported_scenes.yaml --output-dir build/workcell_studio_scene_readiness` and it completed (summary written).  
- ROS build (`colcon build --packages-select workcell_builder`) was not run in this environment because ROS Humble setup was not available here; no ROS/launch commands were added or required for the verifier.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a426bdbeea88331873b915648a122b7)