### PR TITLE
Add web viewer scene summary

### DIFF
--- a/workcell_studio_web/viewer/index.html
+++ b/workcell_studio_web/viewer/index.html
@@ -52,6 +52,18 @@
   <main class="app-shell">
     <aside class="object-panel" aria-label="Object list panel">
       <h2>Objects</h2>
+      <section id="scene-summary" class="scene-summary state empty" aria-live="polite">
+        <h3>Scene summary</h3>
+        <div class="summary-grid">
+          <span>Scene</span><strong data-summary-field="scene-name">No scene loaded</strong>
+          <span>Renderable</span><strong data-summary-field="renderable-count">0</strong>
+          <span>Meshes loaded</span><strong data-summary-field="mesh-loaded-count">0</strong>
+          <span>Fallbacks</span><strong data-summary-field="fallback-count">0</strong>
+          <span>Missing/failed meshes</span><strong data-summary-field="mesh-failed-count">0</strong>
+          <span>Generated/locked</span><strong data-summary-field="generated-locked-count">0</strong>
+          <span>Editable layout/env</span><strong data-summary-field="editable-count">0</strong>
+        </div>
+      </section>
       <div id="empty-state" class="state empty">Choose an exported <code>web_scene.json</code> file to begin.</div>
       <ul id="object-list" class="object-list"></ul>
     </aside>

--- a/workcell_studio_web/viewer/style.css
+++ b/workcell_studio_web/viewer/style.css
@@ -175,6 +175,36 @@ h2 { margin: 0 0 0.75rem; font-size: 0.95rem; color: var(--accent); }
   background: #312914;
   color: #ffe7a3;
 }
+
+.scene-summary {
+  margin-bottom: 0.75rem;
+  padding: 0.65rem;
+}
+.scene-summary h3 {
+  margin: 0 0 0.5rem;
+  color: var(--accent);
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.summary-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.32rem 0.65rem;
+  align-items: baseline;
+  font-size: 0.78rem;
+}
+.summary-grid span { color: var(--muted); }
+.summary-grid strong {
+  max-width: 8rem;
+  color: #c9f2ff;
+  font-size: 0.82rem;
+  overflow: hidden;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .object-list { list-style: none; margin: 0; padding: 0; }
 .object-list li {
   margin-bottom: 0.4rem;

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -34,7 +34,52 @@ const el = {
   list: document.getElementById('object-list'),
   inspector: document.getElementById('inspector'),
   warnings: document.getElementById('warnings'),
+  summary: document.getElementById('scene-summary'),
 };
+
+
+function sceneDisplayName() { return state.sceneJson?.scene?.id || state.sceneJson?.scene_id || state.sourceWebSceneFile || 'No scene loaded'; }
+function isGeneratedOrLockedItem(item) {
+  const sourceIdentity = [item?.source_kind, item?.source_layer, item?.active_visual_source, item?.role, item?.category, item?.id, itemLabel(item || {})]
+    .map(value => String(value || '').toLowerCase())
+    .join(' ');
+  return Boolean(item?.locked || sourceIdentity.includes('generated') || sourceIdentity.includes('urdf') || sourceIdentity.includes('moveit'));
+}
+function isRuntimeFallbackStatus(status) { return /fallback/.test(String(status || '').toLowerCase()); }
+function isMissingOrFailedMeshStatus(status) {
+  return ['missing_file', 'unresolved_package_uri', 'unsafe_path', 'unsupported_format', 'load_error']
+    .includes(String(status || '').toLowerCase());
+}
+function computeSceneSummary() {
+  const rendered = state.objects || [];
+  return {
+    sceneName: sceneDisplayName(),
+    renderableCount: rendered.length,
+    meshLoadedCount: rendered.filter(obj => obj.renderInfo?.render_status === 'mesh_loaded').length,
+    fallbackCount: rendered.filter(obj => isRuntimeFallbackStatus(obj.renderInfo?.render_status || obj.item?.renderInfo?.render_status)).length,
+    meshFailedCount: rendered.filter(obj => isMissingOrFailedMeshStatus(obj.item?.mesh_status)).length,
+    generatedLockedCount: rendered.filter(obj => isGeneratedOrLockedItem(obj.item)).length,
+    editableCount: rendered.filter(obj => canEditItem(obj.item)).length,
+  };
+}
+function renderSceneSummary() {
+  if (!el.summary) return;
+  const summary = computeSceneSummary();
+  el.summary.classList.toggle('empty', !state.sceneJson);
+  const fields = {
+    'scene-name': summary.sceneName,
+    'renderable-count': summary.renderableCount,
+    'mesh-loaded-count': summary.meshLoadedCount,
+    'fallback-count': summary.fallbackCount,
+    'mesh-failed-count': summary.meshFailedCount,
+    'generated-locked-count': summary.generatedLockedCount,
+    'editable-count': summary.editableCount,
+  };
+  for (const [name, value] of Object.entries(fields)) {
+    const node = el.summary.querySelector(`[data-summary-field="${name}"]`);
+    if (node) node.textContent = String(value);
+  }
+}
 
 function showError(message) {
   el.error.textContent = message;
@@ -392,6 +437,7 @@ async function tryLoadMesh(item, rendered, fallback) {
     if (requestedUri) appendRuntimeWarning(item, requestedUri, diagnostic.reason);
     if (itemRequiresMeshBackedVisual(item)) warnRequiredMeshFallback(item, requestedUri, diagnostic.reason);
     if (state.selected === item.id) populateInspector(rendered);
+    renderSceneSummary();
     return;
   }
   try {
@@ -410,6 +456,7 @@ async function tryLoadMesh(item, rendered, fallback) {
     const bounds = computeRenderedBounds();
     if (bounds) frameScene(bounds);
     if (state.selected === item.id) populateInspector(rendered);
+    renderSceneSummary();
   } catch (err) {
     fallback.visible = true;
     item.mesh_status = 'load_error';
@@ -419,6 +466,7 @@ async function tryLoadMesh(item, rendered, fallback) {
     appendRuntimeWarning(item, uri, reason);
     if (itemRequiresMeshBackedVisual(item)) warnRequiredMeshFallback(item, uri, reason);
     if (state.selected === item.id) populateInspector(rendered);
+    renderSceneSummary();
   }
 }
 function collectItems(sceneJson) {
@@ -541,6 +589,7 @@ function clearSceneObjects() {
   state.objects = [];
   state.lastFrameBounds = null;
   if (el.resetView) el.resetView.disabled = true;
+  renderSceneSummary();
 }
 function renderScene(items) {
   clearSceneObjects();
@@ -571,6 +620,7 @@ function renderScene(items) {
   updateLabels();
   const bounds = computeRenderedBounds();
   if (bounds) frameScene(bounds);
+  renderSceneSummary();
 }
 
 function createLabelElement(item) {
@@ -806,7 +856,7 @@ function redoPreviewEdit() {
   state.undoStack.push(entry);
   updateDirtyState();
 }
-function sceneId() { return state.sceneJson?.scene?.id || state.sceneJson?.scene_id || ''; }
+function sceneId() { return state.sceneJson?.scene?.id || state.sceneJson?.scene_id || state.sourceWebSceneFile || ''; }
 function buildEditPatch() {
   const edits = [];
   for (const rendered of state.objects) {
@@ -907,6 +957,7 @@ async function loadFile(file) {
     if (items.length) renderScene(items);
     else renderScene([]);
     refreshWarnings(json);
+    renderSceneSummary();
     el.inspector.className = 'state empty';
     el.inspector.textContent = items.length ? 'Select an object from the list or canvas.' : EMPTY_SCENE_MESSAGE;
   } catch (err) {


### PR DESCRIPTION
### Motivation
- Provide a compact, always-visible status summary in the viewer to make scene health and editability obvious without opening the inspector.  
- Surface key runtime mesh/load bookkeeping so Product View problems (missing meshes, fallback usage, generated preview items) are easy to spot at a glance.

### Description
- Added a `Scene summary` region to `workcell_studio_web/viewer/index.html` that shows scene name, renderable count, mesh-loaded count, fallback count, missing/failed mesh count, generated/locked preview count, and editable layout/environment count.  
- Implemented summary computation and rendering in `workcell_studio_web/viewer/viewer.js` with helper functions `computeSceneSummary()`, `renderSceneSummary()`, `sceneDisplayName()`, `isGeneratedOrLockedItem()`, `isRuntimeFallbackStatus()`, and `isMissingOrFailedMeshStatus()`, and wired updates after scene load and on async mesh load success/failure.  
- Hooked summary updates into existing render lifecycle points (`renderScene`, `clearSceneObjects`, and `tryLoadMesh` success/failure branches) and used `scene.scene.id`, `scene_id`, or the loaded filename as the scene name.  
- Added CSS in `workcell_studio_web/viewer/style.css` to style the summary as a compact two-column grid that fits the object panel.

### Testing
- Ran `node --check workcell_studio_web/viewer/viewer.js` which passed with no syntax errors.  
- Ran unit/smoke tests `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py` which passed (7 tests).  
- No browser-based screenshot or visual browser smoke was captured because no browser executable was available in the container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a452ea78b588331adf13cef01b5f420)