### PR TITLE
Export canonical final transforms for generated preview meshes and prefer them in viewer

### DIFF
--- a/docs/WORKCELL_STUDIO_WEB_3D_TRANSFORMS.md
+++ b/docs/WORKCELL_STUDIO_WEB_3D_TRANSFORMS.md
@@ -1,0 +1,13 @@
+# Workcell Studio Web 3D transform convention
+
+Generated mesh renderables exported by `scripts/export_workcell_studio_web_scene.py` are rendered in ROS world, Z-up coordinates. For generated preview meshes, the exporter publishes one canonical final pose under `final_transform` (also mirrored as `world_from_visual` for explicit naming). That transform is the baked world-from-visual pose: the link world pose multiplied by the URDF visual origin before the payload reaches browser code.
+
+The web viewer must treat `final_transform` / `world_from_visual` as the complete render transform for a generated mesh. Browser code must not re-apply joint origins, link transforms, or `visual_origin` to generated mesh renderables, because those components are already baked into the canonical transform. Diagnostic fields such as `transform_source`, `link_world_pose`, `visual_origin`, `mesh_scale`, `baked_world_visual_matrix`, and `baked_world_visual_quaternion` are included only for inspection and troubleshooting.
+
+Fallback order for generated preview mesh transforms is:
+
+1. `baked_world_visual_pose` exported as `final_transform` / `world_from_visual`.
+2. `pose` when no baked world visual pose is available.
+3. `world_pose` when neither baked nor pose fields are available.
+
+Authored layout/environment items may continue to use their authored `pose`, `pose_xyz`, and `pose_rpy` fields because they are not generated URDF mesh renderables.

--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -385,6 +385,20 @@ def _section_from_item(item: Mapping[str, Any]) -> str:
     return "assets"
 
 
+def _canonical_generated_transform(raw: Mapping[str, Any]) -> Tuple[Optional[Any], Optional[str]]:
+    """Return the browser-ready world-from-visual pose and its source field.
+
+    Generated mesh rows may carry link-frame, visual-origin, and already-baked
+    world visual transforms.  The web viewer consumes the baked transform as a
+    final render pose; it must not multiply the visual origin a second time.
+    """
+    for field in ("baked_world_visual_pose", "pose", "world_pose"):
+        value = raw.get(field)
+        if value not in (None, "", [], {}):
+            return value, field
+    return None, None
+
+
 def _generated_preview_items(index: Mapping[str, Any], scene_dir: Path, warnings: List[Json]) -> Dict[str, List[Json]]:
     sections = {"robots": [], "tools": [], "assets": [], "sensors": [], "zones": []}
     items = _as_list(index.get("visual_items") or index.get("items"))
@@ -393,8 +407,10 @@ def _generated_preview_items(index: Mapping[str, Any], scene_dir: Path, warnings
         return sections
     fields = (
         "id", "type", "category", "role", "display_name", "link", "object_name", "visual", "pose", "world_pose",
-        "baked_world_visual_pose", "visual_origin", "geometry_type", "primitive_geometry_type", "package_uri",
-        "mesh_uri", "source_path", "mesh_path", "resolved_source_path", "scale", "mesh_scale", "source_layer", "active_visual_source",
+        "baked_world_visual_pose", "link_world_pose", "visual_origin", "baked_world_visual_matrix",
+        "baked_world_visual_quaternion", "baked_world_visual_transform_source", "geometry_type",
+        "primitive_geometry_type", "package_uri", "mesh_uri", "source_path", "mesh_path",
+        "resolved_source_path", "scale", "mesh_scale", "source_layer", "active_visual_source",
         "render_expected", "mesh_available", "resolved", "warning",
     )
     for i, raw in enumerate(items):
@@ -403,10 +419,23 @@ def _generated_preview_items(index: Mapping[str, Any], scene_dir: Path, warnings
             continue
         item = _copy_fields(raw, fields, INPUTS["visual_mesh_index"], scene_dir)
         item.setdefault("id", _stable_id("generated_preview", i))
+        final_transform, transform_source = _canonical_generated_transform(raw)
+        if final_transform is not None:
+            item["final_transform"] = final_transform
+            item["world_from_visual"] = final_transform
+            item["transform_source"] = transform_source
+        elif raw.get("baked_world_visual_transform_source"):
+            item["transform_source"] = raw.get("baked_world_visual_transform_source")
         item["locked"] = True
         item["editable"] = False
         item["source_kind"] = "generated_preview"
         item["provenance"].update({"locked": INPUTS["visual_mesh_index"], "editable": INPUTS["visual_mesh_index"], "source_kind": INPUTS["visual_mesh_index"]})
+        if final_transform is not None:
+            item["provenance"].update({
+                "final_transform": INPUTS["visual_mesh_index"],
+                "world_from_visual": INPUTS["visual_mesh_index"],
+                "transform_source": INPUTS["visual_mesh_index"],
+            })
         sections[_section_from_item(raw)].append(item)
     return sections
 

--- a/tests/test_export_workcell_studio_web_scene.py
+++ b/tests/test_export_workcell_studio_web_scene.py
@@ -39,7 +39,20 @@ def test_export_web_scene_contract_and_determinism(tmp_path):
         json.dumps(
             {
                 "visual_items": [
-                    {"id": "robot_mesh", "category": "robot", "role": "robot", "mesh_path": str(scene / "meshes/robot.dae")},
+                    {
+                        "id": "robot_mesh",
+                        "category": "robot",
+                        "role": "robot",
+                        "mesh_path": str(scene / "meshes/robot.dae"),
+                        "pose": {"xyz": [9, 9, 9], "rpy": [0, 0, 0]},
+                        "world_pose": {"xyz": [8, 8, 8], "rpy": [0, 0, 0]},
+                        "link_world_pose": {"xyz": [1, 2, 3], "rpy": [0.1, 0.2, 0.3]},
+                        "visual_origin": {"xyz": [0.1, 0.2, 0.3], "rpy": [0, 0, 1.57]},
+                        "baked_world_visual_pose": {"xyz": [1.1, 2.2, 3.3], "rpy": [0.1, 0.2, 1.87]},
+                        "baked_world_visual_matrix": [[1, 0, 0, 1.1], [0, 1, 0, 2.2], [0, 0, 1, 3.3], [0, 0, 0, 1]],
+                        "baked_world_visual_quaternion": [0, 0, 0, 1],
+                        "mesh_scale": [1, 1, 1],
+                    },
                     {"id": "camera_mesh", "category": "camera", "role": "camera", "package_uri": "package://camera/mesh.dae"},
                 ]
             }
@@ -65,8 +78,17 @@ def test_export_web_scene_contract_and_determinism(tmp_path):
     assert table["editable"] is True
     assert table["mesh_path"] == "meshes/table.stl"
     assert payload["robots"][-1]["mesh_path"] == "meshes/robot.dae"
+    assert payload["robots"][-1]["final_transform"] == {"xyz": [1.1, 2.2, 3.3], "rpy": [0.1, 0.2, 1.87]}
+    assert payload["robots"][-1]["world_from_visual"] == payload["robots"][-1]["final_transform"]
+    assert payload["robots"][-1]["transform_source"] == "baked_world_visual_pose"
+    assert payload["robots"][-1]["link_world_pose"] == {"xyz": [1, 2, 3], "rpy": [0.1, 0.2, 0.3]}
+    assert payload["robots"][-1]["visual_origin"] == {"xyz": [0.1, 0.2, 0.3], "rpy": [0, 0, 1.57]}
+    assert payload["robots"][-1]["mesh_scale"] == [1, 1, 1]
+    assert payload["robots"][-1]["baked_world_visual_matrix"] == [[1, 0, 0, 1.1], [0, 1, 0, 2.2], [0, 0, 1, 3.3], [0, 0, 0, 1]]
+    assert payload["robots"][-1]["baked_world_visual_quaternion"] == [0, 0, 0, 1]
     assert payload["sensors"][-1]["package_uri"] == "package://camera/mesh.dae"
     assert payload["robots"][-1]["provenance"]["mesh_path"] == "generated/scene_visual_mesh_index.json"
+    assert payload["robots"][-1]["provenance"]["final_transform"] == "generated/scene_visual_mesh_index.json"
 
 
 def test_export_web_scene_warns_for_missing_optional_inputs(tmp_path):
@@ -147,3 +169,10 @@ def test_export_web_scene_rejects_unsafe_or_unsupported_mesh_assets(tmp_path):
     assert "Unsupported mesh URI scheme" in by_id["remote"]["mesh_resolve_warning"]
     assert by_id["texture"]["mesh_staging_status"] == "unsupported_format"
     assert "Unsupported mesh format" in by_id["texture"]["mesh_resolve_warning"]
+
+
+def test_web_viewer_prefers_canonical_final_transform_without_visual_origin_recomposition():
+    viewer = Path("workcell_studio_web/viewer/viewer.js").read_text(encoding="utf-8")
+    pose_block = viewer.split("function poseOf(item)", 1)[1].split("function scaleOf", 1)[0]
+    assert "item.final_transform || item.world_from_visual || item.baked_world_visual_pose" in pose_block
+    assert "visual_origin" not in pose_block

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -46,10 +46,17 @@ function vector3(value, fallback = [0, 0, 0]) {
   const arr = Array.isArray(value) ? value : fallback;
   return new THREE.Vector3(Number(arr[0] || 0), Number(arr[1] || 0), Number(arr[2] || 0));
 }
+function canonicalFinalPose(item) {
+  return item.final_transform || item.world_from_visual || item.baked_world_visual_pose || item.pose || item.world_pose || {};
+}
 function poseOf(item) {
-  const pose = item.pose || item.world_pose || item.baked_world_visual_pose || {};
-  const xyz = item.pose_xyz || pose.xyz || pose.position || pose.translation || (Array.isArray(pose) ? pose.slice(0, 3) : [0, 0, 0]);
-  const rpy = item.pose_rpy || pose.rpy || pose.rotation_rpy || (Array.isArray(pose) ? pose.slice(3, 6) : [0, 0, 0]);
+  const pose = canonicalFinalPose(item);
+  const xyz = item.final_transform || item.world_from_visual || item.baked_world_visual_pose
+    ? (pose.xyz || pose.position || pose.translation || (Array.isArray(pose) ? pose.slice(0, 3) : [0, 0, 0]))
+    : (item.pose_xyz || pose.xyz || pose.position || pose.translation || (Array.isArray(pose) ? pose.slice(0, 3) : [0, 0, 0]));
+  const rpy = item.final_transform || item.world_from_visual || item.baked_world_visual_pose
+    ? (pose.rpy || pose.rotation_rpy || (Array.isArray(pose) ? pose.slice(3, 6) : [0, 0, 0]))
+    : (item.pose_rpy || pose.rpy || pose.rotation_rpy || (Array.isArray(pose) ? pose.slice(3, 6) : [0, 0, 0]));
   return { xyz: vector3(xyz), rpy: vector3(rpy) };
 }
 function scaleOf(item) {


### PR DESCRIPTION
### Motivation

- Make generated preview mesh renderables expose a single canonical final transform so browser consumers render meshes using one authoritative world-from-visual pose and avoid double-applying visual origins or joint/link transforms.

### Description

- Add `_canonical_generated_transform` and emit `final_transform`, mirrored as `world_from_visual`, and `transform_source` for generated preview rows in `scripts/export_workcell_studio_web_scene.py`, with provenance entries for the new fields; retain diagnostic fields such as `link_world_pose`, `visual_origin`, `mesh_scale`, `baked_world_visual_matrix`, and `baked_world_visual_quaternion`.
- Update `workcell_studio_web/viewer/viewer.js` so `poseOf`/`transformOf` prefer `final_transform`/`world_from_visual` and avoid re-composing or re-applying `visual_origin` in the browser.
- Add a short doc `docs/WORKCELL_STUDIO_WEB_3D_TRANSFORMS.md` describing the convention and fallback order (baked → pose → world_pose) and advising browser consumers not to re-apply visual origins.
- Add/adjust tests in `tests/test_export_workcell_studio_web_scene.py` to cover canonical transform emission and viewer-change detection.

### Testing

- Ran `python3 -m pytest tests/test_export_workcell_studio_web_scene.py tests/test_workcell_studio_web_scene_contract.py` and both suites passed.
- Ran `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py` and both suites passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45161009a88331bea1803ddda1d1e9)