### PR TITLE
Add guided Web 3D edit workflow

### DIFF
--- a/docs/WORKCELL_STUDIO_WEB_3D_EDIT_PATCH.md
+++ b/docs/WORKCELL_STUDIO_WEB_3D_EDIT_PATCH.md
@@ -149,3 +149,50 @@ Web 3D editing is an authoring surface, not a planning or execution backend. No 
 ## Next phase
 
 Next phase is connecting edit/export/apply/re-export/generate/validate into a guided workflow while preserving preview-only browser edits, backend validation/application, and RViz/MoveIt as planning truth.
+
+## Guided backend edit workflow
+
+Use `scripts/run_workcell_studio_web_edit_workflow.py` to run the supported backend path for a browser-exported Web 3D edit patch without hand-copying every command.
+
+Recommended operator flow:
+
+1. In Workcell Builder, select a scene and use **Export & Open Web 3D Viewer**.
+2. Edit an editable, unlocked physical scene item in the browser.
+3. Export `edit_patch.json` from the browser. The browser exports a preview patch only; it never writes YAML directly.
+4. Run the guided workflow in safe dry-run mode:
+
+   ```bash
+   python3 scripts/run_workcell_studio_web_edit_workflow.py \
+     --scene scenes/ur5_2f_test \
+     --patch build/workcell_studio_web_scene/ur5_2f_test.edit_patch.json
+   ```
+
+   The default command exports `build/workcell_studio_web_scene/<scene_id>.before.web_scene.json`, validates the patch, and runs the existing safe applicator in dry-run mode. It does not mutate source files.
+
+5. When the dry-run output is clean, apply explicitly with `--write`:
+
+   ```bash
+   python3 scripts/run_workcell_studio_web_edit_workflow.py \
+     --scene scenes/ur5_2f_test \
+     --patch build/workcell_studio_web_scene/ur5_2f_test.edit_patch.json \
+     --write
+   ```
+
+   With `--write`, the workflow still validates and dry-runs first, then applies through the safe backend applicator, re-exports `build/workcell_studio_web_scene/<scene_id>.after.web_scene.json`, and runs persistence verification.
+
+Optional modes:
+
+- `--export-only` exports the before web scene and does not require a patch.
+- `--validate-only` validates a patch against the exported before web scene and does not apply it.
+- `--dry-run-apply` is available for explicit dry-run wording; dry-run is already the default when `--write` is omitted.
+- `--verify-persistence` requests persistence verification for write workflows; `--write` already performs it.
+- `--run-readiness` optionally runs the scene readiness matrix after the edit workflow.
+- `--output-dir` changes where before/after web scene JSON files are written.
+
+Safety notes:
+
+- Source scene files are not mutated unless `--write` is present.
+- Locked/generated robot and tool preview edits are rejected by the validator/applicator path.
+- Generated files are not edited directly.
+- Browser edits remain patch requests; YAML persistence is owned by the backend validator/applicator.
+- RViz/MoveIt remains the planning and simulation truth after scene generation and validation.

--- a/scripts/run_workcell_studio_web_edit_workflow.py
+++ b/scripts/run_workcell_studio_web_edit_workflow.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Guided backend workflow for Workcell Studio Web 3D edit patches.
+
+The workflow is safe by default: it exports a before web_scene, validates the
+browser-produced edit_patch, and runs the existing applicator in dry-run mode.
+Source YAML is mutated only when --write is explicitly provided. Browser output
+is never trusted to write scene YAML directly.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from export_workcell_studio_web_scene import build_web_scene  # noqa: E402
+from validate_workcell_studio_web_scene_edit_patch import _load_json, _scene_id, validate  # noqa: E402
+
+
+def _scene_id_from_dir(scene: Path) -> str:
+    return scene.resolve().name
+
+
+def _write_web_scene(scene: Path, output: Path) -> dict[str, Any]:
+    payload = build_web_scene(scene)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return payload
+
+
+def _run_step(label: str, cmd: list[str]) -> int:
+    print(f"\n== {label} ==")
+    print("command: " + " ".join(cmd))
+    result = subprocess.run(cmd, cwd=REPO_ROOT, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if result.stdout:
+        print(result.stdout, end="")
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)
+    print(f"{label} result: {'PASS' if result.returncode == 0 else 'FAIL'}")
+    return result.returncode
+
+
+def _validate_patch(before: dict[str, Any], patch_path: Path) -> tuple[bool, dict[str, Any] | None, list[str]]:
+    try:
+        patch = _load_json(patch_path)
+    except ValueError as exc:
+        return False, None, [str(exc)]
+    errors = validate(before, patch)
+    return not errors, patch, errors
+
+
+def _print_next_write_command(args: argparse.Namespace) -> None:
+    print("\nNext recommended action:")
+    print(
+        "  python3 scripts/run_workcell_studio_web_edit_workflow.py "
+        f"--scene {args.scene} --patch {args.patch} --output-dir {args.output_dir} --write"
+    )
+
+
+def _print_next_generate_validate(scene: Path) -> None:
+    print("\nNext recommended action:")
+    print(f"  python3 scripts/validate_builder_generated_scene.py {scene} --json")
+    print("  Then use the existing fake-hardware RViz/MoveIt workflow when validation is clean.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run the safe guided backend workflow for Workcell Studio Web 3D edit patches.")
+    parser.add_argument("--scene", required=True, type=Path, help="Scene directory, for example scenes/ur5_2f_test")
+    parser.add_argument("--patch", type=Path, help="Browser-exported workcell_studio_web_scene_edit_patch/v1 JSON")
+    parser.add_argument("--output-dir", default=Path("build/workcell_studio_web_scene"), type=Path)
+    parser.add_argument("--export-only", action="store_true", help="Only export the before web_scene; does not require --patch.")
+    parser.add_argument("--validate-only", action="store_true", help="Export before web_scene and validate the patch; do not apply.")
+    parser.add_argument("--dry-run-apply", action="store_true", help="Run the existing applicator in dry-run mode. This is also the default when --write is omitted.")
+    parser.add_argument("--write", action="store_true", help="Explicitly mutate editable source YAML through the safe applicator after validation and dry-run pass.")
+    parser.add_argument("--verify-persistence", action="store_true", help="After --write, re-export and run persistence verification. --write already enables this.")
+    parser.add_argument("--run-readiness", action="store_true", help="Optionally run the scene readiness matrix after the edit workflow.")
+    args = parser.parse_args(argv)
+
+    scene = args.scene
+    output_dir = args.output_dir
+    scene_id = _scene_id_from_dir(scene)
+    before_path = output_dir / f"{scene_id}.before.web_scene.json"
+    after_path = output_dir / f"{scene_id}.after.web_scene.json"
+
+    print("Workcell Studio Web 3D guided edit workflow")
+    print(f"selected scene: {scene}")
+    print(f"patch path: {args.patch if args.patch else '(not required for --export-only)'}")
+    print(f"before web_scene path: {before_path}")
+    print(f"write enabled: {bool(args.write)}")
+
+    if not scene.exists() or not scene.is_dir():
+        print(f"FAIL: scene missing or not a directory: {scene}", file=sys.stderr)
+        return 2
+    if not args.export_only and args.patch is None:
+        print("FAIL: --patch is required unless --export-only is used", file=sys.stderr)
+        return 2
+    if args.patch is not None and not args.patch.exists():
+        print(f"FAIL: patch missing: {args.patch}", file=sys.stderr)
+        return 2
+
+    try:
+        before = _write_web_scene(scene, before_path)
+    except Exception as exc:  # noqa: BLE001 - CLI needs clear operator failure.
+        print(f"FAIL: before web_scene export failed for {scene}: {exc}", file=sys.stderr)
+        return 1
+    print(f"export before result: PASS ({before_path})")
+
+    if args.export_only:
+        print("export-only result: PASS; no patch was required and no source files were modified.")
+        print("Next recommended action: open the web viewer, edit an editable object, and export edit_patch.json.")
+        return 0
+
+    assert args.patch is not None
+    ok, patch, errors = _validate_patch(before, args.patch)
+    if not ok:
+        print("patch validation result: FAIL", file=sys.stderr)
+        for error in errors:
+            print(f"FAIL: {error}", file=sys.stderr)
+        print("write/apply result: SKIPPED because validation failed")
+        return 1
+    print(f"patch validation result: PASS (scene_id={patch.get('scene_id') if patch else _scene_id(before)})")
+
+    if args.validate_only:
+        print("validate-only result: PASS; no apply was attempted and no source files were modified.")
+        _print_next_write_command(args)
+        return 0
+
+    dry_cmd = [sys.executable, str(SCRIPT_DIR / "apply_workcell_studio_web_scene_edit_patch.py"), "--scene", str(scene), "--web-scene", str(before_path), "--patch", str(args.patch)]
+    dry_rc = _run_step("dry-run apply", dry_cmd)
+    if dry_rc != 0:
+        print("dry-run result: FAIL; write/apply is blocked", file=sys.stderr)
+        return dry_rc
+    print("dry-run result: PASS; no source files were modified by the dry run")
+
+    if not args.write:
+        print("write/apply result: SKIPPED; pass --write to mutate editable source YAML through the safe applicator")
+        _print_next_write_command(args)
+        return 0
+
+    write_cmd = [*dry_cmd, "--write"]
+    write_rc = _run_step("write apply", write_cmd)
+    if write_rc != 0:
+        print("write/apply result: FAIL", file=sys.stderr)
+        return write_rc
+    print("write/apply result: PASS")
+
+    try:
+        _write_web_scene(scene, after_path)
+    except Exception as exc:  # noqa: BLE001
+        print(f"FAIL: after web_scene export failed for {scene}: {exc}", file=sys.stderr)
+        return 1
+    print(f"after web_scene path: {after_path}")
+    print("re-export after result: PASS")
+
+    verify_rc = 0
+    if args.write or args.verify_persistence:
+        verify_cmd = [sys.executable, str(SCRIPT_DIR / "verify_workcell_studio_web_scene_edit_persistence.py"), "--scene", str(scene), "--web-scene-before", str(before_path), "--patch", str(args.patch), "--web-scene-after", str(after_path)]
+        verify_rc = _run_step("persistence verification", verify_cmd)
+        print(f"persistence verification result: {'PASS' if verify_rc == 0 else 'FAIL'}")
+        if verify_rc != 0:
+            return verify_rc
+
+    if args.run_readiness:
+        readiness_cmd = [sys.executable, str(SCRIPT_DIR / "run_workcell_studio_scene_readiness_matrix.py"), "--supported-scenes", "scenes/supported_scenes.yaml", "--output-dir", "build/workcell_studio_scene_readiness"]
+        readiness_rc = _run_step("readiness matrix", readiness_cmd)
+        print(f"readiness result: {'PASS' if readiness_rc == 0 else 'FAIL'}")
+        if readiness_rc != 0:
+            return readiness_rc
+    else:
+        print("readiness result: SKIPPED (pass --run-readiness to run it)")
+
+    print("\nWorkflow summary: PASS")
+    _print_next_generate_validate(scene)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_workcell_studio_web_edit_workflow.py
+++ b/tests/test_workcell_studio_web_edit_workflow.py
@@ -1,0 +1,164 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / "scripts" / "run_workcell_studio_web_edit_workflow.py"
+
+
+def _transform(x=0.0):
+    return {"pose": {"xyz": {"x": x, "y": 0.1, "z": 0.2}, "rpy": {"x": 0.0, "y": 0.0, "z": 0.3}}}
+
+
+def _patch(scene_id="tiny_scene", item_id="layout_bin", new_x=0.4):
+    return {
+        "schema_version": "workcell_studio_web_scene_edit_patch/v1",
+        "scene_id": scene_id,
+        "source_scene_schema_version": "workcell_studio_web_scene/v1",
+        "created_at": "2026-06-29T00:00:00Z",
+        "created_by": "static_web_viewer",
+        "provenance": {"viewer_version": "test"},
+        "edits": [{
+            "item_id": item_id,
+            "label": item_id,
+            "source": "user_authored",
+            "type": "box",
+            "editable_required": True,
+            "locked_required": False,
+            "operation": "update_transform",
+            "old_transform": _transform(0.0),
+            "new_transform": _transform(new_x),
+        }],
+    }
+
+
+def _scene(tmp_path):
+    scene = tmp_path / "scenes" / "tiny_scene"
+    (scene / "layout").mkdir(parents=True)
+    (scene / "generated").mkdir()
+    (scene / "scene_manifest.yaml").write_text(yaml.safe_dump({"scene": {"id": "tiny_scene", "name": "tiny_scene"}}, sort_keys=False), encoding="utf-8")
+    (scene / "cell_definition.yaml").write_text(yaml.safe_dump({"cell": {"id": "tiny_scene", "name": "tiny_scene"}}, sort_keys=False), encoding="utf-8")
+    (scene / "layout" / "workcell_studio_layout.yaml").write_text(yaml.safe_dump({
+        "schema_version": "workcell_studio_layout/v1",
+        "items": [
+            {"id": "layout_bin", "type": "bin", "display_name": "Bin", "pose": {"xyz": [0.0, 0.1, 0.2], "rpy": [0.0, 0.0, 0.3]}, "editable": True, "locked": False},
+        ],
+    }, sort_keys=False), encoding="utf-8")
+    (scene / "environment.yaml").write_text(yaml.safe_dump({"schema_version": "workcell_scene/v1", "scene": {"id": "tiny_scene", "name": "tiny_scene"}, "environment": {"assets": []}}, sort_keys=False), encoding="utf-8")
+    (scene / "generated" / "scene_visual_mesh_index.json").write_text(json.dumps({"items": [{"id": "ur5_visual", "role": "robot", "type": "robot", "pose": {"xyz": [0, 0, 0], "rpy": [0, 0, 0]}}]}), encoding="utf-8")
+    return scene
+
+
+def _write_patch(tmp_path, patch):
+    path = tmp_path / "patch.json"
+    path.write_text(json.dumps(patch, indent=2), encoding="utf-8")
+    return path
+
+
+def _run(scene, patch=None, output_dir=None, *extra):
+    cmd = [sys.executable, str(WORKFLOW), "--scene", str(scene)]
+    if patch is not None:
+        cmd += ["--patch", str(patch)]
+    if output_dir is not None:
+        cmd += ["--output-dir", str(output_dir)]
+    cmd += list(extra)
+    return subprocess.run(cmd, cwd=REPO_ROOT, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def test_default_mode_does_not_mutate_source_files_and_creates_before(tmp_path):
+    scene = _scene(tmp_path)
+    patch = _write_patch(tmp_path, _patch())
+    out = tmp_path / "out"
+    layout = scene / "layout" / "workcell_studio_layout.yaml"
+    before_text = layout.read_text(encoding="utf-8")
+    result = _run(scene, patch, out)
+    assert result.returncode == 0, result.stderr
+    assert "dry-run result: PASS" in result.stdout
+    assert "write/apply result: SKIPPED" in result.stdout
+    assert (out / "tiny_scene.before.web_scene.json").exists()
+    assert not (out / "tiny_scene.after.web_scene.json").exists()
+    assert layout.read_text(encoding="utf-8") == before_text
+
+
+def test_write_applies_reexports_and_verifies_persistence(tmp_path):
+    scene = _scene(tmp_path)
+    patch = _write_patch(tmp_path, _patch(new_x=0.7))
+    out = tmp_path / "out"
+    result = _run(scene, patch, out, "--write")
+    assert result.returncode == 0, result.stderr
+    assert "write/apply result: PASS" in result.stdout
+    assert "persistence verification result: PASS" in result.stdout
+    assert (out / "tiny_scene.before.web_scene.json").exists()
+    assert (out / "tiny_scene.after.web_scene.json").exists()
+    data = yaml.safe_load((scene / "layout" / "workcell_studio_layout.yaml").read_text(encoding="utf-8"))
+    assert data["items"][0]["pose"]["xyz"] == [0.7, 0.1, 0.2]
+
+
+def test_invalid_patch_fails_before_write(tmp_path):
+    scene = _scene(tmp_path)
+    bad = _patch()
+    bad["schema_version"] = "wrong"
+    patch = _write_patch(tmp_path, bad)
+    layout = scene / "layout" / "workcell_studio_layout.yaml"
+    before_text = layout.read_text(encoding="utf-8")
+    result = _run(scene, patch, tmp_path / "out", "--write")
+    assert result.returncode == 1
+    assert "patch validation result: FAIL" in result.stderr
+    assert "write/apply result: SKIPPED" in result.stdout + result.stderr
+    assert layout.read_text(encoding="utf-8") == before_text
+
+
+def test_scene_id_mismatch_fails_before_write(tmp_path):
+    scene = _scene(tmp_path)
+    patch = _write_patch(tmp_path, _patch(scene_id="wrong_scene"))
+    result = _run(scene, patch, tmp_path / "out", "--write")
+    assert result.returncode == 1
+    assert "scene_id mismatch" in result.stderr
+
+
+def test_locked_generated_edit_fails_before_write(tmp_path):
+    scene = _scene(tmp_path)
+    patch = _write_patch(tmp_path, _patch(item_id="ur5_visual"))
+    result = _run(scene, patch, tmp_path / "out", "--write")
+    assert result.returncode == 1
+    assert "locked=true items cannot be edited" in result.stderr
+    assert "generated robot/tool preview items cannot be edited" in result.stderr
+
+
+def test_missing_patch_gives_useful_error(tmp_path):
+    scene = _scene(tmp_path)
+    result = _run(scene, tmp_path / "missing.json", tmp_path / "out")
+    assert result.returncode == 2
+    assert "patch missing" in result.stderr
+
+
+def test_export_only_only_exports_and_does_not_require_patch(tmp_path):
+    scene = _scene(tmp_path)
+    out = tmp_path / "out"
+    result = _run(scene, None, out, "--export-only")
+    assert result.returncode == 0, result.stderr
+    assert "export-only result: PASS" in result.stdout
+    assert (out / "tiny_scene.before.web_scene.json").exists()
+
+
+def test_validate_only_validates_and_does_not_write(tmp_path):
+    scene = _scene(tmp_path)
+    patch = _write_patch(tmp_path, _patch(new_x=0.8))
+    layout = scene / "layout" / "workcell_studio_layout.yaml"
+    before_text = layout.read_text(encoding="utf-8")
+    result = _run(scene, patch, tmp_path / "out", "--validate-only")
+    assert result.returncode == 0, result.stderr
+    assert "validate-only result: PASS" in result.stdout
+    assert "dry-run apply" not in result.stdout
+    assert layout.read_text(encoding="utf-8") == before_text
+
+
+def test_run_readiness_is_optional_for_core_flow(tmp_path):
+    scene = _scene(tmp_path)
+    patch = _write_patch(tmp_path, _patch())
+    result = _run(scene, patch, tmp_path / "out")
+    assert result.returncode == 0, result.stderr
+    assert "readiness matrix" not in result.stdout

--- a/workcell_studio_web/viewer/README.md
+++ b/workcell_studio_web/viewer/README.md
@@ -154,3 +154,28 @@ python3 scripts/apply_workcell_studio_web_scene_edit_patch.py \
 ```
 
 Re-export `web_scene.json` after `--write` to confirm the edited pose persists. The applicator does not launch ROS, does not mutate `generated/`, `cell_definition.yaml`, or `scene_manifest.yaml`, and does not replace RViz/MoveIt as the planning and fake-hardware simulation truth.
+
+## Guided backend edit workflow
+
+The static viewer exports preview-only `edit_patch.json` files. It does **not** write scene YAML directly. After editing an unlocked editable object in the browser, use the repository backend workflow to validate, dry-run, apply, re-export, and verify persistence.
+
+Safe dry-run command:
+
+```bash
+python3 scripts/run_workcell_studio_web_edit_workflow.py \
+  --scene scenes/ur5_2f_test \
+  --patch build/workcell_studio_web_scene/ur5_2f_test.edit_patch.json
+```
+
+Apply only after reviewing the dry-run output:
+
+```bash
+python3 scripts/run_workcell_studio_web_edit_workflow.py \
+  --scene scenes/ur5_2f_test \
+  --patch build/workcell_studio_web_scene/ur5_2f_test.edit_patch.json \
+  --write
+```
+
+The guided workflow exports a before `web_scene`, validates the patch, runs the safe applicator in dry-run mode, and only mutates editable source YAML when `--write` is explicit. In write mode it re-exports an after `web_scene` and verifies persistence. Pass `--run-readiness` only when you also want the optional readiness matrix.
+
+This viewer workflow is still upstream of the normal Workcell Studio generate/validate/simulate path. RViz/MoveIt remains the planning truth, and fake-hardware-first safety defaults are unchanged.


### PR DESCRIPTION
### Motivation
- Make the browser → backend edit/apply/re-export/verify path a single guided, safe operator workflow instead of many manual commands.
- Preserve existing safety gates: preview-only browser exports, validation before apply, dry-run by default, and no mutation without explicit `--write`.
- Provide an operator-friendly CLI that reuses existing exporter/validator/applicator/verifier and surfaces clear next steps for generate/validate and readiness runs.

### Description
- Add `scripts/run_workcell_studio_web_edit_workflow.py`, a workflow that exports a before `web_scene`, validates a browser `edit_patch.json`, runs a dry-run apply, optionally runs the safe applicator with `--write`, re-exports an after `web_scene`, runs persistence verification, and can optionally run the readiness matrix. 
- Reuse existing tools: `export_workcell_studio_web_scene.py`, `validate_workcell_studio_web_scene_edit_patch.py`, `apply_workcell_studio_web_scene_edit_patch.py`, `verify_workcell_studio_web_scene_edit_persistence.py`, and `run_workcell_studio_scene_readiness_matrix.py`. 
- Add tests in `tests/test_workcell_studio_web_edit_workflow.py` covering dry-run safety, `--write` apply/re-export/verify, invalid patch/scene_id/locked/generated rejection, missing patch, `--export-only`, and `--validate-only`. 
- Update docs `docs/WORKCELL_STUDIO_WEB_3D_EDIT_PATCH.md` and `workcell_studio_web/viewer/README.md` with a “Guided backend edit workflow” section and usage examples and safety notes.

### Testing
- Ran `pytest -q tests/test_workcell_studio_web_edit_workflow.py tests/test_workcell_studio_web_scene_edit_patch.py tests/test_workcell_studio_web_scene_edit_patch_apply.py tests/test_workcell_studio_web_scene_edit_persistence.py`, which passed (32 tests). 
- Ran `pytest -q tests/test_workcell_studio_web_scene_contract.py tests/test_workcell_studio_web_viewer_transform_ux.py`, which passed (11 tests). 
- Executed `python3 scripts/run_workcell_studio_web_edit_workflow.py --scene scenes/ur5_2f_test --export-only`, which exported the before web_scene successfully, and ran the readiness matrix command `python3 scripts/run_workcell_studio_scene_readiness_matrix.py` which produced a summary (`PASS=0 FAIL=0 BLOCKED=8`); both runs completed in the test environment. 
- `colcon` build for `workcell_builder` was not executed because `/opt/ros/humble/setup.bash` was unavailable in the container and was therefore skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42731b1838833195f5c3d1b16d5c1a)