### PR TITLE
Refresh viewer mesh load status UI

### DIFF
--- a/workcell_studio_web/viewer/style.css
+++ b/workcell_studio_web/viewer/style.css
@@ -242,6 +242,18 @@ h2 { margin: 0 0 0.75rem; font-size: 0.95rem; color: var(--accent); }
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.object-list .status-chip {
+  display: inline-block;
+  margin-top: 0.35rem;
+  padding: 0.12rem 0.35rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: #d8f7df;
+  font-size: 0.68rem;
+  line-height: 1.1;
+}
+.object-list .status-loaded, .object-list .status-mesh_loaded { color: #8df5a8; }
+.object-list .status-load_error, .object-list .status-missing_file, .object-list .status-unsafe_path, .object-list .status-unsupported_format, .object-list .status-unresolved_package_uri { color: #ffb4a8; }
 .inspector-table { width: 100%; border-collapse: collapse; font-size: 0.86rem; }
 .inspector-table th, .inspector-table td { padding: 0.35rem 0.2rem; border-bottom: 1px solid var(--border); vertical-align: top; }
 .inspector-table th { width: 38%; text-align: left; color: var(--muted); font-weight: 600; }

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -265,6 +265,21 @@ function setRenderInfo(rendered, renderStatus, meshUri, fallbackReason) {
   });
   return info;
 }
+
+function refreshMeshLoadUi(rendered) {
+  // Mesh loads complete asynchronously after the hierarchy is first drawn. Refresh
+  // derived UI only; do not touch selection, transform gizmos, or dirty edit state.
+  populateObjectList();
+  renderSceneSummary();
+  if (state.selected === rendered?.item?.id) populateInspector(rendered);
+}
+function meshStatusLabel(rendered) {
+  const status = rendered?.renderInfo?.render_status || rendered?.item?.renderInfo?.render_status || rendered?.item?.mesh_status || 'unknown';
+  if (status === 'mesh_loaded') return 'mesh loaded';
+  if (isRuntimeFallbackStatus(status)) return 'fallback';
+  if (isMissingOrFailedMeshStatus(rendered?.item?.mesh_status)) return 'mesh error';
+  return String(status || 'unknown').replace(/_/g, ' ');
+}
 function appendRuntimeWarning(item, meshUri, reason) {
   state.runtimeWarnings.push({
     source: 'runtime_mesh',
@@ -485,8 +500,7 @@ async function tryLoadMesh(item, rendered, fallback) {
     setRenderInfo(rendered, rendered.renderInfo?.render_status || 'box_fallback', requestedUri, diagnostic.reason);
     if (requestedUri) appendRuntimeWarning(item, requestedUri, diagnostic.reason);
     if (itemRequiresMeshBackedVisual(item)) warnRequiredMeshFallback(item, requestedUri, diagnostic.reason);
-    if (state.selected === item.id) populateInspector(rendered);
-    renderSceneSummary();
+    refreshMeshLoadUi(rendered);
     return;
   }
   try {
@@ -504,8 +518,7 @@ async function tryLoadMesh(item, rendered, fallback) {
     setRenderInfo(rendered, 'mesh_loaded', uri, '');
     const bounds = computeRenderedBounds();
     if (bounds) frameScene(bounds);
-    if (state.selected === item.id) populateInspector(rendered);
-    renderSceneSummary();
+    refreshMeshLoadUi(rendered);
   } catch (err) {
     fallback.visible = true;
     item.mesh_status = 'load_error';
@@ -514,8 +527,7 @@ async function tryLoadMesh(item, rendered, fallback) {
     setRenderInfo(rendered, rendered.renderInfo?.render_status || 'box_fallback', uri, reason);
     appendRuntimeWarning(item, uri, reason);
     if (itemRequiresMeshBackedVisual(item)) warnRequiredMeshFallback(item, uri, reason);
-    if (state.selected === item.id) populateInspector(rendered);
-    renderSceneSummary();
+    refreshMeshLoadUi(rendered);
   }
 }
 function collectItems(sceneJson) {
@@ -757,9 +769,14 @@ function populateObjectList() {
       tag.textContent = itemType(rendered.item);
       li.appendChild(tag);
 
+      const status = document.createElement('span');
+      status.className = `status-chip status-${String(rendered.item.mesh_status || rendered.renderInfo?.render_status || 'unknown').replace(/[^a-z0-9_-]/gi, '-').toLowerCase()}`;
+      status.textContent = meshStatusLabel(rendered);
+      li.appendChild(status);
+
       const meta = document.createElement('span');
       meta.className = 'meta';
-      meta.textContent = `${group} · ${rendered.item.locked ? 'locked/generated' : 'editable/environment'}${state.dirtyTransforms.has(rendered.item.id) ? ' · edited' : ''}`;
+      meta.textContent = `${group} · ${rendered.item.locked ? 'locked/generated' : 'editable/environment'} · ${meshStatusLabel(rendered)}${state.dirtyTransforms.has(rendered.item.id) ? ' · edited' : ''}`;
       li.appendChild(meta);
       li.addEventListener('click', () => selectObject(rendered.item.id));
       el.list.appendChild(li);


### PR DESCRIPTION
### Motivation
- Mesh load outcomes (success, skipped, or failure) should update derived UI so the object hierarchy and scene summary reflect the current loaded/fallback/error state without disturbing selection or preview edit state.

### Description
- Added `refreshMeshLoadUi(rendered)` and `meshStatusLabel(rendered)` helpers to centralize UI refresh logic after async mesh outcomes and to produce human-friendly status text.
- Updated `tryLoadMesh()` to call `refreshMeshLoadUi()` after skipped loads, successful loads, and load errors so render info updates are followed by hierarchy and summary refreshes while keeping inspector updates gated to the currently selected item.
- Enhanced `populateObjectList()` to render a status chip for each entry and to include mesh status in the meta line so list items show `loaded`, `fallback`, or `mesh error` states without clearing selection or dirty transform state.
- Added CSS for the new `.status-chip` and color styles in `workcell_studio_web/viewer/style.css` and made the JavaScript changes in `workcell_studio_web/viewer/viewer.js`.

### Testing
- Ran `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py` and `python3 -m pytest tests/test_workcell_studio_web_viewer_transform_ux.py`, and all tests passed (21 passed).
- The changes are UI-only for the static viewer and do not modify launch files, runtime services, or hardware configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45317019b483318c660b0d3352cf49)