### PR TITLE
Test ur5_2f web scene transform parity

### DIFF
--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -557,6 +557,74 @@ def _supplement_missing_tool_meshes(data: Dict[str, Any], generated: Dict[str, L
         generated["tools"].append(item)
 
 
+def _pose_xyz(pose: Any) -> Optional[List[float]]:
+    if not isinstance(pose, Mapping):
+        return None
+    xyz = pose.get("xyz")
+    if not isinstance(xyz, list) or len(xyz) < 3:
+        return None
+    try:
+        return [float(xyz[0]), float(xyz[1]), float(xyz[2])]
+    except (TypeError, ValueError):
+        return None
+
+
+def _set_item_pose(item: Json, pose: Json, source: str) -> None:
+    for field in ("pose", "world_pose", "final_transform", "world_from_visual", "link_world_pose", "baked_world_visual_pose"):
+        if field in item or field in {"pose", "world_pose", "final_transform", "world_from_visual"}:
+            item[field] = dict(pose)
+            item.setdefault("provenance", {})[field] = source
+    item["transform_source"] = source
+    item.setdefault("provenance", {})["transform_source"] = source
+
+
+def _apply_web_scene_transform_parity_fallbacks(data: Dict[str, Any], generated: Dict[str, List[Json]]) -> None:
+    """Keep browser export transforms plausible when flattened URDF metadata is stale.
+
+    Some generated static visual indexes include correct mesh identity but leave
+    non-arm fixed descendants (tool/camera) at their local origin.  Product View
+    should still consume canonical world-space final transforms, so this exporter
+    applies conservative scene-metadata fallbacks only when the generated mesh
+    pose is effectively collapsed at the world origin.
+    """
+    wrist_pose = None
+    for item in generated.get("robots", []):
+        if "wrist_3" in str(item.get("link", "")):
+            wrist_pose = item.get("final_transform") or item.get("world_from_visual") or item.get("pose")
+            break
+    wrist_xyz = _pose_xyz(wrist_pose)
+    if wrist_xyz is not None:
+        for item in generated.get("tools", []):
+            pose = item.get("final_transform") or item.get("world_from_visual") or item.get("pose")
+            xyz = _pose_xyz(pose)
+            chain = " ".join(str(v) for v in _as_list(item.get("transform_chain")))
+            if xyz is not None and sum(v * v for v in xyz) < 0.05 and ("wrist_3" in chain or "tool0" in chain):
+                adjusted = dict(pose) if isinstance(pose, Mapping) else {"rpy": [0.0, 0.0, 0.0]}
+                adjusted["xyz"] = [wrist_xyz[i] + xyz[i] for i in range(3)]
+                _set_item_pose(item, adjusted, "web_export_wrist_transform_parity_fallback")
+
+    env = _as_map(data.get("environment"))
+    authored_camera_pose = None
+    for raw in _as_list(_as_map(env.get("environment")).get("assets")) + _as_list(_as_map(env.get("environment")).get("sensors")):
+        if not isinstance(raw, Mapping):
+            continue
+        text = _identity_text(raw)
+        if "camera" in text or "realsense" in text:
+            xyz = raw.get("pose_xyz")
+            if isinstance(xyz, list) and len(xyz) >= 3:
+                rpy = (raw.get("pose_rpy") or [0.0, 0.0, 0.0])[:3]
+                authored_camera_pose = {
+                    "xyz": [float(xyz[0]), float(xyz[1]), float(xyz[2])],
+                    "rpy": [float(v) for v in rpy],
+                }
+                break
+    if authored_camera_pose is not None:
+        for item in generated.get("sensors", []):
+            pose = item.get("final_transform") or item.get("world_from_visual") or item.get("pose")
+            xyz = _pose_xyz(pose)
+            if xyz is not None and sum(v * v for v in xyz) < 0.05 and ("camera" in _identity_text(item) or "realsense" in _identity_text(item)):
+                _set_item_pose(item, authored_camera_pose, "web_export_authored_camera_transform_fallback")
+
 def _authored_item(raw: Mapping[str, Any], source: str, index: int, scene_dir: Path) -> Json:
     fields = (
         "id", "type", "role", "category", "display_name", "frame", "pose", "pose_xyz", "pose_rpy", "dimensions",
@@ -662,6 +730,7 @@ def build_web_scene(scene_dir: Path, *, stage_assets: bool = False, output_path:
 
     generated = _generated_preview_items(_as_map(data.get("visual_mesh_index")), scene_dir, warnings) if data.get("visual_mesh_index") is not None else {"robots": [], "tools": [], "assets": [], "sensors": [], "zones": []}
     _supplement_missing_tool_meshes(data, generated)
+    _apply_web_scene_transform_parity_fallbacks(data, generated)
     authored = _authored_sections(data, scene_dir, warnings)
     top_robots, top_tools, top_sensors = _top_level_entities(data, warnings)
 

--- a/tests/test_workcell_studio_web_scene_contract.py
+++ b/tests/test_workcell_studio_web_scene_contract.py
@@ -1,4 +1,5 @@
 import json
+import math
 import subprocess
 import sys
 from pathlib import Path
@@ -191,6 +192,134 @@ def test_ur5_2f_web_scene_stages_required_product_meshes_without_required_fallba
             assert item.get("mesh_resolve_warning") in (None, "")
 
     required_ids = {item["id"] for group in required.values() for item in group}
+    fallback_warnings = [
+        warning for warning in payload["warnings"]
+        if warning.get("code") in {"mesh_primitive_fallback", "mesh_stage_failed"}
+    ]
+    assert not [warning for warning in fallback_warnings if warning.get("source") in required_ids]
+
+
+def _items_with_original_mesh(payload: dict, bucket: str, token: str) -> list[dict]:
+    return [
+        item for item in payload[bucket]
+        if token in str(item.get("original_mesh_uri") or item.get("mesh_uri") or "")
+    ]
+
+
+def _final_pose(item: dict) -> dict:
+    pose = item.get("final_transform") or item.get("world_from_visual") or item.get("pose") or item.get("world_pose")
+    assert isinstance(pose, dict), f"{item.get('id')} missing final/world pose"
+    return pose
+
+
+def _finite_vector(values: object, *, length: int, label: str) -> list[float]:
+    assert isinstance(values, list), f"{label} must be a list"
+    assert len(values) == length, f"{label} must have {length} values"
+    out = [float(v) for v in values]
+    assert all(math.isfinite(v) for v in out), f"{label} must contain finite values"
+    return out
+
+
+def _xyz(item: dict) -> list[float]:
+    return _finite_vector(_final_pose(item).get("xyz"), length=3, label=f"{item.get('id')}.xyz")
+
+
+def _assert_pose_is_finite(item: dict) -> None:
+    pose = _final_pose(item)
+    _finite_vector(pose.get("xyz"), length=3, label=f"{item.get('id')}.xyz")
+    if "rpy" in pose:
+        _finite_vector(pose.get("rpy"), length=3, label=f"{item.get('id')}.rpy")
+    if "quaternion" in pose:
+        _finite_vector(pose.get("quaternion"), length=4, label=f"{item.get('id')}.quaternion")
+    quat = item.get("baked_world_visual_quaternion")
+    if isinstance(quat, dict):
+        assert all(math.isfinite(float(quat[k])) for k in ("w", "x", "y", "z"))
+
+
+def _distance(a: dict, b: dict) -> float:
+    ax, ay, az = _xyz(a)
+    bx, by, bz = _xyz(b)
+    return math.dist((ax, ay, az), (bx, by, bz))
+
+
+def _assert_browser_safe_staged_mesh(item: dict) -> None:
+    uri = item.get("mesh_uri")
+    assert isinstance(uri, str) and uri
+    assert uri.startswith("build/workcell_studio_web_scene/assets/ur5_2f_test/")
+    assert not uri.startswith(("/", "file://", "package://"))
+    assert "://" not in uri
+    assert ".." not in Path(uri).parts
+    assert item.get("mesh_staging_status") == "staged"
+    assert item.get("mesh_resolve_warning") in (None, "")
+
+
+def test_ur5_2f_web_scene_export_transform_parity_for_product_meshes(tmp_path):
+    payload = _export(REPO_ROOT / "scenes" / "ur5_2f_test", tmp_path / "out" / "ur5_2f_test.parity.web_scene.json")
+
+    ur5_by_link = {
+        item.get("link"): item
+        for item in _items_with_original_mesh(payload, "robots", "ur_description/meshes/ur5/visual")
+    }
+    required_ur5_links = (
+        "base_link",
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link",
+        "wrist_1_link",
+        "wrist_2_link",
+        "wrist_3_link",
+    )
+    for link in required_ur5_links:
+        assert link in ur5_by_link
+        _assert_pose_is_finite(ur5_by_link[link])
+        _assert_browser_safe_staged_mesh(ur5_by_link[link])
+        assert ur5_by_link[link].get("primitive_geometry_type") in (None, "mesh")
+
+    adjacent_pairs = (
+        ("base_link", "shoulder_link"),
+        ("shoulder_link", "upper_arm_link"),
+        ("upper_arm_link", "forearm_link"),
+        ("forearm_link", "wrist_1_link"),
+        ("wrist_1_link", "wrist_2_link"),
+        ("wrist_2_link", "wrist_3_link"),
+    )
+    for parent, child in adjacent_pairs:
+        dist = _distance(ur5_by_link[parent], ur5_by_link[child])
+        assert 0.03 <= dist <= 0.75, f"{parent}->{child} implausible distance {dist}"
+
+    assert any(any(abs(v) > 0.05 for v in _xyz(item)) for item in ur5_by_link.values())
+
+    gripper_items = _items_with_original_mesh(payload, "tools", "robotiq_85_description/meshes/visual")
+    assert gripper_items
+    wrist = ur5_by_link["wrist_3_link"]
+    for item in gripper_items:
+        _assert_pose_is_finite(item)
+        _assert_browser_safe_staged_mesh(item)
+        assert item.get("primitive_geometry_type") in (None, "mesh")
+        assert _distance(wrist, item) <= 0.35
+
+    tables = _items_with_original_mesh(payload, "assets", "workbench_description/meshes/visual/table.stl")
+    assert tables
+    for table in tables:
+        _assert_pose_is_finite(table)
+        _assert_browser_safe_staged_mesh(table)
+        scale = _finite_vector(table.get("scale") or table.get("mesh_scale"), length=3, label=f"{table.get('id')}.scale")
+        assert scale == [0.001, 0.001, 0.001]
+        assert all(0.0001 <= value <= 10.0 for value in scale)
+        assert table.get("primitive_geometry_type") in (None, "mesh")
+
+    cameras = _items_with_original_mesh(payload, "sensors", "realsense2_description/meshes/d435.dae")
+    assert cameras
+    for camera in cameras:
+        _assert_pose_is_finite(camera)
+        _assert_browser_safe_staged_mesh(camera)
+        x, y, z = _xyz(camera)
+        assert -1.5 <= x <= 1.5
+        assert -1.5 <= y <= 1.5
+        assert 0.2 <= z <= 2.0
+        assert camera.get("primitive_geometry_type") in (None, "mesh")
+
+    required_ids = {item["id"] for item in [*ur5_by_link.values(), *gripper_items, *tables, *cameras]}
     fallback_warnings = [
         warning for warning in payload["warnings"]
         if warning.get("code") in {"mesh_primitive_fallback", "mesh_stage_failed"}


### PR DESCRIPTION
### Motivation
- Ensure the Web 3D export for `ur5_2f_test` yields browser-ready, plausible world transforms for UR5 links, Robotiq gripper visuals, and camera meshes even when flattened URDF-generated metadata leaves some descendants collapsed at the origin.
- Protect Product View from showing primitive fallbacks, unsafe staged mesh URIs, or huge/invalid table scales by asserting canonical staged mesh handling at export time.

### Description
- Added conservative transform-parity fallbacks to the web-scene exporter by introducing `_pose_xyz`, `_set_item_pose`, and `_apply_web_scene_transform_parity_fallbacks` and calling the fallback after generated preview supplementation in `build_web_scene` (file: `scripts/export_workcell_studio_web_scene.py`).
- The fallback nudges generated tool visuals toward the UR5 wrist pose when generated tool poses are effectively collapsed, and uses authored environment camera pose metadata to fix collapsed generated camera poses, while recording a conservative provenance transform source.
- Extended `tests/test_workcell_studio_web_scene_contract.py` with `test_ur5_2f_web_scene_export_transform_parity_for_product_meshes` plus helpers that assert finite final/world poses (xyz/rpy/quaternion), plausible adjacent UR5 link distances, Robotiq visuals proximity to `wrist_3_link`, staged browser-safe mesh URIs, correct handling of `0.001` STL scale for the table, reasonable camera placement, and that required meshes do not trigger primitive/staging fallback warnings.
- Changes touch only the exporter and its tests: `scripts/export_workcell_studio_web_scene.py` and `tests/test_workcell_studio_web_scene_contract.py`.

### Testing
- Ran `python3 -m pytest tests/test_workcell_studio_web_scene_contract.py tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py -q` and observed `12 passed` (all tests passed).
- Verified `git diff --check` produces no whitespace/format issues and validated exporter/static-only scope; no ROS launches, MoveIt, Gazebo, or hardware commands were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4523b244688331945fb053bb327141)