### PR TITLE
Improve web 3D transform editing UX (gizmo, snap, undo/redo, edit-mode)

### DIFF
--- a/docs/WORKCELL_STUDIO_WEB_3D_EDIT_PATCH.md
+++ b/docs/WORKCELL_STUDIO_WEB_3D_EDIT_PATCH.md
@@ -12,7 +12,7 @@ python3 scripts/export_workcell_studio_web_scene.py \
   --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json
 ```
 
-Open `workcell_studio_web/viewer/index.html`, load the exported `web_scene.json`, edit one `editable=true` and `locked=false` item, then use **Export Edit Patch** to download an edit patch.
+Open `workcell_studio_web/viewer/index.html`, load the exported `web_scene.json`, select one `editable=true` and `locked=false` item, and use edit mode to preview the transform. Editable/unlocked selections show enabled XYZ/RPY/scale fields and a Three.js translation gizmo; locked/generated robot/tool previews remain read-only and explain that source layout/environment should be edited instead. Use **Export Edit Patch** to download an edit patch when the preview state is correct.
 
 Validate the patch before applying it:
 
@@ -50,6 +50,22 @@ python3 scripts/export_workcell_studio_web_scene.py \
   --scene scenes/ur5_2f_test \
   --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json
 ```
+
+
+## Browser edit mode ergonomics
+
+Edit mode is available only for items that are both `editable=true` and `locked=false` and are not generated preview visuals. In edit mode:
+
+- the inspector numeric XYZ/RPY/scale fields remain the authoritative manual transform controls;
+- the Three.js translation gizmo attaches to the selected editable object;
+- gizmo movement updates the inspector fields;
+- inspector numeric changes update the object and attached gizmo;
+- snap can be toggled from the toolbar;
+- translation snap defaults to `0.01` meters;
+- rotation snap defaults to `5` degrees for numeric RPY edits and future rotation-gizmo use;
+- **Undo**, **Redo**, **Clear Preview Edits**, and **Reset Selected** affect browser preview state only.
+
+The dirty state displays “Unsaved preview edits” with the changed item count. Exported `edit_patch.json` records only the final preview transform per changed item, preserving the existing patch schema and backend validator/applicator architecture. The browser does not write source YAML directly, does not mutate `generated/`, and does not apply patches by itself.
 
 ## Persistence verification loop
 
@@ -130,4 +146,4 @@ Web 3D editing is an authoring surface, not a planning or execution backend. No 
 
 ## Next phase
 
-After persistence is proven, the next phase is improving browser transform UX/gizmos while preserving the same dry-run-first backend safety model.
+Next phase is connecting edit/export/apply/re-export/generate/validate into a guided workflow while preserving preview-only browser edits, backend validation/application, and RViz/MoveIt as planning truth.

--- a/tests/test_workcell_studio_web_viewer_transform_ux.py
+++ b/tests/test_workcell_studio_web_viewer_transform_ux.py
@@ -1,0 +1,88 @@
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VIEWER = REPO_ROOT / "workcell_studio_web" / "viewer" / "viewer.js"
+INDEX = REPO_ROOT / "workcell_studio_web" / "viewer" / "index.html"
+
+
+def _viewer_text():
+    return VIEWER.read_text(encoding="utf-8")
+
+
+def _index_text():
+    return INDEX.read_text(encoding="utf-8")
+
+
+def test_viewer_has_edit_mode_guard_for_editable_and_unlocked_items():
+    viewer = _viewer_text()
+    assert "function canEditItem" in viewer
+    assert "item?.locked" in viewer
+    assert "item?.editable !== true" in viewer
+    assert "source.includes('generated')" in viewer
+    assert "sourceIdentity" in viewer
+    assert "active_visual_source" in viewer
+    assert "Edit mode active for editable/unlocked item" in viewer
+
+
+def test_locked_generated_edit_message_exists():
+    assert "Locked/generated preview item; edit source layout/environment instead." in _viewer_text()
+
+
+def test_transform_gizmo_hook_is_loaded_without_build_system():
+    viewer = _viewer_text()
+    assert "TransformControls" in viewer
+    assert "three/addons/controls/TransformControls.js" in viewer
+    assert "attachTransformGizmo" in viewer
+    assert "gizmo.attach(rendered.object3d)" in viewer
+
+
+def test_snap_controls_exist():
+    index = _index_text()
+    viewer = _viewer_text()
+    assert 'id="snap-toggle"' in index
+    assert 'id="translation-snap"' in index
+    assert 'id="rotation-snap"' in index
+    assert "setTranslationSnap" in viewer
+    assert "setRotationSnap" in viewer
+    assert "snapTransform" in viewer
+
+
+def test_undo_redo_clear_preview_edit_controls_exist():
+    index = _index_text()
+    viewer = _viewer_text()
+    assert "Undo" in index
+    assert "Redo" in index
+    assert "Clear Preview Edits" in index
+    assert "undoPreviewEdit" in viewer
+    assert "redoPreviewEdit" in viewer
+    assert "clearPreviewEdits" in viewer
+    assert "undoStack" in viewer
+    assert "redoStack" in viewer
+
+
+def test_patch_export_still_exists_and_remains_preview_only():
+    index = _index_text()
+    viewer = _viewer_text()
+    assert "Export Edit Patch" in index
+    assert "buildEditPatch" in viewer
+    assert "schema_version: EDIT_PATCH_SCHEMA_VERSION" in viewer
+    assert "Preview-only browser transform edit. Source scene files were not modified." in viewer
+
+
+def test_no_direct_yaml_write_or_browser_apply_logic_added():
+    combined = (_viewer_text() + "\n" + _index_text()).lower()
+    forbidden = ["environment.yaml", "workcell_studio_layout.yaml", "yaml.safe_dump", "js-yaml", "apply_workcell_studio_web_scene_edit_patch"]
+    for token in forbidden:
+        assert token not in combined
+
+
+def test_no_generated_scene_json_committed():
+    tracked = subprocess.run(
+        ["git", "ls-files", "*.web_scene.json", "*web_scene.json", "*.edit_patch.json", "*edit_patch.json"],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        check=True,
+    ).stdout.splitlines()
+    assert not tracked

--- a/workcell_studio_web/viewer/README.md
+++ b/workcell_studio_web/viewer/README.md
@@ -104,11 +104,15 @@ The viewer edits are persisted only through the backend applicator; the viewer n
 
 ## Preview-only transform editing and edit patches
 
-The static viewer includes a first-pass safe editing surface for Web 3D. When a selected item is both `editable=true` and `locked=false`, the inspector shows XYZ, RPY, and scale inputs. Changing those inputs updates only the in-browser Three.js preview.
+The static viewer includes a safe editing surface for Web 3D. When a selected item is both `editable=true` and `locked=false`, it enters **edit mode**: the inspector shows XYZ, RPY, and scale inputs, and the Three.js translation gizmo attaches to the selected object. Dragging the gizmo updates the numeric inspector fields; editing numeric fields updates the object and attached gizmo. These changes update only the in-browser Three.js preview.
 
-Locked or generated preview items, including generated robot/tool visuals, keep the transform fields disabled with the reason: “Locked/generated preview item; edit source layout/environment instead.”
+Locked or generated preview items, including generated robot/tool visuals, never enter edit mode. Their transform fields stay disabled with the reason: “Locked/generated preview item; edit source layout/environment instead.”
 
-Use **Export Edit Patch** to download a `workcell_studio_web_scene_edit_patch/v1` JSON file. The patch contains only changed items and does not modify `environment.yaml`, layout YAML, `cell_definition.yaml`, `scene_manifest.yaml`, or generated scene files. **Clear Preview Edits** resets all browser-only changes; **Reset Selected** restores the selected editable item to its original loaded transform.
+The toolbar includes explicit snap controls. **Snap** enables/disables snapping, **Move snap (m)** defaults to `0.01`, and **Rot snap (deg)** defaults to `5`. Translation snap is applied to gizmo movement and numeric preview edits; rotation snap is available for numeric RPY edits and for future gizmo rotation modes. No implicit ground/table snap is performed.
+
+Preview edit history is browser-local. **Undo** reverts the last preview transform change, **Redo** reapplies an undone preview transform change, **Clear Preview Edits** restores every edited object to its loaded transform, and **Reset Selected** restores only the selected editable item. The dirty banner shows “Unsaved preview edits” plus the changed item count.
+
+Use **Export Edit Patch** to download a `workcell_studio_web_scene_edit_patch/v1` JSON file. The patch contains only the final changed preview state and does not modify `environment.yaml`, layout YAML, `cell_definition.yaml`, `scene_manifest.yaml`, or generated scene files. The browser never writes source YAML directly and never bypasses the validator/applicator loop.
 
 Validate exported patches before application:
 

--- a/workcell_studio_web/viewer/index.html
+++ b/workcell_studio_web/viewer/index.html
@@ -26,8 +26,22 @@
         <input id="scene-file" type="file" accept="application/json,.json" />
       </label>
       <button id="reset-view" class="toolbar-button" type="button" disabled>Reset View</button>
+      <button id="undo-edit" class="toolbar-button" type="button" disabled>Undo</button>
+      <button id="redo-edit" class="toolbar-button" type="button" disabled>Redo</button>
       <button id="clear-edits" class="toolbar-button" type="button" disabled>Clear Preview Edits</button>
       <button id="export-edit-patch" class="toolbar-button" type="button" disabled>Export Edit Patch</button>
+      <label class="toolbar-toggle" title="Snap editable preview transforms to grid increments">
+        <input id="snap-toggle" type="checkbox" checked />
+        Snap
+      </label>
+      <label class="toolbar-number" title="Translation snap increment in meters">
+        Move snap (m)
+        <input id="translation-snap" type="number" min="0" step="0.005" value="0.01" />
+      </label>
+      <label class="toolbar-number" title="Rotation snap increment in degrees">
+        Rot snap (deg)
+        <input id="rotation-snap" type="number" min="0" step="1" value="5" />
+      </label>
       <label class="toolbar-toggle" title="Show read-only object labels in the viewer">
         <input id="labels-toggle" type="checkbox" />
         Labels

--- a/workcell_studio_web/viewer/style.css
+++ b/workcell_studio_web/viewer/style.css
@@ -63,6 +63,26 @@ body {
 .toolbar-button:not(:disabled):hover { border-color: var(--accent); background: #14364a; }
 .toolbar-button:disabled { cursor: not-allowed; opacity: 0.45; }
 
+.toolbar-number {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.38rem 0.55rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: rgba(32, 43, 57, 0.72);
+  color: var(--muted);
+  font-size: 0.78rem;
+  white-space: nowrap;
+}
+.toolbar-number input {
+  width: 4.5rem;
+  padding: 0.25rem 0.3rem;
+  border: 1px solid var(--border);
+  border-radius: 0.3rem;
+  background: #0b1018;
+  color: var(--text);
+}
 .toolbar-toggle {
   display: inline-flex;
   align-items: center;
@@ -221,6 +241,7 @@ code { color: #c9f2ff; }
   background: rgba(32, 43, 57, 0.72);
 }
 .transform-editor h3 { margin: 0 0 0.45rem; font-size: 0.9rem; color: var(--accent); }
+.edit-mode-active { border-left: 3px solid var(--accent); padding-left: 0.5rem; }
 .edit-note, .edit-lock-reason { margin: 0 0 0.65rem; color: var(--muted); font-size: 0.8rem; }
 .edit-lock-reason { color: #ffe7a3; }
 .transform-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.45rem; }

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -3,6 +3,7 @@ let OrbitControls;
 let STLLoader;
 let ColladaLoader;
 let OBJLoader;
+let TransformControls;
 
 const SUPPORTED_SCHEMA_VERSION = 'workcell_studio_web_scene/v1';
 const EDIT_PATCH_SCHEMA_VERSION = 'workcell_studio_web_scene_edit_patch/v1';
@@ -11,13 +12,18 @@ const LOCKED_EDIT_REASON = 'Locked/generated preview item; edit source layout/en
 const MIN_FRAME_RADIUS = 1.2;
 const EMPTY_SCENE_MESSAGE = 'Scene contains no renderable robots, tools, assets, sensors, zones, items, or objects.';
 const FRAME_DISTANCE_MULTIPLIER = 2.7;
-const state = { sceneJson: null, sourceWebSceneFile: '', objects: [], selected: null, three: {}, animationId: null, lastFrameBounds: null, runtimeWarnings: [], labelsVisible: false, dirtyTransforms: new Map() };
+const state = { sceneJson: null, sourceWebSceneFile: '', objects: [], selected: null, three: {}, animationId: null, lastFrameBounds: null, runtimeWarnings: [], labelsVisible: false, dirtyTransforms: new Map(), undoStack: [], redoStack: [], gizmoDragStart: null };
 const el = {
   file: document.getElementById('scene-file'),
   resetView: document.getElementById('reset-view'),
+  undoEdit: document.getElementById('undo-edit'),
+  redoEdit: document.getElementById('redo-edit'),
   clearEdits: document.getElementById('clear-edits'),
   exportEditPatch: document.getElementById('export-edit-patch'),
   dirty: document.getElementById('dirty-state'),
+  snapToggle: document.getElementById('snap-toggle'),
+  translationSnap: document.getElementById('translation-snap'),
+  rotationSnap: document.getElementById('rotation-snap'),
   labelsToggle: document.getElementById('labels-toggle'),
   canvas: document.getElementById('scene-canvas'),
   labelLayer: document.getElementById('label-layer'),
@@ -60,10 +66,40 @@ function transformOf(item) {
 }
 function cloneTransform(transform) { return JSON.parse(JSON.stringify(transform)); }
 function sameTransform(a, b) { return JSON.stringify(a) === JSON.stringify(b); }
+function renderedById(id) { return state.objects.find(obj => obj.item.id === id); }
+function transformFromObject(object) {
+  return { pose: { xyz: { x: object.position.x, y: object.position.y, z: object.position.z }, rpy: { x: object.rotation.x, y: object.rotation.y, z: object.rotation.z } }, scale: { x: object.scale.x, y: object.scale.y, z: object.scale.z } };
+}
+function translationSnapValue() { const v = Number(el.translationSnap?.value || 0); return Number.isFinite(v) && v > 0 ? v : null; }
+function rotationSnapRadians() { const v = Number(el.rotationSnap?.value || 0); return Number.isFinite(v) && v > 0 ? THREE.MathUtils.degToRad(v) : null; }
+function snapTransform(transform) {
+  if (!el.snapToggle?.checked) return transform;
+  const out = cloneTransform(transform);
+  const t = translationSnapValue();
+  if (t) for (const axis of ['x', 'y', 'z']) out.pose.xyz[axis] = Math.round(out.pose.xyz[axis] / t) * t;
+  const r = rotationSnapRadians();
+  if (r) for (const axis of ['x', 'y', 'z']) out.pose.rpy[axis] = Math.round(out.pose.rpy[axis] / r) * r;
+  return out;
+}
 function applyTransformToObject(object, transform) {
   object.position.set(transform.pose.xyz.x, transform.pose.xyz.y, transform.pose.xyz.z);
   object.rotation.set(transform.pose.rpy.x, transform.pose.rpy.y, transform.pose.rpy.z, 'XYZ');
   object.scale.set(transform.scale.x, transform.scale.y, transform.scale.z);
+}
+function markDirtyTransform(rendered, next, { pushHistory = true, oldTransform = null } = {}) {
+  if (!rendered || !canEditItem(rendered.item)) return;
+  const previous = oldTransform || state.dirtyTransforms.get(rendered.item.id)?.newTransform || transformFromObject(rendered.object3d);
+  const snapped = snapTransform(next);
+  if (pushHistory && !sameTransform(previous, snapped)) {
+    state.undoStack.push({ itemId: rendered.item.id, before: cloneTransform(previous), after: cloneTransform(snapped) });
+    state.redoStack = [];
+  }
+  applyTransformToObject(rendered.object3d, snapped);
+  if (sameTransform(rendered.originalTransform, snapped)) state.dirtyTransforms.delete(rendered.item.id);
+  else state.dirtyTransforms.set(rendered.item.id, { oldTransform: cloneTransform(rendered.originalTransform), newTransform: cloneTransform(snapped) });
+  syncInspectorTransformFields(rendered);
+  updateDirtyState();
+  updateLabels();
 }
 function primitiveOf(item) {
   return item.primitive || item.primitive_details || item.dimensions || item.geometry || item.primitive_geometry || null;
@@ -252,7 +288,7 @@ function validateSceneJson(json) {
 }
 function initThree() {
   try {
-    if (!THREE?.Scene || !OrbitControls || !STLLoader || !ColladaLoader || !OBJLoader) throw new Error('Three.js modules were not available.');
+    if (!THREE?.Scene || !OrbitControls || !STLLoader || !ColladaLoader || !OBJLoader || !TransformControls) throw new Error('Three.js modules were not available.');
     const renderer = new THREE.WebGLRenderer({ canvas: el.canvas, antialias: true });
     renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
     const scene = new THREE.Scene();
@@ -265,7 +301,25 @@ function initThree() {
     scene.add(new THREE.AxesHelper(0.75));
     scene.add(new THREE.HemisphereLight(0xffffff, 0x223344, 1.2));
     const light = new THREE.DirectionalLight(0xffffff, 1.5); light.position.set(2, -3, 4); scene.add(light);
-    state.three = { renderer, scene, camera, controls, raycaster: new THREE.Raycaster(), pointer: new THREE.Vector2() };
+    const transformControls = new TransformControls(camera, renderer.domElement);
+    transformControls.setMode('translate');
+    transformControls.addEventListener('dragging-changed', event => {
+      controls.enabled = !event.value;
+      const rendered = renderedById(state.selected);
+      if (!rendered || !canEditItem(rendered.item)) return;
+      if (event.value) state.gizmoDragStart = cloneTransform(state.dirtyTransforms.get(rendered.item.id)?.newTransform || transformFromObject(rendered.object3d));
+      else { markDirtyTransform(rendered, transformFromObject(rendered.object3d), { pushHistory: true, oldTransform: state.gizmoDragStart }); state.gizmoDragStart = null; }
+    });
+    transformControls.addEventListener('objectChange', () => {
+      const rendered = renderedById(state.selected);
+      if (!rendered || !canEditItem(rendered.item)) return;
+      const snapped = snapTransform(transformFromObject(rendered.object3d));
+      applyTransformToObject(rendered.object3d, snapped);
+      syncInspectorTransformFields(rendered);
+      updateLabels();
+    });
+    scene.add(transformControls);
+    state.three = { renderer, scene, camera, controls, transformControls, raycaster: new THREE.Raycaster(), pointer: new THREE.Vector2() };
     resize();
     window.addEventListener('resize', resize);
     el.canvas.addEventListener('pointerdown', pickObject);
@@ -340,6 +394,9 @@ function clearSceneObjects() {
 function renderScene(items) {
   clearSceneObjects();
   state.dirtyTransforms.clear();
+  state.undoStack = [];
+  state.redoStack = [];
+  detachTransformGizmo();
   updateDirtyState();
   const scene = state.three.scene;
   for (const item of items) {
@@ -471,7 +528,7 @@ function selectObject(id) {
   }
   updateLabels();
   const rendered = state.objects.find(obj => obj.item.id === id);
-  if (rendered) populateInspector(rendered);
+  if (rendered) { populateInspector(rendered); attachTransformGizmo(rendered); }
 }
 function pickObject(event) {
   const rect = el.canvas.getBoundingClientRect();
@@ -484,8 +541,35 @@ function pickObject(event) {
   if (item?.id) selectObject(item.id);
 }
 
+function attachTransformGizmo(rendered) {
+  const gizmo = state.three.transformControls;
+  if (!gizmo) return;
+  if (rendered && canEditItem(rendered.item)) {
+    gizmo.attach(rendered.object3d);
+    gizmo.visible = true;
+    gizmo.enabled = true;
+    gizmo.setTranslationSnap(el.snapToggle?.checked ? translationSnapValue() : null);
+    gizmo.setRotationSnap(el.snapToggle?.checked ? rotationSnapRadians() : null);
+  } else detachTransformGizmo();
+}
+function detachTransformGizmo() {
+  const gizmo = state.three.transformControls;
+  if (!gizmo) return;
+  gizmo.detach();
+  gizmo.visible = false;
+  gizmo.enabled = false;
+}
+function refreshGizmoSnap() {
+  const gizmo = state.three.transformControls;
+  if (!gizmo) return;
+  gizmo.setTranslationSnap(el.snapToggle?.checked ? translationSnapValue() : null);
+  gizmo.setRotationSnap(el.snapToggle?.checked ? rotationSnapRadians() : null);
+}
 function canEditItem(item) {
-  const source = String(item?.source_kind || item?.source_layer || item?.active_visual_source || '').toLowerCase();
+  const sourceIdentity = [item?.source_kind, item?.source_layer, item?.active_visual_source, item?.role, item?.category]
+    .map(value => String(value || '').toLowerCase())
+    .join(' ');
+  const source = sourceIdentity;
   if (item?.locked || item?.editable !== true || source.includes('generated')) return false;
   return true;
 }
@@ -503,7 +587,15 @@ function renderTransformInputs(rendered) {
     ['scale_x', 'Scale X', transform.scale.x], ['scale_y', 'Scale Y', transform.scale.y], ['scale_z', 'Scale Z', transform.scale.z],
   ];
   const disabled = editable ? '' : 'disabled';
-  return `<section class="transform-editor"><h3>Preview transform editing</h3>${editable ? '<p class="edit-note">Browser preview only. Export Edit Patch to save a JSON patch; source YAML is not modified.</p>' : `<p class="edit-lock-reason">${LOCKED_EDIT_REASON}</p>`}<div class="transform-grid">${fields.map(([name, label, value]) => `<label>${label}<input type="number" step="0.001" data-transform-field="${name}" value="${Number(value).toFixed(6)}" ${disabled}></label>`).join('')}</div><div class="editor-actions"><button id="reset-selected" type="button" ${editable ? '' : 'disabled'}>Reset Selected</button></div></section>`;
+  return `<section class="transform-editor"><h3>Preview transform editing</h3>${editable ? '<p class="edit-note edit-mode-active">Edit mode active for editable/unlocked item. Drag the translation gizmo or use numeric XYZ/RPY/scale fields; browser preview only. Export Edit Patch to save a JSON patch; source YAML is not modified.</p>' : `<p class="edit-lock-reason">${LOCKED_EDIT_REASON}</p>`}<div class="transform-grid">${fields.map(([name, label, value]) => `<label>${label}<input type="number" step="0.001" data-transform-field="${name}" value="${Number(value).toFixed(6)}" ${disabled}></label>`).join('')}</div><div class="editor-actions"><button id="reset-selected" type="button" ${editable ? '' : 'disabled'}>Reset Selected</button></div></section>`;
+}
+function syncInspectorTransformFields(rendered) {
+  if (state.selected !== rendered?.item?.id) return;
+  const editor = el.inspector.querySelector('.transform-editor');
+  if (!editor) return;
+  const transform = state.dirtyTransforms.get(rendered.item.id)?.newTransform || transformFromObject(rendered.object3d);
+  const values = { x: transform.pose.xyz.x, y: transform.pose.xyz.y, z: transform.pose.xyz.z, roll: transform.pose.rpy.x, pitch: transform.pose.rpy.y, yaw: transform.pose.rpy.z, scale_x: transform.scale.x, scale_y: transform.scale.y, scale_z: transform.scale.z };
+  for (const [name, value] of Object.entries(values)) { const input = editor.querySelector(`[data-transform-field="${name}"]`); if (input) input.value = Number(value).toFixed(6); }
 }
 function wireTransformInputs(rendered) {
   const editor = el.inspector.querySelector('.transform-editor');
@@ -512,11 +604,7 @@ function wireTransformInputs(rendered) {
     if (!canEditItem(rendered.item)) return;
     const next = currentTransformFromInputs(editor);
     if (Object.values(next.pose.xyz).concat(Object.values(next.pose.rpy), Object.values(next.scale)).some(v => !Number.isFinite(v))) return;
-    applyTransformToObject(rendered.object3d, next);
-    if (sameTransform(rendered.originalTransform, next)) state.dirtyTransforms.delete(rendered.item.id);
-    else state.dirtyTransforms.set(rendered.item.id, { oldTransform: cloneTransform(rendered.originalTransform), newTransform: cloneTransform(next) });
-    updateDirtyState();
-    updateLabels();
+    markDirtyTransform(rendered, next);
   }));
   const reset = el.inspector.querySelector('#reset-selected');
   if (reset) reset.addEventListener('click', () => resetSelectedTransform(rendered.item.id));
@@ -524,15 +612,15 @@ function wireTransformInputs(rendered) {
 function resetSelectedTransform(id = state.selected) {
   const rendered = state.objects.find(obj => obj.item.id === id);
   if (!rendered || !canEditItem(rendered.item)) return;
-  state.dirtyTransforms.delete(rendered.item.id);
-  applyTransformToObject(rendered.object3d, rendered.originalTransform);
-  updateDirtyState();
+  markDirtyTransform(rendered, rendered.originalTransform);
   populateInspector(rendered);
   updateLabels();
 }
 function updateDirtyState() {
   const dirty = state.dirtyTransforms.size > 0;
   if (el.dirty) { el.dirty.hidden = !dirty; el.dirty.textContent = dirty ? `Unsaved preview edits (${state.dirtyTransforms.size})` : 'No preview edits'; }
+  if (el.undoEdit) el.undoEdit.disabled = state.undoStack.length === 0;
+  if (el.redoEdit) el.redoEdit.disabled = state.redoStack.length === 0;
   if (el.clearEdits) el.clearEdits.disabled = !dirty;
   if (el.exportEditPatch) el.exportEditPatch.disabled = !state.sceneJson;
   populateObjectList();
@@ -540,9 +628,32 @@ function updateDirtyState() {
 function clearPreviewEdits() {
   for (const rendered of state.objects) applyTransformToObject(rendered.object3d, rendered.originalTransform);
   state.dirtyTransforms.clear();
+  state.undoStack = [];
+  state.redoStack = [];
   updateDirtyState();
   if (state.selected) { const rendered = state.objects.find(obj => obj.item.id === state.selected); if (rendered) populateInspector(rendered); }
   updateLabels();
+}
+function applyHistoryEntry(entry, direction) {
+  const rendered = renderedById(entry.itemId);
+  if (!rendered || !canEditItem(rendered.item)) return;
+  const target = direction === 'undo' ? entry.before : entry.after;
+  markDirtyTransform(rendered, target, { pushHistory: false });
+  if (state.selected === rendered.item.id) populateInspector(rendered);
+}
+function undoPreviewEdit() {
+  const entry = state.undoStack.pop();
+  if (!entry) return;
+  applyHistoryEntry(entry, 'undo');
+  state.redoStack.push(entry);
+  updateDirtyState();
+}
+function redoPreviewEdit() {
+  const entry = state.redoStack.pop();
+  if (!entry) return;
+  applyHistoryEntry(entry, 'redo');
+  state.undoStack.push(entry);
+  updateDirtyState();
 }
 function sceneId() { return state.sceneJson?.scene?.id || state.sceneJson?.scene_id || ''; }
 function buildEditPatch() {
@@ -634,6 +745,10 @@ async function loadFile(file) {
     state.sourceWebSceneFile = file.name || '';
     state.runtimeWarnings = [];
     state.dirtyTransforms.clear();
+    state.undoStack = [];
+    state.redoStack = [];
+    state.selected = null;
+    detachTransformGizmo();
     el.empty.hidden = true;
     if (items.length) renderScene(items);
     else renderScene([]);
@@ -647,7 +762,12 @@ async function loadFile(file) {
 
 if (el.resetView) el.resetView.addEventListener('click', resetView);
 if (el.labelsToggle) el.labelsToggle.addEventListener('change', event => setLabelsVisible(event.target.checked));
+if (el.undoEdit) el.undoEdit.addEventListener('click', undoPreviewEdit);
+if (el.redoEdit) el.redoEdit.addEventListener('click', redoPreviewEdit);
 if (el.clearEdits) el.clearEdits.addEventListener('click', clearPreviewEdits);
+if (el.snapToggle) el.snapToggle.addEventListener('change', refreshGizmoSnap);
+if (el.translationSnap) el.translationSnap.addEventListener('input', refreshGizmoSnap);
+if (el.rotationSnap) el.rotationSnap.addEventListener('input', refreshGizmoSnap);
 if (el.exportEditPatch) el.exportEditPatch.addEventListener('click', exportEditPatch);
 
 el.file.addEventListener('change', event => {
@@ -659,11 +779,13 @@ async function boot() {
   try {
     const threeModule = await import('three');
     const controlsModule = await import('three/addons/controls/OrbitControls.js');
+    const transformControlsModule = await import('three/addons/controls/TransformControls.js');
     const stlModule = await import('three/addons/loaders/STLLoader.js');
     const colladaModule = await import('three/addons/loaders/ColladaLoader.js');
     const objModule = await import('three/addons/loaders/OBJLoader.js');
     THREE = threeModule;
     OrbitControls = controlsModule.OrbitControls;
+    TransformControls = transformControlsModule.TransformControls;
     STLLoader = stlModule.STLLoader;
     ColladaLoader = colladaModule.ColladaLoader;
     OBJLoader = objModule.OBJLoader;


### PR DESCRIPTION
### Motivation
- Make browser preview editing more practical and discoverable by adding an edit mode, gizmo, snap, and undo/redo while preserving the existing export/validate/apply persistence architecture.
- Keep safety and provenance guarantees: browser edits remain preview-only, no direct YAML writes, and locked/generated visuals remain non-editable.

### Description
- Add Three.js `TransformControls` translation gizmo (CDN import) that attaches only to items where `editable===true` and not `locked/generated`, and synchronizes with inspector numeric fields (`workcell_studio_web/viewer/viewer.js`).
- Implement snap controls (toolbar UI and snap math) with configurable translation (default `0.01` m) and rotation (default `5`°) and wire them to the gizmo and numeric edits (`index.html`, `style.css`, `viewer.js`).
- Add browser-local undo/redo stacks, `Reset Selected`, `Clear Preview Edits`, dirty tracking banner with changed item count, and history application so exported patches reflect the final preview-only state (`viewer.js`, new tests).
- Preserve edit-patch schema and export behavior (`buildEditPatch` unchanged in contract), keep all backend applicator/validator assumptions intact, and add or update documentation to describe edit mode ergonomics and the preview-only workflow (`workcell_studio_web/viewer/README.md`, `docs/WORKCELL_STUDIO_WEB_3D_EDIT_PATCH.md`).
- Add static tests `tests/test_workcell_studio_web_viewer_transform_ux.py` that assert presence of edit-mode guards, locked/generated messaging, gizmo hook, snap controls, undo/redo/clear controls, and that no browser YAML writes or generated scene JSON files were committed.

### Testing
- Ran `pytest` including the new UX tests: `python3 -m pytest -q tests/test_workcell_studio_web_scene_contract.py tests/test_workcell_studio_web_scene_edit_patch.py tests/test_workcell_studio_web_scene_edit_patch_apply.py tests/test_workcell_studio_web_scene_edit_persistence.py tests/test_workcell_studio_web_viewer_transform_ux.py` — all tests passed (`34 passed`).
- Performed `node --check workcell_studio_web/viewer/viewer.js` which passed and verified module imports for `TransformControls` are used via CDN import map.
- Exported a web scene with `python3 scripts/export_workcell_studio_web_scene.py --scene scenes/ur5_2f_test --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json` and ran readiness summary with `python3 scripts/run_workcell_studio_scene_readiness_matrix.py` which completed successfully in this environment (PASS=0 FAIL=0 BLOCKED=8).
- Did not run ROS/colcon validation because `/home/user/workcell_ws` and `/opt/ros/humble/setup.bash` are not available in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a426e2473308331ba559792f878b658)