### PR TITLE
Add 'Export & Open Web 3D Viewer' action to Workcell Builder

### DIFF
--- a/docs/WORKCELL_STUDIO_WEB_3D_EDIT_PATCH.md
+++ b/docs/WORKCELL_STUDIO_WEB_3D_EDIT_PATCH.md
@@ -14,6 +14,8 @@ python3 scripts/export_workcell_studio_web_scene.py \
 
 Open `workcell_studio_web/viewer/index.html`, load the exported `web_scene.json`, select one `editable=true` and `locked=false` item, and use edit mode to preview the transform. Editable/unlocked selections show enabled XYZ/RPY/scale fields and a Three.js translation gizmo; locked/generated robot/tool previews remain read-only and explain that source layout/environment should be edited instead. Use **Export Edit Patch** to download an edit patch when the preview state is correct.
 
+From Workcell Builder, the **Export & Open Web 3D Viewer** selected-scene action performs only the export-and-open part of this workflow. It writes the export to `build/workcell_studio_web_scene/<scene_id>.web_scene.json` and opens the static viewer. It intentionally does not apply edit patches, write under `scenes/`, mutate source YAML, mutate generated scene files, modify Qt Scene3D visuals, or replace RViz/MoveIt as planning truth. If browser `file://` loading is unreliable, use `python3 -m http.server 8765` from the repository root and browse to `http://localhost:8765/workcell_studio_web/viewer/index.html`.
+
 Validate the patch before applying it:
 
 ```bash

--- a/tests/test_workcell_builder_web_viewer_action.py
+++ b/tests/test_workcell_builder_web_viewer_action.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CPP = ROOT / "workcell_builder/workcell_builder/gui/scene_select.cpp"
+HDR = ROOT / "workcell_builder/workcell_builder/gui/scene_select.h"
+README = ROOT / "workcell_studio_web/viewer/README.md"
+PATCH_DOC = ROOT / "docs/WORKCELL_STUDIO_WEB_3D_EDIT_PATCH.md"
+
+
+def test_web_viewer_action_registered_and_wired_to_export_slot():
+    cpp = CPP.read_text(encoding="utf-8")
+    hdr = HDR.read_text(encoding="utf-8")
+    assert "Export & Open Web 3D Viewer" in cpp
+    assert "export_open_web_3d_viewer_action" in cpp
+    assert "on_export_open_web_3d_viewer_clicked" in cpp
+    assert "void on_export_open_web_3d_viewer_clicked();" in hdr
+    assert "QDesktopServices::openUrl" in cpp
+
+
+def test_web_viewer_action_exports_to_build_not_scenes_or_generated():
+    cpp = CPP.read_text(encoding="utf-8")
+    assert '"scripts" / "export_workcell_studio_web_scene.py"' in cpp
+    assert 'repo_root / "build" / "workcell_studio_web_scene"' in cpp
+    assert 'scene_id + ".web_scene.json"' in cpp
+    assert 'QProcess::execute("python3", args)' in cpp
+    assert '"--scene", QString::fromStdString(scene_dir.string())' in cpp
+    assert '"--output", QString::fromStdString(output_path.string())' in cpp
+    assert 'repo_root / "workcell_studio_web" / "viewer" / "index.html"' in cpp
+
+
+def test_user_facing_failures_and_local_server_fallback_are_present():
+    cpp = CPP.read_text(encoding="utf-8")
+    for text in [
+        "No scene selected",
+        "Exporter script missing",
+        "Scene path missing",
+        "Web 3D scene export failed",
+        "Viewer file missing",
+        "Browser open failed",
+        "python3 -m http.server 8765",
+        "http://localhost:8765/workcell_studio_web/viewer/index.html",
+    ]:
+        assert text in cpp
+
+
+def test_docs_describe_builder_action_and_safety_boundaries():
+    docs = README.read_text(encoding="utf-8") + "\n" + PATCH_DOC.read_text(encoding="utf-8")
+    assert "Export & Open Web 3D Viewer" in docs
+    assert "build/workcell_studio_web_scene/<scene_id>.web_scene.json" in docs
+    assert "does not write under `scenes/`" in docs
+    assert "does not apply edit patches" in docs
+    assert "RViz/MoveIt" in docs
+    assert "python3 -m http.server 8765" in docs

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -50,6 +50,8 @@
 #include <QInputDialog>
 #include <QDir>
 #include <QMessageBox>
+#include <QProcess>
+#include <QPushButton>
 #include <QTreeWidgetItem>
 #include <QHeaderView>
 #include <QSplitter>
@@ -841,6 +843,11 @@ SceneSelect::SceneSelect(QWidget * parent)
   append_info("Task & Grasp Strategy panel initialized for offline recipe preview.");
   append_info("Robot / Tool Compatibility | Check Compatibility | Apply Profile Defaults | Manual Override");
   connect(ui->export_layout_preview_action, &QPushButton::clicked, this, &SceneSelect::export_preview_layout);
+  auto * web_viewer_action = new QPushButton("Export & Open Web 3D Viewer", ui->validate_generate_tab);
+  web_viewer_action->setObjectName("export_open_web_3d_viewer_action");
+  web_viewer_action->setToolTip("Exports the selected scene to build/workcell_studio_web_scene and opens the static browser viewer. Does not mutate scenes or generated files.");
+  ui->generateLayout->insertWidget(8, web_viewer_action);
+  connect(web_viewer_action, &QPushButton::clicked, this, &SceneSelect::on_export_open_web_3d_viewer_clicked);
   connect(ui->fit_cell_action, &QPushButton::clicked, this, &SceneSelect::refresh_preview_status);
   connect(ui->reset_view_action, &QPushButton::clicked, this, [this]() {
     if (ui->visual_layout_canvas) {
@@ -3408,6 +3415,95 @@ void SceneSelect::on_open_scene_folder_clicked()
 // Imported Scene Ready
 // Exported Scene Archive
 
+
+void SceneSelect::on_export_open_web_3d_viewer_clicked()
+{
+  configure_startup_fallback_paths();
+  const int current_index = current_scene_index();
+  if (current_index < 0 || current_index >= static_cast<int>(workcell.scene_vector.size())) {
+    const QString message = "No scene selected. Select or create a scene before opening the Web 3D Viewer.";
+    append_warning(message.toStdString());
+    QMessageBox::warning(this, "Open Web 3D Viewer", message);
+    return;
+  }
+
+  const std::string scene_id = sanitize_scene_name(workcell.scene_vector[current_index].name);
+  const fs::path scene_dir = scenes_path / workcell.scene_vector[current_index].name;
+  if (scene_id.empty()) {
+    const QString message = "No scene selected. The selected scene has an empty or invalid scene ID.";
+    append_error(message.toStdString());
+    QMessageBox::critical(this, "Open Web 3D Viewer", message);
+    return;
+  }
+  boost::system::error_code ec;
+  if (scene_dir.empty() || !fs::exists(scene_dir, ec) || !fs::is_directory(scene_dir, ec)) {
+    const QString message = QString("Scene path missing for selected scene '%1': %2")
+      .arg(QString::fromStdString(scene_id), QString::fromStdString(scene_dir.string()));
+    append_error(message.toStdString());
+    QMessageBox::critical(this, "Open Web 3D Viewer", message);
+    return;
+  }
+
+  fs::path repo_root = resolve_tool_root(workcell_path, scene_dir);
+  fs::path exporter_script;
+  if (!repo_root.empty()) {
+    exporter_script = repo_root / "scripts" / "export_workcell_studio_web_scene.py";
+  }
+  if (repo_root.empty() || !fs::exists(exporter_script, ec)) {
+    const QString message = QString(
+      "Exporter script missing. Expected scripts/export_workcell_studio_web_scene.py under the Workcell Studio repo root. "
+      "Set WORKCELL_STUDIO_REPO_ROOT=/path/to/easy_manipulation_deployment. Scene path: %1")
+      .arg(QString::fromStdString(scene_dir.string()));
+    append_error(message.toStdString());
+    QMessageBox::critical(this, "Open Web 3D Viewer", message);
+    return;
+  }
+
+  const fs::path output_path = repo_root / "build" / "workcell_studio_web_scene" / (scene_id + ".web_scene.json");
+  const fs::path viewer_path = repo_root / "workcell_studio_web" / "viewer" / "index.html";
+  fs::create_directories(output_path.parent_path(), ec);
+  const QStringList args{
+    QString::fromStdString(exporter_script.string()),
+    "--scene", QString::fromStdString(scene_dir.string()),
+    "--output", QString::fromStdString(output_path.string())};
+  append_info("Export Web 3D Viewer scene: python3 " + args.join(' ').toStdString());
+  const int rc = QProcess::execute("python3", args);
+  if (rc != 0 || !fs::exists(output_path, ec)) {
+    const QString message = QString("Web 3D scene export failed with exit code %1. Exporter: %2\nScene: %3\nOutput: %4")
+      .arg(rc)
+      .arg(QString::fromStdString(exporter_script.string()), QString::fromStdString(scene_dir.string()), QString::fromStdString(output_path.string()));
+    append_error(message.toStdString());
+    QMessageBox::critical(this, "Open Web 3D Viewer", message);
+    return;
+  }
+  append_success("Exported Web 3D scene JSON: " + output_path.string());
+
+  if (!fs::exists(viewer_path, ec)) {
+    const QString message = QString("Viewer file missing: %1\nExported JSON: %2")
+      .arg(QString::fromStdString(viewer_path.string()), QString::fromStdString(output_path.string()));
+    append_error(message.toStdString());
+    QMessageBox::critical(this, "Open Web 3D Viewer", message);
+    return;
+  }
+
+  const bool opened = QDesktopServices::openUrl(QUrl::fromLocalFile(QString::fromStdString(viewer_path.string())));
+  const QString fallback = QString(
+    "Viewer path: %1\n"
+    "Exported JSON path: %2\n\n"
+    "If direct file loading is blocked by your browser, run this from the repository root:\n"
+    "python3 -m http.server 8765\n\n"
+    "Then open:\n"
+    "http://localhost:8765/workcell_studio_web/viewer/index.html")
+    .arg(QString::fromStdString(viewer_path.string()), QString::fromStdString(output_path.string()));
+  if (!opened) {
+    const QString message = "Browser open failed. Use the local-server fallback below.\n\n" + fallback;
+    append_error(message.toStdString());
+    QMessageBox::critical(this, "Open Web 3D Viewer", message);
+    return;
+  }
+  append_success("Opened Web 3D Viewer: " + viewer_path.string());
+  QMessageBox::information(this, "Open Web 3D Viewer", fallback);
+}
 
 void SceneSelect::on_export_scene_bundle_clicked()
 {

--- a/workcell_builder/workcell_builder/gui/scene_select.h
+++ b/workcell_builder/workcell_builder/gui/scene_select.h
@@ -124,6 +124,7 @@ private slots:
   void on_browse_scenes_folder_clicked();
   void on_refresh_scenes_button_clicked();
   void on_export_scene_bundle_clicked();
+  void on_export_open_web_3d_viewer_clicked();
   void on_import_scene_bundle_clicked();
   void on_refresh_status_button_clicked();
   void on_validate_scene_button_clicked();

--- a/workcell_studio_web/viewer/README.md
+++ b/workcell_studio_web/viewer/README.md
@@ -14,6 +14,18 @@ python3 scripts/export_workcell_studio_web_scene.py --scene scenes/ur5_2f_test -
 
 `build/` outputs are local artifacts and should not be committed.
 
+### Workcell Builder action
+
+Workcell Builder also exposes a selected-scene action named **Export & Open Web 3D Viewer** in the Safety / Review flow. The action resolves the selected scene, runs `scripts/export_workcell_studio_web_scene.py`, writes only to `build/workcell_studio_web_scene/<scene_id>.web_scene.json`, and opens `workcell_studio_web/viewer/index.html` with Qt/QDesktopServices. It does not write under `scenes/`, mutate source YAML, mutate generated scene files, apply edit patches, or change RViz/MoveIt planning truth.
+
+If direct `file://` loading is blocked or unreliable in your browser, run this from the repository root and open the URL manually:
+
+```bash
+python3 -m http.server 8765
+```
+
+URL: `http://localhost:8765/workcell_studio_web/viewer/index.html`
+
 ## Open the viewer
 
 1. Open `workcell_studio_web/viewer/index.html` directly in a browser.


### PR DESCRIPTION
### Motivation
- Provide a convenient, safe selected-scene action in the Workcell Builder UI to export the current scene for the static Web 3D viewer and open the viewer without mutating source or generated artifacts.
- Keep the workflow read-only and preserve fake-hardware-first safety while improving discoverability of the existing `workcell_studio_web` viewer flow.

### Description
- Added a new selected-scene UI button `Export & Open Web 3D Viewer` in `SceneSelect` that resolves the selected scene and invokes the exporter script `scripts/export_workcell_studio_web_scene.py`. (`workcell_builder/workcell_builder/gui/scene_select.cpp`, `workcell_builder/workcell_builder/gui/scene_select.h`).
- The action writes the export to `build/workcell_studio_web_scene/<scene_id>.web_scene.json` and attempts to open `workcell_studio_web/viewer/index.html` via `QDesktopServices::openUrl`, with a clear local-server fallback (`python3 -m http.server 8765`) and URL `http://localhost:8765/workcell_studio_web/viewer/index.html` if direct file loading fails.
- Surface explicit user-facing failure dialogs for: no scene selected, invalid/empty scene id, scene path missing, exporter script missing, export failure, viewer file missing, and browser-open failure.
- Updated documentation to mention the Workcell Builder action and safety boundaries (`workcell_studio_web/viewer/README.md` and `docs/WORKCELL_STUDIO_WEB_3D_EDIT_PATCH.md`).
- Added lightweight static tests that assert action registration, export path contract, presence of user-facing messages/fallback, and doc updates (`tests/test_workcell_builder_web_viewer_action.py`).

### Testing
- Ran `python3 -m pytest tests/test_workcell_builder_web_viewer_action.py` and it passed (4 tests). 
- Validated the exporter invocation end-to-end with `python3 scripts/export_workcell_studio_web_scene.py --scene scenes/ur5_2f_test --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json` which produced the expected `build/` JSON output. 
- Ran `git diff --check` as a quick code-health check and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4271acae008331ad1f51f704914f18)