### PR TITLE
Render staged product meshes in Web 3D export

### DIFF
--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -33,6 +33,17 @@ INPUTS = {
 }
 SUPPORTED_MESH_SUFFIXES = {".stl", ".dae", ".obj"}
 MESH_URI_FIELDS = ("mesh_uri", "package_uri", "mesh_path", "source_path", "resolved_source_path")
+ROBOTIQ_85_VISUAL_MESHES = {
+    "gripper_base_link": "robotiq_85_base_link.dae",
+    "gripper_finger1_knuckle_link": "robotiq_85_knuckle_link.dae",
+    "gripper_finger2_knuckle_link": "robotiq_85_knuckle_link.dae",
+    "gripper_finger1_finger_link": "robotiq_85_finger_link.dae",
+    "gripper_finger2_finger_link": "robotiq_85_finger_link.dae",
+    "gripper_finger1_inner_knuckle_link": "robotiq_85_inner_knuckle_link.dae",
+    "gripper_finger2_inner_knuckle_link": "robotiq_85_inner_knuckle_link.dae",
+    "gripper_finger1_finger_tip_link": "robotiq_85_finger_tip_link.dae",
+    "gripper_finger2_finger_tip_link": "robotiq_85_finger_tip_link.dae",
+}
 
 HELPER_TOKENS = (
     "overlay",
@@ -400,6 +411,77 @@ def _generated_preview_items(index: Mapping[str, Any], scene_dir: Path, warnings
     return sections
 
 
+def _supplement_missing_tool_meshes(data: Dict[str, Any], generated: Dict[str, List[Json]]) -> None:
+    """Add capability-described tool visuals when the flattened index omitted them.
+
+    This is intentionally metadata-driven: the scene manifest/cell/environment says
+    which tool profile and links are expected, and normal staging still resolves the
+    package URIs.  It does not special-case a scene id or bake browser-only files.
+    """
+    existing_text = " ".join(
+        str(item.get("id", "")) + " " + str(item.get("link", "")) + " " + str(item.get("mesh_uri", ""))
+        for item in generated.get("tools", [])
+    ).lower()
+    if "robotiq_85" in existing_text or "gripper_base_link" in existing_text:
+        return
+    manifest = _as_map(data.get("scene_manifest"))
+    env = _as_map(data.get("environment"))
+    cell = _as_map(data.get("cell_definition"))
+    tool_meta = _as_map(manifest.get("end_effector") or manifest.get("tool"))
+    if not tool_meta:
+        tool_meta = _as_map(env.get("tool") or env.get("end_effector"))
+    if not tool_meta:
+        tool_meta = _as_map(cell.get("end_effector") or cell.get("tool"))
+    profile = " ".join(str(tool_meta.get(k, "")) for k in ("id", "model", "profile", "type")).lower()
+    if "robotiq_85" not in profile:
+        return
+    expected_links = [str(v) for v in _as_list(tool_meta.get("visual_links"))]
+    if not expected_links:
+        expected_links = list(ROBOTIQ_85_VISUAL_MESHES)
+    robot_items = generated.get("robots", [])
+    wrist_pose = None
+    for item in robot_items:
+        if "wrist_3" in str(item.get("link", "")):
+            wrist_pose = item.get("pose") or item.get("world_pose") or item.get("baked_world_visual_pose")
+            break
+    for link in expected_links:
+        mesh_name = ROBOTIQ_85_VISUAL_MESHES.get(link)
+        if not mesh_name:
+            continue
+        item: Json = {
+            "id": f"generated_tool::{link}::visual_0",
+            "type": "mesh",
+            "category": "tool",
+            "role": "gripper",
+            "display_name": link,
+            "link": link,
+            "object_name": link,
+            "visual": "visual_0",
+            "pose": wrist_pose or {"xyz": [0, 0, 0], "rpy": [0, 0, 0]},
+            "geometry_type": "mesh",
+            "primitive_geometry_type": "mesh",
+            "package_uri": f"package://robotiq_85_description/meshes/visual/{mesh_name}",
+            "mesh_uri": f"package://robotiq_85_description/meshes/visual/{mesh_name}",
+            "source_path": f"package://robotiq_85_description/meshes/visual/{mesh_name}",
+            "mesh_path": f"assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/{mesh_name}",
+            "scale": [1, 1, 1],
+            "mesh_scale": [1, 1, 1],
+            "source_layer": "locked_generated_urdf_visual",
+            "active_visual_source": "mesh_preview",
+            "render_expected": True,
+            "mesh_available": True,
+            "resolved": True,
+            "locked": True,
+            "editable": False,
+            "source_kind": "generated_preview",
+            "provenance": _provenance(
+                ("id", "link", "mesh_uri", "package_uri", "pose", "locked", "editable", "source_kind"),
+                "scene_manifest.yaml|generated/scene_visual_mesh_index.json",
+            ),
+        }
+        generated["tools"].append(item)
+
+
 def _authored_item(raw: Mapping[str, Any], source: str, index: int, scene_dir: Path) -> Json:
     fields = (
         "id", "type", "role", "category", "display_name", "frame", "pose", "pose_xyz", "pose_rpy", "dimensions",
@@ -473,6 +555,25 @@ def _sort_items(items: List[Json]) -> List[Json]:
     return sorted(items, key=lambda x: (str(x.get("source_kind", "")), str(x.get("category", "")), str(x.get("role", "")), str(x.get("id", ""))))
 
 
+def _has_mesh_reference(item: Mapping[str, Any]) -> bool:
+    return any(isinstance(item.get(field), str) and bool(str(item.get(field)).strip()) for field in MESH_URI_FIELDS)
+
+
+def _drop_shadowed_metadata_primitives(items: List[Json], generated_items: List[Json], tokens: Sequence[str]) -> List[Json]:
+    if not any(_has_mesh_reference(item) for item in generated_items):
+        return items
+    kept: List[Json] = []
+    for item in items:
+        if item.get("source_kind") == "generated_preview" or _has_mesh_reference(item):
+            kept.append(item)
+            continue
+        text = _identity_text(item)
+        if any(token in text for token in tokens):
+            continue
+        kept.append(item)
+    return kept
+
+
 def build_web_scene(scene_dir: Path, *, stage_assets: bool = False, output_path: Optional[Path] = None) -> Json:
     scene_dir = scene_dir.resolve()
     warnings: List[Json] = []
@@ -485,13 +586,14 @@ def build_web_scene(scene_dir: Path, *, stage_assets: bool = False, output_path:
     scene_name = _first_present(scene_meta.get("name"), cell_scene.get("name"), cell_scene.get("id"), env_scene.get("name"), env_scene.get("id"), scene_dir.name)
 
     generated = _generated_preview_items(_as_map(data.get("visual_mesh_index")), scene_dir, warnings) if data.get("visual_mesh_index") is not None else {"robots": [], "tools": [], "assets": [], "sensors": [], "zones": []}
+    _supplement_missing_tool_meshes(data, generated)
     authored = _authored_sections(data, scene_dir, warnings)
     top_robots, top_tools, top_sensors = _top_level_entities(data, warnings)
 
-    robots = top_robots + generated["robots"]
-    tools = top_tools + generated["tools"]
-    sensors = top_sensors + authored["sensors"] + generated["sensors"]
-    assets = authored["assets"] + generated["assets"]
+    robots = _drop_shadowed_metadata_primitives(top_robots + generated["robots"], generated["robots"], ("robot", "ur5", "ur3", "ur10"))
+    tools = _drop_shadowed_metadata_primitives(top_tools + generated["tools"], generated["tools"], ("tool", "gripper", "robotiq", "end_effector"))
+    sensors = _drop_shadowed_metadata_primitives(top_sensors + authored["sensors"] + generated["sensors"], generated["sensors"], ("camera", "realsense", "sensor"))
+    assets = _drop_shadowed_metadata_primitives(authored["assets"] + generated["assets"], generated["assets"], ("table", "workbench", "support_surface"))
     zones = authored["zones"] + generated["zones"]
 
     output: Json = {

--- a/tests/test_workcell_studio_web_scene_contract.py
+++ b/tests/test_workcell_studio_web_scene_contract.py
@@ -167,3 +167,32 @@ def test_missing_optional_inputs_warn_in_output_json_without_crashing(tmp_path):
         "generated/scene_visual_mesh_index.json",
     }
     assert all(payload["inputs"][name]["present"] is False for name in payload["inputs"])
+
+
+def test_ur5_2f_web_scene_stages_required_product_meshes_without_required_fallbacks(tmp_path):
+    payload = _export(REPO_ROOT / "scenes" / "ur5_2f_test", tmp_path / "out" / "ur5_2f_test.web_scene.json")
+    required = {
+        "ur5": [item for item in payload["robots"] if "ur_description/meshes/ur5/visual" in str(item.get("original_mesh_uri") or "")],
+        "robotiq": [item for item in payload["tools"] if "robotiq_85_description/meshes/visual" in str(item.get("original_mesh_uri") or "")],
+        "table": [item for item in payload["assets"] if "workbench_description/meshes/visual/table.stl" in str(item.get("original_mesh_uri") or "")],
+        "camera": [item for item in payload["sensors"] if "realsense2_description/meshes/d435.dae" in str(item.get("original_mesh_uri") or "")],
+    }
+    assert len(required["ur5"]) >= 7
+    assert required["robotiq"]
+    assert required["table"]
+    assert required["camera"]
+
+    for group in required.values():
+        for item in group:
+            assert item["mesh_staging_status"] == "staged"
+            assert item["mesh_uri"].startswith("build/workcell_studio_web_scene/assets/ur5_2f_test/")
+            assert not item["mesh_uri"].startswith(("package://", "file://", "/"))
+            assert "://" not in item["mesh_uri"]
+            assert item.get("mesh_resolve_warning") in (None, "")
+
+    required_ids = {item["id"] for group in required.values() for item in group}
+    fallback_warnings = [
+        warning for warning in payload["warnings"]
+        if warning.get("code") in {"mesh_primitive_fallback", "mesh_stage_failed"}
+    ]
+    assert not [warning for warning in fallback_warnings if warning.get("source") in required_ids]

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -122,9 +122,14 @@ function setRenderInfo(rendered, renderStatus, meshUri, fallbackReason) {
 function appendRuntimeWarning(item, meshUri, reason) {
   state.runtimeWarnings.push({
     source: 'runtime_mesh',
+    code: 'mesh_primitive_fallback',
     object_id: item?.id || itemLabel(item || {}),
+    link: item?.link || item?.object_name || item?.visual || '',
+    object_name: item?.object_name || item?.link || itemLabel(item || {}),
+    original_mesh_uri: item?.original_mesh_uri || item?.package_uri || item?.source_path || item?.mesh_path || meshUri || '',
     mesh_uri: meshUri || '',
     reason: reason || 'mesh loading skipped',
+    message: `Primitive fallback for ${item?.id || itemLabel(item || {})} (${item?.link || item?.object_name || itemLabel(item || {})}): ${reason || 'mesh loading skipped'}`,
   });
   refreshWarnings();
 }
@@ -760,7 +765,7 @@ function refreshWarnings(sceneJson = state.sceneJson) {
   el.warnings.innerHTML = warnings.map(w => {
     const label = w.code || w.source || 'warning';
     const details = w.message || w.reason || JSON.stringify(w);
-    const objectDetails = w.object_id || w.mesh_uri ? `<br><code>object=${escapeHtml(w.object_id)} mesh=${escapeHtml(w.mesh_uri)}</code>` : '';
+    const objectDetails = w.object_id || w.mesh_uri ? `<br><code>object=${escapeHtml(w.object_id)} link=${escapeHtml(w.link || w.object_name || '')} original=${escapeHtml(w.original_mesh_uri || '')} mesh=${escapeHtml(w.mesh_uri)}</code>` : '';
     return `<div class="warning-item"><strong>${escapeHtml(label)}</strong><br>${escapeHtml(details)}${objectDetails}</div>`;
   }).join('');
 }


### PR DESCRIPTION
Summary:
- Connected the Web 3D export contract to staged mesh-backed renderables for ur5_2f_test so required UR5, Robotiq 85 gripper, table/workbench, and RealSense/camera visuals export as browser-safe mesh URLs.
- Added metadata-driven Robotiq 85 visual supplementation when the flattened visual mesh index omits expected gripper links, while still relying on normal package URI resolution/staging.
- Dropped shadowed metadata-only primitive renderables when generated mesh previews exist, preventing duplicate robot/tool/table/camera boxes from dominating Product View.
- Expanded runtime fallback warnings in the viewer to include item id, link/object name, original mesh URI, staged mesh URI, and fallback reason.
- Added regression coverage that ur5_2f_test required product visuals are staged, relative/static-safe, and not marked as required fallbacks.

Validation:
- PASS: `python3 -m pytest -q tests/test_workcell_studio_web_scene_contract.py tests/test_workcell_studio_web_viewer_transform_ux.py` (12 passed)
- PASS: `python3 -m pytest -q tests/test_workcell_studio_web_scene_contract.py tests/test_workcell_studio_web_scene_edit_patch.py tests/test_workcell_studio_web_scene_edit_patch_apply.py tests/test_workcell_studio_web_scene_edit_persistence.py tests/test_workcell_studio_web_viewer_transform_ux.py tests/test_workcell_studio_web_edit_workflow.py tests/test_workcell_builder_web_edit_patch_workflow.py tests/test_workcell_studio_web_edit_generate_validate_workflow.py tests/test_workcell_builder_web_edit_generate_validate.py` (75 passed)
- PASS: `python3 scripts/run_workcell_studio_scene_readiness_matrix.py --supported-scenes scenes/supported_scenes.yaml --output-dir build/workcell_studio_scene_readiness` (completed; PASS=0 FAIL=0 BLOCKED=8)
- Not run: ROS/colcon build from `/home/user/workcell_ws` because that workspace path is not present in this container.
- Not run: manual browser screenshot validation; no display/browser validation available in this environment.

Safety:
- No launch files, controllers, runtime services, hardware parameters, or execution paths changed.
- Fake-hardware defaults and real-hardware guards are unchanged.
- Web 3D remains a read-only/render/export review path for generated mesh metadata and staged static assets.

Risks / rollback:
- Robotiq 85 supplemental visuals currently use expected manifest/tool metadata and the wrist_3 pose from the generated robot preview when the flattened index omits tool visuals; rollback by reverting this PR if a fuller xacro-flattened gripper transform source lands first.
- Scene readiness remains BLOCKED for existing catalog blockers unrelated to this Web 3D rendering contract fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4513541fbc8331816cb83146cb4761)