### PR TITLE
Update Web 3D viewer wording and add manual ur5_2f_test visual checks

### DIFF
--- a/workcell_studio_web/viewer/README.md
+++ b/workcell_studio_web/viewer/README.md
@@ -1,8 +1,8 @@
-# Workcell Studio static web scene viewer
+# Workcell Studio Web 3D Viewer
 
-This directory contains a **Phase 3 proof-of-life** browser viewer for the Workcell Studio `workcell_studio_web_scene/v1` JSON contract. It is intentionally tiny: static HTML, CSS, and JavaScript only, with no npm package, no bundler, no generated scene outputs committed to the repository, and no replacement of the existing Workcell Builder or RViz/MoveIt validation flow.
+This directory contains the **Workcell Studio Web 3D Viewer** for the Workcell Studio `workcell_studio_web_scene/v1` JSON contract. Web 3D is now the preferred fast Workcell Studio visual path for browser-based scene review and layout inspection. It remains intentionally lightweight: static HTML, CSS, and JavaScript only, with no npm package, no bundler, no generated scene outputs committed to the repository, and no replacement of the existing Workcell Builder or RViz/MoveIt validation flow.
 
-The viewer uses an isolated browser import map that loads Three.js and OrbitControls from a CDN at runtime. That keeps this proof-of-life self-contained while avoiding a committed frontend build system.
+The viewer uses an isolated browser import map that loads Three.js and OrbitControls from a CDN at runtime. That keeps the viewer self-contained while avoiding a committed frontend build system.
 
 ## Export a scene JSON
 
@@ -43,9 +43,9 @@ Expected result: when source meshes exist and are supported by the exporter/view
 
 Because Three.js is loaded by CDN import map, the browser needs network access for the viewer to render. If the CDN modules cannot load, the page shows a clear Three.js/CDN load failure rather than silently pretending the scene rendered.
 
-## Phase 3 readability improvements
+## Web 3D readability improvements
 
-Phase 3 focuses on making exported scenes easier to inspect in a browser without claiming that the static viewer is a full editor or simulator:
+Web 3D focuses on making exported scenes easier to inspect in a browser without claiming that the static viewer is a full editor or simulator:
 
 - Scene auto-framing computes bounds from visible scene content and starts the camera at a useful overview angle instead of leaving the user to hunt for the cell manually.
 - **Reset View** restores the camera to the computed scene overview after orbiting, panning, or zooming.
@@ -73,6 +73,21 @@ Phase 3 focuses on making exported scenes easier to inspect in a browser without
 - Object selection from the list and basic canvas picking.
 - Inspector fields for ID, label, type, source, pose XYZ/RPY, scale, editable, locked, mesh URI, original mesh URI where exported, `render_status`, and primitive details.
 - JSON warnings and runtime mesh warnings rendered in a dedicated warnings panel.
+
+## Manual `ur5_2f_test` visual checks
+
+Use the Web 3D Viewer as the preferred fast Workcell Studio visual path for quick scene review. For the canonical `ur5_2f_test` scene, manually confirm:
+
+- UR5 is assembled and not exploded into disconnected fallback pieces.
+- Robotiq 2F gripper is attached to the robot wrist.
+- Table/workbench is upright and positioned as a physical work surface.
+- Camera/RealSense is visible; if the exact mesh is unavailable, it is clearly marked as a camera/sensor fallback.
+- Grid and axes are visible for spatial orientation.
+- No required item is fallback-only; any fallback required for review has a clear warning or diagnostic reason.
+- Default camera view opens from a useful angle that frames the workcell.
+- **Fit/Reset** recenters the scene correctly after orbiting, panning, or zooming.
+
+RViz/MoveIt remains the planning and fake-hardware validation truth. Passing Web 3D visual checks does not prove MoveIt planning, controller wiring, fake-hardware launch readiness, or real-hardware safety.
 
 ## Mesh asset staging and primitive fallback troubleshooting
 
@@ -110,7 +125,7 @@ Recommended workflow:
 9. Do not launch robot hardware from this step.
 10. Use fake-hardware RViz/MoveIt launch verification as the next phase.
 
-This generation/validation step does not launch ROS, RViz, MoveIt, Gazebo, fake hardware, or real hardware. RViz/MoveIt remains the future planning truth after Web 3D authoring and backend scene generation.
+This generation/validation step does not launch ROS, RViz, MoveIt, Gazebo, fake hardware, or real hardware. RViz/MoveIt remains the planning and fake-hardware validation truth after Web 3D authoring and backend scene generation.
 
 ## Intentional exclusions and limitations
 
@@ -128,7 +143,7 @@ This is not the final Web Studio editor. It intentionally excludes:
 - Arbitrary local filesystem mesh access from the browser. Browser security rules only allow safe access to files made available through staged assets, the selected file context, a local server, or other browser-permitted URLs.
 - Authentication, deployment packaging, and frontend framework scaffolding.
 
-This static viewer is only a lightweight browser proof-of-life for reviewing exported scene contract data. It improves readability of exported scenes, but the source-of-truth editing, scene generation, validation, and fake-hardware simulation flows remain in Workcell Studio, generated packages, and RViz/MoveIt.
+This static viewer is the preferred fast visual review path for exported scene contract data. It improves readability of exported scenes, but the source-of-truth editing, scene generation, validation, planning, and fake-hardware simulation flows remain in Workcell Studio, generated packages, and RViz/MoveIt.
 
 ## Persistence verification loop
 

--- a/workcell_studio_web/viewer/index.html
+++ b/workcell_studio_web/viewer/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Workcell Studio Web Scene Viewer</title>
+  <title>Workcell Studio Web 3D Viewer</title>
   <link rel="stylesheet" href="style.css" />
   <script type="importmap">
     {
@@ -17,8 +17,8 @@
 <body>
   <header class="topbar">
     <div>
-      <h1>Workcell Studio Web Scene Viewer</h1>
-      <p>Static Phase 3 proof-of-life viewer for <code>web_scene.json</code>.</p>
+      <h1>Workcell Studio Web 3D Viewer</h1>
+      <p>Fast browser-based 3D visual review for Workcell Studio <code>web_scene.json</code> exports.</p>
     </div>
     <div class="toolbar">
       <label class="file-picker">


### PR DESCRIPTION
### Motivation

- Align the lightweight browser viewer language with product goals by presenting it as the preferred fast Workcell Studio Web 3D visual review path rather than a Phase 3 proof-of-life demo. 
- Provide a brief, actionable checklist for quick manual verification of the canonical `ur5_2f_test` scene to make visual smoke-checking repeatable and clear. 
- Re-emphasize that RViz/MoveIt remains the planning and fake-hardware validation truth so users do not mistake the browser preview for a simulator or validator.

### Description

- Updated the page metadata, header, and subtitle in `workcell_studio_web/viewer/index.html` to `Workcell Studio Web 3D Viewer` and changed the subtitle to describe it as a fast browser-based 3D visual review. 
- Rewrote the introduction and readability headings in `workcell_studio_web/viewer/README.md` to present Web 3D as the preferred fast visual path and to remove the Phase 3/proof-of-life wording. 
- Added a short `Manual 60ur5_2f_test60 visual checks` section in `workcell_studio_web/viewer/README.md` that lists specific checks (UR5 assembly, Robotiq attachment, table/workbench orientation, camera visibility/marking, grid/axes, fallback visibility, default camera framing, and Fit/Reset behavior). 
- Clarified multiple places in the README that RViz/MoveIt remain the planning and fake-hardware validation truth and that the viewer does not replace backend validation or execution flows.

### Testing

- Ran a targeted text search with `rg -n 'Phase 3|proof-of-life|Workcell Studio Web Scene Viewer|Workcell Studio Web 3D Viewer|Manual \`ur5_2f_test\` visual checks|RViz/MoveIt remains' workcell_studio_web/viewer/index.html workcell_studio_web/viewer/README.md` and confirmed the old phrasing is removed and new guidance is present. 
- Ran `git diff --check` and confirmed there are no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4525bd824c8331b7d5169a4b43cd2f)