### PR TITLE
Add Generate & Validate Scene action to Workcell Builder UI

### DIFF
--- a/tests/test_workcell_builder_web_edit_patch_workflow.py
+++ b/tests/test_workcell_builder_web_edit_patch_workflow.py
@@ -16,10 +16,32 @@ def test_visible_workcell_builder_patch_actions_are_registered():
     assert "Validate Web Edit Patch…" in source
     assert "Dry Run Web Edit Patch…" in source
     assert "Apply Web Edit Patch…" in source
+    assert "Generate & Validate Scene" in source
     assert "validate_web_edit_patch_action" in source
     assert "dry_run_web_edit_patch_action" in source
     assert "apply_web_edit_patch_action" in source
-    assert "on_validate_web_edit_patch_clicked" in HEADER.read_text(encoding="utf-8")
+    assert "generate_validate_after_web_edit_action" in source
+    header = HEADER.read_text(encoding="utf-8")
+    assert "on_validate_web_edit_patch_clicked" in header
+    assert "on_generate_validate_after_web_edit_clicked" in header
+
+
+def test_generate_validate_scene_action_uses_backend_without_patch_and_requires_confirmation():
+    source = _cpp()
+    section = source[source.index("bool SceneSelect::run_generate_validate_after_web_edit") : source.index("bool SceneSelect::execute_web_edit_patch_workflow")]
+    assert "Confirm Generate & Validate Scene" in section
+    assert "QMessageBox::question" in section
+    assert "QFileDialog::getOpenFileName" not in section
+    assert "--patch" not in section
+    assert "--generate-and-validate" in source
+    assert "python3 scripts/run_workcell_studio_web_edit_workflow.py" in source
+    assert "Generate & Validate Scene PASS" in source
+    assert "Generate & Validate Scene FAIL" in source
+    assert "Patch applied and verified. You can now Generate & Validate Scene." in source
+    assert "generation/validation is explicit" in source
+    assert "browser never writes YAML directly" in source
+    assert "this does not launch fake hardware" in source
+    assert "this does not move real hardware" in source
 
 
 def test_workflow_script_is_reused_instead_of_duplicate_backend_logic():

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -864,6 +864,11 @@ SceneSelect::SceneSelect(QWidget * parent)
   apply_web_patch_action->setToolTip("Dry-run, require explicit confirmation, then apply a Web 3D edit patch through the backend workflow with --write.");
   ui->generateLayout->insertWidget(11, apply_web_patch_action);
   connect(apply_web_patch_action, &QPushButton::clicked, this, &SceneSelect::on_apply_web_edit_patch_clicked);
+  auto * generate_validate_scene_action = new QPushButton("Generate & Validate Scene", ui->validate_generate_tab);
+  generate_validate_scene_action->setObjectName("generate_validate_after_web_edit_action");
+  generate_validate_scene_action->setToolTip("Explicitly regenerate and validate the selected scene through scripts/run_workcell_studio_web_edit_workflow.py. No patch is required, no hardware is launched, and RViz/MoveIt remains the later planning truth.");
+  ui->generateLayout->insertWidget(12, generate_validate_scene_action);
+  connect(generate_validate_scene_action, &QPushButton::clicked, this, &SceneSelect::on_generate_validate_after_web_edit_clicked);
   connect(ui->fit_cell_action, &QPushButton::clicked, this, &SceneSelect::refresh_preview_status);
   connect(ui->reset_view_action, &QPushButton::clicked, this, [this]() {
     if (ui->visual_layout_canvas) {
@@ -3419,6 +3424,109 @@ void SceneSelect::on_apply_web_edit_patch_clicked()
   run_web_edit_patch_workflow(false, true);
 }
 
+void SceneSelect::on_generate_validate_after_web_edit_clicked()
+{
+  run_generate_validate_after_web_edit();
+}
+
+bool SceneSelect::execute_generate_validate_after_web_edit(
+  const fs::path & repo_root,
+  const fs::path & scene_dir,
+  QString * output)
+{
+  const QString workflow_script = "scripts/run_workcell_studio_web_edit_workflow.py";
+  QStringList args{
+    workflow_script,
+    "--scene", QString::fromStdString(scene_dir.string()),
+    "--generate-and-validate"};
+
+  append_info("Generate & Validate Scene safety: generation/validation is explicit; browser never writes YAML directly; edit patches are validated/dry-run before apply; this does not launch fake hardware; this does not move real hardware; RViz/MoveIt remains the later planning truth.");
+  append_info("Generate & Validate Scene command template: python3 scripts/run_workcell_studio_web_edit_workflow.py --scene <selected-scene> --generate-and-validate");
+  append_info("Run Generate & Validate Scene: python3 " + args.join(' ').toStdString());
+
+  QProcess process;
+  process.setWorkingDirectory(QString::fromStdString(repo_root.string()));
+  process.start("python3", args);
+  if (!process.waitForStarted()) {
+    const QString message = "Python executable 'python3' could not be started. Install Python 3 or ensure it is on PATH.";
+    append_error(message.toStdString());
+    if (output) {
+      *output = message;
+    }
+    return false;
+  }
+  process.waitForFinished(-1);
+  const QString stdout_text = QString::fromLocal8Bit(process.readAllStandardOutput());
+  const QString stderr_text = QString::fromLocal8Bit(process.readAllStandardError());
+  const bool ok = process.exitStatus() == QProcess::NormalExit && process.exitCode() == 0;
+  const QString summary = QString("Generate & Validate Scene %1 for selected scene: %2\nExit code: %3\n\nCommand: python3 %4\n\nSTDOUT:\n%5\n\nSTDERR:\n%6")
+    .arg(QString(ok ? "PASS" : "FAIL"))
+    .arg(QString::fromStdString(scene_dir.string()))
+    .arg(process.exitCode())
+    .arg(args.join(' '))
+    .arg(stdout_text)
+    .arg(stderr_text);
+  if (output) {
+    *output = summary;
+  }
+  if (!stdout_text.trimmed().isEmpty()) {
+    append_info(stdout_text.toStdString());
+  }
+  if (!stderr_text.trimmed().isEmpty()) {
+    append_warning(stderr_text.toStdString());
+  }
+  if (ok) {
+    append_success(summary.toStdString());
+  } else {
+    append_error(summary.toStdString());
+  }
+  return ok;
+}
+
+bool SceneSelect::run_generate_validate_after_web_edit()
+{
+  configure_startup_fallback_paths();
+  const int current_index = current_scene_index();
+  if (current_index < 0 || current_index >= static_cast<int>(workcell.scene_vector.size())) {
+    const QString message = "No scene selected. Select a scene before running Generate & Validate Scene.";
+    append_warning(message.toStdString());
+    QMessageBox::warning(this, "Generate & Validate Scene", message);
+    return false;
+  }
+
+  const fs::path scene_dir = scene_dir_for_current_selection();
+  boost::system::error_code ec;
+  if (scene_dir.empty() || !fs::exists(scene_dir, ec) || !fs::is_directory(scene_dir, ec)) {
+    const QString message = QString("Scene path missing for selected scene '%1': %2")
+      .arg(QString::fromStdString(workcell.scene_vector[current_index].name), QString::fromStdString(scene_dir.string()));
+    append_error(message.toStdString());
+    QMessageBox::critical(this, "Generate & Validate Scene", message);
+    return false;
+  }
+  const fs::path repo_root = resolve_tool_root(workcell_path, scene_dir);
+  const fs::path workflow_script = repo_root / "scripts" / "run_workcell_studio_web_edit_workflow.py";
+  if (repo_root.empty() || !fs::exists(workflow_script, ec)) {
+    const QString message = QString("Workflow script missing. Expected scripts/run_workcell_studio_web_edit_workflow.py under the Workcell Studio repo root. Scene path: %1")
+      .arg(QString::fromStdString(scene_dir.string()));
+    append_error(message.toStdString());
+    QMessageBox::critical(this, "Generate & Validate Scene", message);
+    return false;
+  }
+
+  const QString confirm = QString(
+    "Generate and validate the selected scene now?\n\nScene path: %1\n\nThis may mutate generated scene/package outputs. Generation/validation is explicit. Browser never writes YAML directly. Edit patches are validated/dry-run before apply. This does not launch fake hardware. This does not move real hardware. RViz/MoveIt remains the later planning truth.")
+    .arg(QString::fromStdString(scene_dir.string()));
+  if (QMessageBox::question(this, "Confirm Generate & Validate Scene", confirm, QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes) {
+    append_warning("Generate & Validate Scene cancelled before mutating generated outputs.");
+    return false;
+  }
+
+  QString output;
+  const bool ok = execute_generate_validate_after_web_edit(repo_root, scene_dir, &output);
+  QMessageBox::information(this, ok ? "Generate & Validate Scene PASS" : "Generate & Validate Scene FAIL", output);
+  return ok;
+}
+
 bool SceneSelect::execute_web_edit_patch_workflow(
   const fs::path & repo_root,
   const fs::path & scene_dir,
@@ -3560,6 +3668,11 @@ bool SceneSelect::run_web_edit_patch_workflow(bool validate_only, bool write)
 
   QString apply_output;
   const bool apply_ok = execute_web_edit_patch_workflow(repo_root, scene_dir, patch_path, false, true, &apply_output);
+  if (apply_ok) {
+    const QString next_step = "Patch applied and verified. You can now Generate & Validate Scene.";
+    append_success(next_step.toStdString());
+    apply_output += "\n\n" + next_step;
+  }
   QMessageBox::information(this, apply_ok ? "Web Edit Patch Applied" : "Web Edit Patch Failed", apply_output);
   return apply_ok;
 }

--- a/workcell_builder/workcell_builder/gui/scene_select.h
+++ b/workcell_builder/workcell_builder/gui/scene_select.h
@@ -128,6 +128,7 @@ private slots:
   void on_validate_web_edit_patch_clicked();
   void on_dry_run_web_edit_patch_clicked();
   void on_apply_web_edit_patch_clicked();
+  void on_generate_validate_after_web_edit_clicked();
   void on_import_scene_bundle_clicked();
   void on_refresh_status_button_clicked();
   void on_validate_scene_button_clicked();
@@ -201,6 +202,8 @@ private:
   boost::filesystem::path scene_dir_for_current_selection() const;
   bool validate_description_xacros(const Scene & scene, const std::string & context_label);
   bool run_web_edit_patch_workflow(bool validate_only, bool write);
+  bool run_generate_validate_after_web_edit();
+  bool execute_generate_validate_after_web_edit(const boost::filesystem::path & repo_root, const boost::filesystem::path & scene_dir, QString * output);
   bool execute_web_edit_patch_workflow(const boost::filesystem::path & repo_root, const boost::filesystem::path & scene_dir, const boost::filesystem::path & patch_path, bool validate_only, bool write, QString * output);
   void configure_startup_fallback_paths();
   void show_invalid_workcell_error(const std::string & error_message);


### PR DESCRIPTION
### Motivation
- Provide an explicit, visible UI action to regenerate and validate the currently selected scene without requiring a browser-exported patch.
- Reuse the existing safe backend workflow instead of reimplementing generation/validation logic in C++. 
- Preserve safety: require a selected scene, explicit confirmation before mutating generated outputs, and clear messaging that no hardware is launched and browser edits never write YAML directly.

### Description
- Added a `Generate & Validate Scene` button to the validate/generate tab and wired it to a new slot `on_generate_validate_after_web_edit_clicked` in `scene_select.cpp` and `scene_select.h`.
- Implemented `run_generate_validate_after_web_edit()` and `execute_generate_validate_after_web_edit(...)` which invoke the backend script using `python3 scripts/run_workcell_studio_web_edit_workflow.py --scene <selected-scene> --generate-and-validate`, capture stdout/stderr, and emit PASS/FAIL summaries to the log and dialog.
- Added selected-scene existence checks, an explicit confirmation dialog prior to any potentially mutating generation step, and a safety info log line explaining that generation/validation is explicit, browsers never write YAML, patches are validated/dry-run before apply, no fake-hardware is launched, and no real robot motion is started.
- After a successful patch apply/persistence verification the UI now appends the guidance message: `Patch applied and verified. You can now Generate & Validate Scene.` and tests were extended to cover the new action and messaging.

### Testing
- Ran `python3 -m pytest tests/test_workcell_builder_web_edit_patch_workflow.py` which passed (`9 passed`).
- Ran `python3 -m pytest tests/test_workcell_studio_web_edit_workflow.py` which passed (`12 passed`).
- No ROS/Qt build was executed in this environment; the change is covered by static C++ wiring tests and the backend workflow tests listed above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42b6036d448331b4b168bf7905804c)