### PR TITLE
Fix Web 3D viewer launch asset root

### DIFF
--- a/tests/test_workcell_builder_web_viewer_action.py
+++ b/tests/test_workcell_builder_web_viewer_action.py
@@ -25,7 +25,11 @@ def test_web_viewer_action_exports_to_build_not_scenes_or_generated():
     assert 'QProcess::execute("python3", args)' in cpp
     assert '"--scene", QString::fromStdString(scene_dir.string())' in cpp
     assert '"--output", QString::fromStdString(output_path.string())' in cpp
+    assert '"--stage-assets"' in cpp
     assert 'repo_root / "workcell_studio_web" / "viewer" / "index.html"' in cpp
+    assert "QProcess::startDetached" in cpp
+    assert "python3 -m http.server 8765 --bind 127.0.0.1" in cpp
+    assert "http://127.0.0.1:8765/workcell_studio_web/viewer/index.html?scene=" in cpp
 
 
 def test_user_facing_failures_and_local_server_fallback_are_present():
@@ -37,8 +41,8 @@ def test_user_facing_failures_and_local_server_fallback_are_present():
         "Web 3D scene export failed",
         "Viewer file missing",
         "Browser open failed",
-        "python3 -m http.server 8765",
-        "http://localhost:8765/workcell_studio_web/viewer/index.html",
+        "python3 -m http.server 8765 --bind 127.0.0.1",
+        "http://127.0.0.1:8765/workcell_studio_web/viewer/index.html?scene=",
     ]:
         assert text in cpp
 

--- a/tests/test_workcell_studio_web_mesh_staging.py
+++ b/tests/test_workcell_studio_web_mesh_staging.py
@@ -3,6 +3,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urljoin, urlparse
 
 import yaml
 
@@ -150,8 +151,39 @@ def test_viewer_uri_policy_allows_staged_assets_and_rejects_traversal():
 
     assert "build/workcell_studio_web_scene/assets/" in js
     assert "allowedRoots.some(root => pathOnly.startsWith(root))" in js
+    assert "repoRootRelativeUrl(uri)" in js
+    assert "fetch(repoRootRelativeUrl(sceneUrl)" in js
     assert "part === '..'" in js
     assert "mesh_uri path traversal rejected" in js
+
+
+def test_staged_ur5_mesh_uri_resolves_from_builder_http_launch_context(tmp_path):
+    scene = REPO_ROOT / "scenes" / "ur5_2f_test"
+    output = REPO_ROOT / "build" / "workcell_studio_web_scene" / "ur5_2f_test.web_scene.json"
+
+    subprocess.run(
+        [sys.executable, str(EXPORTER), "--scene", str(scene), "--output", str(output), "--stage-assets"],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    staged_items = [
+        item for item in _all_renderable_items(payload)
+        if str(item.get("mesh_uri") or "").startswith("build/workcell_studio_web_scene/assets/ur5_2f_test/")
+    ]
+
+    assert staged_items, "Expected ur5_2f_test export to include staged mesh URIs."
+    viewer_url = "http://127.0.0.1:8765/workcell_studio_web/viewer/index.html?scene=build%2Fworkcell_studio_web_scene%2Fur5_2f_test.web_scene.json"
+    for item in staged_items[:10]:
+        mesh_uri = item["mesh_uri"]
+        browser_request = urljoin("http://127.0.0.1:8765/", mesh_uri)
+        parsed = urlparse(browser_request)
+        assert parsed.netloc == "127.0.0.1:8765"
+        assert parsed.path.startswith("/build/workcell_studio_web_scene/assets/ur5_2f_test/")
+        assert (REPO_ROOT / parsed.path.lstrip("/")).is_file(), f"{mesh_uri} from {viewer_url} should target an existing staged file"
 
 
 def _fallback_causes(payload: dict) -> list[str]:

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -3750,11 +3750,16 @@ void SceneSelect::on_export_open_web_3d_viewer_clicked()
 
   const fs::path output_path = repo_root / "build" / "workcell_studio_web_scene" / (scene_id + ".web_scene.json");
   const fs::path viewer_path = repo_root / "workcell_studio_web" / "viewer" / "index.html";
+  const QString web_scene_url_path = QString("build/workcell_studio_web_scene/%1.web_scene.json")
+    .arg(QString::fromStdString(scene_id));
+  const QString viewer_url = QString("http://127.0.0.1:8765/workcell_studio_web/viewer/index.html?scene=%1")
+    .arg(QString::fromUtf8(QUrl::toPercentEncoding(web_scene_url_path)));
   fs::create_directories(output_path.parent_path(), ec);
   const QStringList args{
     QString::fromStdString(exporter_script.string()),
     "--scene", QString::fromStdString(scene_dir.string()),
-    "--output", QString::fromStdString(output_path.string())};
+    "--output", QString::fromStdString(output_path.string()),
+    "--stage-assets"};
   append_info("Export Web 3D Viewer scene: python3 " + args.join(' ').toStdString());
   const int rc = QProcess::execute("python3", args);
   if (rc != 0 || !fs::exists(output_path, ec)) {
@@ -3775,22 +3780,37 @@ void SceneSelect::on_export_open_web_3d_viewer_clicked()
     return;
   }
 
-  const bool opened = QDesktopServices::openUrl(QUrl::fromLocalFile(QString::fromStdString(viewer_path.string())));
+  qint64 server_pid = 0;
+  const bool server_started = QProcess::startDetached(
+    "python3",
+    QStringList{"-m", "http.server", "8765", "--bind", "127.0.0.1"},
+    QString::fromStdString(repo_root.string()),
+    &server_pid);
+  if (server_started) {
+    append_info("Started local Web 3D Viewer server from repo root: python3 -m http.server 8765 --bind 127.0.0.1");
+  } else {
+    append_warning("Could not start local Web 3D Viewer server on 127.0.0.1:8765; opening the repo-root HTTP URL anyway in case a server is already running.");
+  }
+
+  const bool opened = QDesktopServices::openUrl(QUrl(viewer_url));
   const QString fallback = QString(
-    "Viewer path: %1\n"
-    "Exported JSON path: %2\n\n"
-    "If direct file loading is blocked by your browser, run this from the repository root:\n"
-    "python3 -m http.server 8765\n\n"
+    "Viewer URL: %1\n"
+    "Viewer path: %2\n"
+    "Exported JSON path: %3\n\n"
+    "The viewer is opened through a repository-root HTTP server so staged meshes resolve under:\n"
+    "build/workcell_studio_web_scene/assets/%4/...\n\n"
+    "If the browser cannot connect, run this from the repository root:\n"
+    "python3 -m http.server 8765 --bind 127.0.0.1\n\n"
     "Then open:\n"
-    "http://localhost:8765/workcell_studio_web/viewer/index.html")
-    .arg(QString::fromStdString(viewer_path.string()), QString::fromStdString(output_path.string()));
+    "%1")
+    .arg(viewer_url, QString::fromStdString(viewer_path.string()), QString::fromStdString(output_path.string()), QString::fromStdString(scene_id));
   if (!opened) {
-    const QString message = "Browser open failed. Use the local-server fallback below.\n\n" + fallback;
+    const QString message = "Browser open failed. Use the local-server URL below.\n\n" + fallback;
     append_error(message.toStdString());
     QMessageBox::critical(this, "Open Web 3D Viewer", message);
     return;
   }
-  append_success("Opened Web 3D Viewer: " + viewer_path.string());
+  append_success("Opened Web 3D Viewer: " + viewer_url.toStdString());
   QMessageBox::information(this, "Open Web 3D Viewer", fallback);
 }
 

--- a/workcell_studio_web/viewer/README.md
+++ b/workcell_studio_web/viewer/README.md
@@ -16,25 +16,25 @@ Browsers cannot load ROS `package://` URIs directly and cannot read arbitrary pa
 
 ### Workcell Builder action
 
-Workcell Builder also exposes a selected-scene action named **Export & Open Web 3D Viewer** in the Safety / Review flow. The action resolves the selected scene, runs `scripts/export_workcell_studio_web_scene.py`, writes only to `build/workcell_studio_web_scene/<scene_id>.web_scene.json`, and opens `workcell_studio_web/viewer/index.html` with Qt/QDesktopServices. It does not write under `scenes/`, mutate source YAML, mutate generated scene files, apply edit patches, or change RViz/MoveIt planning truth.
+Workcell Builder also exposes a selected-scene action named **Export & Open Web 3D Viewer** in the Safety / Review flow. The action resolves the selected scene, runs `scripts/export_workcell_studio_web_scene.py --stage-assets`, writes only to `build/workcell_studio_web_scene/<scene_id>.web_scene.json`, starts a repository-root local HTTP server on `127.0.0.1:8765`, and opens `http://127.0.0.1:8765/workcell_studio_web/viewer/index.html?scene=build%2Fworkcell_studio_web_scene%2F<scene_id>.web_scene.json` with Qt/QDesktopServices. Opening through the repository root is important because staged mesh requests resolve as `build/workcell_studio_web_scene/assets/<scene_id>/...`. It does not write under `scenes/`, mutate source YAML, mutate generated scene files, apply edit patches, or change RViz/MoveIt planning truth.
 
 If direct `file://` loading is blocked or unreliable in your browser, or if you staged mesh assets and want relative mesh URLs to resolve consistently, run this from the repository root and open the URL manually:
 
 ```bash
-python3 -m http.server 8765
+python3 -m http.server 8765 --bind 127.0.0.1
 ```
 
-URL: `http://localhost:8765/workcell_studio_web/viewer/index.html`
+URL: `http://127.0.0.1:8765/workcell_studio_web/viewer/index.html?scene=build%2Fworkcell_studio_web_scene%2Fur5_2f_test.web_scene.json`
 
 ## Open the viewer
 
 1. Serve the repository root when using staged assets:
 
    ```bash
-   python3 -m http.server 8765
+   python3 -m http.server 8765 --bind 127.0.0.1
    ```
 
-2. Open `http://localhost:8765/workcell_studio_web/viewer/index.html` in a browser. Directly opening `workcell_studio_web/viewer/index.html` can still work for JSON-only review, but served HTTP is the expected path for relative staged mesh assets.
+2. Open `http://127.0.0.1:8765/workcell_studio_web/viewer/index.html?scene=build%2Fworkcell_studio_web_scene%2Fur5_2f_test.web_scene.json` in a browser. Directly opening `workcell_studio_web/viewer/index.html` can still work for JSON-only review, but served HTTP is the expected path for relative staged mesh assets.
 3. Use the **Load web_scene.json** file picker.
 4. Select the exported JSON, for example:
    `build/workcell_studio_web_scene/ur5_2f_test.web_scene.json`.

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -358,6 +358,9 @@ function meshUriDiagnostic(item) {
 function safeMeshUri(item) {
   return meshUriDiagnostic(item).uri;
 }
+function repoRootRelativeUrl(uri) {
+  return new URL(uri, `${window.location.origin}/`).href;
+}
 function itemType(item) { return item.type || item.category || item.role || item.source_kind || 'asset'; }
 function itemLabel(item) { return item.label || item.display_name || item.name || item.id || 'unnamed'; }
 function viewerGroupIdentity(item) {
@@ -506,9 +509,10 @@ async function tryLoadMesh(item, rendered, fallback) {
   try {
     const ext = uri.split(/[?#]/, 1)[0].slice(uri.split(/[?#]/, 1)[0].lastIndexOf('.') + 1).toLowerCase();
     let loaded;
-    if (ext === 'stl') loaded = await new STLLoader().loadAsync(uri);
-    else if (ext === 'dae') loaded = await new ColladaLoader().loadAsync(uri);
-    else loaded = await new OBJLoader().loadAsync(uri);
+    const loadUrl = repoRootRelativeUrl(uri);
+    if (ext === 'stl') loaded = await new STLLoader().loadAsync(loadUrl);
+    else if (ext === 'dae') loaded = await new ColladaLoader().loadAsync(loadUrl);
+    else loaded = await new OBJLoader().loadAsync(loadUrl);
     const meshObject = materializeLoadedMesh(item, uri, loaded);
     fallback.visible = false;
     rendered.object3d.add(meshObject);
@@ -1031,6 +1035,58 @@ async function loadFile(file) {
   }
 }
 
+function safeRelativeSceneUrl(raw) {
+  if (typeof raw !== 'string' || !raw.trim()) throw new Error('Empty scene URL parameter.');
+  const uri = raw.trim();
+  const lower = uri.toLowerCase();
+  if (
+    lower.startsWith('http://') ||
+    lower.startsWith('https://') ||
+    lower.startsWith('file://') ||
+    lower.startsWith('data:') ||
+    lower.startsWith('//') ||
+    uri.startsWith('/') ||
+    uri.startsWith('\\') ||
+    /^[a-zA-Z]:[\\/]/.test(uri) ||
+    /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(uri) ||
+    uri.includes('\\')
+  ) throw new Error(`unsafe scene URL rejected by viewer policy: ${uri}`);
+  const pathOnly = uri.split(/[?#]/, 1)[0];
+  if (pathOnly.split('/').some(part => part === '..')) {
+    throw new Error(`scene URL path traversal rejected: ${uri}`);
+  }
+  if (!pathOnly.startsWith('build/workcell_studio_web_scene/') || !pathOnly.endsWith('.web_scene.json')) {
+    throw new Error(`scene URL must point under build/workcell_studio_web_scene/*.web_scene.json: ${uri}`);
+  }
+  return uri;
+}
+
+async function loadSceneUrl(rawUrl) {
+  const sceneUrl = safeRelativeSceneUrl(rawUrl);
+  try {
+    const response = await fetch(repoRootRelativeUrl(sceneUrl), { cache: 'no-store' });
+    if (!response.ok) throw new Error(`HTTP ${response.status} ${response.statusText}`);
+    const json = await response.json();
+    const items = validateSceneJson(json);
+    state.sceneJson = json;
+    state.sourceWebSceneFile = sceneUrl;
+    state.runtimeWarnings = [];
+    state.dirtyTransforms.clear();
+    state.undoStack = [];
+    state.redoStack = [];
+    state.selected = null;
+    detachTransformGizmo();
+    el.empty.hidden = true;
+    renderScene(items);
+    refreshWarnings(json);
+    renderSceneSummary();
+    el.inspector.className = 'state empty';
+    el.inspector.textContent = items.length ? 'Select an object from the list or canvas.' : EMPTY_SCENE_MESSAGE;
+  } catch (err) {
+    showError(`Failed to load scene from ${sceneUrl}: ${err.message || err}`);
+  }
+}
+
 if (el.resetView) el.resetView.addEventListener('click', resetView);
 if (el.labelsToggle) el.labelsToggle.addEventListener('change', event => setLabelsVisible(event.target.checked));
 if (el.undoEdit) el.undoEdit.addEventListener('click', undoPreviewEdit);
@@ -1062,6 +1118,8 @@ async function boot() {
     OBJLoader = objModule.OBJLoader;
     initThree();
     setLabelsVisible(el.labelsToggle?.checked || false);
+    const sceneParam = new URLSearchParams(window.location.search).get('scene');
+    if (sceneParam) await loadSceneUrl(sceneParam);
   } catch (err) {
     showError(`Three.js/CDN load failure: ${err.message || err}`);
   }


### PR DESCRIPTION
### Motivation
- The Workcell Builder viewer action opened the viewer via a direct `file://` path which prevents staged mesh URLs under `build/workcell_studio_web_scene/assets/...` from resolving in the browser; the intent is to reliably open the web viewer so staged assets load.

### Description
- Changed the Builder action to call the exporter with `--stage-assets`, keep output at `build/workcell_studio_web_scene/<scene_id>.web_scene.json`, start a repo-root HTTP server on `127.0.0.1:8765`, and open the viewer URL `http://127.0.0.1:8765/workcell_studio_web/viewer/index.html?scene=...` instead of a `file://` URL (`workcell_builder/workcell_builder/gui/scene_select.cpp`).
- Updated the static viewer to accept a safe repo-root-relative `scene` query parameter and to fetch the exported JSON and staged mesh requests relative to the repository-root HTTP origin while preserving the existing unsafe/traversal rejection policy (`workcell_studio_web/viewer/viewer.js`).
- Added a small helper to convert repo-root relative paths to full fetch URLs and updated Three.js loaders to use those URLs so `build/workcell_studio_web_scene/assets/...` resolves when served (`workcell_studio_web/viewer/viewer.js`).
- Added a regression test that exports `ur5_2f_test` with staged assets and asserts staged `mesh_uri` entries resolve to existing files under the repo-root HTTP path, and updated unit tests and README to document the served viewer path (`tests/test_workcell_builder_web_viewer_action.py`, `tests/test_workcell_studio_web_mesh_staging.py`, `workcell_studio_web/viewer/README.md`).

### Testing
- Ran `pytest tests/test_workcell_builder_web_viewer_action.py tests/test_workcell_studio_web_mesh_staging.py` and all tests passed (`11 passed`).
- Ran the exporter manually with `python3 scripts/export_workcell_studio_web_scene.py --scene scenes/ur5_2f_test --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json --stage-assets` and verified staged meshes exist and several UR5/Robotiq/workbench/camera rows are mesh-backed.
- Confirmed no ROS, controllers, RViz, MoveIt, fake hardware, or real robot motion were launched and that source scene files were not mutated; outputs remain under `build/workcell_studio_web_scene/`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4792106f088331bfe2054a7af9f20a)