### PR TITLE
Harden web viewer mesh URI handling

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -31,6 +31,10 @@ def test_viewer_js_schema_and_inspector_hooks():
     assert "primitive" in js
     assert "editable" in js
     assert "locked" in js
+    assert "original_mesh_uri" in js
+    assert "mesh_staging_status" in js
+    assert "mesh_staged_path" in js
+    assert "mesh_resolve_warning" in js
 
 
 def test_viewer_records_render_status_for_inspector():
@@ -42,7 +46,7 @@ def test_viewer_records_render_status_for_inspector():
         "mesh_loaded",
         "primitive_fallback",
         "box_fallback",
-        "mesh_failed",
+        "load_error",
     ]:
         assert token in js
     assert "child.userData.renderInfo" in js
@@ -93,12 +97,15 @@ def test_viewer_includes_render_status_strings_and_fallback_reasons():
         "mesh_loaded",
         "primitive_fallback",
         "box_fallback",
-        "mesh_failed",
-        "mesh_loading",
-        "mesh_unavailable",
+        "load_error",
+        "loading",
+        "missing_file",
+        "unsafe_path",
+        "unsupported_format",
+        "unresolved_package_uri",
         "primitive geometry rendered while mesh loads or is unavailable",
         "no primitive geometry or mesh was provided; using box fallback",
-        "unsupported or unsafe mesh_uri",
+        "unsafe mesh_uri rejected by viewer policy",
         "no mesh_uri provided",
         "mesh loader failed",
     ]:
@@ -119,6 +126,9 @@ def test_viewer_includes_mesh_loader_references_and_safe_mesh_uri_logic():
         "loadAsync(uri)",
         "materializeLoadedMesh",
         "appendRuntimeWarning",
+        "build/workcell_studio_web_scene/assets/",
+        "workcell_studio_web/",
+        "assets/",
         "['stl', 'dae', 'obj'].includes(ext)",
     ]:
         assert token in js

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -129,14 +129,19 @@ function appendRuntimeWarning(item, meshUri, reason) {
   refreshWarnings();
 }
 
-function safeMeshUri(item) {
+function meshUriDiagnostic(item) {
   const raw = item?.mesh_uri;
-  if (typeof raw !== 'string') return null;
+  const requested = displayMeshUri(item);
+  if (typeof raw !== 'string' || !raw.trim()) {
+    if (requested && String(requested).startsWith('package://')) {
+      return { uri: null, status: 'unresolved_package_uri', reason: `package URI was not staged for browser loading: ${requested}` };
+    }
+    return { uri: null, status: 'missing_file', reason: requested ? `mesh_uri was not staged for browser loading: ${requested}` : 'no mesh_uri provided' };
+  }
   const uri = raw.trim();
-  if (!uri) return null;
   const lower = uri.toLowerCase();
+  if (lower.startsWith('package://')) return { uri: null, status: 'unresolved_package_uri', reason: `package URI must be resolved and staged before browser loading: ${uri}` };
   if (
-    lower.startsWith('package://') ||
     lower.startsWith('http://') ||
     lower.startsWith('https://') ||
     lower.startsWith('file://') ||
@@ -147,13 +152,34 @@ function safeMeshUri(item) {
     /^[a-zA-Z]:[\\/]/.test(uri) ||
     /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(uri) ||
     uri.includes('\\')
-  ) return null;
+  ) return { uri: null, status: 'unsafe_path', reason: `unsafe mesh_uri rejected by viewer policy: ${uri}` };
   const pathOnly = uri.split(/[?#]/, 1)[0];
   const parts = pathOnly.split('/');
-  if (parts.some(part => part === '..')) return null;
-  const ext = pathOnly.slice(pathOnly.lastIndexOf('.') + 1).toLowerCase();
-  if (!['stl', 'dae', 'obj'].includes(ext)) return null;
-  return uri;
+  if (parts.some(part => part === '..')) return { uri: null, status: 'unsafe_path', reason: `mesh_uri path traversal rejected: ${uri}` };
+  const allowedRoots = [
+    'build/workcell_studio_web_scene/assets/',
+    'workcell_studio_web/',
+    'assets/',
+  ];
+  if (!allowedRoots.some(root => pathOnly.startsWith(root))) {
+    return { uri: null, status: 'unsafe_path', reason: `mesh_uri must be staged under build/workcell_studio_web_scene/assets/, workcell_studio_web/, or assets/: ${uri}` };
+  }
+  const ext = pathOnly.includes('.') ? pathOnly.slice(pathOnly.lastIndexOf('.') + 1).toLowerCase() : '';
+  if (!['stl', 'dae', 'obj'].includes(ext)) return { uri: null, status: 'unsupported_format', reason: `unsupported mesh format .${ext || 'unknown'} for ${uri}` };
+  const stagingStatus = String(item?.mesh_staging_status || '').toLowerCase();
+  if (stagingStatus && !['staged', 'copied', 'available', 'loaded'].includes(stagingStatus)) {
+    const status = stagingStatus === 'unsupported_format' ? 'unsupported_format'
+      : stagingStatus === 'unsafe_path' || stagingStatus === 'unsafe_destination' || stagingStatus === 'unsupported_scheme' ? 'unsafe_path'
+      : stagingStatus === 'no_mesh_uri' ? 'missing_file'
+      : stagingStatus === 'resolve_failed' ? 'missing_file'
+      : stagingStatus === 'unresolved_package_uri' ? 'unresolved_package_uri'
+      : 'missing_file';
+    return { uri: null, status, reason: item?.mesh_resolve_warning || `mesh staging did not produce a loadable file (mesh_staging_status=${stagingStatus})` };
+  }
+  return { uri, status: 'loaded', reason: '' };
+}
+function safeMeshUri(item) {
+  return meshUriDiagnostic(item).uri;
 }
 function itemType(item) { return item.type || item.category || item.role || item.source_kind || 'asset'; }
 function itemLabel(item) { return item.label || item.display_name || item.name || item.id || 'unnamed'; }
@@ -240,13 +266,14 @@ function materializeLoadedMesh(item, uri, loaded) {
   return object;
 }
 async function tryLoadMesh(item, rendered, fallback) {
-  const uri = safeMeshUri(item);
+  const diagnostic = meshUriDiagnostic(item);
+  const uri = diagnostic.uri;
   const requestedUri = displayMeshUri(item);
-  item.mesh_status = uri ? 'mesh_loading' : 'mesh_unavailable';
+  item.mesh_status = uri ? 'loading' : diagnostic.status;
   if (!uri) {
-    const reason = requestedUri ? `unsupported or unsafe mesh_uri: ${requestedUri}` : (rendered.renderInfo?.fallback_reason || 'no mesh_uri provided');
-    setRenderInfo(rendered, rendered.renderInfo?.render_status || 'box_fallback', requestedUri, reason);
-    if (requestedUri) appendRuntimeWarning(item, requestedUri, reason);
+    setRenderInfo(rendered, rendered.renderInfo?.render_status || 'box_fallback', requestedUri, diagnostic.reason);
+    if (requestedUri) appendRuntimeWarning(item, requestedUri, diagnostic.reason);
+    if (state.selected === item.id) populateInspector(rendered);
     return;
   }
   try {
@@ -259,7 +286,7 @@ async function tryLoadMesh(item, rendered, fallback) {
     fallback.visible = false;
     rendered.object3d.add(meshObject);
     rendered.meshObject = meshObject;
-    item.mesh_status = 'mesh_loaded';
+    item.mesh_status = 'loaded';
     item.mesh_load_error = '';
     setRenderInfo(rendered, 'mesh_loaded', uri, '');
     const bounds = computeRenderedBounds();
@@ -267,10 +294,11 @@ async function tryLoadMesh(item, rendered, fallback) {
     if (state.selected === item.id) populateInspector(rendered);
   } catch (err) {
     fallback.visible = true;
-    item.mesh_status = 'mesh_failed';
+    item.mesh_status = 'load_error';
     item.mesh_load_error = err?.message || String(err);
-    setRenderInfo(rendered, 'mesh_failed', uri, item.mesh_load_error);
-    appendRuntimeWarning(item, uri, `mesh loader failed: ${item.mesh_load_error}`);
+    const reason = `mesh loader failed: ${item.mesh_load_error}`;
+    setRenderInfo(rendered, rendered.renderInfo?.render_status || 'box_fallback', uri, reason);
+    appendRuntimeWarning(item, uri, reason);
     if (state.selected === item.id) populateInspector(rendered);
   }
 }
@@ -703,7 +731,10 @@ function populateInspector(renderedOrItem) {
     'pose rpy': [pose.rpy.x, pose.rpy.y, pose.rpy.z].map(n => n.toFixed(3)).join(', '),
     scale: JSON.stringify(item.scale || item.mesh_scale || [1, 1, 1]), editable: String(Boolean(item.editable)), locked: String(Boolean(item.locked)),
     render_status: renderInfo.render_status, mesh_uri: renderInfo.mesh_uri || displayMeshUri(item), fallback_reason: renderInfo.fallback_reason,
-    mesh_status: item.mesh_status, mesh_load_error: item.mesh_load_error, primitive: JSON.stringify(primitiveOf(item) || 'box fallback'),
+    mesh_status: item.mesh_status, mesh_load_error: item.mesh_load_error,
+    original_mesh_uri: item.original_mesh_uri, mesh_staging_status: item.mesh_staging_status,
+    mesh_staged_path: item.mesh_staged_path, mesh_resolve_warning: item.mesh_resolve_warning,
+    primitive: JSON.stringify(primitiveOf(item) || 'box fallback'),
   };
   if (isSensor(item)) {
     Object.assign(rows, {


### PR DESCRIPTION
### Motivation
- Prevent the static web viewer from loading unsafe or unsupported mesh URIs and provide precise diagnostics when meshes are not staged or fail to load.
- Ensure the viewer only accepts staged relative `.stl`, `.dae`, or `.obj` files from known asset roots so exported scenes are reproducible and safe.

### Description
- Add `meshUriDiagnostic(item)` and make `safeMeshUri(item)` return the diagnostic `uri`, performing explicit checks and returning precise statuses like `unresolved_package_uri`, `missing_file`, `unsafe_path`, and `unsupported_format`.
- Restrict allowed relative mesh roots to `build/workcell_studio_web_scene/assets/`, `workcell_studio_web/`, and `assets/`, and reject `package://`, `file://`, `http(s)://`, protocol-relative, absolute, Windows drive, backslash, and `..` traversal paths.
- Update mesh staging/loading flow in `tryLoadMesh` to preserve primitive fallback visibility, set `item.mesh_status` to `loading`, `loaded`, or `load_error` (or a diagnostic status), set `render_status` to `mesh_loaded` on success, and write specific `fallback_reason`/diagnostic messages when validation or loading fails.
- Extend the inspector in `populateInspector()` to expose exporter provenance and diagnostics: `original_mesh_uri`, `mesh_staging_status`, `mesh_staged_path`, and `mesh_resolve_warning`.
- Update static viewer assertions to reflect new diagnostic tokens and allowed roots.

### Testing
- Ran `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py tests/test_export_workcell_studio_web_scene.py` and all tests passed (14 tests).
- Static assertions were exercised to confirm presence of new diagnostic strings, allowed staged roots, and inspector fields.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4392e936448331b5f521b81c16d273)