### PR TITLE
Document Web 3D mesh asset staging and browser-safe export

### DIFF
--- a/docs/WORKCELL_STUDIO_WEB_3D_EDIT_PATCH.md
+++ b/docs/WORKCELL_STUDIO_WEB_3D_EDIT_PATCH.md
@@ -9,12 +9,15 @@ Export the current scene for the static viewer:
 ```bash
 python3 scripts/export_workcell_studio_web_scene.py \
   --scene scenes/ur5_2f_test \
-  --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json
+  --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json \
+  --stage-assets
 ```
+
+Use `--stage-assets` for mesh-backed browser review. Browsers cannot load ROS `package://` URIs directly, so the exporter copies supported meshes under `build/workcell_studio_web_scene/assets/<scene_id>/...`, rewrites exported `mesh_uri` values to browser-safe relative URLs, and preserves the ROS/source URI in `original_mesh_uri`. Edit patches operate on item identity and transforms; they do not rewrite `mesh_uri`, `original_mesh_uri`, `mesh_staging_status`, `mesh_resolve_warning`, `mesh_status`, or `fallback_reason`. Those mesh fields are preserved/exported for review and troubleshooting remaining `primitive_fallback` visuals.
 
 Open `workcell_studio_web/viewer/index.html`, load the exported `web_scene.json`, select one `editable=true` and `locked=false` item, and use edit mode to preview the transform. Editable/unlocked selections show enabled XYZ/RPY/scale fields and a Three.js translation gizmo; locked/generated robot/tool previews remain read-only and explain that source layout/environment should be edited instead. Use **Export Edit Patch** to download an edit patch when the preview state is correct.
 
-From Workcell Builder, the **Export & Open Web 3D Viewer** selected-scene action performs only the export-and-open part of this workflow. It writes the export to `build/workcell_studio_web_scene/<scene_id>.web_scene.json` and opens the static viewer. It intentionally does not apply edit patches, write under `scenes/`, mutate source YAML, mutate generated scene files, modify Qt Scene3D visuals, or replace RViz/MoveIt as planning truth. If browser `file://` loading is unreliable, use `python3 -m http.server 8765` from the repository root and browse to `http://localhost:8765/workcell_studio_web/viewer/index.html`.
+From Workcell Builder, the **Export & Open Web 3D Viewer** selected-scene action performs only the export-and-open part of this workflow. It writes the export to `build/workcell_studio_web_scene/<scene_id>.web_scene.json` and opens the static viewer. It intentionally does not apply edit patches, write under `scenes/`, mutate source YAML, mutate generated scene files, modify Qt Scene3D visuals, or replace RViz/MoveIt as planning truth. If browser `file://` loading is unreliable, or if staged mesh asset URLs need to resolve consistently, use `python3 -m http.server 8765` from the repository root and browse to `http://localhost:8765/workcell_studio_web/viewer/index.html`.
 
 Validate the patch before applying it:
 

--- a/docs/WORKCELL_STUDIO_WEB_3D_SCENE_CONTRACT.md
+++ b/docs/WORKCELL_STUDIO_WEB_3D_SCENE_CONTRACT.md
@@ -108,9 +108,14 @@ Use the dependency-light exporter to materialize the v1 contract for a scene dir
 ```bash
 python3 scripts/export_workcell_studio_web_scene.py \
   --scene scenes/ur5_2f_test \
-  --output build/workcell_studio/ur5_2f_test.web_scene.json
+  --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json \
+  --stage-assets
 ```
 
 The exporter reads only optional scene inputs (`scene_manifest.yaml`, `cell_definition.yaml`, `environment.yaml`, `layout/workcell_studio_layout.yaml`, and `generated/scene_visual_mesh_index.json`) and writes one deterministic JSON file. The payload includes `inputs` presence metadata, per-item provenance, editability/lock state, ROS world Z-up units, and backend action descriptors that are requests for backend workflows rather than frontend-side execution hooks.
+
+Browsers cannot load ROS `package://` URIs directly. When `--stage-assets` is used, the exporter resolves and copies supported meshes into `build/workcell_studio_web_scene/assets/<scene_id>/...`, rewrites each staged item's `mesh_uri` to a browser-safe relative URL, and preserves the ROS/source URI in `original_mesh_uri`. Serve the repository root with `python3 -m http.server 8765` and load `http://localhost:8765/workcell_studio_web/viewer/index.html`; then choose the exported `build/workcell_studio_web_scene/<scene_id>.web_scene.json`. For `ur5_2f_test`, the expected browser result is that robot, table/workbench, camera, and gripper/tool meshes are recognizable when the source meshes exist and use supported formats.
+
+Items that still render as `primitive_fallback` should carry diagnostic fields rather than failing silently. Use `mesh_staging_status`, `mesh_resolve_warning`, `mesh_status`, and `fallback_reason` to distinguish missing source meshes, unresolved ROS packages, unsupported mesh formats, failed staging, and browser load failures.
 
 The `plan_simulate` action is intentionally exported as disabled in this first contract. It documents the intended guarded backend request path while avoiding any accidental real-hardware or runtime execution enablement from a static JSON export.

--- a/workcell_studio_web/viewer/README.md
+++ b/workcell_studio_web/viewer/README.md
@@ -9,16 +9,16 @@ The viewer uses an isolated browser import map that loads Three.js and OrbitCont
 From the repository root, export a browser-readable scene file into `build/`:
 
 ```bash
-python3 scripts/export_workcell_studio_web_scene.py --scene scenes/ur5_2f_test --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json
+python3 scripts/export_workcell_studio_web_scene.py --scene scenes/ur5_2f_test --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json --stage-assets
 ```
 
-`build/` outputs are local artifacts and should not be committed.
+Browsers cannot load ROS `package://` URIs directly and cannot read arbitrary package files from your local ROS workspace. Use `--stage-assets` when you want recognizable mesh-backed browser previews: the exporter resolves supported mesh references, copies them under `build/workcell_studio_web_scene/assets/<scene_id>/...`, rewrites exported `mesh_uri` values to browser-safe relative URLs, and preserves the original ROS/source reference in `original_mesh_uri`. `build/` outputs are local artifacts and should not be committed.
 
 ### Workcell Builder action
 
 Workcell Builder also exposes a selected-scene action named **Export & Open Web 3D Viewer** in the Safety / Review flow. The action resolves the selected scene, runs `scripts/export_workcell_studio_web_scene.py`, writes only to `build/workcell_studio_web_scene/<scene_id>.web_scene.json`, and opens `workcell_studio_web/viewer/index.html` with Qt/QDesktopServices. It does not write under `scenes/`, mutate source YAML, mutate generated scene files, apply edit patches, or change RViz/MoveIt planning truth.
 
-If direct `file://` loading is blocked or unreliable in your browser, run this from the repository root and open the URL manually:
+If direct `file://` loading is blocked or unreliable in your browser, or if you staged mesh assets and want relative mesh URLs to resolve consistently, run this from the repository root and open the URL manually:
 
 ```bash
 python3 -m http.server 8765
@@ -28,10 +28,18 @@ URL: `http://localhost:8765/workcell_studio_web/viewer/index.html`
 
 ## Open the viewer
 
-1. Open `workcell_studio_web/viewer/index.html` directly in a browser.
-2. Use the **Load web_scene.json** file picker.
-3. Select the exported JSON, for example:
+1. Serve the repository root when using staged assets:
+
+   ```bash
+   python3 -m http.server 8765
+   ```
+
+2. Open `http://localhost:8765/workcell_studio_web/viewer/index.html` in a browser. Directly opening `workcell_studio_web/viewer/index.html` can still work for JSON-only review, but served HTTP is the expected path for relative staged mesh assets.
+3. Use the **Load web_scene.json** file picker.
+4. Select the exported JSON, for example:
    `build/workcell_studio_web_scene/ur5_2f_test.web_scene.json`.
+
+Expected result: when source meshes exist and are supported by the exporter/viewer, the robot, table/workbench, camera, and gripper/tool should be recognizable mesh-backed visuals rather than only generic boxes.
 
 Because Three.js is loaded by CDN import map, the browser needs network access for the viewer to render. If the CDN modules cannot load, the page shows a clear Three.js/CDN load failure rather than silently pretending the scene rendered.
 
@@ -41,7 +49,7 @@ Phase 3 focuses on making exported scenes easier to inspect in a browser without
 
 - Scene auto-framing computes bounds from visible scene content and starts the camera at a useful overview angle instead of leaving the user to hunt for the cell manually.
 - **Reset View** restores the camera to the computed scene overview after orbiting, panning, or zooming.
-- Browser-safe mesh loading attempts are made for relative/local `.stl`, `.dae`, and `.obj` mesh references where the browser and Three.js loaders can support them from the selected/exported scene context.
+- Browser-safe mesh loading attempts are made for relative staged `.stl`, `.dae`, and `.obj` mesh references where the browser and Three.js loaders can support them from the selected/exported scene context. ROS `package://` URIs must be resolved by the exporter first; browsers cannot fetch them directly.
 - Mesh loading remains best-effort. If a mesh URI cannot be fetched, parsed, or rendered safely in the browser, the viewer keeps the scene readable with a primitive or box fallback instead of hiding the object.
 - The inspector exposes `render_status` so users can distinguish loaded meshes, primitive fallbacks, and failed mesh attempts for the selected object.
 - Runtime mesh warnings are surfaced in the warnings panel and inspector context so missing, blocked, or unsupported assets are visible during review.
@@ -55,7 +63,7 @@ Phase 3 focuses on making exported scenes easier to inspect in a browser without
 - Orbit, pan, and zoom camera controls.
 - Scene auto-framing with **Reset View**.
 - Primitive objects from exported primitive/fallback data.
-- Browser-safe relative/local `.stl`, `.dae`, and `.obj` mesh attempts where supported.
+- Browser-safe relative staged `.stl`, `.dae`, and `.obj` mesh attempts where supported.
 - Box fallback for unknown assets, unsupported mesh URIs, blocked mesh access, and mesh-only assets that cannot be rendered by the browser.
 - Camera/sensor markers with simple frustum lines.
 - Pick, place, spawn, and safety zones as simple transparent geometry when present in the JSON.
@@ -63,8 +71,27 @@ Phase 3 focuses on making exported scenes easier to inspect in a browser without
 - Grouped object list with IDs and labels.
 - Simple in-scene labels for readable object identification.
 - Object selection from the list and basic canvas picking.
-- Inspector fields for ID, label, type, source, pose XYZ/RPY, scale, editable, locked, mesh URI, `render_status`, and primitive details.
+- Inspector fields for ID, label, type, source, pose XYZ/RPY, scale, editable, locked, mesh URI, original mesh URI where exported, `render_status`, and primitive details.
 - JSON warnings and runtime mesh warnings rendered in a dedicated warnings panel.
+
+## Mesh asset staging and primitive fallback troubleshooting
+
+For the canonical manual export, run this from the repository root:
+
+```bash
+python3 scripts/export_workcell_studio_web_scene.py --scene scenes/ur5_2f_test --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json --stage-assets
+```
+
+With `--stage-assets`, supported meshes are resolved and copied under `build/workcell_studio_web_scene/assets/ur5_2f_test/...`. The exported `web_scene.json` uses browser-safe relative `mesh_uri` values that point at those staged files, while `original_mesh_uri` preserves the ROS `package://`, source-relative, or other original URI for diagnostics and backend traceability.
+
+If an item still appears as `primitive_fallback`, inspect the selected item in the JSON or viewer inspector and warnings panel:
+
+- `mesh_staging_status`: whether the exporter staged the mesh, skipped it, or failed to stage it.
+- `mesh_resolve_warning`: why the source URI could not be resolved or copied, such as an unknown package, missing file, or unsupported URI form.
+- `mesh_status`: whether the item has a mesh candidate, staged mesh, unsupported mesh, or fallback-only visual.
+- `fallback_reason`: the viewer/exporter reason a primitive was used, such as unsupported mesh type, failed browser load, missing mesh metadata, or no source mesh.
+
+Remaining primitive fallbacks are expected for assets without source meshes or unsupported mesh formats. They should not be treated as proof that scene generation, RViz/MoveIt, or fake-hardware validation is complete.
 
 ## Generate and validate after Web 3D edits
 
@@ -97,8 +124,8 @@ This is not the final Web Studio editor. It intentionally excludes:
 - MoveIt planning or execution.
 - EPD live input or perception runtime streaming.
 - Mesh-perfect rendering.
-- `package://` URI resolution in the browser.
-- Arbitrary local filesystem mesh access from the browser. Browser security rules only allow safe access to files made available through the selected file context, a local server, or other browser-permitted URLs.
+- `package://` URI resolution in the browser. Browsers cannot load ROS package URIs directly; run `scripts/export_workcell_studio_web_scene.py --stage-assets` so supported meshes are copied to `build/workcell_studio_web_scene/assets/<scene_id>/...` and `mesh_uri` is rewritten to a browser-safe relative URL while `original_mesh_uri` keeps the ROS/source URI for traceability.
+- Arbitrary local filesystem mesh access from the browser. Browser security rules only allow safe access to files made available through staged assets, the selected file context, a local server, or other browser-permitted URLs.
 - Authentication, deployment packaging, and frontend framework scaffolding.
 
 This static viewer is only a lightweight browser proof-of-life for reviewing exported scene contract data. It improves readability of exported scenes, but the source-of-truth editing, scene generation, validation, and fake-hardware simulation flows remain in Workcell Studio, generated packages, and RViz/MoveIt.


### PR DESCRIPTION
### Motivation

- Clarify how browser security and URI limitations affect Web 3D exports so users can produce mesh-backed browser previews reliably. 
- Make the exporter-to-viewer workflow discoverable and reduce confusion when exported scenes show primitive fallbacks instead of meshes. 
- Ensure edit-patch semantics are clear: patches modify transforms only and do not rewrite mesh/staging diagnostic fields. 

### Description

- Updated `workcell_studio_web/viewer/README.md`, `docs/WORKCELL_STUDIO_WEB_3D_SCENE_CONTRACT.md`, and `docs/WORKCELL_STUDIO_WEB_3D_EDIT_PATCH.md` to document the `--stage-assets` exporter behavior and browser limitations with `package://` URIs. 
- Documented that `scripts/export_workcell_studio_web_scene.py --stage-assets` resolves supported meshes and copies them under `build/workcell_studio_web_scene/assets/<scene_id>/...`, rewrites exported `mesh_uri` to browser-safe relative URLs, and preserves the original ROS/source URI in `original_mesh_uri`. 
- Added explicit manual export and serve instructions using `python3 scripts/export_workcell_studio_web_scene.py --scene ... --stage-assets`, `python3 -m http.server 8765`, and the viewer load URL `http://localhost:8765/workcell_studio_web/viewer/index.html`. 
- Added troubleshooting guidance for remaining primitive fallbacks and diagnostic fields to inspect: `mesh_staging_status`, `mesh_resolve_warning`, `mesh_status`, and `fallback_reason`, and clarified that edit patches do not rewrite mesh/staging fields. 

### Testing

- Ran `git diff --check` which passed with no whitespace/format errors. 
- Verified presence of the requested terms with ripgrep: `rg -n -e "--stage-assets|original_mesh_uri|mesh_staging_status|mesh_resolve_warning|mesh_status|fallback_reason|http://localhost:8765|package://"` against the three updated docs, and the checks passed. 
- Change is documentation-only; no runtime, launch, or hardware tests were required or executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a439a0140608331980c91e9219d2f1c)