### PR TITLE
Add unit tests for web-edit generate/validate workflow and surface generated/readiness summary paths

### DIFF
--- a/scripts/run_workcell_studio_web_edit_workflow.py
+++ b/scripts/run_workcell_studio_web_edit_workflow.py
@@ -111,6 +111,15 @@ def _readiness_cmd(output_dir: Path) -> list[str]:
     ]
 
 
+def _generated_summary_paths(scene: Path) -> list[Path]:
+    return [
+        scene / "package.xml",
+        scene / "CMakeLists.txt",
+        scene / "generated" / "cell_definition.yaml",
+        scene / "generated" / "environment_layout.yaml",
+    ]
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Run the safe guided backend workflow for Workcell Studio Web 3D edit patches.")
     parser.add_argument("--scene", required=True, type=Path, help="Scene directory, for example scenes/ur5_2f_test")
@@ -243,6 +252,7 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print("validation command/result: SKIPPED (pass --validate or --generate-and-validate)")
 
+    readiness_output_dir: Path | None = None
     if args.run_readiness:
         readiness_output_dir = Path("build/workcell_studio_scene_readiness")
         readiness_cmd = _readiness_cmd(readiness_output_dir)
@@ -253,6 +263,14 @@ def main(argv: list[str] | None = None) -> int:
             return readiness_rc
     else:
         print("readiness result: SKIPPED (pass --run-readiness to run it)")
+
+    if generation_rc == 0:
+        print("generated output paths:")
+        for generated_path in _generated_summary_paths(scene):
+            print(f"  - {generated_path}")
+    if readiness_output_dir is not None:
+        print("readiness output paths:")
+        print(f"  - {readiness_output_dir / 'scene_readiness_summary.json'}")
 
     print(f"\nWorkflow summary: PASS (selected scene: {scene}; patch_applied={patch_applied}; generation={'PASS' if generation_rc == 0 else 'SKIPPED'}; validation={'PASS' if validation_rc == 0 else 'SKIPPED'})")
     _print_next_generate_validate(scene, generated=bool(generation_rc == 0), validated=bool(validation_rc == 0))

--- a/tests/test_workcell_studio_web_edit_generate_validate_workflow.py
+++ b/tests/test_workcell_studio_web_edit_generate_validate_workflow.py
@@ -1,0 +1,175 @@
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = REPO_ROOT / "scripts" / "run_workcell_studio_web_edit_workflow.py"
+
+
+def _load_workflow():
+    spec = importlib.util.spec_from_file_location("workflow_under_test", WORKFLOW_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def workflow(monkeypatch):
+    module = _load_workflow()
+    monkeypatch.setattr(module, "build_web_scene", lambda scene: {"schema_version": "workcell_studio_web_scene/v1", "scene_id": scene.name, "items": []})
+    return module
+
+
+@pytest.fixture()
+def scene(tmp_path):
+    scene_dir = tmp_path / "scenes" / "ur5_2f_test"
+    (scene_dir / "generated").mkdir(parents=True)
+    return scene_dir
+
+
+def _patch(tmp_path):
+    patch_path = tmp_path / "patch.json"
+    patch_path.write_text('{"schema_version":"workcell_studio_web_scene_edit_patch/v1"}\n', encoding="utf-8")
+    return patch_path
+
+
+class RunRecorder:
+    def __init__(self, returncodes=None):
+        self.commands = []
+        self.returncodes = list(returncodes or [])
+
+    def __call__(self, cmd, **kwargs):
+        self.commands.append([str(part) for part in cmd])
+        rc = self.returncodes.pop(0) if self.returncodes else 0
+        return subprocess.CompletedProcess(cmd, rc, stdout=f"stub rc={rc}\n", stderr="")
+
+    def joined(self):
+        return "\n".join(" ".join(cmd) for cmd in self.commands)
+
+
+def test_default_guided_workflow_does_not_generate_or_validate_automatically(workflow, scene, tmp_path, monkeypatch, capsys):
+    recorder = RunRecorder([0])
+    monkeypatch.setattr(workflow.subprocess, "run", recorder)
+    monkeypatch.setattr(workflow, "_validate_patch", lambda before, patch_path: (True, {"scene_id": scene.name}, []))
+
+    rc = workflow.main(["--scene", str(scene), "--patch", str(_patch(tmp_path)), "--output-dir", str(tmp_path / "out")])
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "generation requested: False" in out
+    assert "validation requested: False" in out
+    assert "write/apply result: SKIPPED" in out
+    assert "scene generation" not in out
+    assert "selected-scene validation" not in out
+    assert len(recorder.commands) == 1
+
+
+def test_generate_and_validate_triggers_generation_validation_path(workflow, scene, tmp_path, monkeypatch, capsys):
+    recorder = RunRecorder([0, 0])
+    monkeypatch.setattr(workflow.subprocess, "run", recorder)
+
+    rc = workflow.main(["--scene", str(scene), "--generate-and-validate", "--output-dir", str(tmp_path / "out")])
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "generation requested: True" in out
+    assert "validation requested: True" in out
+    assert "== scene generation ==" in out
+    assert "== selected-scene validation ==" in out
+    assert any("validate_builder_generated_scene.py" in " ".join(cmd) for cmd in recorder.commands)
+
+
+def test_generation_not_attempted_if_patch_validation_fails(workflow, scene, tmp_path, monkeypatch):
+    recorder = RunRecorder()
+    monkeypatch.setattr(workflow.subprocess, "run", recorder)
+    monkeypatch.setattr(workflow, "_validate_patch", lambda before, patch_path: (False, None, ["bad patch"]))
+
+    rc = workflow.main(["--scene", str(scene), "--patch", str(_patch(tmp_path)), "--write", "--generate-and-validate"])
+
+    assert rc == 1
+    assert "scene generation" not in recorder.joined()
+    assert recorder.commands == []
+
+
+def test_generation_not_attempted_if_patch_apply_fails(workflow, scene, tmp_path, monkeypatch):
+    recorder = RunRecorder([23])
+    monkeypatch.setattr(workflow.subprocess, "run", recorder)
+    monkeypatch.setattr(workflow, "_validate_patch", lambda before, patch_path: (True, {"scene_id": scene.name}, []))
+
+    rc = workflow.main(["--scene", str(scene), "--patch", str(_patch(tmp_path)), "--write", "--generate-and-validate"])
+
+    assert rc == 23
+    assert len(recorder.commands) == 1
+    assert "apply_workcell_studio_web_scene_edit_patch.py" in recorder.joined()
+    assert "scene generation" not in recorder.joined()
+
+
+def test_generation_not_attempted_if_persistence_verification_fails(workflow, scene, tmp_path, monkeypatch):
+    recorder = RunRecorder([0, 0, 24])
+    monkeypatch.setattr(workflow.subprocess, "run", recorder)
+    monkeypatch.setattr(workflow, "_validate_patch", lambda before, patch_path: (True, {"scene_id": scene.name}, []))
+
+    rc = workflow.main(["--scene", str(scene), "--patch", str(_patch(tmp_path)), "--write", "--generate-and-validate"])
+
+    assert rc == 24
+    assert "verify_workcell_studio_web_scene_edit_persistence.py" in recorder.joined()
+    assert "scene generation" not in recorder.joined()
+
+
+def test_validation_failure_returns_nonzero_and_emits_clear_failure_summary(workflow, scene, monkeypatch, capsys):
+    recorder = RunRecorder([0, 42])
+    monkeypatch.setattr(workflow.subprocess, "run", recorder)
+
+    rc = workflow.main(["--scene", str(scene), "--generate-and-validate"])
+
+    out = capsys.readouterr().out
+    assert rc == 42
+    assert "validation command/result:" in out
+    assert "-> FAIL" in out
+    assert "Review the failed command output above" in out
+
+
+def test_generate_only_current_scene_path_works_when_supported(workflow, scene, monkeypatch, capsys):
+    recorder = RunRecorder([0])
+    monkeypatch.setattr(workflow.subprocess, "run", recorder)
+
+    rc = workflow.main(["--scene", str(scene), "--generate"])
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "patch applied/skipped: SKIPPED (no --patch provided)" in out
+    assert "== scene generation ==" in out
+    assert "validation command/result: SKIPPED" in out
+    assert len(recorder.commands) == 1
+
+
+def test_output_summary_includes_generated_and_readiness_paths_where_applicable(workflow, scene, monkeypatch, capsys):
+    recorder = RunRecorder([0, 0])
+    monkeypatch.setattr(workflow.subprocess, "run", recorder)
+
+    rc = workflow.main(["--scene", str(scene), "--generate", "--run-readiness"])
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "generated output paths:" in out
+    assert str(scene / "generated" / "cell_definition.yaml") in out
+    assert "readiness output path:" in out
+    assert "readiness output paths:" in out
+    assert "scene_readiness_summary.json" in out
+
+
+def test_no_ros_rviz_moveit_gazebo_launch_command_is_introduced():
+    source = WORKFLOW_PATH.read_text(encoding="utf-8")
+    forbidden = ("ros2 launch", "launch_rviz", "rviz2", "move_group", "gazebo", "ign gazebo")
+    for token in forbidden:
+        assert token not in source
+
+
+def test_no_qt_scene3d_visual_topology_screenshot_wording_is_reintroduced():
+    source = WORKFLOW_PATH.read_text(encoding="utf-8")
+    forbidden = ("Qt Scene3D visual", "topology", "screenshot")
+    for token in forbidden:
+        assert token not in source


### PR DESCRIPTION
### Motivation

- Ensure the Workcell Studio Web edit guided workflow enforces explicit generation/validation and does not auto-run generation or launch simulation tooling.
- Provide deterministic, unit-style coverage for failure modes (patch validation/apply/persistence) without launching ROS/RViz/MoveIt/Gazebo or mutating real outputs.
- Surface useful CLI summary output (generated artifact and readiness summary paths) to make post-run results easier to inspect.

### Description

- Added `tests/test_workcell_studio_web_edit_generate_validate_workflow.py` which exercises default no-generation behavior, `--generate-and-validate` flow, blocked generation when patch validation/apply/persistence fails, validation-failure summary behavior, generate-only flow, output-summary checks, and forbids introduction of ROS/RViz/MoveIt/Gazebo and Qt Scene3D wording regressions.
- Tests use a monkeypatched `subprocess.run` recorder and import the workflow module directly so the suite is static and does not launch external tools or write generated artifacts.  The test file is self-contained and focuses on CLI behavior and control flow.
- Updated `scripts/run_workcell_studio_web_edit_workflow.py` to add `_generated_summary_paths(scene)` and print generated artifact paths and readiness summary paths when applicable (without changing any runtime behaviour that would enable real hardware or launch simulation).

### Testing

- Ran `python3 -m pytest tests/test_workcell_studio_web_edit_generate_validate_workflow.py tests/test_workcell_studio_web_edit_workflow.py`, and the suite passed (22 tests total). 
- Tests are unit/static in nature and rely on monkeypatched `subprocess.run` to avoid launching ROS or mutating repo files. 
- Confirmed the workflow script does not introduce any `ros2 launch`/`rviz2`/`move_group`/`gazebo` calls or reintroduce Qt Scene3D/`topology`/`screenshot` wording.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42dc4e80b88331b401be23fa65804b)