### PR TITLE
Fix UR5 visual mesh index metadata

### DIFF
--- a/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json
@@ -1,1 +1,6443 @@
-{"scene_name":"ur5_2f_test","visual_count":9,"resolved":9,"unresolved":0,"generated_at":"2099-01-01T00:00:00+00:00","extractor_version":"2.15-generated-ur5-rviz-parity-seed","path_reference_root":"repository","extraction_mode":"urdf_flattened","urdf_expansion_mode":"xacro_expanded","xacro_available":true,"source_urdf_xacro_path":"scenes/ur5_2f_test/urdf/scene.urdf.xacro","source_mtime":4102444800.0,"ros_to_viewport_basis_applied":false,"safe_for_preview":true,"stale_index":false,"stale_reasons":[],"blockers":[],"warnings":[],"renderable_mesh_count":9,"renderable_item_count":9,"required_visible_ur5_links":["base_link_inertia","shoulder_link","upper_arm_link","forearm_link","wrist_1_link","wrist_2_link","wrist_3_link"],"ur5_visual_mesh_diagnostics":{"package_name":"ur_description","source":"repo_assets/ur_description","mesh_items_generated":7,"mesh_files_found":7,"status":"resolved"},"visual_items":[{"id":"generated_urdf::base_link_inertia::visual_0::0","source":"urdf_flattened","source_layer":"locked_generated_urdf_visual","active_visual_source":"mesh_preview","link":"base_link_inertia","object_name":"base_link_inertia","visual":"visual_0","visual_name":"visual_0","parent_link":"world","root_link":"world","link_chain":["world","base_link_inertia"],"pose":{"xyz":[0,0,0],"rpy":[0,0,0]},"world_pose":{"xyz":[0,0,0],"rpy":[0,0,0]},"link_world_pose":{"xyz":[0,0,0],"rpy":[0,0,0]},"baked_world_visual_pose":{"xyz":[0,0,0],"rpy":[0,0,0]},"visual_origin":{"xyz":[0,0,0],"rpy":[0,0,0]},"baked_world_visual_transform_source":"generated_urdf_identity_rviz_parity_seed","geometry_type":"mesh","primitive_geometry_type":"mesh","type":"mesh","category":"robot","role":"robot","package_uri":"package://ur_description/meshes/ur5/visual/base.dae","source_path":"package://ur_description/meshes/ur5/visual/base.dae","mesh_path":"assets/robots/universal_robot/ur_description/meshes/ur5/visual/base.dae","resolved_source_path":"assets/robots/universal_robot/ur_description/meshes/ur5/visual/base.dae","resolved":true,"mesh_available":true,"has_mesh_metadata":true,"render_expected":true,"transform_status":"resolved","link_transform_status":"resolved","metadata_tags":"source=urdf_flattened;locked_generated_urdf_visual;rviz_parity_seed","visual_index_link_name":"base_link_inertia","visual_index_package_uri":"package://ur_description/meshes/ur5/visual/base.dae","visual_index_mesh_uri":"package://ur_description/meshes/ur5/visual/base.dae","scale":[1,1,1],"mesh_scale":[1,1,1],"render_skip_reason":"","warning":""},{"id":"generated_urdf::shoulder_link::visual_1::1","source":"urdf_flattened","source_layer":"locked_generated_urdf_visual","active_visual_source":"mesh_preview","link":"shoulder_link","object_name":"shoulder_link","visual":"visual_1","visual_name":"visual_1","parent_link":"base_link_inertia","root_link":"world","link_chain":["world","base_link_inertia","shoulder_link"],"pose":{"xyz":[0,0,0.089159],"rpy":[0,0,0]},"world_pose":{"xyz":[0,0,0.089159],"rpy":[0,0,0]},"link_world_pose":{"xyz":[0,0,0.089159],"rpy":[0,0,0]},"baked_world_visual_pose":{"xyz":[0,0,0.089159],"rpy":[0,0,0]},"visual_origin":{"xyz":[0,0,0],"rpy":[0,0,0]},"baked_world_visual_transform_source":"generated_urdf_identity_rviz_parity_seed","geometry_type":"mesh","primitive_geometry_type":"mesh","type":"mesh","category":"robot","role":"robot","package_uri":"package://ur_description/meshes/ur5/visual/shoulder.dae","source_path":"package://ur_description/meshes/ur5/visual/shoulder.dae","mesh_path":"assets/robots/universal_robot/ur_description/meshes/ur5/visual/shoulder.dae","resolved_source_path":"assets/robots/universal_robot/ur_description/meshes/ur5/visual/shoulder.dae","resolved":true,"mesh_available":true,"has_mesh_metadata":true,"render_expected":true,"transform_status":"resolved","link_transform_status":"resolved","metadata_tags":"source=urdf_flattened;locked_generated_urdf_visual;rviz_parity_seed","visual_index_link_name":"shoulder_link","visual_index_package_uri":"package://ur_description/meshes/ur5/visual/shoulder.dae","visual_index_mesh_uri":"package://ur_description/meshes/ur5/visual/shoulder.dae","scale":[1,1,1],"mesh_scale":[1,1,1],"render_skip_reason":"","warning":""},{"id":"generated_urdf::upper_arm_link::visual_2::2","source":"urdf_flattened","source_layer":"locked_generated_urdf_visual","active_visual_source":"mesh_preview","link":"upper_arm_link","object_name":"upper_arm_link","visual":"visual_2","visual_name":"visual_2","parent_link":"shoulder_link","root_link":"world","link_chain":["world","shoulder_link","upper_arm_link"],"pose":{"xyz":[0,0.13585,0.089159],"rpy":[0,-3.6732051032936018e-06,0]},"world_pose":{"xyz":[0,0.13585,0.089159],"rpy":[0,-3.6732051032936018e-06,0]},"link_world_pose":{"xyz":[0,0.13585,0.089159],"rpy":[0,-3.6732051032936018e-06,0]},"baked_world_visual_pose":{"xyz":[0,0.13585,0.089159],"rpy":[0,-3.6732051032936018e-06,0]},"visual_origin":{"xyz":[0,0,0],"rpy":[0,0,0]},"baked_world_visual_transform_source":"generated_urdf_identity_rviz_parity_seed","geometry_type":"mesh","primitive_geometry_type":"mesh","type":"mesh","category":"robot","role":"robot","package_uri":"package://ur_description/meshes/ur5/visual/upperarm.dae","source_path":"package://ur_description/meshes/ur5/visual/upperarm.dae","mesh_path":"assets/robots/universal_robot/ur_description/meshes/ur5/visual/upperarm.dae","resolved_source_path":"assets/robots/universal_robot/ur_description/meshes/ur5/visual/upperarm.dae","resolved":true,"mesh_available":true,"has_mesh_metadata":true,"render_expected":true,"transform_status":"resolved","link_transform_status":"resolved","metadata_tags":"source=urdf_flattened;locked_generated_urdf_visual;rviz_parity_seed","visual_index_link_name":"upper_arm_link","visual_index_package_uri":"package://ur_description/meshes/ur5/visual/upperarm.dae","visual_index_mesh_uri":"package://ur_description/meshes/ur5/visual/upperarm.dae","scale":[1,1,1],"mesh_scale":[1,1,1],"render_skip_reason":"","warning":""},{"id":"generated_urdf::forearm_link::visual_3::3","source":"urdf_flattened","source_layer":"locked_generated_urdf_visual","active_visual_source":"mesh_preview","link":"forearm_link","object_name":"forearm_link","visual":"visual_3","visual_name":"visual_3","parent_link":"upper_arm_link","root_link":"world","link_chain":["world","upper_arm_link","forearm_link"],"pose":{"xyz":[-1.5611121689202732e-06,0.016500000087168957,0.5141589999937487],"rpy":[-1.5707966253386139,1.5707963118937354,-1.5707966253386139]},"world_pose":{"xyz":[-1.5611121689202732e-06,0.016500000087168957,0.5141589999937487],"rpy":[-1.5707966253386139,1.5707963118937354,-1.5707966253386139]},"link_world_pose":{"xyz":[-1.5611121689202732e-06,0.016500000087168957,0.5141589999937487],"rpy":[-1.5707966253386139,1.5707963118937354,-1.5707966253386139]},"baked_world_visual_pose":{"xyz":[-1.5611121689202732e-06,0.016500000087168957,0.5141589999937487],"rpy":[-1.5707966253386139,1.5707963118937354,-1.5707966253386139]},"visual_origin":{"xyz":[0,0,0],"rpy":[0,0,0]},"baked_world_visual_transform_source":"generated_urdf_identity_rviz_parity_seed","geometry_type":"mesh","primitive_geometry_type":"mesh","type":"mesh","category":"robot","role":"robot","package_uri":"package://ur_description/meshes/ur5/visual/forearm.dae","source_path":"package://ur_description/meshes/ur5/visual/forearm.dae","mesh_path":"assets/robots/universal_robot/ur_description/meshes/ur5/visual/forearm.dae","resolved_source_path":"assets/robots/universal_robot/ur_description/meshes/ur5/visual/forearm.dae","resolved":true,"mesh_available":true,"has_mesh_metadata":true,"render_expected":true,"transform_status":"resolved","link_transform_status":"resolved","metadata_tags":"source=urdf_flattened;locked_generated_urdf_visual;rviz_parity_seed","visual_index_link_name":"forearm_link","visual_index_package_uri":"package://ur_description/meshes/ur5/visual/forearm.dae","visual_index_mesh_uri":"package://ur_description/meshes/ur5/visual/forearm.dae","scale":[1,1,1],"mesh_scale":[1,1,1],"render_skip_reason":"","warning":""},{"id":"generated_urdf::wrist_1_link::visual_4::4","source":"urdf_flattened","source_layer":"locked_generated_urdf_visual","active_visual_source":"mesh_preview","link":"wrist_1_link","object_name":"wrist_1_link","visual":"visual_4","visual_name":"visual_4","parent_link":"forearm_link","root_link":"world","link_chain":["world","forearm_link","wrist_1_link"],"pose":{"xyz":[0.392248438887831,0.01615000008716891,0.5141589999938204],"rpy":[-5.5837728232363146e-05,1.5707926535453185,-5.583772823204767e-05]},"world_pose":{"xyz":[0.392248438887831,0.01615000008716891,0.5141589999938204],"rpy":[-5.5837728232363146e-05,1.5707926535453185,-5.583772823204767e-05]},"link_world_pose":{"xyz":[0.392248438887831,0.01615000008716891,0.5141589999938204],"rpy":[-5.5837728232363146e-05,1.5707926535453185,-5.583772823204767e-05]},"baked_world_visual_pose":{"xyz":[0.392248438887831,0.01615000008716891,0.5141589999938204],"rpy":[-5.5837728232363146e-05,1.5707926535453185,-5.583772823204767e-05]},"visual_origin":{"xyz":[0,0,0],"rpy":[0,0,0]},"baked_world_visual_transform_source":"generated_urdf_identity_rviz_parity_seed","geometry_type":"mesh","primitive_geometry_type":"mesh","type":"mesh","category":"robot","role":"robot","package_uri":"package://ur_description/meshes/ur5/visual/wrist1.dae","source_path":"package://ur_description/meshes/ur5/visual/wrist1.dae","mesh_path":"assets/robots/universal_robot/ur_description/meshes/ur5/visual/wrist1.dae","resolved_source_path":"assets/robots/universal_robot/ur_description/meshes/ur5/visual/wrist1.dae","resolved":true,"mesh_available":true,"has_mesh_metadata":true,"render_expected":true,"transform_status":"resolved","link_transform_status":"resolved","metadata_tags":"source=urdf_flattened;locked_generated_urdf_visual;rviz_parity_seed","visual_index_link_name":"wrist_1_link","visual_index_package_uri":"package://ur_description/meshes/ur5/visual/wrist1.dae","visual_index_mesh_uri":"package://ur_description/meshes/ur5/visual/wrist1.dae","scale":[1,1,1],"mesh_scale":[1,1,1],"render_skip_reason":"","warning":""},{"id":"generated_urdf::wrist_2_link::visual_5::5","source":"urdf_flattened","source_layer":"locked_generated_urdf_visual","active_visual_source":"mesh_preview","link":"wrist_2_link","object_name":"wrist_2_link","visual":"visual_5","visual_name":"visual_5","parent_link":"wrist_1_link","root_link":"world","link_chain":["world","wrist_1_link","wrist_2_link"],"pose":{"xyz":[0.3918984388878334,0.10915000008724068,0.514158998689124],"rpy":[-1.5707926535897931,-3.6734102060051815e-06,-1.5707963270134926]},"world_pose":{"xyz":[0.3918984388878334,0.10915000008724068,0.514158998689124],"rpy":[-1.5707926535897931,-3.6734102060051815e-06,-1.5707963270134926]},"link_world_pose":{"xyz":[0.3918984388878334,0.10915000008724068,0.514158998689124],"rpy":[-1.5707926535897931,-3.6734102060051815e-06,-1.5707963270134926]},"baked_world_visual_pose":{"xyz":[0.3918984388878334,0.10915000008724068,0.514158998689124],"rpy":[-1.5707926535897931,-3.6734102060051815e-06,-1.5707963270134926]},"visual_origin":{"xyz":[0,0,0],"rpy":[0,0,0]},"baked_world_visual_transform_source":"generated_urdf_identity_rviz_parity_seed","geometry_type":"mesh","primitive_geometry_type":"mesh","type":"mesh","category":"robot","role":"robot","package_uri":"package://ur_description/meshes/ur5/visual/wrist2.dae","source_path":"package://ur_description/meshes/ur5/visual/wrist2.dae","mesh_path":"assets/robots/universal_robot/ur_description/meshes/ur5/visual/wrist2.dae","resolved_source_path":"assets/robots/universal_robot/ur_description/meshes/ur5/visual/wrist2.dae","resolved":true,"mesh_available":true,"has_mesh_metadata":true,"render_expected":true,"transform_status":"resolved","link_transform_status":"resolved","metadata_tags":"source=urdf_flattened;locked_generated_urdf_visual;rviz_parity_seed","visual_index_link_name":"wrist_2_link","visual_index_package_uri":"package://ur_description/meshes/ur5/visual/wrist2.dae","visual_index_mesh_uri":"package://ur_description/meshes/ur5/visual/wrist2.dae","scale":[1,1,1],"mesh_scale":[1,1,1],"render_skip_reason":"","warning":""},{"id":"generated_urdf::wrist_3_link::visual_6::6","source":"urdf_flattened","source_layer":"locked_generated_urdf_visual","active_visual_source":"mesh_preview","link":"wrist_3_link","object_name":"wrist_3_link","visual":"visual_6","visual_name":"visual_6","parent_link":"wrist_2_link","root_link":"world","link_chain":["world","wrist_2_link","wrist_3_link"],"pose":{"xyz":[0.4868987411750924,0.10914969774609591,0.513659],"rpy":[-1.5341792327998767,1.5706962591554918,-1.5340829063937342]},"world_pose":{"xyz":[0.4868987411750924,0.10914969774609591,0.513659],"rpy":[-1.5341792327998767,1.5706962591554918,-1.5340829063937342]},"link_world_pose":{"xyz":[0.4868987411750924,0.10914969774609591,0.513659],"rpy":[-1.5341792327998767,1.5706962591554918,-1.5340829063937342]},"baked_world_visual_pose":{"xyz":[0.4868987411750924,0.10914969774609591,0.513659],"rpy":[-1.5341792327998767,1.5706962591554918,-1.5340829063937342]},"visual_origin":{"xyz":[0,0,0],"rpy":[0,0,0]},"baked_world_visual_transform_source":"generated_urdf_identity_rviz_parity_seed","geometry_type":"mesh","primitive_geometry_type":"mesh","type":"mesh","category":"robot","role":"robot","package_uri":"package://ur_description/meshes/ur5/visual/wrist3.dae","source_path":"package://ur_description/meshes/ur5/visual/wrist3.dae","mesh_path":"assets/robots/universal_robot/ur_description/meshes/ur5/visual/wrist3.dae","resolved_source_path":"assets/robots/universal_robot/ur_description/meshes/ur5/visual/wrist3.dae","resolved":true,"mesh_available":true,"has_mesh_metadata":true,"render_expected":true,"transform_status":"resolved","link_transform_status":"resolved","metadata_tags":"source=urdf_flattened;locked_generated_urdf_visual;rviz_parity_seed","visual_index_link_name":"wrist_3_link","visual_index_package_uri":"package://ur_description/meshes/ur5/visual/wrist3.dae","visual_index_mesh_uri":"package://ur_description/meshes/ur5/visual/wrist3.dae","scale":[1,1,1],"mesh_scale":[1,1,1],"render_skip_reason":"","warning":""},{"id":"generated_urdf::table_::none_::16","source":"urdf_flattened","source_layer":"locked_generated_urdf_visual","active_visual_source":"mesh_preview","link":"table_","object_name":"table_","visual":"none_","visual_name":"none_","parent_link":"world","root_link":"world","link_chain":["world","table_"],"pose":{"xyz":[0,0,0],"rpy":[0,0,0]},"world_pose":{"xyz":[0,0,0],"rpy":[0,0,0]},"link_world_pose":{"xyz":[0,0,0],"rpy":[0,0,0]},"baked_world_visual_pose":{"xyz":[0,0,0],"rpy":[0,0,0]},"visual_origin":{"xyz":[0,0,0],"rpy":[0,0,0]},"baked_world_visual_transform_source":"generated_urdf_identity_rviz_parity_seed","geometry_type":"mesh","primitive_geometry_type":"mesh","type":"mesh","category":"table/workbench","role":"table/workbench","package_uri":"package://workbench_description/meshes/visual/table.stl","source_path":"package://workbench_description/meshes/visual/table.stl","mesh_path":"assets/environment/table_description/meshes/visual/table.stl","resolved_source_path":"assets/environment/table_description/meshes/visual/table.stl","resolved":true,"mesh_available":true,"has_mesh_metadata":true,"render_expected":true,"transform_status":"resolved","link_transform_status":"resolved","metadata_tags":"source=urdf_flattened;locked_generated_urdf_visual;rviz_parity_seed","visual_index_link_name":"table_","visual_index_package_uri":"package://workbench_description/meshes/visual/table.stl","visual_index_mesh_uri":"package://workbench_description/meshes/visual/table.stl","scale":[1,1,1],"mesh_scale":[1,1,1],"render_skip_reason":"","warning":""},{"id":"generated_urdf::camera_link::visual_17::17","source":"urdf_flattened","source_layer":"locked_generated_urdf_visual","active_visual_source":"mesh_preview","link":"camera_link","object_name":"camera_link","visual":"visual_17","visual_name":"visual_17","parent_link":"world","root_link":"world","link_chain":["world","camera_link"],"pose":{"xyz":[0.45,-0.55,1.15],"rpy":[0,0,0]},"world_pose":{"xyz":[0.45,-0.55,1.15],"rpy":[0,0,0]},"link_world_pose":{"xyz":[0.45,-0.55,1.15],"rpy":[0,0,0]},"baked_world_visual_pose":{"xyz":[0.45,-0.55,1.15],"rpy":[0,0,0]},"visual_origin":{"xyz":[0,0,0],"rpy":[0,0,0]},"baked_world_visual_transform_source":"generated_urdf_identity_rviz_parity_seed","geometry_type":"mesh","primitive_geometry_type":"mesh","type":"mesh","category":"camera","role":"camera","package_uri":"package://realsense2_description/meshes/d435.dae","source_path":"package://realsense2_description/meshes/d435.dae","mesh_path":"assets/environment/realsense2_description/meshes/d435.dae","resolved_source_path":"assets/environment/realsense2_description/meshes/d435.dae","resolved":true,"mesh_available":true,"has_mesh_metadata":true,"render_expected":true,"transform_status":"resolved","link_transform_status":"resolved","metadata_tags":"source=urdf_flattened;locked_generated_urdf_visual;rviz_parity_seed","visual_index_link_name":"camera_link","visual_index_package_uri":"package://realsense2_description/meshes/d435.dae","visual_index_mesh_uri":"package://realsense2_description/meshes/d435.dae","scale":[1,1,1],"mesh_scale":[1,1,1],"render_skip_reason":"","warning":""}]}
+{
+  "scene_name": "ur5_2f_test",
+  "visual_count": 25,
+  "resolved": 18,
+  "unresolved": 7,
+  "generated_at": "2026-07-01T14:13:08.402980+00:00",
+  "extractor_version": "2.12",
+  "path_reference_root": "repository",
+  "extraction_mode": "urdf_flattened",
+  "urdf_expansion_mode": "xacro_lite_expanded",
+  "xacro_available": false,
+  "source_urdf_xacro_path": "scenes/ur5_2f_test/urdf/scene.urdf.xacro",
+  "source_launch_xacro_request": {
+    "launch_path": "scenes/ur5_2f_test/launch/demo.launch.py",
+    "package_name": "ur5_2f_test",
+    "rel_path": "urdf/scene.urdf.xacro",
+    "mappings": {
+      "ur_type": "ur5",
+      "name": "ur5",
+      "tf_prefix": "",
+      "world_frame": "world",
+      "tool_mount_link": "tool0",
+      "gripper_profile": "robotiq_85_gripper",
+      "grasp_frame": "ee_palm",
+      "use_fake_hardware": "true"
+    }
+  },
+  "source_mtime": 1782912584.4753911,
+  "source_expanded_urdf_path": "",
+  "ros_to_viewport_basis_applied": false,
+  "fallback_reason": "xacro executable unavailable; used safe repo-local xacro-lite expansion",
+  "xacro_real_command_succeeded": false,
+  "xacro_status": "real_xacro_unavailable",
+  "xacro_diagnostics": {
+    "xacro_status": "real_xacro_unavailable",
+    "xacro_command": [
+      "xacro-lite",
+      "scenes/ur5_2f_test/urdf/scene.urdf.xacro"
+    ],
+    "xacro_returncode": null,
+    "xacro_stdout": "",
+    "xacro_stderr": "",
+    "xacro_diagnostic": "xacro executable unavailable; used safe repo-local xacro-lite expansion",
+    "fallback_reason": "real xacro unavailable; xacro executable unavailable; used safe repo-local xacro-lite expansion",
+    "xacro_lite_command": [
+      "xacro-lite",
+      "scenes/ur5_2f_test/urdf/scene.urdf.xacro"
+    ]
+  },
+  "safe_for_preview": false,
+  "unresolved_placeholder_count": 0,
+  "has_transform_collapse_warning": false,
+  "candidate_mesh_count": 25,
+  "emitted_visual_count": 25,
+  "robotiq_85_visual_repair_applied": false,
+  "root_links": [
+    "world"
+  ],
+  "visual_parent_link_counts": {
+    "world": 18
+  },
+  "missing_parent_links": [],
+  "transform_chain_diagnostics": [],
+  "initial_joint_source": "initial_positions.yaml",
+  "ur5_preview_joint_pose": {
+    "source": "workcell_preview_home_pose_all_zero_initial_positions",
+    "joints": {
+      "shoulder_pan_joint": 0.0,
+      "shoulder_lift_joint": -1.5708,
+      "elbow_joint": 1.5708,
+      "wrist_1_joint": -1.5708,
+      "wrist_2_joint": -1.5708,
+      "wrist_3_joint": 0.0
+    }
+  },
+  "joint_defaults_used": [
+    "elbow_joint",
+    "shoulder_lift_joint",
+    "shoulder_pan_joint",
+    "wrist_1_joint",
+    "wrist_2_joint",
+    "wrist_3_joint"
+  ],
+  "transform_status_counts": {
+    "resolved": 18,
+    "static_mesh_resolved": 7
+  },
+  "mesh_format_counts": {
+    "unknown": 7,
+    ".dae": 17,
+    ".stl": 1
+  },
+  "renderable_mesh_count": 18,
+  "renderable_item_count": 18,
+  "static_robot_primitive_fallback_count": 0,
+  "static_robot_mesh_visual_count": 7,
+  "legacy_static_fallback_metadata": {
+    "legacy_static_fallback_requested": true,
+    "legacy_static_fallback_skipped": false,
+    "legacy_static_fallback_skip_reason": "",
+    "authoritative_source": "urdf_flattened",
+    "authoritative_ur5_links": [],
+    "legacy_static_fallback_source": "legacy_static_fallback",
+    "legacy_static_fallback_counts": {
+      "mesh_visual": 7,
+      "primitive": 0
+    }
+  },
+  "ur5_visual_mesh_diagnostics": {
+    "package_name": "ur_description",
+    "source": "repo_assets/ur_description",
+    "root_path": "assets/robots/universal_robot/ur_description",
+    "visual_folder": "assets/robots/universal_robot/ur_description/meshes/ur5/visual",
+    "visual_folder_exists": true,
+    "mesh_files_found": 7,
+    "mesh_items_generated": 7,
+    "static_fallback_items_generated": 0,
+    "status": "resolved",
+    "missing_expected_files": []
+  },
+  "static_parent_resolved_count": 0,
+  "stale_index": false,
+  "stale_reasons": [],
+  "blockers": [],
+  "warnings": [
+    "xacro-lite preview is degraded and is not equivalent to real xacro-expanded output"
+  ],
+  "visual_items": [
+    {
+      "id": "urdf_visual_0_base_link_inertia_visual_0_mesh",
+      "source": "urdf_flattened",
+      "link": "base_link_inertia",
+      "object_name": "base_link_inertia",
+      "visual": "visual_0",
+      "visual_name": "visual_0",
+      "visual_index": 0,
+      "source_row_index": 0,
+      "parent_link": "base_link",
+      "immediate_parent_link": "base_link",
+      "root_link": "world",
+      "link_chain": [
+        "world",
+        "base_link",
+        "base_link_inertia"
+      ],
+      "joint_parent_link": "base_link",
+      "parent_joint": "base_link-base_link_inertia",
+      "parent_joint_name": "base_link-base_link_inertia",
+      "parent_joint_type": "fixed",
+      "parent_joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          3.141592653589793
+        ]
+      },
+      "parent_joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "parent_joint_value": 0.0,
+      "parent_joint_value_source": "zero_default",
+      "joint_type": "fixed",
+      "joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          3.141592653589793
+        ]
+      },
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          -2.4492935982947064e-16
+        ]
+      },
+      "chain_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          -2.4492935982947064e-16
+        ]
+      },
+      "world_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          -2.4492935982947064e-16
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          3.141592653589793
+        ]
+      },
+      "expected_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          -2.4492935982947064e-16
+        ]
+      },
+      "baked_world_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          -2.4492935982947064e-16
+        ]
+      },
+      "baked_world_visual_matrix": [
+        [
+          1.0,
+          2.4492935982947064e-16,
+          0.0,
+          0.0
+        ],
+        [
+          -2.4492935982947064e-16,
+          1.0,
+          0.0,
+          0.0
+        ],
+        [
+          0.0,
+          0.0,
+          1.0,
+          0.0
+        ],
+        [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      ],
+      "baked_world_visual_quaternion": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": -1.2246467991473532e-16,
+        "w": 1.0
+      },
+      "baked_world_visual_transform_source": "urdf_fk_link_world_times_visual_origin",
+      "visual_origin_applied_to_pose": true,
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          3.141592653589793
+        ]
+      },
+      "joint_name": "base_link-base_link_inertia",
+      "joint_value": 0.0,
+      "applied_joint_value": 0.0,
+      "joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "joint_value_source": "zero_default",
+      "applied_joint_value_source": "zero_default",
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "color": null,
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->base_link(fixed)",
+        "base_link->base_link_inertia(fixed)"
+      ],
+      "render_expected": false,
+      "mesh_uri": "${mesh}",
+      "geometry_type": "mesh",
+      "package_uri": "",
+      "source_path": "${mesh}",
+      "mesh_path": "${mesh}",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "resolved_source_path": "${mesh}",
+      "resolved_source_path_is_repo_relative": false,
+      "resolved": false,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "file_not_found",
+      "warning": "file_not_found",
+      "repo_relative_source_path": "${mesh}",
+      "scene_relative_source_path": "",
+      "asset_relative_source_path": ""
+    },
+    {
+      "id": "urdf_visual_1_shoulder_link_visual_1_mesh",
+      "source": "urdf_flattened",
+      "link": "shoulder_link",
+      "object_name": "shoulder_link",
+      "visual": "visual_1",
+      "visual_name": "visual_1",
+      "visual_index": 1,
+      "source_row_index": 1,
+      "parent_link": "base_link_inertia",
+      "immediate_parent_link": "base_link_inertia",
+      "root_link": "world",
+      "link_chain": [
+        "world",
+        "base_link",
+        "base_link_inertia",
+        "shoulder_link"
+      ],
+      "joint_parent_link": "base_link_inertia",
+      "parent_joint": "shoulder_pan_joint",
+      "parent_joint_name": "shoulder_pan_joint",
+      "parent_joint_type": "revolute",
+      "parent_joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "parent_joint_axis": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "parent_joint_value": 0.0,
+      "parent_joint_value_source": "fake-hardware default",
+      "joint_type": "revolute",
+      "joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          -2.4492935982947064e-16
+        ]
+      },
+      "chain_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          -2.4492935982947064e-16
+        ]
+      },
+      "world_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          -2.4492935982947064e-16
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          3.141592653589793
+        ]
+      },
+      "expected_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          -2.4492935982947064e-16
+        ]
+      },
+      "baked_world_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          -2.4492935982947064e-16
+        ]
+      },
+      "baked_world_visual_matrix": [
+        [
+          1.0,
+          2.4492935982947064e-16,
+          0.0,
+          0.0
+        ],
+        [
+          -2.4492935982947064e-16,
+          1.0,
+          0.0,
+          0.0
+        ],
+        [
+          0.0,
+          0.0,
+          1.0,
+          0.0
+        ],
+        [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      ],
+      "baked_world_visual_quaternion": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": -1.2246467991473532e-16,
+        "w": 1.0
+      },
+      "baked_world_visual_transform_source": "urdf_fk_link_world_times_visual_origin",
+      "visual_origin_applied_to_pose": true,
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          3.141592653589793
+        ]
+      },
+      "joint_name": "shoulder_pan_joint",
+      "joint_value": 0.0,
+      "applied_joint_value": 0.0,
+      "joint_axis": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "joint_value_source": "fake-hardware default",
+      "applied_joint_value_source": "fake-hardware default",
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "color": null,
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->base_link(fixed)",
+        "base_link->base_link_inertia(fixed)",
+        "base_link_inertia->shoulder_link(revolute)"
+      ],
+      "render_expected": false,
+      "mesh_uri": "${mesh}",
+      "geometry_type": "mesh",
+      "package_uri": "",
+      "source_path": "${mesh}",
+      "mesh_path": "${mesh}",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "resolved_source_path": "${mesh}",
+      "resolved_source_path_is_repo_relative": false,
+      "resolved": false,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "file_not_found",
+      "warning": "file_not_found",
+      "repo_relative_source_path": "${mesh}",
+      "scene_relative_source_path": "",
+      "asset_relative_source_path": ""
+    },
+    {
+      "id": "urdf_visual_2_upper_arm_link_visual_2_mesh",
+      "source": "urdf_flattened",
+      "link": "upper_arm_link",
+      "object_name": "upper_arm_link",
+      "visual": "visual_2",
+      "visual_name": "visual_2",
+      "visual_index": 2,
+      "source_row_index": 2,
+      "parent_link": "shoulder_link",
+      "immediate_parent_link": "shoulder_link",
+      "root_link": "world",
+      "link_chain": [
+        "world",
+        "base_link",
+        "base_link_inertia",
+        "shoulder_link",
+        "upper_arm_link"
+      ],
+      "joint_parent_link": "shoulder_link",
+      "parent_joint": "shoulder_lift_joint",
+      "parent_joint_name": "shoulder_lift_joint",
+      "parent_joint_type": "revolute",
+      "parent_joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "parent_joint_axis": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "parent_joint_value": -1.5708,
+      "parent_joint_value_source": "fake-hardware default",
+      "joint_type": "revolute",
+      "joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707963267948966,
+          -0.0,
+          -3.6732051034160666e-06
+        ]
+      },
+      "chain_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707963267948966,
+          -0.0,
+          -3.6732051034160666e-06
+        ]
+      },
+      "world_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707963267948966,
+          -0.0,
+          -3.6732051034160666e-06
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          1.5707926535897931
+        ]
+      },
+      "expected_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707963267948966,
+          -0.0,
+          -3.6732051034160666e-06
+        ]
+      },
+      "baked_world_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707963267948966,
+          -0.0,
+          -3.6732051034160666e-06
+        ]
+      },
+      "baked_world_visual_matrix": [
+        [
+          0.9999999999932537,
+          2.249189436250046e-22,
+          -3.6732051034078064e-06,
+          0.0
+        ],
+        [
+          -3.6732051034078064e-06,
+          6.123233995695457e-17,
+          -0.9999999999932537,
+          0.0
+        ],
+        [
+          0.0,
+          1.0,
+          6.123233995736766e-17,
+          0.0
+        ],
+        [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      ],
+      "baked_world_visual_quaternion": {
+        "x": 0.707106781185355,
+        "y": -1.298674118656537e-06,
+        "z": -1.298674118656537e-06,
+        "w": 0.707106781185355
+      },
+      "baked_world_visual_transform_source": "urdf_fk_link_world_times_visual_origin",
+      "visual_origin_applied_to_pose": true,
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707963267948966,
+          0.0,
+          -1.5707963267948966
+        ]
+      },
+      "joint_name": "shoulder_lift_joint",
+      "joint_value": -1.5708,
+      "applied_joint_value": -1.5708,
+      "joint_axis": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "joint_value_source": "fake-hardware default",
+      "applied_joint_value_source": "fake-hardware default",
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "color": null,
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->base_link(fixed)",
+        "base_link->base_link_inertia(fixed)",
+        "base_link_inertia->shoulder_link(revolute)",
+        "shoulder_link->upper_arm_link(revolute)"
+      ],
+      "render_expected": false,
+      "mesh_uri": "${mesh}",
+      "geometry_type": "mesh",
+      "package_uri": "",
+      "source_path": "${mesh}",
+      "mesh_path": "${mesh}",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "resolved_source_path": "${mesh}",
+      "resolved_source_path_is_repo_relative": false,
+      "resolved": false,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "file_not_found",
+      "warning": "file_not_found",
+      "repo_relative_source_path": "${mesh}",
+      "scene_relative_source_path": "",
+      "asset_relative_source_path": ""
+    },
+    {
+      "id": "urdf_visual_3_forearm_link_visual_3_mesh",
+      "source": "urdf_flattened",
+      "link": "forearm_link",
+      "object_name": "forearm_link",
+      "visual": "visual_3",
+      "visual_name": "visual_3",
+      "visual_index": 3,
+      "source_row_index": 3,
+      "parent_link": "upper_arm_link",
+      "immediate_parent_link": "upper_arm_link",
+      "root_link": "world",
+      "link_chain": [
+        "world",
+        "base_link",
+        "base_link_inertia",
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link"
+      ],
+      "joint_parent_link": "upper_arm_link",
+      "parent_joint": "elbow_joint",
+      "parent_joint_name": "elbow_joint",
+      "parent_joint_type": "revolute",
+      "parent_joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "parent_joint_axis": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "parent_joint_value": 1.5708,
+      "parent_joint_value_source": "fake-hardware default",
+      "joint_type": "revolute",
+      "joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707963267948966,
+          -0.0,
+          1.5707963267948966
+        ]
+      },
+      "chain_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707963267948966,
+          -0.0,
+          1.5707963267948966
+        ]
+      },
+      "world_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707963267948966,
+          -0.0,
+          1.5707963267948966
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          3.141592653589793
+        ]
+      },
+      "expected_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707963267948966,
+          -0.0,
+          1.5707963267948966
+        ]
+      },
+      "baked_world_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707963267948966,
+          -0.0,
+          1.5707963267948966
+        ]
+      },
+      "baked_world_visual_matrix": [
+        [
+          6.123253058960635e-17,
+          -6.123233995736765e-17,
+          0.9999999999999999,
+          0.0
+        ],
+        [
+          0.9999999999999999,
+          3.74941112951269e-33,
+          -6.123253058960635e-17,
+          0.0
+        ],
+        [
+          0.0,
+          1.0,
+          6.123233995736766e-17,
+          0.0
+        ],
+        [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      ],
+      "baked_world_visual_quaternion": {
+        "x": 0.5,
+        "y": 0.49999999999999994,
+        "z": 0.5,
+        "w": 0.5
+      },
+      "baked_world_visual_transform_source": "urdf_fk_link_world_times_visual_origin",
+      "visual_origin_applied_to_pose": true,
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707963267948966,
+          0.0,
+          -1.5707963267948966
+        ]
+      },
+      "joint_name": "elbow_joint",
+      "joint_value": 1.5708,
+      "applied_joint_value": 1.5708,
+      "joint_axis": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "joint_value_source": "fake-hardware default",
+      "applied_joint_value_source": "fake-hardware default",
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "color": null,
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->base_link(fixed)",
+        "base_link->base_link_inertia(fixed)",
+        "base_link_inertia->shoulder_link(revolute)",
+        "shoulder_link->upper_arm_link(revolute)",
+        "upper_arm_link->forearm_link(revolute)"
+      ],
+      "render_expected": false,
+      "mesh_uri": "${mesh}",
+      "geometry_type": "mesh",
+      "package_uri": "",
+      "source_path": "${mesh}",
+      "mesh_path": "${mesh}",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "resolved_source_path": "${mesh}",
+      "resolved_source_path_is_repo_relative": false,
+      "resolved": false,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "file_not_found",
+      "warning": "file_not_found",
+      "repo_relative_source_path": "${mesh}",
+      "scene_relative_source_path": "",
+      "asset_relative_source_path": ""
+    },
+    {
+      "id": "urdf_visual_4_wrist_1_link_visual_4_mesh",
+      "source": "urdf_flattened",
+      "link": "wrist_1_link",
+      "object_name": "wrist_1_link",
+      "visual": "visual_4",
+      "visual_name": "visual_4",
+      "visual_index": 4,
+      "source_row_index": 4,
+      "parent_link": "forearm_link",
+      "immediate_parent_link": "forearm_link",
+      "root_link": "world",
+      "link_chain": [
+        "world",
+        "base_link",
+        "base_link_inertia",
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link",
+        "wrist_1_link"
+      ],
+      "joint_parent_link": "forearm_link",
+      "parent_joint": "wrist_1_joint",
+      "parent_joint_name": "wrist_1_joint",
+      "parent_joint_type": "revolute",
+      "parent_joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "parent_joint_axis": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "parent_joint_value": -1.5708,
+      "parent_joint_value_source": "fake-hardware default",
+      "joint_type": "revolute",
+      "joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707963267948966,
+          -0.0,
+          1.5707926535897931
+        ]
+      },
+      "chain_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707963267948966,
+          -0.0,
+          1.5707926535897931
+        ]
+      },
+      "world_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707963267948966,
+          -0.0,
+          1.5707926535897931
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          1.5707926535897931
+        ]
+      },
+      "expected_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707963267948966,
+          -0.0,
+          1.5707926535897931
+        ]
+      },
+      "baked_world_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707963267948966,
+          -0.0,
+          1.5707926535897931
+        ]
+      },
+      "baked_world_visual_matrix": [
+        [
+          3.6732051034690384e-06,
+          -6.123233995695457e-17,
+          0.9999999999932536,
+          0.0
+        ],
+        [
+          0.9999999999932536,
+          2.2491894362875403e-22,
+          -3.6732051034690384e-06,
+          0.0
+        ],
+        [
+          0.0,
+          1.0,
+          6.123233995736766e-17,
+          0.0
+        ],
+        [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      ],
+      "baked_world_visual_quaternion": {
+        "x": 0.5000009183004327,
+        "y": 0.4999990816978808,
+        "z": 0.4999990816978809,
+        "w": 0.5000009183004327
+      },
+      "baked_world_visual_transform_source": "urdf_fk_link_world_times_visual_origin",
+      "visual_origin_applied_to_pose": true,
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707963267948966,
+          0.0,
+          0.0
+        ]
+      },
+      "joint_name": "wrist_1_joint",
+      "joint_value": -1.5708,
+      "applied_joint_value": -1.5708,
+      "joint_axis": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "joint_value_source": "fake-hardware default",
+      "applied_joint_value_source": "fake-hardware default",
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "color": null,
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->base_link(fixed)",
+        "base_link->base_link_inertia(fixed)",
+        "base_link_inertia->shoulder_link(revolute)",
+        "shoulder_link->upper_arm_link(revolute)",
+        "upper_arm_link->forearm_link(revolute)",
+        "forearm_link->wrist_1_link(revolute)"
+      ],
+      "render_expected": false,
+      "mesh_uri": "${mesh}",
+      "geometry_type": "mesh",
+      "package_uri": "",
+      "source_path": "${mesh}",
+      "mesh_path": "${mesh}",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "resolved_source_path": "${mesh}",
+      "resolved_source_path_is_repo_relative": false,
+      "resolved": false,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "file_not_found",
+      "warning": "file_not_found",
+      "repo_relative_source_path": "${mesh}",
+      "scene_relative_source_path": "",
+      "asset_relative_source_path": ""
+    },
+    {
+      "id": "urdf_visual_5_wrist_2_link_visual_5_mesh",
+      "source": "urdf_flattened",
+      "link": "wrist_2_link",
+      "object_name": "wrist_2_link",
+      "visual": "visual_5",
+      "visual_name": "visual_5",
+      "visual_index": 5,
+      "source_row_index": 5,
+      "parent_link": "wrist_1_link",
+      "immediate_parent_link": "wrist_1_link",
+      "root_link": "world",
+      "link_chain": [
+        "world",
+        "base_link",
+        "base_link_inertia",
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link",
+        "wrist_1_link",
+        "wrist_2_link"
+      ],
+      "joint_parent_link": "wrist_1_link",
+      "parent_joint": "wrist_2_joint",
+      "parent_joint_name": "wrist_2_joint",
+      "parent_joint_type": "revolute",
+      "parent_joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "parent_joint_axis": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "parent_joint_value": -1.5708,
+      "parent_joint_value_source": "fake-hardware default",
+      "joint_type": "revolute",
+      "joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          -7.346410206832133e-06
+        ]
+      },
+      "chain_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          -7.346410206832133e-06
+        ]
+      },
+      "world_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          -7.346410206832133e-06
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          -7.346410206832133e-06
+        ]
+      },
+      "expected_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          -7.346410206832133e-06
+        ]
+      },
+      "baked_world_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          -7.346410206832133e-06
+        ]
+      },
+      "baked_world_visual_matrix": [
+        [
+          0.9999999999730149,
+          7.346410206766051e-06,
+          0.0,
+          0.0
+        ],
+        [
+          -7.346410206766051e-06,
+          0.9999999999730149,
+          0.0,
+          0.0
+        ],
+        [
+          0.0,
+          0.0,
+          1.0,
+          0.0
+        ],
+        [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      ],
+      "baked_world_visual_quaternion": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": -3.6732051034078064e-06,
+        "w": 0.9999999999932538
+      },
+      "baked_world_visual_transform_source": "urdf_fk_link_world_times_visual_origin",
+      "visual_origin_applied_to_pose": true,
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "joint_name": "wrist_2_joint",
+      "joint_value": -1.5708,
+      "applied_joint_value": -1.5708,
+      "joint_axis": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "joint_value_source": "fake-hardware default",
+      "applied_joint_value_source": "fake-hardware default",
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "color": null,
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->base_link(fixed)",
+        "base_link->base_link_inertia(fixed)",
+        "base_link_inertia->shoulder_link(revolute)",
+        "shoulder_link->upper_arm_link(revolute)",
+        "upper_arm_link->forearm_link(revolute)",
+        "forearm_link->wrist_1_link(revolute)",
+        "wrist_1_link->wrist_2_link(revolute)"
+      ],
+      "render_expected": false,
+      "mesh_uri": "${mesh}",
+      "geometry_type": "mesh",
+      "package_uri": "",
+      "source_path": "${mesh}",
+      "mesh_path": "${mesh}",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "resolved_source_path": "${mesh}",
+      "resolved_source_path_is_repo_relative": false,
+      "resolved": false,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "file_not_found",
+      "warning": "file_not_found",
+      "repo_relative_source_path": "${mesh}",
+      "scene_relative_source_path": "",
+      "asset_relative_source_path": ""
+    },
+    {
+      "id": "urdf_visual_6_wrist_3_link_visual_6_mesh",
+      "source": "urdf_flattened",
+      "link": "wrist_3_link",
+      "object_name": "wrist_3_link",
+      "visual": "visual_6",
+      "visual_name": "visual_6",
+      "visual_index": 6,
+      "source_row_index": 6,
+      "parent_link": "wrist_2_link",
+      "immediate_parent_link": "wrist_2_link",
+      "root_link": "world",
+      "link_chain": [
+        "world",
+        "base_link",
+        "base_link_inertia",
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link",
+        "wrist_1_link",
+        "wrist_2_link",
+        "wrist_3_link"
+      ],
+      "joint_parent_link": "wrist_2_link",
+      "parent_joint": "wrist_3_joint",
+      "parent_joint_name": "wrist_3_joint",
+      "parent_joint_type": "${wrist_3_joint_type}",
+      "parent_joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "parent_joint_axis": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "parent_joint_value": 0.0,
+      "parent_joint_value_source": "fake-hardware default",
+      "joint_type": "${wrist_3_joint_type}",
+      "joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707963267948966,
+          -0.0,
+          -7.346410206832133e-06
+        ]
+      },
+      "chain_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707963267948966,
+          -0.0,
+          -7.346410206832133e-06
+        ]
+      },
+      "world_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707963267948966,
+          -0.0,
+          -7.346410206832133e-06
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          -7.346410206832133e-06
+        ]
+      },
+      "expected_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707963267948966,
+          -0.0,
+          -7.346410206832133e-06
+        ]
+      },
+      "baked_world_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707963267948966,
+          -0.0,
+          -7.346410206832133e-06
+        ]
+      },
+      "baked_world_visual_matrix": [
+        [
+          0.9999999999730149,
+          4.498378872469745e-22,
+          -7.346410206766051e-06,
+          0.0
+        ],
+        [
+          -7.346410206766051e-06,
+          6.12323399557153e-17,
+          -0.9999999999730149,
+          0.0
+        ],
+        [
+          0.0,
+          1.0,
+          6.123233995736766e-17,
+          0.0
+        ],
+        [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      ],
+      "baked_world_visual_quaternion": {
+        "x": 0.7071067811817772,
+        "y": -2.597348237308693e-06,
+        "z": -2.5973482373086936e-06,
+        "w": 0.7071067811817774
+      },
+      "baked_world_visual_transform_source": "urdf_fk_link_world_times_visual_origin",
+      "visual_origin_applied_to_pose": true,
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707963267948966,
+          0.0,
+          0.0
+        ]
+      },
+      "joint_name": "wrist_3_joint",
+      "joint_value": 0.0,
+      "applied_joint_value": 0.0,
+      "joint_axis": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "joint_value_source": "fake-hardware default",
+      "applied_joint_value_source": "fake-hardware default",
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "color": null,
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->base_link(fixed)",
+        "base_link->base_link_inertia(fixed)",
+        "base_link_inertia->shoulder_link(revolute)",
+        "shoulder_link->upper_arm_link(revolute)",
+        "upper_arm_link->forearm_link(revolute)",
+        "forearm_link->wrist_1_link(revolute)",
+        "wrist_1_link->wrist_2_link(revolute)",
+        "wrist_2_link->wrist_3_link(${wrist_3_joint_type})"
+      ],
+      "render_expected": false,
+      "mesh_uri": "${mesh}",
+      "geometry_type": "mesh",
+      "package_uri": "",
+      "source_path": "${mesh}",
+      "mesh_path": "${mesh}",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "resolved_source_path": "${mesh}",
+      "resolved_source_path_is_repo_relative": false,
+      "resolved": false,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "file_not_found",
+      "warning": "file_not_found",
+      "repo_relative_source_path": "${mesh}",
+      "scene_relative_source_path": "",
+      "asset_relative_source_path": ""
+    },
+    {
+      "id": "urdf_visual_7_gripper_base_link_visual_7_package_robotiq_85_description_meshes_visual_robotiq_85_base_link_dae",
+      "source": "urdf_flattened",
+      "link": "gripper_base_link",
+      "object_name": "gripper_base_link",
+      "visual": "visual_7",
+      "visual_name": "visual_7",
+      "visual_index": 7,
+      "source_row_index": 7,
+      "parent_link": "tool0",
+      "immediate_parent_link": "tool0",
+      "root_link": "world",
+      "link_chain": [
+        "world",
+        "base_link",
+        "base_link_inertia",
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link",
+        "wrist_1_link",
+        "wrist_2_link",
+        "wrist_3_link",
+        "flange",
+        "tool0",
+        "gripper_base_link"
+      ],
+      "joint_parent_link": "tool0",
+      "parent_joint": "gripper_base_joint",
+      "parent_joint_name": "gripper_base_joint",
+      "parent_joint_type": "fixed",
+      "parent_joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "parent_joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "parent_joint_value": 0.0,
+      "parent_joint_value_source": "zero_default",
+      "joint_type": "fixed",
+      "joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "chain_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "world_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "expected_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "baked_world_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "baked_world_visual_matrix": [
+        [
+          0.9999999999730149,
+          7.346410206704819e-06,
+          -6.12323399557153e-17,
+          0.0
+        ],
+        [
+          -7.346410206704819e-06,
+          0.9999999999730149,
+          4.498378872432251e-22,
+          0.0
+        ],
+        [
+          6.123233995736766e-17,
+          0.0,
+          1.0,
+          0.0
+        ],
+        [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      ],
+      "baked_world_visual_quaternion": {
+        "x": -1.12459471811565e-22,
+        "y": -3.0616169978477297e-17,
+        "z": -3.6732051033771904e-06,
+        "w": 0.9999999999932538
+      },
+      "baked_world_visual_transform_source": "urdf_fk_link_world_times_visual_origin",
+      "visual_origin_applied_to_pose": true,
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "joint_name": "gripper_base_joint",
+      "joint_value": 0.0,
+      "applied_joint_value": 0.0,
+      "joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "joint_value_source": "zero_default",
+      "applied_joint_value_source": "zero_default",
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "color": null,
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->base_link(fixed)",
+        "base_link->base_link_inertia(fixed)",
+        "base_link_inertia->shoulder_link(revolute)",
+        "shoulder_link->upper_arm_link(revolute)",
+        "upper_arm_link->forearm_link(revolute)",
+        "forearm_link->wrist_1_link(revolute)",
+        "wrist_1_link->wrist_2_link(revolute)",
+        "wrist_2_link->wrist_3_link(${wrist_3_joint_type})",
+        "wrist_3_link->flange(fixed)",
+        "flange->tool0(fixed)",
+        "tool0->gripper_base_link(fixed)"
+      ],
+      "render_expected": true,
+      "mesh_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "mesh_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "resolved_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "resolved_source_path_is_repo_relative": true,
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "",
+      "repo_relative_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "scene_relative_source_path": "",
+      "asset_relative_source_path": "end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae"
+    },
+    {
+      "id": "urdf_visual_8_gripper_finger1_knuckle_link_visual_8_package_robotiq_85_description_meshes_visual_robotiq_85_knuckle_link_dae",
+      "source": "urdf_flattened",
+      "link": "gripper_finger1_knuckle_link",
+      "object_name": "gripper_finger1_knuckle_link",
+      "visual": "visual_8",
+      "visual_name": "visual_8",
+      "visual_index": 8,
+      "source_row_index": 8,
+      "parent_link": "gripper_base_link",
+      "immediate_parent_link": "gripper_base_link",
+      "root_link": "world",
+      "link_chain": [
+        "world",
+        "base_link",
+        "base_link_inertia",
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link",
+        "wrist_1_link",
+        "wrist_2_link",
+        "wrist_3_link",
+        "flange",
+        "tool0",
+        "gripper_base_link",
+        "gripper_finger1_knuckle_link"
+      ],
+      "joint_parent_link": "gripper_base_link",
+      "parent_joint": "gripper_finger1_joint",
+      "parent_joint_name": "gripper_finger1_joint",
+      "parent_joint_type": "revolute",
+      "parent_joint_origin": {
+        "xyz": [
+          0.05490451627,
+          0.03060114443,
+          0.0
+        ],
+        "rpy": [
+          3.141592653589793,
+          0.0,
+          0.0
+        ]
+      },
+      "parent_joint_axis": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "parent_joint_value": 0.0,
+      "parent_joint_value_source": "zero_default",
+      "joint_type": "revolute",
+      "joint_origin": {
+        "xyz": [
+          0.05490451627,
+          0.03060114443,
+          0.0
+        ],
+        "rpy": [
+          3.141592653589793,
+          0.0,
+          0.0
+        ]
+      },
+      "pose": {
+        "xyz": [
+          0.05490474107707818,
+          0.03060074107807551,
+          3.361932005439464e-18
+        ],
+        "rpy": [
+          3.141592653589793,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "chain_pose": {
+        "xyz": [
+          0.05490474107707818,
+          0.03060074107807551,
+          3.361932005439464e-18
+        ],
+        "rpy": [
+          3.141592653589793,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "world_pose": {
+        "xyz": [
+          0.05490474107707818,
+          0.03060074107807551,
+          3.361932005439464e-18
+        ],
+        "rpy": [
+          3.141592653589793,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.05490474107707818,
+          0.03060074107807551,
+          3.361932005439464e-18
+        ],
+        "rpy": [
+          3.141592653589793,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "expected_visual_pose": {
+        "xyz": [
+          0.05490474107707818,
+          0.03060074107807551,
+          3.361932005439464e-18
+        ],
+        "rpy": [
+          3.141592653589793,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "baked_world_visual_pose": {
+        "xyz": [
+          0.05490474107707818,
+          0.03060074107807551,
+          3.361932005439464e-18
+        ],
+        "rpy": [
+          3.141592653589793,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "baked_world_visual_matrix": [
+        [
+          0.9999999999730149,
+          -7.346410206704819e-06,
+          6.123144027994082e-17,
+          0.05490474107707818
+        ],
+        [
+          -7.346410206704819e-06,
+          -0.9999999999730149,
+          -1.2246512974931786e-16,
+          0.03060074107807551
+        ],
+        [
+          6.123233995736766e-17,
+          1.2246467991473532e-16,
+          -1.0,
+          3.361932005439464e-18
+        ],
+        [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      ],
+      "baked_world_visual_quaternion": {
+        "x": 0.9999999999932538,
+        "y": -3.6732051033771904e-06,
+        "z": 3.061594505953367e-17,
+        "w": 6.12324524164264e-17
+      },
+      "baked_world_visual_transform_source": "urdf_fk_link_world_times_visual_origin",
+      "visual_origin_applied_to_pose": true,
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "joint_name": "gripper_finger1_joint",
+      "joint_value": 0.0,
+      "applied_joint_value": 0.0,
+      "joint_axis": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "joint_value_source": "zero_default",
+      "applied_joint_value_source": "zero_default",
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "color": null,
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->base_link(fixed)",
+        "base_link->base_link_inertia(fixed)",
+        "base_link_inertia->shoulder_link(revolute)",
+        "shoulder_link->upper_arm_link(revolute)",
+        "upper_arm_link->forearm_link(revolute)",
+        "forearm_link->wrist_1_link(revolute)",
+        "wrist_1_link->wrist_2_link(revolute)",
+        "wrist_2_link->wrist_3_link(${wrist_3_joint_type})",
+        "wrist_3_link->flange(fixed)",
+        "flange->tool0(fixed)",
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger1_knuckle_link(revolute)"
+      ],
+      "render_expected": true,
+      "mesh_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "mesh_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "resolved_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "resolved_source_path_is_repo_relative": true,
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "",
+      "repo_relative_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "scene_relative_source_path": "",
+      "asset_relative_source_path": "end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae"
+    },
+    {
+      "id": "urdf_visual_9_gripper_finger2_knuckle_link_visual_9_package_robotiq_85_description_meshes_visual_robotiq_85_knuckle_link_dae",
+      "source": "urdf_flattened",
+      "link": "gripper_finger2_knuckle_link",
+      "object_name": "gripper_finger2_knuckle_link",
+      "visual": "visual_9",
+      "visual_name": "visual_9",
+      "visual_index": 9,
+      "source_row_index": 9,
+      "parent_link": "gripper_base_link",
+      "immediate_parent_link": "gripper_base_link",
+      "root_link": "world",
+      "link_chain": [
+        "world",
+        "base_link",
+        "base_link_inertia",
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link",
+        "wrist_1_link",
+        "wrist_2_link",
+        "wrist_3_link",
+        "flange",
+        "tool0",
+        "gripper_base_link",
+        "gripper_finger2_knuckle_link"
+      ],
+      "joint_parent_link": "gripper_base_link",
+      "parent_joint": "gripper_finger2_joint",
+      "parent_joint_name": "gripper_finger2_joint",
+      "parent_joint_type": "revolute",
+      "parent_joint_origin": {
+        "xyz": [
+          0.05490451627,
+          -0.03060114443,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "parent_joint_axis": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "parent_joint_value": 0.0,
+      "parent_joint_value_source": "zero_default",
+      "joint_type": "revolute",
+      "joint_origin": {
+        "xyz": [
+          0.05490451627,
+          -0.03060114443,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "pose": {
+        "xyz": [
+          0.05490429145995863,
+          -0.030601547780272947,
+          3.361932005439464e-18
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "chain_pose": {
+        "xyz": [
+          0.05490429145995863,
+          -0.030601547780272947,
+          3.361932005439464e-18
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "world_pose": {
+        "xyz": [
+          0.05490429145995863,
+          -0.030601547780272947,
+          3.361932005439464e-18
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.05490429145995863,
+          -0.030601547780272947,
+          3.361932005439464e-18
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "expected_visual_pose": {
+        "xyz": [
+          0.05490429145995863,
+          -0.030601547780272947,
+          3.361932005439464e-18
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "baked_world_visual_pose": {
+        "xyz": [
+          0.05490429145995863,
+          -0.030601547780272947,
+          3.361932005439464e-18
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "baked_world_visual_matrix": [
+        [
+          0.9999999999730149,
+          7.346410206704819e-06,
+          -6.12323399557153e-17,
+          0.05490429145995863
+        ],
+        [
+          -7.346410206704819e-06,
+          0.9999999999730149,
+          4.498378872432251e-22,
+          -0.030601547780272947
+        ],
+        [
+          6.123233995736766e-17,
+          0.0,
+          1.0,
+          3.361932005439464e-18
+        ],
+        [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      ],
+      "baked_world_visual_quaternion": {
+        "x": -1.12459471811565e-22,
+        "y": -3.0616169978477297e-17,
+        "z": -3.6732051033771904e-06,
+        "w": 0.9999999999932538
+      },
+      "baked_world_visual_transform_source": "urdf_fk_link_world_times_visual_origin",
+      "visual_origin_applied_to_pose": true,
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "joint_name": "gripper_finger2_joint",
+      "joint_value": 0.0,
+      "applied_joint_value": 0.0,
+      "joint_axis": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "joint_value_source": "zero_default",
+      "applied_joint_value_source": "zero_default",
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "color": null,
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->base_link(fixed)",
+        "base_link->base_link_inertia(fixed)",
+        "base_link_inertia->shoulder_link(revolute)",
+        "shoulder_link->upper_arm_link(revolute)",
+        "upper_arm_link->forearm_link(revolute)",
+        "forearm_link->wrist_1_link(revolute)",
+        "wrist_1_link->wrist_2_link(revolute)",
+        "wrist_2_link->wrist_3_link(${wrist_3_joint_type})",
+        "wrist_3_link->flange(fixed)",
+        "flange->tool0(fixed)",
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger2_knuckle_link(revolute)"
+      ],
+      "render_expected": true,
+      "mesh_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "mesh_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "resolved_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "resolved_source_path_is_repo_relative": true,
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "",
+      "repo_relative_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "scene_relative_source_path": "",
+      "asset_relative_source_path": "end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae"
+    },
+    {
+      "id": "urdf_visual_10_gripper_finger1_finger_link_visual_10_package_robotiq_85_description_meshes_visual_robotiq_85_finger_link_dae",
+      "source": "urdf_flattened",
+      "link": "gripper_finger1_finger_link",
+      "object_name": "gripper_finger1_finger_link",
+      "visual": "visual_10",
+      "visual_name": "visual_10",
+      "visual_index": 10,
+      "source_row_index": 10,
+      "parent_link": "gripper_finger1_knuckle_link",
+      "immediate_parent_link": "gripper_finger1_knuckle_link",
+      "root_link": "world",
+      "link_chain": [
+        "world",
+        "base_link",
+        "base_link_inertia",
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link",
+        "wrist_1_link",
+        "wrist_2_link",
+        "wrist_3_link",
+        "flange",
+        "tool0",
+        "gripper_base_link",
+        "gripper_finger1_knuckle_link",
+        "gripper_finger1_finger_link"
+      ],
+      "joint_parent_link": "gripper_finger1_knuckle_link",
+      "parent_joint": "gripper_finger1_finger_joint",
+      "parent_joint_name": "gripper_finger1_finger_joint",
+      "parent_joint_type": "fixed",
+      "parent_joint_origin": {
+        "xyz": [
+          -0.00408552455,
+          -0.03148604435,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "parent_joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "parent_joint_value": 0.0,
+      "parent_joint_value_source": "zero_default",
+      "joint_type": "fixed",
+      "joint_origin": {
+        "xyz": [
+          -0.00408552455,
+          -0.03148604435,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "pose": {
+        "xyz": [
+          0.050819447836586006,
+          0.06208681544116511,
+          -7.441625658142177e-19
+        ],
+        "rpy": [
+          3.141592653589793,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "chain_pose": {
+        "xyz": [
+          0.050819447836586006,
+          0.06208681544116511,
+          -7.441625658142177e-19
+        ],
+        "rpy": [
+          3.141592653589793,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "world_pose": {
+        "xyz": [
+          0.050819447836586006,
+          0.06208681544116511,
+          -7.441625658142177e-19
+        ],
+        "rpy": [
+          3.141592653589793,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.050819447836586006,
+          0.06208681544116511,
+          -7.441625658142177e-19
+        ],
+        "rpy": [
+          3.141592653589793,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "expected_visual_pose": {
+        "xyz": [
+          0.050819447836586006,
+          0.06208681544116511,
+          -7.441625658142177e-19
+        ],
+        "rpy": [
+          3.141592653589793,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "baked_world_visual_pose": {
+        "xyz": [
+          0.050819447836586006,
+          0.06208681544116511,
+          -7.441625658142177e-19
+        ],
+        "rpy": [
+          3.141592653589793,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "baked_world_visual_matrix": [
+        [
+          0.9999999999730149,
+          -7.346410206704819e-06,
+          6.123144027994082e-17,
+          0.050819447836586006
+        ],
+        [
+          -7.346410206704819e-06,
+          -0.9999999999730149,
+          -1.2246512974931786e-16,
+          0.06208681544116511
+        ],
+        [
+          6.123233995736766e-17,
+          1.2246467991473532e-16,
+          -1.0,
+          -7.441625658142177e-19
+        ],
+        [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      ],
+      "baked_world_visual_quaternion": {
+        "x": 0.9999999999932538,
+        "y": -3.6732051033771904e-06,
+        "z": 3.061594505953367e-17,
+        "w": 6.12324524164264e-17
+      },
+      "baked_world_visual_transform_source": "urdf_fk_link_world_times_visual_origin",
+      "visual_origin_applied_to_pose": true,
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "joint_name": "gripper_finger1_finger_joint",
+      "joint_value": 0.0,
+      "applied_joint_value": 0.0,
+      "joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "joint_value_source": "zero_default",
+      "applied_joint_value_source": "zero_default",
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "color": null,
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->base_link(fixed)",
+        "base_link->base_link_inertia(fixed)",
+        "base_link_inertia->shoulder_link(revolute)",
+        "shoulder_link->upper_arm_link(revolute)",
+        "upper_arm_link->forearm_link(revolute)",
+        "forearm_link->wrist_1_link(revolute)",
+        "wrist_1_link->wrist_2_link(revolute)",
+        "wrist_2_link->wrist_3_link(${wrist_3_joint_type})",
+        "wrist_3_link->flange(fixed)",
+        "flange->tool0(fixed)",
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger1_knuckle_link(revolute)",
+        "gripper_finger1_knuckle_link->gripper_finger1_finger_link(fixed)"
+      ],
+      "render_expected": true,
+      "mesh_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "mesh_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "resolved_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "resolved_source_path_is_repo_relative": true,
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "",
+      "repo_relative_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "scene_relative_source_path": "",
+      "asset_relative_source_path": "end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae"
+    },
+    {
+      "id": "urdf_visual_11_gripper_finger2_finger_link_visual_11_package_robotiq_85_description_meshes_visual_robotiq_85_finger_link_dae",
+      "source": "urdf_flattened",
+      "link": "gripper_finger2_finger_link",
+      "object_name": "gripper_finger2_finger_link",
+      "visual": "visual_11",
+      "visual_name": "visual_11",
+      "visual_index": 11,
+      "source_row_index": 11,
+      "parent_link": "gripper_finger2_knuckle_link",
+      "immediate_parent_link": "gripper_finger2_knuckle_link",
+      "root_link": "world",
+      "link_chain": [
+        "world",
+        "base_link",
+        "base_link_inertia",
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link",
+        "wrist_1_link",
+        "wrist_2_link",
+        "wrist_3_link",
+        "flange",
+        "tool0",
+        "gripper_base_link",
+        "gripper_finger2_knuckle_link",
+        "gripper_finger2_finger_link"
+      ],
+      "joint_parent_link": "gripper_finger2_knuckle_link",
+      "parent_joint": "gripper_finger2_finger_joint",
+      "parent_joint_name": "gripper_finger2_finger_joint",
+      "parent_joint_type": "fixed",
+      "parent_joint_origin": {
+        "xyz": [
+          -0.00408552455,
+          -0.03148604435,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "parent_joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "parent_joint_value": 0.0,
+      "parent_joint_value_source": "zero_default",
+      "joint_type": "fixed",
+      "joint_origin": {
+        "xyz": [
+          -0.00408552455,
+          -0.03148604435,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "pose": {
+        "xyz": [
+          0.050818535600671295,
+          -0.06208756211548404,
+          3.1117657772896924e-18
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "chain_pose": {
+        "xyz": [
+          0.050818535600671295,
+          -0.06208756211548404,
+          3.1117657772896924e-18
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "world_pose": {
+        "xyz": [
+          0.050818535600671295,
+          -0.06208756211548404,
+          3.1117657772896924e-18
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.050818535600671295,
+          -0.06208756211548404,
+          3.1117657772896924e-18
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "expected_visual_pose": {
+        "xyz": [
+          0.050818535600671295,
+          -0.06208756211548404,
+          3.1117657772896924e-18
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "baked_world_visual_pose": {
+        "xyz": [
+          0.050818535600671295,
+          -0.06208756211548404,
+          3.1117657772896924e-18
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "baked_world_visual_matrix": [
+        [
+          0.9999999999730149,
+          7.346410206704819e-06,
+          -6.12323399557153e-17,
+          0.050818535600671295
+        ],
+        [
+          -7.346410206704819e-06,
+          0.9999999999730149,
+          4.498378872432251e-22,
+          -0.06208756211548404
+        ],
+        [
+          6.123233995736766e-17,
+          0.0,
+          1.0,
+          3.1117657772896924e-18
+        ],
+        [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      ],
+      "baked_world_visual_quaternion": {
+        "x": -1.12459471811565e-22,
+        "y": -3.0616169978477297e-17,
+        "z": -3.6732051033771904e-06,
+        "w": 0.9999999999932538
+      },
+      "baked_world_visual_transform_source": "urdf_fk_link_world_times_visual_origin",
+      "visual_origin_applied_to_pose": true,
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "joint_name": "gripper_finger2_finger_joint",
+      "joint_value": 0.0,
+      "applied_joint_value": 0.0,
+      "joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "joint_value_source": "zero_default",
+      "applied_joint_value_source": "zero_default",
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "color": null,
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->base_link(fixed)",
+        "base_link->base_link_inertia(fixed)",
+        "base_link_inertia->shoulder_link(revolute)",
+        "shoulder_link->upper_arm_link(revolute)",
+        "upper_arm_link->forearm_link(revolute)",
+        "forearm_link->wrist_1_link(revolute)",
+        "wrist_1_link->wrist_2_link(revolute)",
+        "wrist_2_link->wrist_3_link(${wrist_3_joint_type})",
+        "wrist_3_link->flange(fixed)",
+        "flange->tool0(fixed)",
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger2_knuckle_link(revolute)",
+        "gripper_finger2_knuckle_link->gripper_finger2_finger_link(fixed)"
+      ],
+      "render_expected": true,
+      "mesh_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "mesh_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "resolved_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "resolved_source_path_is_repo_relative": true,
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "",
+      "repo_relative_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "scene_relative_source_path": "",
+      "asset_relative_source_path": "end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae"
+    },
+    {
+      "id": "urdf_visual_12_gripper_finger1_inner_knuckle_link_visual_12_package_robotiq_85_description_meshes_visual_robotiq_85_inner_knuckle_link_dae",
+      "source": "urdf_flattened",
+      "link": "gripper_finger1_inner_knuckle_link",
+      "object_name": "gripper_finger1_inner_knuckle_link",
+      "visual": "visual_12",
+      "visual_name": "visual_12",
+      "visual_index": 12,
+      "source_row_index": 12,
+      "parent_link": "gripper_base_link",
+      "immediate_parent_link": "gripper_base_link",
+      "root_link": "world",
+      "link_chain": [
+        "world",
+        "base_link",
+        "base_link_inertia",
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link",
+        "wrist_1_link",
+        "wrist_2_link",
+        "wrist_3_link",
+        "flange",
+        "tool0",
+        "gripper_base_link",
+        "gripper_finger1_inner_knuckle_link"
+      ],
+      "joint_parent_link": "gripper_base_link",
+      "parent_joint": "gripper_finger1_inner_knuckle_joint",
+      "parent_joint_name": "gripper_finger1_inner_knuckle_joint",
+      "parent_joint_type": "continuous",
+      "parent_joint_origin": {
+        "xyz": [
+          0.06142,
+          0.0127,
+          0.0
+        ],
+        "rpy": [
+          3.141592653589793,
+          0.0,
+          0.0
+        ]
+      },
+      "parent_joint_axis": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "parent_joint_value": 0.0,
+      "parent_joint_value_source": "zero_default",
+      "joint_type": "continuous",
+      "joint_origin": {
+        "xyz": [
+          0.06142,
+          0.0127,
+          0.0
+        ],
+        "rpy": [
+          3.141592653589793,
+          0.0,
+          0.0
+        ]
+      },
+      "pose": {
+        "xyz": [
+          0.0614200932977522,
+          0.012699548783142393,
+          3.7608903201815215e-18
+        ],
+        "rpy": [
+          3.141592653589793,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "chain_pose": {
+        "xyz": [
+          0.0614200932977522,
+          0.012699548783142393,
+          3.7608903201815215e-18
+        ],
+        "rpy": [
+          3.141592653589793,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "world_pose": {
+        "xyz": [
+          0.0614200932977522,
+          0.012699548783142393,
+          3.7608903201815215e-18
+        ],
+        "rpy": [
+          3.141592653589793,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.0614200932977522,
+          0.012699548783142393,
+          3.7608903201815215e-18
+        ],
+        "rpy": [
+          3.141592653589793,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "expected_visual_pose": {
+        "xyz": [
+          0.0614200932977522,
+          0.012699548783142393,
+          3.7608903201815215e-18
+        ],
+        "rpy": [
+          3.141592653589793,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "baked_world_visual_pose": {
+        "xyz": [
+          0.0614200932977522,
+          0.012699548783142393,
+          3.7608903201815215e-18
+        ],
+        "rpy": [
+          3.141592653589793,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "baked_world_visual_matrix": [
+        [
+          0.9999999999730149,
+          -7.346410206704819e-06,
+          6.123144027994082e-17,
+          0.0614200932977522
+        ],
+        [
+          -7.346410206704819e-06,
+          -0.9999999999730149,
+          -1.2246512974931786e-16,
+          0.012699548783142393
+        ],
+        [
+          6.123233995736766e-17,
+          1.2246467991473532e-16,
+          -1.0,
+          3.7608903201815215e-18
+        ],
+        [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      ],
+      "baked_world_visual_quaternion": {
+        "x": 0.9999999999932538,
+        "y": -3.6732051033771904e-06,
+        "z": 3.061594505953367e-17,
+        "w": 6.12324524164264e-17
+      },
+      "baked_world_visual_transform_source": "urdf_fk_link_world_times_visual_origin",
+      "visual_origin_applied_to_pose": true,
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "joint_name": "gripper_finger1_inner_knuckle_joint",
+      "joint_value": 0.0,
+      "applied_joint_value": 0.0,
+      "joint_axis": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "joint_value_source": "zero_default",
+      "applied_joint_value_source": "zero_default",
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "color": null,
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->base_link(fixed)",
+        "base_link->base_link_inertia(fixed)",
+        "base_link_inertia->shoulder_link(revolute)",
+        "shoulder_link->upper_arm_link(revolute)",
+        "upper_arm_link->forearm_link(revolute)",
+        "forearm_link->wrist_1_link(revolute)",
+        "wrist_1_link->wrist_2_link(revolute)",
+        "wrist_2_link->wrist_3_link(${wrist_3_joint_type})",
+        "wrist_3_link->flange(fixed)",
+        "flange->tool0(fixed)",
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger1_inner_knuckle_link(continuous)"
+      ],
+      "render_expected": true,
+      "mesh_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "mesh_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "resolved_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "resolved_source_path_is_repo_relative": true,
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "",
+      "repo_relative_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "scene_relative_source_path": "",
+      "asset_relative_source_path": "end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae"
+    },
+    {
+      "id": "urdf_visual_13_gripper_finger2_inner_knuckle_link_visual_13_package_robotiq_85_description_meshes_visual_robotiq_85_inner_knuckle_link_dae",
+      "source": "urdf_flattened",
+      "link": "gripper_finger2_inner_knuckle_link",
+      "object_name": "gripper_finger2_inner_knuckle_link",
+      "visual": "visual_13",
+      "visual_name": "visual_13",
+      "visual_index": 13,
+      "source_row_index": 13,
+      "parent_link": "gripper_base_link",
+      "immediate_parent_link": "gripper_base_link",
+      "root_link": "world",
+      "link_chain": [
+        "world",
+        "base_link",
+        "base_link_inertia",
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link",
+        "wrist_1_link",
+        "wrist_2_link",
+        "wrist_3_link",
+        "flange",
+        "tool0",
+        "gripper_base_link",
+        "gripper_finger2_inner_knuckle_link"
+      ],
+      "joint_parent_link": "gripper_base_link",
+      "parent_joint": "gripper_finger2_inner_knuckle_joint",
+      "parent_joint_name": "gripper_finger2_inner_knuckle_joint",
+      "parent_joint_type": "continuous",
+      "parent_joint_origin": {
+        "xyz": [
+          0.06142,
+          -0.0127,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "parent_joint_axis": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "parent_joint_value": 0.0,
+      "parent_joint_value_source": "zero_default",
+      "joint_type": "continuous",
+      "joint_origin": {
+        "xyz": [
+          0.06142,
+          -0.0127,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "pose": {
+        "xyz": [
+          0.061419906698932956,
+          -0.012700451216172186,
+          3.7608903201815215e-18
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "chain_pose": {
+        "xyz": [
+          0.061419906698932956,
+          -0.012700451216172186,
+          3.7608903201815215e-18
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "world_pose": {
+        "xyz": [
+          0.061419906698932956,
+          -0.012700451216172186,
+          3.7608903201815215e-18
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.061419906698932956,
+          -0.012700451216172186,
+          3.7608903201815215e-18
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "expected_visual_pose": {
+        "xyz": [
+          0.061419906698932956,
+          -0.012700451216172186,
+          3.7608903201815215e-18
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "baked_world_visual_pose": {
+        "xyz": [
+          0.061419906698932956,
+          -0.012700451216172186,
+          3.7608903201815215e-18
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "baked_world_visual_matrix": [
+        [
+          0.9999999999730149,
+          7.346410206704819e-06,
+          -6.12323399557153e-17,
+          0.061419906698932956
+        ],
+        [
+          -7.346410206704819e-06,
+          0.9999999999730149,
+          4.498378872432251e-22,
+          -0.012700451216172186
+        ],
+        [
+          6.123233995736766e-17,
+          0.0,
+          1.0,
+          3.7608903201815215e-18
+        ],
+        [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      ],
+      "baked_world_visual_quaternion": {
+        "x": -1.12459471811565e-22,
+        "y": -3.0616169978477297e-17,
+        "z": -3.6732051033771904e-06,
+        "w": 0.9999999999932538
+      },
+      "baked_world_visual_transform_source": "urdf_fk_link_world_times_visual_origin",
+      "visual_origin_applied_to_pose": true,
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "joint_name": "gripper_finger2_inner_knuckle_joint",
+      "joint_value": 0.0,
+      "applied_joint_value": 0.0,
+      "joint_axis": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "joint_value_source": "zero_default",
+      "applied_joint_value_source": "zero_default",
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "color": null,
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->base_link(fixed)",
+        "base_link->base_link_inertia(fixed)",
+        "base_link_inertia->shoulder_link(revolute)",
+        "shoulder_link->upper_arm_link(revolute)",
+        "upper_arm_link->forearm_link(revolute)",
+        "forearm_link->wrist_1_link(revolute)",
+        "wrist_1_link->wrist_2_link(revolute)",
+        "wrist_2_link->wrist_3_link(${wrist_3_joint_type})",
+        "wrist_3_link->flange(fixed)",
+        "flange->tool0(fixed)",
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger2_inner_knuckle_link(continuous)"
+      ],
+      "render_expected": true,
+      "mesh_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "mesh_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "resolved_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "resolved_source_path_is_repo_relative": true,
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "",
+      "repo_relative_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "scene_relative_source_path": "",
+      "asset_relative_source_path": "end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae"
+    },
+    {
+      "id": "urdf_visual_14_gripper_finger1_finger_tip_link_visual_14_package_robotiq_85_description_meshes_visual_robotiq_85_finger_tip_link_dae",
+      "source": "urdf_flattened",
+      "link": "gripper_finger1_finger_tip_link",
+      "object_name": "gripper_finger1_finger_tip_link",
+      "visual": "visual_14",
+      "visual_name": "visual_14",
+      "visual_index": 14,
+      "source_row_index": 14,
+      "parent_link": "gripper_finger1_inner_knuckle_link",
+      "immediate_parent_link": "gripper_finger1_inner_knuckle_link",
+      "root_link": "world",
+      "link_chain": [
+        "world",
+        "base_link",
+        "base_link_inertia",
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link",
+        "wrist_1_link",
+        "wrist_2_link",
+        "wrist_3_link",
+        "flange",
+        "tool0",
+        "gripper_base_link",
+        "gripper_finger1_inner_knuckle_link",
+        "gripper_finger1_finger_tip_link"
+      ],
+      "joint_parent_link": "gripper_finger1_inner_knuckle_link",
+      "parent_joint": "gripper_finger1_finger_tip_joint",
+      "parent_joint_name": "gripper_finger1_finger_tip_joint",
+      "parent_joint_type": "continuous",
+      "parent_joint_origin": {
+        "xyz": [
+          0.04303959807,
+          -0.03759940821,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "parent_joint_axis": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "parent_joint_value": 0.0,
+      "parent_joint_value_source": "zero_default",
+      "joint_type": "continuous",
+      "joint_origin": {
+        "xyz": [
+          0.04303959807,
+          -0.03759940821,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "pose": {
+        "xyz": [
+          0.10445996758726701,
+          0.05029864080558521,
+          1.7917061294111054e-18
+        ],
+        "rpy": [
+          3.141592653589793,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "chain_pose": {
+        "xyz": [
+          0.10445996758726701,
+          0.05029864080558521,
+          1.7917061294111054e-18
+        ],
+        "rpy": [
+          3.141592653589793,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "world_pose": {
+        "xyz": [
+          0.10445996758726701,
+          0.05029864080558521,
+          1.7917061294111054e-18
+        ],
+        "rpy": [
+          3.141592653589793,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.10445996758726701,
+          0.05029864080558521,
+          1.7917061294111054e-18
+        ],
+        "rpy": [
+          3.141592653589793,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "expected_visual_pose": {
+        "xyz": [
+          0.10445996758726701,
+          0.05029864080558521,
+          1.7917061294111054e-18
+        ],
+        "rpy": [
+          3.141592653589793,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "baked_world_visual_pose": {
+        "xyz": [
+          0.10445996758726701,
+          0.05029864080558521,
+          1.7917061294111054e-18
+        ],
+        "rpy": [
+          3.141592653589793,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "baked_world_visual_matrix": [
+        [
+          0.9999999999730149,
+          -7.346410206704819e-06,
+          6.123144027994082e-17,
+          0.10445996758726701
+        ],
+        [
+          -7.346410206704819e-06,
+          -0.9999999999730149,
+          -1.2246512974931786e-16,
+          0.05029864080558521
+        ],
+        [
+          6.123233995736766e-17,
+          1.2246467991473532e-16,
+          -1.0,
+          1.7917061294111054e-18
+        ],
+        [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      ],
+      "baked_world_visual_quaternion": {
+        "x": 0.9999999999932538,
+        "y": -3.6732051033771904e-06,
+        "z": 3.061594505953367e-17,
+        "w": 6.12324524164264e-17
+      },
+      "baked_world_visual_transform_source": "urdf_fk_link_world_times_visual_origin",
+      "visual_origin_applied_to_pose": true,
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "joint_name": "gripper_finger1_finger_tip_joint",
+      "joint_value": 0.0,
+      "applied_joint_value": 0.0,
+      "joint_axis": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "joint_value_source": "zero_default",
+      "applied_joint_value_source": "zero_default",
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "color": null,
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->base_link(fixed)",
+        "base_link->base_link_inertia(fixed)",
+        "base_link_inertia->shoulder_link(revolute)",
+        "shoulder_link->upper_arm_link(revolute)",
+        "upper_arm_link->forearm_link(revolute)",
+        "forearm_link->wrist_1_link(revolute)",
+        "wrist_1_link->wrist_2_link(revolute)",
+        "wrist_2_link->wrist_3_link(${wrist_3_joint_type})",
+        "wrist_3_link->flange(fixed)",
+        "flange->tool0(fixed)",
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger1_inner_knuckle_link(continuous)",
+        "gripper_finger1_inner_knuckle_link->gripper_finger1_finger_tip_link(continuous)"
+      ],
+      "render_expected": true,
+      "mesh_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "mesh_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "resolved_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "resolved_source_path_is_repo_relative": true,
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "",
+      "repo_relative_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "scene_relative_source_path": "",
+      "asset_relative_source_path": "end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae"
+    },
+    {
+      "id": "urdf_visual_15_gripper_finger2_finger_tip_link_visual_15_package_robotiq_85_description_meshes_visual_robotiq_85_finger_tip_link_dae",
+      "source": "urdf_flattened",
+      "link": "gripper_finger2_finger_tip_link",
+      "object_name": "gripper_finger2_finger_tip_link",
+      "visual": "visual_15",
+      "visual_name": "visual_15",
+      "visual_index": 15,
+      "source_row_index": 15,
+      "parent_link": "gripper_finger2_inner_knuckle_link",
+      "immediate_parent_link": "gripper_finger2_inner_knuckle_link",
+      "root_link": "world",
+      "link_chain": [
+        "world",
+        "base_link",
+        "base_link_inertia",
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link",
+        "wrist_1_link",
+        "wrist_2_link",
+        "wrist_3_link",
+        "flange",
+        "tool0",
+        "gripper_base_link",
+        "gripper_finger2_inner_knuckle_link",
+        "gripper_finger2_finger_tip_link"
+      ],
+      "joint_parent_link": "gripper_finger2_inner_knuckle_link",
+      "parent_joint": "gripper_finger2_finger_tip_joint",
+      "parent_joint_name": "gripper_finger2_finger_tip_joint",
+      "parent_joint_type": "continuous",
+      "parent_joint_origin": {
+        "xyz": [
+          0.04303959807,
+          -0.03759940821,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "parent_joint_axis": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "parent_joint_value": 0.0,
+      "parent_joint_value_source": "zero_default",
+      "joint_type": "continuous",
+      "joint_origin": {
+        "xyz": [
+          0.04303959807,
+          -0.03759940821,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "pose": {
+        "xyz": [
+          0.10445922854709529,
+          -0.05030017561170011,
+          6.396305620832227e-18
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "chain_pose": {
+        "xyz": [
+          0.10445922854709529,
+          -0.05030017561170011,
+          6.396305620832227e-18
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "world_pose": {
+        "xyz": [
+          0.10445922854709529,
+          -0.05030017561170011,
+          6.396305620832227e-18
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.10445922854709529,
+          -0.05030017561170011,
+          6.396305620832227e-18
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "expected_visual_pose": {
+        "xyz": [
+          0.10445922854709529,
+          -0.05030017561170011,
+          6.396305620832227e-18
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "baked_world_visual_pose": {
+        "xyz": [
+          0.10445922854709529,
+          -0.05030017561170011,
+          6.396305620832227e-18
+        ],
+        "rpy": [
+          0.0,
+          -6.123233995736766e-17,
+          -7.346410206770901e-06
+        ]
+      },
+      "baked_world_visual_matrix": [
+        [
+          0.9999999999730149,
+          7.346410206704819e-06,
+          -6.12323399557153e-17,
+          0.10445922854709529
+        ],
+        [
+          -7.346410206704819e-06,
+          0.9999999999730149,
+          4.498378872432251e-22,
+          -0.05030017561170011
+        ],
+        [
+          6.123233995736766e-17,
+          0.0,
+          1.0,
+          6.396305620832227e-18
+        ],
+        [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      ],
+      "baked_world_visual_quaternion": {
+        "x": -1.12459471811565e-22,
+        "y": -3.0616169978477297e-17,
+        "z": -3.6732051033771904e-06,
+        "w": 0.9999999999932538
+      },
+      "baked_world_visual_transform_source": "urdf_fk_link_world_times_visual_origin",
+      "visual_origin_applied_to_pose": true,
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "joint_name": "gripper_finger2_finger_tip_joint",
+      "joint_value": 0.0,
+      "applied_joint_value": 0.0,
+      "joint_axis": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "joint_value_source": "zero_default",
+      "applied_joint_value_source": "zero_default",
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "color": null,
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->base_link(fixed)",
+        "base_link->base_link_inertia(fixed)",
+        "base_link_inertia->shoulder_link(revolute)",
+        "shoulder_link->upper_arm_link(revolute)",
+        "upper_arm_link->forearm_link(revolute)",
+        "forearm_link->wrist_1_link(revolute)",
+        "wrist_1_link->wrist_2_link(revolute)",
+        "wrist_2_link->wrist_3_link(${wrist_3_joint_type})",
+        "wrist_3_link->flange(fixed)",
+        "flange->tool0(fixed)",
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger2_inner_knuckle_link(continuous)",
+        "gripper_finger2_inner_knuckle_link->gripper_finger2_finger_tip_link(continuous)"
+      ],
+      "render_expected": true,
+      "mesh_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "mesh_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "resolved_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "resolved_source_path_is_repo_relative": true,
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "",
+      "repo_relative_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "scene_relative_source_path": "",
+      "asset_relative_source_path": "end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae"
+    },
+    {
+      "id": "urdf_visual_16_table_None_package_workbench_description_meshes_visual_table_stl",
+      "source": "urdf_flattened",
+      "link": "table_",
+      "object_name": "table_",
+      "visual": "None_",
+      "visual_name": "None_",
+      "visual_index": 16,
+      "source_row_index": 16,
+      "parent_link": "world",
+      "immediate_parent_link": "world",
+      "root_link": "world",
+      "link_chain": [
+        "world",
+        "table_"
+      ],
+      "joint_parent_link": "world",
+      "parent_joint": "table_base_joint_",
+      "parent_joint_name": "table_base_joint_",
+      "parent_joint_type": "fixed",
+      "parent_joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "parent_joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "parent_joint_value": 0.0,
+      "parent_joint_value_source": "zero_default",
+      "joint_type": "fixed",
+      "joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "chain_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "world_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "expected_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "baked_world_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "baked_world_visual_matrix": [
+        [
+          1.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        [
+          0.0,
+          1.0,
+          0.0,
+          0.0
+        ],
+        [
+          0.0,
+          0.0,
+          1.0,
+          0.0
+        ],
+        [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      ],
+      "baked_world_visual_quaternion": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 1.0
+      },
+      "baked_world_visual_transform_source": "urdf_fk_link_world_times_visual_origin",
+      "visual_origin_applied_to_pose": true,
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "joint_name": "table_base_joint_",
+      "joint_value": 0.0,
+      "applied_joint_value": 0.0,
+      "joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "joint_value_source": "zero_default",
+      "applied_joint_value_source": "zero_default",
+      "material": {
+        "name": "aluminum",
+        "color": [
+          0.549,
+          0.557,
+          0.529,
+          1.0
+        ]
+      },
+      "color": [
+        0.549,
+        0.557,
+        0.529,
+        1.0
+      ],
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)"
+      ],
+      "render_expected": true,
+      "mesh_uri": "package://workbench_description/meshes/visual/table.stl",
+      "geometry_type": "mesh",
+      "package_uri": "package://workbench_description/meshes/visual/table.stl",
+      "source_path": "package://workbench_description/meshes/visual/table.stl",
+      "mesh_path": "assets/environment/workbench_description/meshes/visual/table.stl",
+      "scale": [
+        0.001,
+        0.001,
+        0.001
+      ],
+      "resolved_source_path": "assets/environment/workbench_description/meshes/visual/table.stl",
+      "resolved_source_path_is_repo_relative": true,
+      "resolved": true,
+      "mesh_scale": [
+        0.001,
+        0.001,
+        0.001
+      ],
+      "render_skip_reason": "",
+      "warning": "",
+      "repo_relative_source_path": "assets/environment/workbench_description/meshes/visual/table.stl",
+      "scene_relative_source_path": "",
+      "asset_relative_source_path": "environment/workbench_description/meshes/visual/table.stl"
+    },
+    {
+      "id": "urdf_visual_17_camera_link_visual_17_package_realsense2_description_meshes_d435_dae",
+      "source": "urdf_flattened",
+      "link": "camera_link",
+      "object_name": "camera_link",
+      "visual": "visual_17",
+      "visual_name": "visual_17",
+      "visual_index": 17,
+      "source_row_index": 17,
+      "parent_link": "camera_bottom_screw_frame",
+      "immediate_parent_link": "camera_bottom_screw_frame",
+      "root_link": "world",
+      "link_chain": [
+        "world",
+        "table_",
+        "camera_bottom_screw_frame",
+        "camera_link"
+      ],
+      "joint_parent_link": "camera_bottom_screw_frame",
+      "parent_joint": "camera_link_joint",
+      "parent_joint_name": "camera_link_joint",
+      "parent_joint_type": "fixed",
+      "parent_joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "parent_joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "parent_joint_value": 0.0,
+      "parent_joint_value_source": "zero_default",
+      "joint_type": "fixed",
+      "joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "chain_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "world_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "expected_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "baked_world_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "baked_world_visual_matrix": [
+        [
+          1.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        [
+          0.0,
+          1.0,
+          0.0,
+          0.0
+        ],
+        [
+          0.0,
+          0.0,
+          1.0,
+          0.0
+        ],
+        [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      ],
+      "baked_world_visual_quaternion": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 1.0
+      },
+      "baked_world_visual_transform_source": "urdf_fk_link_world_times_visual_origin",
+      "visual_origin_applied_to_pose": true,
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "joint_name": "camera_link_joint",
+      "joint_value": 0.0,
+      "applied_joint_value": 0.0,
+      "joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "joint_value_source": "zero_default",
+      "applied_joint_value_source": "zero_default",
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "color": null,
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)",
+        "table_->camera_bottom_screw_frame(fixed)",
+        "camera_bottom_screw_frame->camera_link(fixed)"
+      ],
+      "render_expected": true,
+      "mesh_uri": "package://realsense2_description/meshes/d435.dae",
+      "geometry_type": "mesh",
+      "package_uri": "package://realsense2_description/meshes/d435.dae",
+      "source_path": "package://realsense2_description/meshes/d435.dae",
+      "mesh_path": "assets/environment/realsense2_description/meshes/d435.dae",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "resolved_source_path": "assets/environment/realsense2_description/meshes/d435.dae",
+      "resolved_source_path_is_repo_relative": true,
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "",
+      "repo_relative_source_path": "assets/environment/realsense2_description/meshes/d435.dae",
+      "scene_relative_source_path": "",
+      "asset_relative_source_path": "environment/realsense2_description/meshes/d435.dae"
+    },
+    {
+      "id": "urdf_static_mesh_ur5_static_base",
+      "source": "legacy_static_fallback",
+      "link": "base_link",
+      "visual": "static_mesh_visual",
+      "parent_link": "world",
+      "immediate_parent_link": "world",
+      "joint_parent_link": "world",
+      "parent_joint": "",
+      "parent_joint_name": "",
+      "parent_joint_type": "static_preview",
+      "parent_joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "parent_joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "parent_joint_value": 0.0,
+      "parent_joint_value_source": "zero_default",
+      "joint_name": "",
+      "joint_type": "static_preview",
+      "joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "joint_value": 0.0,
+      "joint_value_source": "zero_default",
+      "applied_joint_value": 0.0,
+      "applied_joint_value_source": "zero_default",
+      "link_chain": [
+        "world",
+        "base_link"
+      ],
+      "category": "robot_static_mesh_visual",
+      "role": "robot",
+      "source_layer": "locked_generated_urdf_visual",
+      "active_visual_source": "mesh_preview",
+      "geometry_type": "mesh",
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.08
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "chain_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.08
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "world_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.08
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.08
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "expected_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.08
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "baked_world_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.08
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "baked_world_visual_matrix": [
+        [
+          1.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        [
+          0.0,
+          1.0,
+          0.0,
+          0.0
+        ],
+        [
+          -0.0,
+          0.0,
+          1.0,
+          0.08
+        ],
+        [
+          0,
+          0,
+          0,
+          1
+        ]
+      ],
+      "baked_world_visual_quaternion": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 1.0
+      },
+      "baked_world_visual_transform_source": "legacy_static_fallback_resolved_ur5_mesh_pose",
+      "visual_origin_applied_to_pose": true,
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "link_transform_status": "static_mesh_resolved",
+      "transform_status": "static_mesh_resolved",
+      "transform_chain": [],
+      "render_expected": true,
+      "resolved": true,
+      "primitive_fallback": false,
+      "fallback_reason": "",
+      "mesh_uri": "package://ur_description/meshes/ur5/visual/base.dae",
+      "source_path": "package://ur_description/meshes/ur5/visual/base.dae",
+      "mesh_path": "assets/robots/universal_robot/ur_description/meshes/ur5/visual/base.dae",
+      "resolved_source_path": "assets/robots/universal_robot/ur_description/meshes/ur5/visual/base.dae",
+      "resolved_source_path_is_repo_relative": true,
+      "package_uri": "package://ur_description/meshes/ur5/visual/base.dae",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "mesh_available": true,
+      "has_mesh_metadata": true,
+      "material": {
+        "name": "scene3d_static_robot_mesh",
+        "color": null
+      },
+      "render_skip_reason": "",
+      "warning": "ur_robot xacro macro unavailable; used resolved UR mesh asset with static preview pose",
+      "repo_relative_source_path": "assets/robots/universal_robot/ur_description/meshes/ur5/visual/base.dae",
+      "scene_relative_source_path": "",
+      "asset_relative_source_path": "robots/universal_robot/ur_description/meshes/ur5/visual/base.dae"
+    },
+    {
+      "id": "urdf_static_mesh_ur5_static_shoulder",
+      "source": "legacy_static_fallback",
+      "link": "shoulder_link",
+      "visual": "static_mesh_visual",
+      "parent_link": "world",
+      "immediate_parent_link": "world",
+      "joint_parent_link": "world",
+      "parent_joint": "",
+      "parent_joint_name": "",
+      "parent_joint_type": "static_preview",
+      "parent_joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "parent_joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "parent_joint_value": 0.0,
+      "parent_joint_value_source": "zero_default",
+      "joint_name": "",
+      "joint_type": "static_preview",
+      "joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "joint_value": 0.0,
+      "joint_value_source": "zero_default",
+      "applied_joint_value": 0.0,
+      "applied_joint_value_source": "zero_default",
+      "link_chain": [
+        "world",
+        "shoulder_link"
+      ],
+      "category": "robot_static_mesh_visual",
+      "role": "robot",
+      "source_layer": "locked_generated_urdf_visual",
+      "active_visual_source": "mesh_preview",
+      "geometry_type": "mesh",
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.34
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "chain_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.34
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "world_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.34
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.34
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "expected_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.34
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "baked_world_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.34
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "baked_world_visual_matrix": [
+        [
+          1.0,
+          0.0,
+          0.0,
+          0.0
+        ],
+        [
+          0.0,
+          1.0,
+          0.0,
+          0.0
+        ],
+        [
+          -0.0,
+          0.0,
+          1.0,
+          0.34
+        ],
+        [
+          0,
+          0,
+          0,
+          1
+        ]
+      ],
+      "baked_world_visual_quaternion": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 1.0
+      },
+      "baked_world_visual_transform_source": "legacy_static_fallback_resolved_ur5_mesh_pose",
+      "visual_origin_applied_to_pose": true,
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "link_transform_status": "static_mesh_resolved",
+      "transform_status": "static_mesh_resolved",
+      "transform_chain": [],
+      "render_expected": true,
+      "resolved": true,
+      "primitive_fallback": false,
+      "fallback_reason": "",
+      "mesh_uri": "package://ur_description/meshes/ur5/visual/shoulder.dae",
+      "source_path": "package://ur_description/meshes/ur5/visual/shoulder.dae",
+      "mesh_path": "assets/robots/universal_robot/ur_description/meshes/ur5/visual/shoulder.dae",
+      "resolved_source_path": "assets/robots/universal_robot/ur_description/meshes/ur5/visual/shoulder.dae",
+      "resolved_source_path_is_repo_relative": true,
+      "package_uri": "package://ur_description/meshes/ur5/visual/shoulder.dae",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "mesh_available": true,
+      "has_mesh_metadata": true,
+      "material": {
+        "name": "scene3d_static_robot_mesh",
+        "color": null
+      },
+      "render_skip_reason": "",
+      "warning": "ur_robot xacro macro unavailable; used resolved UR mesh asset with static preview pose",
+      "repo_relative_source_path": "assets/robots/universal_robot/ur_description/meshes/ur5/visual/shoulder.dae",
+      "scene_relative_source_path": "",
+      "asset_relative_source_path": "robots/universal_robot/ur_description/meshes/ur5/visual/shoulder.dae"
+    },
+    {
+      "id": "urdf_static_mesh_ur5_static_upper_arm",
+      "source": "legacy_static_fallback",
+      "link": "upper_arm_link",
+      "visual": "static_mesh_visual",
+      "parent_link": "world",
+      "immediate_parent_link": "world",
+      "joint_parent_link": "world",
+      "parent_joint": "",
+      "parent_joint_name": "",
+      "parent_joint_type": "static_preview",
+      "parent_joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "parent_joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "parent_joint_value": 0.0,
+      "parent_joint_value_source": "zero_default",
+      "joint_name": "",
+      "joint_type": "static_preview",
+      "joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "joint_value": 0.0,
+      "joint_value_source": "zero_default",
+      "applied_joint_value": 0.0,
+      "applied_joint_value_source": "zero_default",
+      "link_chain": [
+        "world",
+        "upper_arm_link"
+      ],
+      "category": "robot_static_mesh_visual",
+      "role": "robot",
+      "source_layer": "locked_generated_urdf_visual",
+      "active_visual_source": "mesh_preview",
+      "geometry_type": "mesh",
+      "pose": {
+        "xyz": [
+          0.27,
+          0.0,
+          0.58
+        ],
+        "rpy": [
+          0.0,
+          0.35,
+          0.0
+        ]
+      },
+      "chain_pose": {
+        "xyz": [
+          0.27,
+          0.0,
+          0.58
+        ],
+        "rpy": [
+          0.0,
+          0.35,
+          0.0
+        ]
+      },
+      "world_pose": {
+        "xyz": [
+          0.27,
+          0.0,
+          0.58
+        ],
+        "rpy": [
+          0.0,
+          0.35,
+          0.0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.27,
+          0.0,
+          0.58
+        ],
+        "rpy": [
+          0.0,
+          0.35,
+          0.0
+        ]
+      },
+      "expected_visual_pose": {
+        "xyz": [
+          0.27,
+          0.0,
+          0.58
+        ],
+        "rpy": [
+          0.0,
+          0.35,
+          0.0
+        ]
+      },
+      "baked_world_visual_pose": {
+        "xyz": [
+          0.27,
+          0.0,
+          0.58
+        ],
+        "rpy": [
+          0.0,
+          0.35,
+          0.0
+        ]
+      },
+      "baked_world_visual_matrix": [
+        [
+          0.9393727128473789,
+          0.0,
+          0.34289780745545134,
+          0.27
+        ],
+        [
+          0.0,
+          1.0,
+          0.0,
+          0.0
+        ],
+        [
+          -0.34289780745545134,
+          0.0,
+          0.9393727128473789,
+          0.58
+        ],
+        [
+          0,
+          0,
+          0,
+          1
+        ]
+      ],
+      "baked_world_visual_quaternion": {
+        "x": 0.0,
+        "y": 0.17410813759359597,
+        "z": 0.0,
+        "w": 0.9847265389049336
+      },
+      "baked_world_visual_transform_source": "legacy_static_fallback_resolved_ur5_mesh_pose",
+      "visual_origin_applied_to_pose": true,
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "link_transform_status": "static_mesh_resolved",
+      "transform_status": "static_mesh_resolved",
+      "transform_chain": [],
+      "render_expected": true,
+      "resolved": true,
+      "primitive_fallback": false,
+      "fallback_reason": "",
+      "mesh_uri": "package://ur_description/meshes/ur5/visual/upperarm.dae",
+      "source_path": "package://ur_description/meshes/ur5/visual/upperarm.dae",
+      "mesh_path": "assets/robots/universal_robot/ur_description/meshes/ur5/visual/upperarm.dae",
+      "resolved_source_path": "assets/robots/universal_robot/ur_description/meshes/ur5/visual/upperarm.dae",
+      "resolved_source_path_is_repo_relative": true,
+      "package_uri": "package://ur_description/meshes/ur5/visual/upperarm.dae",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "mesh_available": true,
+      "has_mesh_metadata": true,
+      "material": {
+        "name": "scene3d_static_robot_mesh",
+        "color": null
+      },
+      "render_skip_reason": "",
+      "warning": "ur_robot xacro macro unavailable; used resolved UR mesh asset with static preview pose",
+      "repo_relative_source_path": "assets/robots/universal_robot/ur_description/meshes/ur5/visual/upperarm.dae",
+      "scene_relative_source_path": "",
+      "asset_relative_source_path": "robots/universal_robot/ur_description/meshes/ur5/visual/upperarm.dae"
+    },
+    {
+      "id": "urdf_static_mesh_ur5_static_forearm",
+      "source": "legacy_static_fallback",
+      "link": "forearm_link",
+      "visual": "static_mesh_visual",
+      "parent_link": "world",
+      "immediate_parent_link": "world",
+      "joint_parent_link": "world",
+      "parent_joint": "",
+      "parent_joint_name": "",
+      "parent_joint_type": "static_preview",
+      "parent_joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "parent_joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "parent_joint_value": 0.0,
+      "parent_joint_value_source": "zero_default",
+      "joint_name": "",
+      "joint_type": "static_preview",
+      "joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "joint_value": 0.0,
+      "joint_value_source": "zero_default",
+      "applied_joint_value": 0.0,
+      "applied_joint_value_source": "zero_default",
+      "link_chain": [
+        "world",
+        "forearm_link"
+      ],
+      "category": "robot_static_mesh_visual",
+      "role": "robot",
+      "source_layer": "locked_generated_urdf_visual",
+      "active_visual_source": "mesh_preview",
+      "geometry_type": "mesh",
+      "pose": {
+        "xyz": [
+          0.58,
+          0.0,
+          0.43
+        ],
+        "rpy": [
+          0.0,
+          -0.45,
+          0.0
+        ]
+      },
+      "chain_pose": {
+        "xyz": [
+          0.58,
+          0.0,
+          0.43
+        ],
+        "rpy": [
+          0.0,
+          -0.45,
+          0.0
+        ]
+      },
+      "world_pose": {
+        "xyz": [
+          0.58,
+          0.0,
+          0.43
+        ],
+        "rpy": [
+          0.0,
+          -0.45,
+          0.0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.58,
+          0.0,
+          0.43
+        ],
+        "rpy": [
+          0.0,
+          -0.45,
+          0.0
+        ]
+      },
+      "expected_visual_pose": {
+        "xyz": [
+          0.58,
+          0.0,
+          0.43
+        ],
+        "rpy": [
+          0.0,
+          -0.45,
+          0.0
+        ]
+      },
+      "baked_world_visual_pose": {
+        "xyz": [
+          0.58,
+          0.0,
+          0.43
+        ],
+        "rpy": [
+          0.0,
+          -0.45,
+          0.0
+        ]
+      },
+      "baked_world_visual_matrix": [
+        [
+          0.9004471023526769,
+          -0.0,
+          -0.43496553411123023,
+          0.58
+        ],
+        [
+          0.0,
+          1.0,
+          -0.0,
+          0.0
+        ],
+        [
+          0.43496553411123023,
+          0.0,
+          0.9004471023526769,
+          0.43
+        ],
+        [
+          0,
+          0,
+          0,
+          1
+        ]
+      ],
+      "baked_world_visual_quaternion": {
+        "x": 0.0,
+        "y": -0.2231063621317455,
+        "z": 0.0,
+        "w": 0.9747941070689433
+      },
+      "baked_world_visual_transform_source": "legacy_static_fallback_resolved_ur5_mesh_pose",
+      "visual_origin_applied_to_pose": true,
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "link_transform_status": "static_mesh_resolved",
+      "transform_status": "static_mesh_resolved",
+      "transform_chain": [],
+      "render_expected": true,
+      "resolved": true,
+      "primitive_fallback": false,
+      "fallback_reason": "",
+      "mesh_uri": "package://ur_description/meshes/ur5/visual/forearm.dae",
+      "source_path": "package://ur_description/meshes/ur5/visual/forearm.dae",
+      "mesh_path": "assets/robots/universal_robot/ur_description/meshes/ur5/visual/forearm.dae",
+      "resolved_source_path": "assets/robots/universal_robot/ur_description/meshes/ur5/visual/forearm.dae",
+      "resolved_source_path_is_repo_relative": true,
+      "package_uri": "package://ur_description/meshes/ur5/visual/forearm.dae",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "mesh_available": true,
+      "has_mesh_metadata": true,
+      "material": {
+        "name": "scene3d_static_robot_mesh",
+        "color": null
+      },
+      "render_skip_reason": "",
+      "warning": "ur_robot xacro macro unavailable; used resolved UR mesh asset with static preview pose",
+      "repo_relative_source_path": "assets/robots/universal_robot/ur_description/meshes/ur5/visual/forearm.dae",
+      "scene_relative_source_path": "",
+      "asset_relative_source_path": "robots/universal_robot/ur_description/meshes/ur5/visual/forearm.dae"
+    },
+    {
+      "id": "urdf_static_mesh_ur5_static_wrist_1",
+      "source": "legacy_static_fallback",
+      "link": "wrist_1_link",
+      "visual": "static_mesh_visual",
+      "parent_link": "world",
+      "immediate_parent_link": "world",
+      "joint_parent_link": "world",
+      "parent_joint": "",
+      "parent_joint_name": "",
+      "parent_joint_type": "static_preview",
+      "parent_joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "parent_joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "parent_joint_value": 0.0,
+      "parent_joint_value_source": "zero_default",
+      "joint_name": "",
+      "joint_type": "static_preview",
+      "joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "joint_value": 0.0,
+      "joint_value_source": "zero_default",
+      "applied_joint_value": 0.0,
+      "applied_joint_value_source": "zero_default",
+      "link_chain": [
+        "world",
+        "wrist_1_link"
+      ],
+      "category": "robot_static_mesh_visual",
+      "role": "robot",
+      "source_layer": "locked_generated_urdf_visual",
+      "active_visual_source": "mesh_preview",
+      "geometry_type": "mesh",
+      "pose": {
+        "xyz": [
+          0.82,
+          0.0,
+          0.31
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "chain_pose": {
+        "xyz": [
+          0.82,
+          0.0,
+          0.31
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "world_pose": {
+        "xyz": [
+          0.82,
+          0.0,
+          0.31
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.82,
+          0.0,
+          0.31
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "expected_visual_pose": {
+        "xyz": [
+          0.82,
+          0.0,
+          0.31
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "baked_world_visual_pose": {
+        "xyz": [
+          0.82,
+          0.0,
+          0.31
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "baked_world_visual_matrix": [
+        [
+          1.0,
+          0.0,
+          0.0,
+          0.82
+        ],
+        [
+          0.0,
+          1.0,
+          0.0,
+          0.0
+        ],
+        [
+          -0.0,
+          0.0,
+          1.0,
+          0.31
+        ],
+        [
+          0,
+          0,
+          0,
+          1
+        ]
+      ],
+      "baked_world_visual_quaternion": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 1.0
+      },
+      "baked_world_visual_transform_source": "legacy_static_fallback_resolved_ur5_mesh_pose",
+      "visual_origin_applied_to_pose": true,
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "link_transform_status": "static_mesh_resolved",
+      "transform_status": "static_mesh_resolved",
+      "transform_chain": [],
+      "render_expected": true,
+      "resolved": true,
+      "primitive_fallback": false,
+      "fallback_reason": "",
+      "mesh_uri": "package://ur_description/meshes/ur5/visual/wrist1.dae",
+      "source_path": "package://ur_description/meshes/ur5/visual/wrist1.dae",
+      "mesh_path": "assets/robots/universal_robot/ur_description/meshes/ur5/visual/wrist1.dae",
+      "resolved_source_path": "assets/robots/universal_robot/ur_description/meshes/ur5/visual/wrist1.dae",
+      "resolved_source_path_is_repo_relative": true,
+      "package_uri": "package://ur_description/meshes/ur5/visual/wrist1.dae",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "mesh_available": true,
+      "has_mesh_metadata": true,
+      "material": {
+        "name": "scene3d_static_robot_mesh",
+        "color": null
+      },
+      "render_skip_reason": "",
+      "warning": "ur_robot xacro macro unavailable; used resolved UR mesh asset with static preview pose",
+      "repo_relative_source_path": "assets/robots/universal_robot/ur_description/meshes/ur5/visual/wrist1.dae",
+      "scene_relative_source_path": "",
+      "asset_relative_source_path": "robots/universal_robot/ur_description/meshes/ur5/visual/wrist1.dae"
+    },
+    {
+      "id": "urdf_static_mesh_ur5_static_wrist_2",
+      "source": "legacy_static_fallback",
+      "link": "wrist_2_link",
+      "visual": "static_mesh_visual",
+      "parent_link": "world",
+      "immediate_parent_link": "world",
+      "joint_parent_link": "world",
+      "parent_joint": "",
+      "parent_joint_name": "",
+      "parent_joint_type": "static_preview",
+      "parent_joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "parent_joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "parent_joint_value": 0.0,
+      "parent_joint_value_source": "zero_default",
+      "joint_name": "",
+      "joint_type": "static_preview",
+      "joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "joint_value": 0.0,
+      "joint_value_source": "zero_default",
+      "applied_joint_value": 0.0,
+      "applied_joint_value_source": "zero_default",
+      "link_chain": [
+        "world",
+        "wrist_2_link"
+      ],
+      "category": "robot_static_mesh_visual",
+      "role": "robot",
+      "source_layer": "locked_generated_urdf_visual",
+      "active_visual_source": "mesh_preview",
+      "geometry_type": "mesh",
+      "pose": {
+        "xyz": [
+          0.92,
+          0.0,
+          0.28
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "chain_pose": {
+        "xyz": [
+          0.92,
+          0.0,
+          0.28
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "world_pose": {
+        "xyz": [
+          0.92,
+          0.0,
+          0.28
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.92,
+          0.0,
+          0.28
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "expected_visual_pose": {
+        "xyz": [
+          0.92,
+          0.0,
+          0.28
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "baked_world_visual_pose": {
+        "xyz": [
+          0.92,
+          0.0,
+          0.28
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "baked_world_visual_matrix": [
+        [
+          1.0,
+          0.0,
+          0.0,
+          0.92
+        ],
+        [
+          0.0,
+          1.0,
+          0.0,
+          0.0
+        ],
+        [
+          -0.0,
+          0.0,
+          1.0,
+          0.28
+        ],
+        [
+          0,
+          0,
+          0,
+          1
+        ]
+      ],
+      "baked_world_visual_quaternion": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 1.0
+      },
+      "baked_world_visual_transform_source": "legacy_static_fallback_resolved_ur5_mesh_pose",
+      "visual_origin_applied_to_pose": true,
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "link_transform_status": "static_mesh_resolved",
+      "transform_status": "static_mesh_resolved",
+      "transform_chain": [],
+      "render_expected": true,
+      "resolved": true,
+      "primitive_fallback": false,
+      "fallback_reason": "",
+      "mesh_uri": "package://ur_description/meshes/ur5/visual/wrist2.dae",
+      "source_path": "package://ur_description/meshes/ur5/visual/wrist2.dae",
+      "mesh_path": "assets/robots/universal_robot/ur_description/meshes/ur5/visual/wrist2.dae",
+      "resolved_source_path": "assets/robots/universal_robot/ur_description/meshes/ur5/visual/wrist2.dae",
+      "resolved_source_path_is_repo_relative": true,
+      "package_uri": "package://ur_description/meshes/ur5/visual/wrist2.dae",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "mesh_available": true,
+      "has_mesh_metadata": true,
+      "material": {
+        "name": "scene3d_static_robot_mesh",
+        "color": null
+      },
+      "render_skip_reason": "",
+      "warning": "ur_robot xacro macro unavailable; used resolved UR mesh asset with static preview pose",
+      "repo_relative_source_path": "assets/robots/universal_robot/ur_description/meshes/ur5/visual/wrist2.dae",
+      "scene_relative_source_path": "",
+      "asset_relative_source_path": "robots/universal_robot/ur_description/meshes/ur5/visual/wrist2.dae"
+    },
+    {
+      "id": "urdf_static_mesh_ur5_static_wrist_3",
+      "source": "legacy_static_fallback",
+      "link": "wrist_3_link",
+      "visual": "static_mesh_visual",
+      "parent_link": "world",
+      "immediate_parent_link": "world",
+      "joint_parent_link": "world",
+      "parent_joint": "",
+      "parent_joint_name": "",
+      "parent_joint_type": "static_preview",
+      "parent_joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "parent_joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "parent_joint_value": 0.0,
+      "parent_joint_value_source": "zero_default",
+      "joint_name": "",
+      "joint_type": "static_preview",
+      "joint_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "joint_axis": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "joint_value": 0.0,
+      "joint_value_source": "zero_default",
+      "applied_joint_value": 0.0,
+      "applied_joint_value_source": "zero_default",
+      "link_chain": [
+        "world",
+        "wrist_3_link"
+      ],
+      "category": "robot_static_mesh_visual",
+      "role": "robot",
+      "source_layer": "locked_generated_urdf_visual",
+      "active_visual_source": "mesh_preview",
+      "geometry_type": "mesh",
+      "pose": {
+        "xyz": [
+          0.98,
+          0.0,
+          0.28
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "chain_pose": {
+        "xyz": [
+          0.98,
+          0.0,
+          0.28
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "world_pose": {
+        "xyz": [
+          0.98,
+          0.0,
+          0.28
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.98,
+          0.0,
+          0.28
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "expected_visual_pose": {
+        "xyz": [
+          0.98,
+          0.0,
+          0.28
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "baked_world_visual_pose": {
+        "xyz": [
+          0.98,
+          0.0,
+          0.28
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "baked_world_visual_matrix": [
+        [
+          1.0,
+          0.0,
+          0.0,
+          0.98
+        ],
+        [
+          0.0,
+          1.0,
+          0.0,
+          0.0
+        ],
+        [
+          -0.0,
+          0.0,
+          1.0,
+          0.28
+        ],
+        [
+          0,
+          0,
+          0,
+          1
+        ]
+      ],
+      "baked_world_visual_quaternion": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 1.0
+      },
+      "baked_world_visual_transform_source": "legacy_static_fallback_resolved_ur5_mesh_pose",
+      "visual_origin_applied_to_pose": true,
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "link_transform_status": "static_mesh_resolved",
+      "transform_status": "static_mesh_resolved",
+      "transform_chain": [],
+      "render_expected": true,
+      "resolved": true,
+      "primitive_fallback": false,
+      "fallback_reason": "",
+      "mesh_uri": "package://ur_description/meshes/ur5/visual/wrist3.dae",
+      "source_path": "package://ur_description/meshes/ur5/visual/wrist3.dae",
+      "mesh_path": "assets/robots/universal_robot/ur_description/meshes/ur5/visual/wrist3.dae",
+      "resolved_source_path": "assets/robots/universal_robot/ur_description/meshes/ur5/visual/wrist3.dae",
+      "resolved_source_path_is_repo_relative": true,
+      "package_uri": "package://ur_description/meshes/ur5/visual/wrist3.dae",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "mesh_available": true,
+      "has_mesh_metadata": true,
+      "material": {
+        "name": "scene3d_static_robot_mesh",
+        "color": null
+      },
+      "render_skip_reason": "",
+      "warning": "ur_robot xacro macro unavailable; used resolved UR mesh asset with static preview pose",
+      "repo_relative_source_path": "assets/robots/universal_robot/ur_description/meshes/ur5/visual/wrist3.dae",
+      "scene_relative_source_path": "",
+      "asset_relative_source_path": "robots/universal_robot/ur_description/meshes/ur5/visual/wrist3.dae"
+    }
+  ],
+  "xacro_command": [
+    "xacro-lite",
+    "scenes/ur5_2f_test/urdf/scene.urdf.xacro"
+  ],
+  "package_resolution_diagnostics": {
+    "resolved_packages": [
+      {
+        "package_name": "fanuc_description",
+        "root_path": "assets/robots/fanuc/fanuc_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/robots/fanuc/fanuc_description/package.xml"
+      },
+      {
+        "package_name": "fanuc_moveit_config",
+        "root_path": "assets/robots/fanuc/fanuc_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/robots/fanuc/fanuc_moveit_config/package.xml"
+      },
+      {
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "assets/environment/flat_plate_camera_bracket_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/environment/flat_plate_camera_bracket_description/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+      },
+      {
+        "package_name": "overhead_camera_gantry_description",
+        "root_path": "assets/environment/overhead_camera_gantry_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/environment/overhead_camera_gantry_description/package.xml"
+      },
+      {
+        "package_name": "panda_description",
+        "root_path": "assets/robots/panda_robot/panda_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/robots/panda_robot/panda_description/package.xml"
+      },
+      {
+        "package_name": "panda_moveit_config",
+        "root_path": "assets/robots/panda_robot/panda_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/robots/panda_robot/panda_moveit_config/package.xml"
+      },
+      {
+        "package_name": "pipe_camera_stand_description",
+        "root_path": "assets/environment/pipe_camera_stand_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/environment/pipe_camera_stand_description/package.xml"
+      },
+      {
+        "package_name": "realsense2_description",
+        "root_path": "assets/environment/realsense2_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/environment/realsense2_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_3f_gripper_description",
+        "root_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_3f_moveit_config",
+        "root_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml"
+      },
+      {
+        "package_name": "robotiq_85_description",
+        "root_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
+      },
+      {
+        "package_name": "simple_conveyor_description",
+        "root_path": "assets/environment/simple_conveyor_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/environment/simple_conveyor_description/package.xml"
+      },
+      {
+        "package_name": "single_suction_description",
+        "root_path": "assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+      },
+      {
+        "package_name": "single_suction_moveit_config",
+        "root_path": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
+      },
+      {
+        "package_name": "sorting_bin_description",
+        "root_path": "assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/environment/sorting_bin_description/package.xml"
+      },
+      {
+        "package_name": "table_clamp_camera_mount_description",
+        "root_path": "assets/environment/table_clamp_camera_mount_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/environment/table_clamp_camera_mount_description/package.xml"
+      },
+      {
+        "package_name": "table_description",
+        "root_path": "assets/environment/table_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/environment/table_description/package.xml"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/environment/tslot_camera_frame_description/package.xml"
+      },
+      {
+        "package_name": "ur10_moveit_config",
+        "root_path": "assets/robots/universal_robot/ur10_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/robots/universal_robot/ur10_moveit_config/package.xml"
+      },
+      {
+        "package_name": "ur3_moveit_config",
+        "root_path": "assets/robots/universal_robot/ur3_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/robots/universal_robot/ur3_moveit_config/package.xml"
+      },
+      {
+        "package_name": "ur5_moveit_config",
+        "root_path": "assets/robots/universal_robot/ur5_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/robots/universal_robot/ur5_moveit_config/package.xml"
+      },
+      {
+        "package_name": "ur_description",
+        "root_path": "assets/robots/universal_robot/ur_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/robots/universal_robot/ur_description/package.xml"
+      },
+      {
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "assets/environment/vslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/environment/vslot_camera_frame_description/package.xml"
+      },
+      {
+        "package_name": "workbench_description",
+        "root_path": "assets/environment/workbench_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/environment/workbench_description/package.xml"
+      }
+    ],
+    "shadowed_packages": [
+      {
+        "package_name": "ur_description",
+        "root_path": "assets/robots/universal_robot/ur_description",
+        "source_tier": "repo_assets_ur_description",
+        "package_xml": "assets/robots/universal_robot/ur_description/package.xml",
+        "shadowed_by": "assets/robots/universal_robot/ur_description"
+      }
+    ],
+    "resolution_paths": [
+      {
+        "package_name": "fanuc_description",
+        "root_path": "assets/robots/fanuc/fanuc_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "fanuc_moveit_config",
+        "root_path": "assets/robots/fanuc/fanuc_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "assets/environment/flat_plate_camera_bracket_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "overhead_camera_gantry_description",
+        "root_path": "assets/environment/overhead_camera_gantry_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "panda_description",
+        "root_path": "assets/robots/panda_robot/panda_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "panda_moveit_config",
+        "root_path": "assets/robots/panda_robot/panda_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "pipe_camera_stand_description",
+        "root_path": "assets/environment/pipe_camera_stand_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "realsense2_description",
+        "root_path": "assets/environment/realsense2_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_3f_gripper_description",
+        "root_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_3f_moveit_config",
+        "root_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_85_description",
+        "root_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "simple_conveyor_description",
+        "root_path": "assets/environment/simple_conveyor_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "single_suction_description",
+        "root_path": "assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "single_suction_moveit_config",
+        "root_path": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "sorting_bin_description",
+        "root_path": "assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "table_clamp_camera_mount_description",
+        "root_path": "assets/environment/table_clamp_camera_mount_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "table_description",
+        "root_path": "assets/environment/table_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "ur10_moveit_config",
+        "root_path": "assets/robots/universal_robot/ur10_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "ur3_moveit_config",
+        "root_path": "assets/robots/universal_robot/ur3_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "ur5_moveit_config",
+        "root_path": "assets/robots/universal_robot/ur5_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "ur_description",
+        "root_path": "assets/robots/universal_robot/ur_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "assets/environment/vslot_camera_frame_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "workbench_description",
+        "root_path": "assets/environment/workbench_description",
+        "source_tier": "repo_assets"
+      }
+    ],
+    "ros_resolution_attempts": [
+      {
+        "package_name": "fanuc_description",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "fanuc_moveit_config",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "flat_plate_camera_bracket_description",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "overhead_camera_gantry_description",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "panda_description",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "panda_moveit_config",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "pipe_camera_stand_description",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "robotiq_3f_gripper_description",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "robotiq_3f_moveit_config",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "robotiq_85_moveit_config",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "simple_conveyor_description",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "single_suction_description",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "single_suction_moveit_config",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "sorting_bin_description",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "table_clamp_camera_mount_description",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "table_description",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "ur10_moveit_config",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "ur3_moveit_config",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "ur5_moveit_config",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "vslot_camera_frame_description",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      }
+    ],
+    "unresolved_packages": []
+  }
+}

--- a/scripts/extract_scene_urdf_visual_mesh_index.py
+++ b/scripts/extract_scene_urdf_visual_mesh_index.py
@@ -1132,9 +1132,20 @@ def append_static_ur5_mesh_visuals(items, package_map, authoritative_links=None)
             'applied_joint_value_source': 'zero_default',
             'link_chain': ['world', spec['link']],
             'category': 'robot_static_mesh_visual',
+            'role': 'robot',
+            'source_layer': 'locked_generated_urdf_visual',
+            'active_visual_source': 'mesh_preview',
             'geometry_type': 'mesh',
             'pose': {'xyz': xyz, 'rpy': rpy},
             'chain_pose': {'xyz': xyz, 'rpy': rpy},
+            'world_pose': {'xyz': xyz, 'rpy': rpy},
+            'link_world_pose': {'xyz': xyz, 'rpy': rpy},
+            'expected_visual_pose': {'xyz': xyz, 'rpy': rpy},
+            'baked_world_visual_pose': {'xyz': xyz, 'rpy': rpy},
+            'baked_world_visual_matrix': tf_from_xyz_rpy(xyz, rpy),
+            'baked_world_visual_quaternion': quaternion_from_tf(tf_from_xyz_rpy(xyz, rpy)),
+            'baked_world_visual_transform_source': 'legacy_static_fallback_resolved_ur5_mesh_pose',
+            'visual_origin_applied_to_pose': True,
             'visual_origin': {'xyz': [0.0, 0.0, 0.0], 'rpy': [0.0, 0.0, 0.0]},
             'link_transform_status': 'static_mesh_resolved',
             'transform_status': 'static_mesh_resolved',
@@ -1143,12 +1154,18 @@ def append_static_ur5_mesh_visuals(items, package_map, authoritative_links=None)
             'resolved': True,
             'primitive_fallback': False,
             'fallback_reason': '',
+            'mesh_uri': package_uri,
             'source_path': package_uri,
+            'mesh_path': _repo_relative_path(resolved_path),
             'resolved_source_path': _repo_relative_path(resolved_path),
             'resolved_source_path_is_repo_relative': bool(resolved_path and _repo_relative_path(resolved_path) != str(resolved_path)),
             'package_uri': package_uri,
+            'scale': [1.0, 1.0, 1.0],
             'mesh_scale': [1.0, 1.0, 1.0],
+            'mesh_available': True,
+            'has_mesh_metadata': True,
             'material': {'name': 'scene3d_static_robot_mesh', 'color': None},
+            'render_skip_reason': '',
             'warning': 'ur_robot xacro macro unavailable; used resolved UR mesh asset with static preview pose',
         })
         existing_ids.add(item_id)
@@ -1259,6 +1276,35 @@ def resolve_static_tool0_children(items):
         item['static_parent_resolved'] = True
         fixed += 1
     return fixed
+
+def add_portable_mesh_path_metadata(items, scene_dir):
+    for item in items or []:
+        if not isinstance(item, dict):
+            continue
+        source = str(item.get('resolved_source_path') or item.get('mesh_path') or '')
+        repo_rel = _repo_relative_path(source) if source else ''
+        item.setdefault('repo_relative_source_path', repo_rel if repo_rel and not Path(repo_rel).is_absolute() else '')
+        scene_rel = ''
+        if source:
+            try:
+                source_path = Path(source)
+                if not source_path.is_absolute():
+                    source_path = ROOT / source_path
+                scene_rel = source_path.resolve().relative_to(Path(scene_dir).resolve()).as_posix()
+            except Exception:
+                scene_rel = ''
+        item.setdefault('scene_relative_source_path', scene_rel)
+        asset_rel = ''
+        if source:
+            try:
+                source_path = Path(source)
+                if not source_path.is_absolute():
+                    source_path = ROOT / source_path
+                asset_rel = source_path.resolve().relative_to((ROOT / 'assets').resolve()).as_posix()
+            except Exception:
+                asset_rel = ''
+        item.setdefault('asset_relative_source_path', asset_rel)
+
 
 def resolve_mesh_uri(uri, package_map):
     u=(uri or '').strip()
@@ -1588,6 +1634,7 @@ def main():
         if scene_dir.name.startswith('ur5_') or _contains_unresolved_ur_robot(source_xacro_text):
             _log_ur5_visual_mesh_diagnostics(scene_dir.name, ur5_visual_diagnostics)
         static_parent_resolved_count = resolve_static_tool0_children(items)
+        add_portable_mesh_path_metadata(items, scene_dir)
         ur5_transform_table = build_ur5_transform_table(items)
         if scene_dir.name.startswith('ur5_'):
             print_ur5_transform_table(scene_dir.name, ur5_transform_table)

--- a/tests/test_scene3d_generated_mesh_index_contract.py
+++ b/tests/test_scene3d_generated_mesh_index_contract.py
@@ -4,7 +4,14 @@ import json
 from pathlib import Path
 
 
-def _resolve_mesh_path(scene_dir: Path, source_path: str, package_uri: str) -> Path | None:
+def _resolve_mesh_path(scene_dir: Path, source_path: str, package_uri: str, resolved_source_path: str = "") -> Path | None:
+    if resolved_source_path:
+        p = Path(resolved_source_path)
+        candidates = [p] if p.is_absolute() else [Path.cwd() / p, scene_dir / p]
+        for c in candidates:
+            if c.is_file():
+                return c.resolve()
+
     if source_path:
         p = Path(source_path)
         candidates = [p] if p.is_absolute() else [scene_dir / p]
@@ -55,7 +62,12 @@ def test_ur5_2f_generated_visual_index_contains_resolvable_mesh_items() -> None:
     for item in visual_items:
         if item.get("geometry_type") != "mesh":
             continue
-        mesh_path = _resolve_mesh_path(scene_dir, item.get("source_path", ""), item.get("package_uri", ""))
+        mesh_path = _resolve_mesh_path(
+            scene_dir,
+            item.get("source_path", ""),
+            item.get("package_uri", ""),
+            item.get("resolved_source_path", "") or item.get("mesh_path", ""),
+        )
         if not mesh_path:
             continue
         converted.append(
@@ -74,4 +86,72 @@ def test_ur5_2f_generated_visual_index_contains_resolvable_mesh_items() -> None:
         and x["source_layer"] == "generated_urdf_visual"
         and x["active_visual_source"] == "mesh_preview"
         for x in converted
+    )
+
+
+def _finite_pose(value: dict) -> bool:
+    return (
+        isinstance(value, dict)
+        and isinstance(value.get("xyz"), list)
+        and len(value["xyz"]) == 3
+        and isinstance(value.get("rpy"), list)
+        and len(value["rpy"]) == 3
+    )
+
+
+def test_ur5_2f_required_visuals_carry_mesh_and_transform_metadata() -> None:
+    scene_dir = Path("scenes/ur5_2f_test")
+    index_path = scene_dir / "generated" / "scene_visual_mesh_index.json"
+    assert index_path.is_file(), f"missing index: {index_path}"
+
+    data = json.loads(index_path.read_text(encoding="utf-8"))
+    visual_items = data.get("visual_items", [])
+    renderable_by_link = {
+        item.get("link"): item
+        for item in visual_items
+        if item.get("geometry_type") == "mesh"
+        and item.get("render_expected") is True
+        and item.get("resolved") is True
+    }
+
+    assert {"base_link", "base_link_inertia"} & set(renderable_by_link), (
+        "expected a renderable UR5 base visual for base_link or base_link_inertia"
+    )
+    for link in [
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link",
+        "wrist_1_link",
+        "wrist_2_link",
+        "wrist_3_link",
+    ]:
+        assert link in renderable_by_link, f"missing renderable UR5 visual for {link}"
+
+    required_links = [
+        next(link for link in ("base_link_inertia", "base_link") if link in renderable_by_link),
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link",
+        "wrist_1_link",
+        "wrist_2_link",
+        "wrist_3_link",
+    ]
+    for link in required_links:
+        item = renderable_by_link[link]
+        mesh_uri = item.get("mesh_uri") or item.get("package_uri") or item.get("source_path")
+        assert isinstance(mesh_uri, str) and mesh_uri.startswith("package://ur_description/meshes/ur5/visual/"), link
+        assert item.get("mesh_path") or item.get("resolved_source_path"), link
+        assert _finite_pose(item.get("baked_world_visual_pose", {})), link
+        assert _finite_pose(item.get("visual_origin", {})), link
+        assert item.get("joint_parent_link") or item.get("parent_link") is not None, link
+        assert "joint_type" in item or "parent_joint_type" in item, link
+        assert item.get("mesh_scale") == [1.0, 1.0, 1.0], link
+        assert item.get("render_expected") is True, link
+        assert item.get("resolved") is True, link
+
+    gripper_mount = renderable_by_link.get("gripper_base_link")
+    assert gripper_mount, "missing renderable Robotiq gripper mount visual"
+    assert gripper_mount.get("joint_parent_link") == "tool0" or "tool0" in gripper_mount.get("link_chain", [])
+    assert str(gripper_mount.get("mesh_uri") or gripper_mount.get("package_uri") or "").startswith(
+        "package://robotiq_85_description/meshes/visual/"
     )


### PR DESCRIPTION
### Motivation
- Scene3D preview index was emitting UR5/table/camera visuals with empty `mesh_uri` and missing baked pose/resolution metadata when xacro expansion was unavailable, making checked-in `generated/scene_visual_mesh_index.json` unusable for mesh-backed previews.
- The extractor must emit repo-portable mesh path metadata and full visual transform/mesh fields so the Workcell Builder Product View can show mesh-backed UR5 visuals and the gripper mount reliably without requiring a live xacro/ROS environment.

### Description
- Updated `scripts/extract_scene_urdf_visual_mesh_index.py` to populate complete metadata for resolved UR5 static mesh fallback entries, adding `mesh_uri`, `mesh_path`/`resolved_source_path`, `baked_world_visual_pose`/`matrix`/`quaternion`, `visual_origin`, `world_pose`/`link_world_pose`/`expected_visual_pose`, `baked_world_visual_transform_source`, `mesh_available`, `has_mesh_metadata`, `scale`, `mesh_scale`, `render_skip_reason`, `role`, `source_layer`, and `active_visual_source` where appropriate (in `append_static_ur5_mesh_visuals`).
- Added `add_portable_mesh_path_metadata(items, scene_dir)` to enrich each visual item with `repo_relative_source_path`, `scene_relative_source_path`, and `asset_relative_source_path`, and invoked it before transform-table generation so indices are portable and resolvable from the repo.
- Regenerated the tracked scene index artifact `scenes/ur5_2f_test/generated/scene_visual_mesh_index.json` to include the new mesh-backed UR5/table/camera entries and repaired Robotiq gripper mount metadata.
- Strengthened tests by updating mesh resolution helper usage and adding assertions in `tests/test_scene3d_generated_mesh_index_contract.py` that require mesh and transform metadata for UR5 links (`base_link`/`base_link_inertia`, `shoulder_link`, `upper_arm_link`, `forearm_link`, `wrist_1_link`, `wrist_2_link`, `wrist_3_link`) and the Robotiq gripper mount under `gripper_base_link`.
- Files changed: `scripts/extract_scene_urdf_visual_mesh_index.py`, `scenes/ur5_2f_test/generated/scene_visual_mesh_index.json` (regenerated), and `tests/test_scene3d_generated_mesh_index_contract.py` (assertions/mesh-path helper update).

### Testing
- Ran the extractor locally: `python3 scripts/extract_scene_urdf_visual_mesh_index.py --scene ur5_2f_test`, which produced a regenerated index including mesh URIs and baked poses (success).
- Static checks: `python3 -m py_compile scripts/extract_scene_urdf_visual_mesh_index.py` (success).
- Unit tests executed: `python3 -m pytest tests/test_scene3d_generated_mesh_index_contract.py -q` (passed) and `python3 -m pytest tests/test_visual_mesh_index_portability.py::test_portable_fields_exist -q` (passed).
- Combined validation: ran `pytest` invocations referenced above during development; all targeted automated tests listed above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a451fdea99c8331aaaa8fa7b0892456)