### PR TITLE
Clarify web viewer Fit Scene control

### DIFF
--- a/workcell_studio_web/viewer/index.html
+++ b/workcell_studio_web/viewer/index.html
@@ -25,7 +25,7 @@
         Load web_scene.json
         <input id="scene-file" type="file" accept="application/json,.json" />
       </label>
-      <button id="reset-view" class="toolbar-button" type="button" disabled>Reset View</button>
+      <button id="reset-view" class="toolbar-button" type="button" disabled title="Fit Scene / Reset View: recomputes and reapplies the fitted workcell overview from renderable bounds." aria-label="Fit Scene / Reset View">Fit Scene / Reset View</button>
       <button id="undo-edit" class="toolbar-button" type="button" disabled>Undo</button>
       <button id="redo-edit" class="toolbar-button" type="button" disabled>Redo</button>
       <button id="clear-edits" class="toolbar-button" type="button" disabled>Clear Preview Edits</button>

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -13,6 +13,8 @@ const MIN_FRAME_RADIUS = 1.2;
 const EMPTY_SCENE_MESSAGE = 'Scene contains no renderable robots, tools, assets, sensors, zones, items, or objects.';
 const FRAME_DISTANCE_MULTIPLIER = 2.7;
 const state = { sceneJson: null, sourceWebSceneFile: '', objects: [], selected: null, three: {}, animationId: null, lastFrameBounds: null, runtimeWarnings: [], labelsVisible: false, dirtyTransforms: new Map(), undoStack: [], redoStack: [], gizmoDragStart: null };
+const RESET_VIEW_TITLE = 'Fit Scene / Reset View: recomputes and reapplies the fitted workcell overview from renderable bounds.';
+
 const el = {
   file: document.getElementById('scene-file'),
   resetView: document.getElementById('reset-view'),
@@ -522,6 +524,10 @@ function frameScene(bounds) {
 function resetView() {
   const bounds = state.lastFrameBounds || computeRenderedBounds();
   if (bounds) frameScene(bounds);
+}
+if (el.resetView) {
+  el.resetView.title = RESET_VIEW_TITLE;
+  el.resetView.setAttribute('aria-label', 'Fit Scene / Reset View');
 }
 
 function clearLabels() {


### PR DESCRIPTION
### Motivation
- Make the toolbar control’s label and tooltip clearer so users understand the button recomputes and reapplies a fitted workcell overview rather than changing edit/transform behavior.

### Description
- Updated `workcell_studio_web/viewer/index.html` to show the `#reset-view` button as `Fit Scene / Reset View` and added a descriptive `title` and `aria-label` on the button.
- Added a `RESET_VIEW_TITLE` constant in `workcell_studio_web/viewer/viewer.js` and applied it to the `#reset-view` element without changing the existing `resetView()` handler or transform/edit logic.

### Testing
- Ran `git diff --check` which passed and verified presence of the new label/tooltip and handler with `rg -n "Fit Scene / Reset View|RESET_VIEW_TITLE|function resetView"` which also passed; the change was committed successfully.
- No browser GUI smoke test was executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a452837e9a88331a9824067660a05a7)