### PR TITLE
tests: extend web scene/export and viewer UX tests for identity, mesh staging, and camera fit

### DIFF
--- a/tests/test_workcell_studio_web_scene_contract.py
+++ b/tests/test_workcell_studio_web_scene_contract.py
@@ -209,9 +209,30 @@ def test_ur5_2f_web_scene_stages_required_product_meshes_without_required_fallba
         assert summary["required_item_status"][category]["status"] in {"mesh_backed", "missing_or_failed_mesh"}
         assert summary["required_item_status"][category]["item_ids"]
 
+    required_identity_expectations = {
+        "ur5": ("robots", "robot", "ur5", ("category", "role", "id", "source_kind", "source_layer", "active_visual_source", "link", "original_mesh_uri", "mesh_uri")),
+        "robotiq": ("tools", "tool", "robotiq", ("id", "source_kind", "link", "original_mesh_uri", "mesh_uri")),
+        "table": ("assets", "table", "workbench", ("id", "source_kind", "link", "original_mesh_uri", "mesh_uri")),
+        "camera": ("sensors", "camera", "realsense", ("id", "source_kind", "link", "original_mesh_uri", "mesh_uri")),
+    }
+    for family, (_bucket, required_category, identity_token, identity_fields) in required_identity_expectations.items():
+        assert summary["required_item_status"][required_category]["status"] == "mesh_backed", family
+        for item in required[family]:
+            identity_text = " ".join(str(item.get(field, "")).lower() for field in identity_fields)
+            assert identity_token in identity_text, item["id"]
+            assert item["id"] in summary["required_item_status"][required_category]["item_ids"]
+            for field in identity_fields:
+                assert field in item, f"{item['id']} should export identity field {field}"
+
     for group in required.values():
         for item in group:
             assert item["mesh_staging_status"] == "staged"
+            assert summary["required_item_status"][
+                "robot" if item in required["ur5"] else
+                "tool" if item in required["robotiq"] else
+                "table" if item in required["table"] else
+                "camera"
+            ]["status"] != "primitive_fallback"
             assert item["mesh_uri"].startswith("build/workcell_studio_web_scene/assets/ur5_2f_test/")
             assert not item["mesh_uri"].startswith(("package://", "file://", "/"))
             assert "://" not in item["mesh_uri"]
@@ -223,6 +244,40 @@ def test_ur5_2f_web_scene_stages_required_product_meshes_without_required_fallba
         if warning.get("code") in {"mesh_primitive_fallback", "mesh_stage_failed"}
     ]
     assert not [warning for warning in fallback_warnings if warning.get("source") in required_ids]
+
+
+def test_web_scene_export_status_summary_counts_mesh_fallback_and_missing_items(tmp_path):
+    scene = _tiny_scene_fixture(tmp_path)
+    (scene / "meshes").mkdir()
+    (scene / "meshes" / "ur5.dae").write_text("<COLLADA></COLLADA>\n", encoding="utf-8")
+    # Leave robotiq_2f.dae and layout_bin mesh absent so the summary must report
+    # missing/failed meshes while authored table/camera remain primitive fallbacks.
+
+    payload = _export(scene, tmp_path / "out" / "summary.web_scene.json")
+    summary = payload["viewer_summary"]
+    renderable = [
+        item
+        for bucket in ("robots", "tools", "assets", "sensors", "zones")
+        for item in payload[bucket]
+    ]
+
+    assert summary["renderable_count"] == len(renderable)
+    assert summary["mesh_backed_count"] == 1
+    assert summary["fallback_count"] == 2
+    assert summary["missing_or_failed_mesh_count"] == 2
+    assert (
+        summary["mesh_backed_count"]
+        + summary["fallback_count"]
+        + summary["missing_or_failed_mesh_count"]
+    ) == summary["renderable_count"]
+    robot = next(item for item in payload["robots"] if item["id"] == "ur5_visual")
+    tool = next(item for item in payload["tools"] if item["id"] == "robotiq_2f_visual")
+    assert robot["mesh_staging_status"] == "staged"
+    assert tool["mesh_staging_status"] == "resolve_failed"
+    assert summary["required_item_status"]["robot"]["present"] is True
+    assert summary["required_item_status"]["tool"]["status"] == "missing_or_failed_mesh"
+    assert summary["required_item_status"]["table"]["status"] == "primitive_fallback"
+    assert summary["required_item_status"]["camera"]["status"] == "primitive_fallback"
 
 
 def _items_with_original_mesh(payload: dict, bucket: str, token: str) -> list[dict]:

--- a/tests/test_workcell_studio_web_viewer_transform_ux.py
+++ b/tests/test_workcell_studio_web_viewer_transform_ux.py
@@ -1,4 +1,5 @@
 import subprocess
+import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -68,6 +69,9 @@ def test_patch_export_still_exists_and_remains_preview_only():
     assert "buildEditPatch" in viewer
     assert "schema_version: EDIT_PATCH_SCHEMA_VERSION" in viewer
     assert "Preview-only browser transform edit. Source scene files were not modified." in viewer
+    assert "canEditItem" in viewer
+    assert "item?.editable !== true" in viewer
+    assert "item?.locked" in viewer
 
 
 def test_no_direct_yaml_write_or_browser_apply_logic_added():
@@ -86,3 +90,41 @@ def test_no_generated_scene_json_committed():
         check=True,
     ).stdout.splitlines()
     assert not tracked
+
+
+def test_status_summary_reports_loaded_fallback_and_failed_meshes():
+    index = _index_text()
+    viewer = _viewer_text()
+    assert "meshLoadedCount" in viewer
+    assert "fallbackCount" in viewer
+    assert "meshFailedCount" in viewer
+    assert "render_status === 'mesh_loaded'" in viewer
+    assert "isRuntimeFallbackStatus" in viewer
+    assert "isMissingOrFailedMeshStatus" in viewer
+    assert 'data-summary-field="mesh-loaded-count"' in index
+    assert 'data-summary-field="fallback-count"' in index
+    assert 'data-summary-field="mesh-failed-count"' in index
+
+
+def test_camera_fit_constants_cover_ur5_2f_sized_workcell_without_clipping():
+    viewer = _viewer_text()
+    min_radius = float(re.search(r"const MIN_FRAME_RADIUS = ([0-9.]+);", viewer).group(1))
+    distance_multiplier = float(re.search(r"const FRAME_DISTANCE_MULTIPLIER = ([0-9.]+);", viewer).group(1))
+    near_formula = re.search(r"camera\.near = Math\.max\(0\.01, radius / ([0-9.]+)\);", viewer)
+    far_formula = re.search(r"camera\.far = Math\.max\(100, distance \+ radius \* ([0-9.]+)\);", viewer)
+    assert near_formula
+    assert far_formula
+
+    # Roughly ur5_2f_test-sized bounds: workbench, robot, camera, and bins fit in
+    # about a 2.0 m x 1.6 m x 0.85 m envelope. The fitted near/far values should
+    # have a wide margin around the workcell rather than clipping table/camera.
+    span = (2.0, 1.6, 0.85)
+    scene_radius = max((sum((axis / 2.0) ** 2 for axis in span)) ** 0.5, min_radius)
+    distance = max(scene_radius * distance_multiplier, min_radius * distance_multiplier)
+    near = max(0.01, scene_radius / float(near_formula.group(1)))
+    far = max(100.0, distance + scene_radius * float(far_formula.group(1)))
+
+    assert near <= 0.02
+    assert far >= 100.0
+    assert far > distance + scene_radius
+    assert far / near >= 5000


### PR DESCRIPTION
### Motivation
- Ensure the web-scene exporter emits sufficient identity fields so required products (UR5, Robotiq 2F, workbench/table, RealSense camera) are discoverable and verifiable by the viewer and downstream tooling.
- Prevent regressions where staged mesh-backed visuals are incorrectly reported as primitive-only fallbacks or missing in the viewer summary.
- Guard viewer auto-fit logic so near/far plane calculations do not clip a canonical `ur5_2f_test`-sized workcell while preserving the preview-only edit-patch UX.

### Description
- Extended `tests/test_workcell_studio_web_scene_contract.py` to assert exported identity fields (e.g. `id`, `source_kind`, `source_layer`, `active_visual_source`, `link`, `original_mesh_uri`, `mesh_uri`) for UR5, Robotiq, table, and camera and to verify those required items are reported as `mesh_backed` when staged assets exist.
- Added a fixture-based export summary test in `tests/test_workcell_studio_web_scene_contract.py` that creates a minimal scene, stages one mesh file, leaves others missing, and asserts `mesh_backed_count`, `fallback_count`, and `missing_or_failed_mesh_count` add up and reflect the expected statuses.
- Extended `tests/test_workcell_studio_web_viewer_transform_ux.py` to ensure the edit-patch/export workflow remains preview-only and guarded, to verify viewer summary fields (`meshLoadedCount`, `fallbackCount`, `meshFailedCount`) are present, and to assert camera fit constants (`MIN_FRAME_RADIUS`, `FRAME_DISTANCE_MULTIPLIER`) and the near/far formulas produce a safe range for a `ur5_2f_test`-sized envelope.

### Testing
- Ran the focused pytest command `python3 -m pytest tests/test_workcell_studio_web_scene_contract.py tests/test_workcell_studio_web_viewer_transform_ux.py -q`, which completed with all tests passing (`16 passed`).
- The added tests exercise the exporter staging path and viewer constants to detect regressions in mesh staging, summary counts, identity fields, and camera framing behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a453068c5a88331a04a8d66614bf853)