### PR TITLE
Add Workcell Builder Web Edit Patch workflow (Validate / Dry-run / Apply)

### DIFF
--- a/docs/WORKCELL_STUDIO_WEB_3D_EDIT_PATCH.md
+++ b/docs/WORKCELL_STUDIO_WEB_3D_EDIT_PATCH.md
@@ -196,3 +196,17 @@ Safety notes:
 - Generated files are not edited directly.
 - Browser edits remain patch requests; YAML persistence is owned by the backend validator/applicator.
 - RViz/MoveIt remains the planning and simulation truth after scene generation and validation.
+
+## Applying Web 3D edit patches from Workcell Builder
+
+Phase 5C adds a guided Workcell Builder UI path around the existing backend workflow script. It does not duplicate validator, applicator, re-export, or persistence verification logic in Qt.
+
+1. Select the intended scene in Workcell Builder and choose **Export & Open Web 3D Viewer**. The builder exports `build/workcell_studio_web_scene/<scene_id>.web_scene.json` and opens the static browser viewer.
+2. In the browser, edit only an editable, unlocked physical layout/environment item. Browser edits are preview-only.
+3. Use **Export Edit Patch** in the browser to save an `edit_patch.json` file, normally under `build/workcell_studio_web_scene`.
+4. Return to Workcell Builder and choose **Validate Web Edit Patch…** or **Dry Run Web Edit Patch…**. The patch picker defaults to `build/workcell_studio_web_scene`, requires an existing JSON file, and runs `scripts/run_workcell_studio_web_edit_workflow.py` for the selected scene.
+5. To persist a patch, choose **Apply Web Edit Patch…**. Workcell Builder first runs the same workflow without `--write`. If that dry-run fails, write mode is not offered.
+6. If dry-run passes, Workcell Builder shows an explicit confirmation dialog with the scene path, patch path, workflow output/change summary, and a warning that editable source YAML may be updated.
+7. Only after confirmation does Workcell Builder rerun `scripts/run_workcell_studio_web_edit_workflow.py` with `--write`. The backend workflow validates, applies through the safe applicator, re-exports an after web scene, and verifies persistence.
+
+Safety boundaries remain unchanged: generated files are not edited directly, the browser never writes YAML, Workcell Builder uses backend validation/dry-run before applying, and RViz/MoveIt remains the planning and simulation truth. This workflow does not start ROS launch files and does not enable real robot motion.

--- a/tests/test_workcell_builder_web_edit_patch_workflow.py
+++ b/tests/test_workcell_builder_web_edit_patch_workflow.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+SCENE_SELECT = REPO / "workcell_builder/workcell_builder/gui/scene_select.cpp"
+HEADER = REPO / "workcell_builder/workcell_builder/gui/scene_select.h"
+DOC = REPO / "docs/WORKCELL_STUDIO_WEB_3D_EDIT_PATCH.md"
+VIEWER_README = REPO / "workcell_studio_web/viewer/README.md"
+
+
+def _cpp() -> str:
+    return SCENE_SELECT.read_text(encoding="utf-8")
+
+
+def test_visible_workcell_builder_patch_actions_are_registered():
+    source = _cpp()
+    assert "Validate Web Edit Patch…" in source
+    assert "Dry Run Web Edit Patch…" in source
+    assert "Apply Web Edit Patch…" in source
+    assert "validate_web_edit_patch_action" in source
+    assert "dry_run_web_edit_patch_action" in source
+    assert "apply_web_edit_patch_action" in source
+    assert "on_validate_web_edit_patch_clicked" in HEADER.read_text(encoding="utf-8")
+
+
+def test_workflow_script_is_reused_instead_of_duplicate_backend_logic():
+    source = _cpp()
+    assert "scripts" in source
+    assert "run_workcell_studio_web_edit_workflow.py" in source
+    assert "validate_workcell_studio_web_scene_edit_patch.py" not in source
+    assert "apply_workcell_studio_web_scene_edit_patch.py" not in source
+    assert "verify_workcell_studio_web_scene_edit_persistence.py" not in source
+
+
+def test_dry_run_command_omits_write_and_apply_write_is_confirmation_gated():
+    source = _cpp()
+    dry_run_section = source[source.index("bool SceneSelect::execute_web_edit_patch_workflow") : source.index("bool SceneSelect::run_web_edit_patch_workflow")]
+    assert 'args << "--dry-run-apply"' in dry_run_section
+    assert 'if (write) {\n    args << "--write";' in dry_run_section
+    workflow_section = source[source.index("bool SceneSelect::run_web_edit_patch_workflow") :]
+    confirm_index = workflow_section.index("Confirm Apply Web Edit Patch")
+    write_call_index = workflow_section.index("execute_web_edit_patch_workflow(repo_root, scene_dir, patch_path, false, true")
+    assert confirm_index < write_call_index
+    first_dry_run_index = workflow_section.index("execute_web_edit_patch_workflow(repo_root, scene_dir, patch_path, validate_only, false")
+    assert first_dry_run_index < confirm_index
+
+
+def test_default_patch_folder_and_patch_json_validation():
+    source = _cpp()
+    assert 'repo_root / "build" / "workcell_studio_web_scene"' in source
+    assert "QFileDialog::getOpenFileName" in source
+    assert 'patch_info.suffix().compare("json"' in source
+    assert "QJsonParseError" in source
+
+
+def test_generated_directory_write_target_is_not_introduced():
+    source = _cpp()
+    workflow_source = source[source.index("void SceneSelect::on_validate_web_edit_patch_clicked") :]
+    assert ' / "generated"' not in workflow_source
+    assert 'generated/' not in workflow_source[source.index("Web edit patch workflow safety") :]
+
+
+def test_safety_wording_mentions_dry_run_confirmation_and_no_robot_motion():
+    combined = "\n".join(path.read_text(encoding="utf-8") for path in (SCENE_SELECT, DOC, VIEWER_README))
+    assert "dry-run" in combined.lower()
+    assert "explicit confirmation" in combined.lower()
+    assert "no real robot motion" in combined.lower()
+    assert "RViz/MoveIt remains" in combined
+    assert "browser edits are preview-only" in combined
+
+
+def test_no_direct_browser_yaml_write_or_frontend_stack_logic_added():
+    combined = "\n".join(path.read_text(encoding="utf-8") for path in (SCENE_SELECT, DOC, VIEWER_README))
+    assert "browser never writes source YAML" in combined
+    assert "npm" not in SCENE_SELECT.read_text(encoding="utf-8").lower()
+    assert "package.json" not in SCENE_SELECT.read_text(encoding="utf-8").lower()
+
+
+def test_no_qt_scene3d_visual_topology_screenshot_scope_reintroduced():
+    workflow_source = _cpp()[_cpp().index("void SceneSelect::on_validate_web_edit_patch_clicked") :]
+    forbidden = ("Qt Scene3D visual", "topology", "screenshot")
+    for token in forbidden:
+        assert token not in workflow_source

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -46,6 +46,7 @@
 #include <QLineEdit>
 #include <QFileDialog>
 #include <QFileInfo>
+#include <QFile>
 #include <QListWidgetItem>
 #include <QInputDialog>
 #include <QDir>
@@ -848,6 +849,21 @@ SceneSelect::SceneSelect(QWidget * parent)
   web_viewer_action->setToolTip("Exports the selected scene to build/workcell_studio_web_scene and opens the static browser viewer. Does not mutate scenes or generated files.");
   ui->generateLayout->insertWidget(8, web_viewer_action);
   connect(web_viewer_action, &QPushButton::clicked, this, &SceneSelect::on_export_open_web_3d_viewer_clicked);
+  auto * validate_web_patch_action = new QPushButton("Validate Web Edit Patch…", ui->validate_generate_tab);
+  validate_web_patch_action->setObjectName("validate_web_edit_patch_action");
+  validate_web_patch_action->setToolTip("Validate a browser-exported edit_patch.json through scripts/run_workcell_studio_web_edit_workflow.py without writing scene YAML.");
+  ui->generateLayout->insertWidget(9, validate_web_patch_action);
+  connect(validate_web_patch_action, &QPushButton::clicked, this, &SceneSelect::on_validate_web_edit_patch_clicked);
+  auto * dry_run_web_patch_action = new QPushButton("Dry Run Web Edit Patch…", ui->validate_generate_tab);
+  dry_run_web_patch_action->setObjectName("dry_run_web_edit_patch_action");
+  dry_run_web_patch_action->setToolTip("Run the guided Web 3D edit patch workflow in dry-run mode; --write is deliberately omitted.");
+  ui->generateLayout->insertWidget(10, dry_run_web_patch_action);
+  connect(dry_run_web_patch_action, &QPushButton::clicked, this, &SceneSelect::on_dry_run_web_edit_patch_clicked);
+  auto * apply_web_patch_action = new QPushButton("Apply Web Edit Patch…", ui->validate_generate_tab);
+  apply_web_patch_action->setObjectName("apply_web_edit_patch_action");
+  apply_web_patch_action->setToolTip("Dry-run, require explicit confirmation, then apply a Web 3D edit patch through the backend workflow with --write.");
+  ui->generateLayout->insertWidget(11, apply_web_patch_action);
+  connect(apply_web_patch_action, &QPushButton::clicked, this, &SceneSelect::on_apply_web_edit_patch_clicked);
   connect(ui->fit_cell_action, &QPushButton::clicked, this, &SceneSelect::refresh_preview_status);
   connect(ui->reset_view_action, &QPushButton::clicked, this, [this]() {
     if (ui->visual_layout_canvas) {
@@ -3387,6 +3403,166 @@ void SceneSelect::on_open_scene_folder_clicked()
     QUrl::fromLocalFile(QString::fromStdString(scene_dir.string())));
 }
 
+
+void SceneSelect::on_validate_web_edit_patch_clicked()
+{
+  run_web_edit_patch_workflow(true, false);
+}
+
+void SceneSelect::on_dry_run_web_edit_patch_clicked()
+{
+  run_web_edit_patch_workflow(false, false);
+}
+
+void SceneSelect::on_apply_web_edit_patch_clicked()
+{
+  run_web_edit_patch_workflow(false, true);
+}
+
+bool SceneSelect::execute_web_edit_patch_workflow(
+  const fs::path & repo_root,
+  const fs::path & scene_dir,
+  const fs::path & patch_path,
+  bool validate_only,
+  bool write,
+  QString * output)
+{
+  const fs::path workflow_script = repo_root / "scripts" / "run_workcell_studio_web_edit_workflow.py";
+  QStringList args{
+    QString::fromStdString(workflow_script.string()),
+    "--scene", QString::fromStdString(scene_dir.string()),
+    "--patch", QString::fromStdString(patch_path.string())};
+  if (validate_only) {
+    args << "--validate-only";
+  } else if (!write) {
+    args << "--dry-run-apply";
+  }
+  if (write) {
+    args << "--write";
+  }
+
+  append_info("Web edit patch workflow safety: browser edits are preview-only until edit_patch.json is exported; Workcell Builder validates and dry-runs patches before applying; applying requires explicit confirmation; RViz/MoveIt remains planning truth; no real robot motion is started.");
+  append_info("Run Web Edit Patch Workflow: python3 " + args.join(' ').toStdString());
+
+  QProcess process;
+  process.setWorkingDirectory(QString::fromStdString(repo_root.string()));
+  process.start("python3", args);
+  if (!process.waitForStarted()) {
+    const QString message = "Python executable 'python3' could not be started. Install Python 3 or ensure it is on PATH.";
+    append_error(message.toStdString());
+    if (output) {
+      *output = message;
+    }
+    return false;
+  }
+  process.waitForFinished(-1);
+  const QString stdout_text = QString::fromLocal8Bit(process.readAllStandardOutput());
+  const QString stderr_text = QString::fromLocal8Bit(process.readAllStandardError());
+  const QString combined = QString("Command: python3 %1\n\nSTDOUT:\n%2\n\nSTDERR:\n%3")
+    .arg(args.join(' '), stdout_text, stderr_text);
+  if (output) {
+    *output = combined;
+  }
+  if (!stdout_text.trimmed().isEmpty()) {
+    append_info(stdout_text.toStdString());
+  }
+  if (!stderr_text.trimmed().isEmpty()) {
+    append_warning(stderr_text.toStdString());
+  }
+  const bool ok = process.exitStatus() == QProcess::NormalExit && process.exitCode() == 0;
+  if (!ok) {
+    append_error(QString("Web edit patch workflow failed with exit code %1. Common causes include scene ID mismatch, locked/generated edit rejection, invalid patch JSON, or persistence verification failure.\n%2")
+      .arg(process.exitCode())
+      .arg(combined).toStdString());
+  } else {
+    append_success("Web edit patch workflow completed successfully.");
+  }
+  return ok;
+}
+
+bool SceneSelect::run_web_edit_patch_workflow(bool validate_only, bool write)
+{
+  configure_startup_fallback_paths();
+  const int current_index = current_scene_index();
+  if (current_index < 0 || current_index >= static_cast<int>(workcell.scene_vector.size())) {
+    const QString message = "No scene selected. Select a scene before running a Web 3D edit patch workflow.";
+    append_warning(message.toStdString());
+    QMessageBox::warning(this, "Web Edit Patch Workflow", message);
+    return false;
+  }
+
+  const fs::path scene_dir = scene_dir_for_current_selection();
+  boost::system::error_code ec;
+  if (scene_dir.empty() || !fs::exists(scene_dir, ec) || !fs::is_directory(scene_dir, ec)) {
+    const QString message = QString("Scene path missing for selected scene '%1': %2")
+      .arg(QString::fromStdString(workcell.scene_vector[current_index].name), QString::fromStdString(scene_dir.string()));
+    append_error(message.toStdString());
+    QMessageBox::critical(this, "Web Edit Patch Workflow", message);
+    return false;
+  }
+  const fs::path repo_root = resolve_tool_root(workcell_path, scene_dir);
+  const fs::path workflow_script = repo_root / "scripts" / "run_workcell_studio_web_edit_workflow.py";
+  if (repo_root.empty() || !fs::exists(workflow_script, ec)) {
+    const QString message = QString("Workflow script missing. Expected scripts/run_workcell_studio_web_edit_workflow.py under the Workcell Studio repo root. Scene path: %1")
+      .arg(QString::fromStdString(scene_dir.string()));
+    append_error(message.toStdString());
+    QMessageBox::critical(this, "Web Edit Patch Workflow", message);
+    return false;
+  }
+
+  const QString patch_file = QFileDialog::getOpenFileName(
+    this,
+    "Select Web 3D edit_patch.json",
+    QString::fromStdString((repo_root / "build" / "workcell_studio_web_scene").string()),
+    "JSON patch files (*.json);;All files (*)");
+  if (patch_file.isEmpty()) {
+    append_warning("Web edit patch workflow cancelled before patch selection.");
+    return false;
+  }
+  const QFileInfo patch_info(patch_file);
+  if (!patch_info.exists() || !patch_info.isFile() || patch_info.suffix().compare("json", Qt::CaseInsensitive) != 0) {
+    const QString message = QString("Invalid patch path/JSON. Select an existing .json edit patch file. Path: %1").arg(patch_file);
+    append_error(message.toStdString());
+    QMessageBox::critical(this, "Web Edit Patch Workflow", message);
+    return false;
+  }
+  QFile patch_reader(patch_file);
+  if (!patch_reader.open(QIODevice::ReadOnly)) {
+    const QString message = QString("Invalid patch path/JSON. Could not read patch file: %1").arg(patch_file);
+    append_error(message.toStdString());
+    QMessageBox::critical(this, "Web Edit Patch Workflow", message);
+    return false;
+  }
+  QJsonParseError parse_error;
+  QJsonDocument::fromJson(patch_reader.readAll(), &parse_error);
+  if (parse_error.error != QJsonParseError::NoError) {
+    const QString message = QString("Invalid patch path/JSON. JSON parse failed for %1: %2").arg(patch_file, parse_error.errorString());
+    append_error(message.toStdString());
+    QMessageBox::critical(this, "Web Edit Patch Workflow", message);
+    return false;
+  }
+
+  const fs::path patch_path(patch_file.toStdString());
+  QString dry_run_output;
+  const bool dry_ok = execute_web_edit_patch_workflow(repo_root, scene_dir, patch_path, validate_only, false, &dry_run_output);
+  if (!dry_ok || !write) {
+    QMessageBox::information(this, "Web Edit Patch Workflow", dry_run_output);
+    return dry_ok;
+  }
+
+  const QString confirm = QString(
+    "Dry-run passed. Apply this Web 3D edit patch now?\n\nScene path: %1\nPatch path: %2\n\nWorkflow output/change summary:\n%3\n\nWarning: applying may update editable source YAML. Generated files are not edited directly. Browser edits are preview-only until this backend apply step. RViz/MoveIt remains planning truth and no real robot motion is started.")
+    .arg(QString::fromStdString(scene_dir.string()), patch_file, dry_run_output.left(6000));
+  if (QMessageBox::question(this, "Confirm Apply Web Edit Patch", confirm, QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes) {
+    append_warning("Apply Web Edit Patch cancelled after successful dry-run; --write was not run.");
+    return false;
+  }
+
+  QString apply_output;
+  const bool apply_ok = execute_web_edit_patch_workflow(repo_root, scene_dir, patch_path, false, true, &apply_output);
+  QMessageBox::information(this, apply_ok ? "Web Edit Patch Applied" : "Web Edit Patch Failed", apply_output);
+  return apply_ok;
+}
 
 // Object Placement Manager markers for generated scene artifacts
 [[maybe_unused]] static const char * kObjectPlacementManagerLabel = "Object Placement Manager";

--- a/workcell_builder/workcell_builder/gui/scene_select.h
+++ b/workcell_builder/workcell_builder/gui/scene_select.h
@@ -125,6 +125,9 @@ private slots:
   void on_refresh_scenes_button_clicked();
   void on_export_scene_bundle_clicked();
   void on_export_open_web_3d_viewer_clicked();
+  void on_validate_web_edit_patch_clicked();
+  void on_dry_run_web_edit_patch_clicked();
+  void on_apply_web_edit_patch_clicked();
   void on_import_scene_bundle_clicked();
   void on_refresh_status_button_clicked();
   void on_validate_scene_button_clicked();
@@ -197,6 +200,8 @@ private:
   QString ensure_selected_template();
   boost::filesystem::path scene_dir_for_current_selection() const;
   bool validate_description_xacros(const Scene & scene, const std::string & context_label);
+  bool run_web_edit_patch_workflow(bool validate_only, bool write);
+  bool execute_web_edit_patch_workflow(const boost::filesystem::path & repo_root, const boost::filesystem::path & scene_dir, const boost::filesystem::path & patch_path, bool validate_only, bool write, QString * output);
   void configure_startup_fallback_paths();
   void show_invalid_workcell_error(const std::string & error_message);
   void discover_scene_packages_on_startup();

--- a/workcell_studio_web/viewer/README.md
+++ b/workcell_studio_web/viewer/README.md
@@ -179,3 +179,16 @@ python3 scripts/run_workcell_studio_web_edit_workflow.py \
 The guided workflow exports a before `web_scene`, validates the patch, runs the safe applicator in dry-run mode, and only mutates editable source YAML when `--write` is explicit. In write mode it re-exports an after `web_scene` and verifies persistence. Pass `--run-readiness` only when you also want the optional readiness matrix.
 
 This viewer workflow is still upstream of the normal Workcell Studio generate/validate/simulate path. RViz/MoveIt remains the planning truth, and fake-hardware-first safety defaults are unchanged.
+
+## Applying Web 3D edit patches from Workcell Builder
+
+The recommended UI workflow is:
+
+1. In Workcell Builder, select a scene and run **Export & Open Web 3D Viewer**.
+2. Load the exported `build/workcell_studio_web_scene/<scene_id>.web_scene.json` in this static viewer if it was not loaded automatically by your browser workflow.
+3. Edit an editable, unlocked item. These edits remain browser preview state only.
+4. Export an `edit_patch.json` from the browser. The browser never writes YAML and never mutates generated files.
+5. In Workcell Builder, use **Validate Web Edit Patch…** or **Dry Run Web Edit Patch…** and select the exported JSON patch. The file picker defaults to `build/workcell_studio_web_scene`.
+6. Use **Apply Web Edit Patch…** only when the dry-run output is clean. Workcell Builder requires explicit confirmation before it runs the backend workflow with `--write`.
+
+Workcell Builder orchestrates `scripts/run_workcell_studio_web_edit_workflow.py`; the Qt UI does not reimplement the patch validator/applicator. In apply mode the backend re-exports the web scene and verifies persistence. Generated-file safety remains in force, browser-side YAML writes are forbidden, RViz/MoveIt remains planning truth, and no real robot motion is started by this patch workflow.


### PR DESCRIPTION
### Motivation
- Provide a Phase 5C UI workflow in Workcell Builder to validate, dry-run, and apply browser-exported Web 3D edit patches without duplicating backend patch logic. 
- Ensure the UI reuses the existing guided backend script and enforces safety boundaries (dry-run first, explicit confirmation for writes, no direct browser YAML writes, and RViz/MoveIt remains planning truth). 

### Description
- Added three selected-scene actions and handlers in `scene_select.cpp`: `Validate Web Edit Patch…`, `Dry Run Web Edit Patch…`, and `Apply Web Edit Patch…` placed next to the existing `Export & Open Web 3D Viewer` action. 
- Declared helper slots and orchestration methods in `scene_select.h` and implemented `run_web_edit_patch_workflow` and `execute_web_edit_patch_workflow` in `scene_select.cpp` to drive `scripts/run_workcell_studio_web_edit_workflow.py` via `QProcess` and capture `stdout`/`stderr`. 
- Enforced selected-scene resolution, required patch file selection via `QFileDialog::getOpenFileName` (defaulting to `repo_root / "build" / "workcell_studio_web_scene"`), validated file existence and JSON parsing, and surfaced clear user-facing errors for missing scene, missing script, missing Python start, invalid JSON, workflow failures, scene mismatch, locked/generated rejections, and persistence failures. 
- Implemented dry-run-before-write orchestration where the apply path runs a dry-run first, shows an explicit confirmation dialog with scene/patch/workflow summary and warnings, and only then re-runs the workflow with `--write`. 
- Updated docs with an “Applying Web 3D edit patches from Workcell Builder” section in `docs/WORKCELL_STUDIO_WEB_3D_EDIT_PATCH.md` and `workcell_studio_web/viewer/README.md`. 
- Added static tests `tests/test_workcell_builder_web_edit_patch_workflow.py` covering visible UI labels, reuse of the backend script, dry-run/write flag behavior, default patch folder, JSON validation, generated-file safety wording, and that no direct browser YAML write or Qt Scene3D/screenshot scope was reintroduced. 

### Testing
- Ran `python3 -m pytest tests/test_workcell_builder_web_edit_patch_workflow.py` and all tests passed. 
- Ran `git diff --check` to ensure no whitespace or diff issues and it passed. 
- Did not run a full Qt/ROS build or runtime launches in this environment because the ROS 2 Humble workspace and display environment were not sourced/available here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a427d35f68c8331b2eb5ba5832eee62)