### PR TITLE
Add deterministic viewer_summary to web scene export

### DIFF
--- a/schemas/workcell_studio_web_scene_v1.schema.json
+++ b/schemas/workcell_studio_web_scene_v1.schema.json
@@ -5,7 +5,7 @@
   "description": "Browser-facing, dependency-light scene JSON exported from Workcell Studio authored and generated scene inputs.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "scene", "inputs", "robots", "tools", "assets", "sensors", "zones", "warnings", "backend_actions"],
+  "required": ["schema_version", "scene", "inputs", "robots", "tools", "assets", "sensors", "zones", "viewer_summary", "warnings", "backend_actions"],
   "properties": {
     "schema_version": {"const": "workcell_studio_web_scene/v1"},
     "scene": {"$ref": "#/$defs/scene"},
@@ -26,6 +26,7 @@
     "assets": {"type": "array", "items": {"$ref": "#/$defs/item"}},
     "sensors": {"type": "array", "items": {"$ref": "#/$defs/item"}},
     "zones": {"type": "array", "items": {"$ref": "#/$defs/item"}},
+    "viewer_summary": {"$ref": "#/$defs/viewerSummary"},
     "warnings": {"type": "array", "items": {"$ref": "#/$defs/warning"}},
     "backend_actions": {"type": "array", "items": {"$ref": "#/$defs/backendAction"}}
   },
@@ -99,6 +100,50 @@
         "description": {"type": "string"},
         "safety_note": {"type": "string"}
       }
-    }
+    },
+    "viewerSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scene_bounds", "renderable_count", "mesh_backed_count", "fallback_count", "missing_or_failed_mesh_count", "required_item_status"],
+      "properties": {
+        "scene_bounds": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["min", "max", "source_count", "sources"],
+          "properties": {
+            "min": {"$ref": "#/$defs/number3"},
+            "max": {"$ref": "#/$defs/number3"},
+            "source_count": {"type": "integer", "minimum": 0},
+            "sources": {"type": "array", "items": {"type": "string"}}
+          }
+        },
+        "renderable_count": {"type": "integer", "minimum": 0},
+        "mesh_backed_count": {"type": "integer", "minimum": 0},
+        "fallback_count": {"type": "integer", "minimum": 0},
+        "missing_or_failed_mesh_count": {"type": "integer", "minimum": 0},
+        "required_item_status": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["robot", "tool", "table", "camera"],
+          "properties": {
+            "robot": {"$ref": "#/$defs/requiredItemStatus"},
+            "tool": {"$ref": "#/$defs/requiredItemStatus"},
+            "table": {"$ref": "#/$defs/requiredItemStatus"},
+            "camera": {"$ref": "#/$defs/requiredItemStatus"}
+          }
+        }
+      }
+    },
+    "requiredItemStatus": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["present", "status", "item_ids"],
+      "properties": {
+        "present": {"type": "boolean"},
+        "status": {"enum": ["missing", "mesh_backed", "primitive_fallback", "missing_or_failed_mesh"]},
+        "item_ids": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "number3": {"type": "array", "minItems": 3, "maxItems": 3, "items": {"type": "number"}}
   }
 }

--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -717,6 +717,139 @@ def _drop_shadowed_metadata_primitives(items: List[Json], generated_items: List[
     return kept
 
 
+
+def _finite_num3(value: Any) -> Optional[List[float]]:
+    if not isinstance(value, list) or len(value) < 3:
+        return None
+    try:
+        out = [float(value[0]), float(value[1]), float(value[2])]
+    except (TypeError, ValueError):
+        return None
+    if any(not (v == v and abs(v) != float("inf")) for v in out):
+        return None
+    return out
+
+
+def _item_pose_xyz(item: Mapping[str, Any]) -> Optional[List[float]]:
+    for field in ("final_transform", "world_from_visual", "pose", "world_pose", "baked_world_visual_pose"):
+        xyz = _pose_xyz(item.get(field))
+        if xyz is not None:
+            return xyz
+    return _finite_num3(item.get("pose_xyz"))
+
+
+def _item_local_bounds(item: Mapping[str, Any]) -> Optional[Tuple[List[float], List[float], str]]:
+    for field in ("mesh_bounds", "local_bounds", "bounds"):
+        bounds = item.get(field)
+        if isinstance(bounds, Mapping):
+            mn = _finite_num3(bounds.get("min") or bounds.get("min_xyz") or bounds.get("local_min"))
+            mx = _finite_num3(bounds.get("max") or bounds.get("max_xyz") or bounds.get("local_max"))
+            if mn is not None and mx is not None:
+                return mn, mx, field
+    mn = _finite_num3(item.get("local_bounds_min") or item.get("mesh_bounds_min"))
+    mx = _finite_num3(item.get("local_bounds_max") or item.get("mesh_bounds_max"))
+    if mn is not None and mx is not None:
+        return mn, mx, "local_bounds_min/max"
+    dims = _finite_num3(item.get("dimensions") or item.get("size") or item.get("primitive_dimensions"))
+    if dims is not None:
+        half = [abs(v) / 2.0 for v in dims]
+        return [-half[0], -half[1], -half[2]], [half[0], half[1], half[2]], "dimensions"
+    return None
+
+
+def _scaled_bounds(bounds: Tuple[List[float], List[float], str], item: Mapping[str, Any]) -> Tuple[List[float], List[float], str]:
+    mn, mx, source = bounds
+    scale = _finite_num3(item.get("scale") or item.get("mesh_scale")) or [1.0, 1.0, 1.0]
+    scaled_min: List[float] = []
+    scaled_max: List[float] = []
+    for i in range(3):
+        a = mn[i] * scale[i]
+        b = mx[i] * scale[i]
+        scaled_min.append(min(a, b))
+        scaled_max.append(max(a, b))
+    return scaled_min, scaled_max, source
+
+
+def _viewer_item_status(item: Mapping[str, Any]) -> str:
+    status = str(item.get("mesh_staging_status") or "")
+    if status == "staged":
+        return "mesh_backed"
+    if status in {"resolve_failed", "unsupported_format", "unsafe_path", "unsupported_scheme", "unsafe_destination"}:
+        return "missing_or_failed_mesh"
+    if _has_mesh_reference(item):
+        return "missing_or_failed_mesh"
+    return "primitive_fallback"
+
+
+def _viewer_summary(payload: Json) -> Json:
+    sections: Sequence[str] = ("robots", "tools", "assets", "sensors", "zones")
+    renderable: List[Tuple[str, Json]] = []
+    for section in sections:
+        for item in payload.get(section, []):
+            if isinstance(item, dict):
+                renderable.append((section, item))
+
+    scene_min: Optional[List[float]] = None
+    scene_max: Optional[List[float]] = None
+    bounds_sources: List[str] = []
+    mesh_backed = 0
+    fallback = 0
+    missing = 0
+    required: Dict[str, Json] = {key: {"present": False, "status": "missing", "item_ids": []} for key in ("robot", "tool", "table", "camera")}
+
+    for _section, item in renderable:
+        status = _viewer_item_status(item)
+        if status == "mesh_backed":
+            mesh_backed += 1
+        elif status == "missing_or_failed_mesh":
+            missing += 1
+        else:
+            fallback += 1
+
+        xyz = _item_pose_xyz(item)
+        if xyz is not None:
+            local = _item_local_bounds(item)
+            if local is not None:
+                mn, mx, source = _scaled_bounds(local, item)
+                item_min = [xyz[i] + mn[i] for i in range(3)]
+                item_max = [xyz[i] + mx[i] for i in range(3)]
+                bounds_sources.append(f"{item.get('id')}:{source}")
+            else:
+                item_min = list(xyz)
+                item_max = list(xyz)
+                bounds_sources.append(f"{item.get('id')}:pose")
+            scene_min = item_min if scene_min is None else [min(scene_min[i], item_min[i]) for i in range(3)]
+            scene_max = item_max if scene_max is None else [max(scene_max[i], item_max[i]) for i in range(3)]
+
+        text = _identity_text(item)
+        categories: List[str] = []
+        if "robot" in text or str(item.get("category", "")).lower() == "robot":
+            categories.append("robot")
+        if any(token in text for token in ("tool", "gripper", "robotiq", "end_effector", "suction")):
+            categories.append("tool")
+        if any(token in text for token in ("table", "workbench", "support_surface")):
+            categories.append("table")
+        if any(token in text for token in ("camera", "realsense")):
+            categories.append("camera")
+        for category in categories:
+            entry = required[category]
+            entry["present"] = True
+            entry["item_ids"].append(str(item.get("id")))
+            if entry["status"] in {"missing", "primitive_fallback"} or status == "missing_or_failed_mesh":
+                entry["status"] = status
+
+    for entry in required.values():
+        entry["item_ids"] = sorted(set(entry["item_ids"]))
+    bounds = {"min": scene_min or [0.0, 0.0, 0.0], "max": scene_max or [0.0, 0.0, 0.0], "source_count": len(bounds_sources), "sources": sorted(bounds_sources)}
+    return {
+        "scene_bounds": bounds,
+        "renderable_count": len(renderable),
+        "mesh_backed_count": mesh_backed,
+        "fallback_count": fallback,
+        "missing_or_failed_mesh_count": missing,
+        "required_item_status": required,
+    }
+
 def build_web_scene(scene_dir: Path, *, stage_assets: bool = False, output_path: Optional[Path] = None) -> Json:
     scene_dir = scene_dir.resolve()
     warnings: List[Json] = []
@@ -797,6 +930,7 @@ def build_web_scene(scene_dir: Path, *, stage_assets: bool = False, output_path:
     }
     if stage_assets:
         _stage_visual_meshes(output, scene_dir, output_path or Path("build/workcell_studio_web_scene/scene.web_scene.json"))
+    output["viewer_summary"] = _viewer_summary(output)
     return output
 
 

--- a/tests/test_workcell_studio_web_scene_contract.py
+++ b/tests/test_workcell_studio_web_scene_contract.py
@@ -127,6 +127,18 @@ def test_tiny_scene_exports_generated_and_authored_asset_contract(tmp_path):
     assert payload1["inputs"]["layout"]["present"] is True
     assert payload1["inputs"]["visual_mesh_index"]["present"] is True
 
+    summary = payload1["viewer_summary"]
+    assert summary["renderable_count"] == sum(len(payload1[bucket]) for bucket in ("robots", "tools", "assets", "sensors", "zones"))
+    assert summary["mesh_backed_count"] >= 0
+    assert summary["fallback_count"] >= 1
+    assert summary["missing_or_failed_mesh_count"] >= 1
+    assert summary["scene_bounds"]["min"][0] <= 0.0
+    assert summary["scene_bounds"]["max"][2] >= 1.1
+    assert summary["required_item_status"]["robot"]["present"] is True
+    assert summary["required_item_status"]["tool"]["present"] is True
+    assert summary["required_item_status"]["table"]["present"] is True
+    assert summary["required_item_status"]["camera"]["present"] is True
+
     robot = next(item for item in payload1["robots"] if item["id"] == "ur5_visual")
     tool = next(item for item in payload1["tools"] if item["id"] == "robotiq_2f_visual")
     for generated in (robot, tool):
@@ -159,6 +171,8 @@ def test_missing_optional_inputs_warn_in_output_json_without_crashing(tmp_path):
     schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
     Draft202012Validator(schema).validate(payload)
     assert payload["schema_version"] == "workcell_studio_web_scene/v1"
+    assert payload["viewer_summary"]["renderable_count"] == 0
+    assert payload["viewer_summary"]["scene_bounds"] == {"min": [0.0, 0.0, 0.0], "max": [0.0, 0.0, 0.0], "source_count": 0, "sources": []}
     missing = [warning for warning in payload["warnings"] if warning["code"] == "optional_file_missing"]
     assert {warning["source"] for warning in missing} == {
         "scene_manifest.yaml",
@@ -182,6 +196,18 @@ def test_ur5_2f_web_scene_stages_required_product_meshes_without_required_fallba
     assert required["robotiq"]
     assert required["table"]
     assert required["camera"]
+
+    summary = payload["viewer_summary"]
+    assert summary["renderable_count"] >= 20
+    assert summary["mesh_backed_count"] >= len(required["ur5"]) + len(required["robotiq"]) + len(required["table"]) + len(required["camera"])
+    assert summary["missing_or_failed_mesh_count"] >= 1
+    assert summary["scene_bounds"]["source_count"] == summary["renderable_count"]
+    for axis in range(3):
+        assert summary["scene_bounds"]["min"][axis] <= summary["scene_bounds"]["max"][axis]
+    for category in ("robot", "tool", "table", "camera"):
+        assert summary["required_item_status"][category]["present"] is True
+        assert summary["required_item_status"][category]["status"] in {"mesh_backed", "missing_or_failed_mesh"}
+        assert summary["required_item_status"][category]["item_ids"]
 
     for group in required.values():
         for item in group:


### PR DESCRIPTION
### Motivation
- Provide a deterministic, top-level summary in exported web scene JSON so viewers and downstream tools can quickly consume scene bounds and renderability diagnostics without re-scanning items.
- Make export-time mesh/primitive status explicit (mesh staged, fallback, missing/failed) and ensure required item presence for robot/tool/table/camera is obvious to callers.

### Description
- Added `_viewer_summary` computation and helpers to `scripts/export_workcell_studio_web_scene.py` to produce a deterministic `viewer_summary` object containing `scene_bounds`, `renderable_count`, `mesh_backed_count`, `fallback_count`, `missing_or_failed_mesh_count`, and `required_item_status` for `robot`, `tool`, `table`, and `camera`; the summary is attached after asset staging so staged URIs count as mesh-backed.
- Implemented bounding extraction that uses mesh/local bounds or primitive `dimensions` when available and composes world-space min/max by combining item poses with local bounds where possible.
- Classified item mesh status deterministically from `mesh_staging_status` and mesh URI presence to drive the mesh/fallback/missing counters.
- Updated the JSON schema `schemas/workcell_studio_web_scene_v1.schema.json` to require and validate `viewer_summary` and its sub-structure.
- Extended `tests/test_workcell_studio_web_scene_contract.py` to assert the presence and basic invariants of `viewer_summary` for tiny fixtures, missing-input exports, and the canonical `ur5_2f_test` payload.

### Testing
- Ran Python compile check `python3 -m py_compile scripts/export_workcell_studio_web_scene.py` which passed.
- Ran contract tests `python3 -m pytest tests/test_workcell_studio_web_scene_contract.py` which passed (all tests green).
- Ran additional product-view related tests `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py` which also passed, and reported no schema or lint issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4528d533e4833185578589300e073d)