### PR TITLE
Viewer: Preflight mesh URL checks and richer loader diagnostics

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -107,7 +107,7 @@ def test_viewer_includes_render_status_strings_and_fallback_reasons():
         "no primitive geometry or mesh was provided; using box fallback",
         "unsafe mesh_uri rejected by viewer policy",
         "no mesh_uri provided",
-        "mesh loader failed",
+        "loader_failure",
     ]:
         assert token in js
 
@@ -123,7 +123,7 @@ def test_viewer_includes_mesh_loader_references_and_safe_mesh_uri_logic():
         "three/addons/loaders/OBJLoader.js",
         "safeMeshUri",
         "displayMeshUri",
-        "loadAsync(uri)",
+        "loadAsync(loadUrl)",
         "materializeLoadedMesh",
         "appendRuntimeWarning",
         "build/workcell_studio_web_scene/assets/",
@@ -184,3 +184,34 @@ def test_viewer_validates_renderable_transforms_and_required_mesh_fallbacks():
         assert token in js
     assert "if (!applyPose(object3d, item)) continue;" in js
     assert "if (itemRequiresMeshBackedVisual(item)) warnRequiredMeshFallback" in js
+
+
+def test_viewer_mesh_preflight_surfaces_distinct_failure_reasons():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    for token in [
+        "unsupported_format",
+        "unsupported mesh format",
+        "preflightMeshUrl",
+        "fetch(url, { method: 'HEAD' })",
+        "method: 'GET'",
+        "url_not_served",
+        "mesh_url_not_served",
+        "file_access_blocked",
+        "mesh_file_access_blocked",
+        "loader_failure",
+        "mesh_loader_failure",
+        "meshLoaderNameForExtension",
+        "extension: ext",
+        "loader: loaderName",
+        "invalid_renderable_transform",
+        "scale must be positive on every axis",
+        "scale contains non-finite values",
+    ]:
+        assert token in js
+    preflight_body = js.split("async function preflightMeshUrl", 1)[1].split("function itemType", 1)[0]
+    assert "response.status" in preflight_body
+    assert "!response.ok" in preflight_body
+    try_load_body = js.split("async function tryLoadMesh", 1)[1].split("function collectItems", 1)[0]
+    assert try_load_body.index("await preflightMeshUrl") < try_load_body.index("new STLLoader().loadAsync")
+    assert "item.mesh_status = preflight.status || 'url_not_served'" in try_load_body
+    assert "item.mesh_status = 'loader_failure'" in try_load_body

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -14,6 +14,11 @@ const EMPTY_SCENE_MESSAGE = 'Scene contains no renderable robots, tools, assets,
 const FRAME_DISTANCE_MULTIPLIER = 2.7;
 const state = { sceneJson: null, sourceWebSceneFile: '', objects: [], selected: null, three: {}, animationId: null, lastFrameBounds: null, runtimeWarnings: [], labelsVisible: false, dirtyTransforms: new Map(), undoStack: [], redoStack: [], gizmoDragStart: null };
 const RESET_VIEW_TITLE = 'Fit Scene / Reset View: recomputes and reapplies the fitted workcell overview from renderable bounds.';
+const STAGED_MESH_ROOTS = [
+  'build/workcell_studio_web_scene/assets/',
+  'workcell_studio_web/',
+  'assets/',
+];
 
 const el = {
   file: document.getElementById('scene-file'),
@@ -47,7 +52,7 @@ function isGeneratedOrLockedItem(item) {
 }
 function isRuntimeFallbackStatus(status) { return /fallback/.test(String(status || '').toLowerCase()); }
 function isMissingOrFailedMeshStatus(status) {
-  return ['missing_file', 'unresolved_package_uri', 'unsafe_path', 'unsupported_format', 'load_error']
+  return ['missing_file', 'unresolved_package_uri', 'unsafe_path', 'unsupported_format', 'load_error', 'url_not_served', 'file_access_blocked', 'loader_failure']
     .includes(String(status || '').toLowerCase());
 }
 function computeSceneSummary() {
@@ -280,10 +285,10 @@ function meshStatusLabel(rendered) {
   if (isMissingOrFailedMeshStatus(rendered?.item?.mesh_status)) return 'mesh error';
   return String(status || 'unknown').replace(/_/g, ' ');
 }
-function appendRuntimeWarning(item, meshUri, reason) {
+function appendRuntimeWarning(item, meshUri, reason, code = 'mesh_primitive_fallback', extra = {}) {
   state.runtimeWarnings.push({
     source: 'runtime_mesh',
-    code: 'mesh_primitive_fallback',
+    code,
     object_id: item?.id || itemLabel(item || {}),
     link: item?.link || item?.object_name || item?.visual || '',
     object_name: item?.object_name || item?.link || itemLabel(item || {}),
@@ -301,7 +306,8 @@ function appendRuntimeWarning(item, meshUri, reason) {
     mesh_scale: item?.mesh_scale,
     fallback_or_skip_reason: reason || 'mesh loading skipped',
     reason: reason || 'mesh loading skipped',
-    message: `Primitive fallback for ${item?.id || itemLabel(item || {})} (${item?.link || item?.object_name || itemLabel(item || {})}): ${reason || 'mesh loading skipped'}`,
+    message: `${code}: Primitive fallback for ${item?.id || itemLabel(item || {})} (${item?.link || item?.object_name || itemLabel(item || {})}): ${reason || 'mesh loading skipped'}`,
+    ...extra,
   });
   refreshWarnings();
 }
@@ -318,6 +324,17 @@ function meshUriDiagnostic(item) {
   const uri = raw.trim();
   const lower = uri.toLowerCase();
   if (lower.startsWith('package://')) return { uri: null, status: 'unresolved_package_uri', reason: `package URI must be resolved and staged before browser loading: ${uri}` };
+  const stagedHttpUrl = (() => {
+    if (!lower.startsWith('http://') && !lower.startsWith('https://')) return null;
+    try {
+      const parsed = new URL(uri);
+      const currentOrigin = window.location?.origin || '';
+      const stagedPath = parsed.pathname.replace(/^\/+/, '');
+      if (currentOrigin && currentOrigin !== 'null' && parsed.origin === currentOrigin && STAGED_MESH_ROOTS.some(root => stagedPath.startsWith(root))) return stagedPath + parsed.search + parsed.hash;
+    } catch (_) { /* fall through to unsafe_path below */ }
+    return null;
+  })();
+  if (stagedHttpUrl) return meshUriDiagnostic({ ...item, mesh_uri: stagedHttpUrl });
   if (
     lower.startsWith('http://') ||
     lower.startsWith('https://') ||
@@ -333,12 +350,7 @@ function meshUriDiagnostic(item) {
   const pathOnly = uri.split(/[?#]/, 1)[0];
   const parts = pathOnly.split('/');
   if (parts.some(part => part === '..')) return { uri: null, status: 'unsafe_path', reason: `mesh_uri path traversal rejected: ${uri}` };
-  const allowedRoots = [
-    'build/workcell_studio_web_scene/assets/',
-    'workcell_studio_web/',
-    'assets/',
-  ];
-  if (!allowedRoots.some(root => pathOnly.startsWith(root))) {
+  if (!STAGED_MESH_ROOTS.some(root => pathOnly.startsWith(root))) {
     return { uri: null, status: 'unsafe_path', reason: `mesh_uri must be staged under build/workcell_studio_web_scene/assets/, workcell_studio_web/, or assets/: ${uri}` };
   }
   const ext = pathOnly.includes('.') ? pathOnly.slice(pathOnly.lastIndexOf('.') + 1).toLowerCase() : '';
@@ -359,7 +371,51 @@ function safeMeshUri(item) {
   return meshUriDiagnostic(item).uri;
 }
 function repoRootRelativeUrl(uri) {
-  return new URL(uri, `${window.location.origin}/`).href;
+  const origin = window.location?.origin;
+  const base = origin && origin !== 'null' ? `${origin}/` : (document.baseURI || window.location?.href || '');
+  return new URL(uri, base).href;
+}
+
+function meshLoaderNameForExtension(ext) {
+  if (ext === 'stl') return 'STLLoader';
+  if (ext === 'dae') return 'ColladaLoader';
+  if (ext === 'obj') return 'OBJLoader';
+  return 'unknown_loader';
+}
+function meshExtensionFromUri(uri) {
+  const pathOnly = String(uri || '').split(/[?#]/, 1)[0];
+  return pathOnly.includes('.') ? pathOnly.slice(pathOnly.lastIndexOf('.') + 1).toLowerCase() : '';
+}
+async function preflightMeshUrl(uri, loadUrl) {
+  if (typeof fetch !== 'function') {
+    return { ok: true, status: 'preflight_unavailable', reason: 'fetch is unavailable; loader will report any mesh access failure' };
+  }
+  const url = loadUrl || repoRootRelativeUrl(uri);
+  const fileLike = String(window.location?.protocol || '').toLowerCase() === 'file:' || String(url).toLowerCase().startsWith('file:');
+  const describeFailure = err => {
+    const status = fileLike ? 'file_access_blocked' : 'url_not_served';
+    const code = fileLike ? 'mesh_file_access_blocked' : 'mesh_url_not_served';
+    return { ok: false, status, code, reason: `${status}: browser could not preflight mesh URL ${url} (${err?.message || err || 'fetch failed'})`, url };
+  };
+  try {
+    let response = await fetch(url, { method: 'HEAD' });
+    if (response.status === 405 || response.status === 501) {
+      response = await fetch(url, { method: 'GET', headers: { Range: 'bytes=0-0' } });
+    }
+    if (!response.ok) {
+      return {
+        ok: false,
+        status: 'url_not_served',
+        code: 'mesh_url_not_served',
+        reason: `url_not_served: mesh URL returned HTTP ${response.status} ${response.statusText || ''} for ${url}`.trim(),
+        http_status: response.status,
+        url,
+      };
+    }
+    return { ok: true, status: 'url_served', reason: `mesh URL preflight succeeded for ${url}`, http_status: response.status, url };
+  } catch (err) {
+    return describeFailure(err);
+  }
 }
 function itemType(item) { return item.type || item.category || item.role || item.source_kind || 'asset'; }
 function itemLabel(item) { return item.label || item.display_name || item.name || item.id || 'unnamed'; }
@@ -506,10 +562,22 @@ async function tryLoadMesh(item, rendered, fallback) {
     refreshMeshLoadUi(rendered);
     return;
   }
+  const ext = meshExtensionFromUri(uri);
+  const loaderName = meshLoaderNameForExtension(ext);
+  const loadUrl = repoRootRelativeUrl(uri);
+  const preflight = await preflightMeshUrl(uri, loadUrl);
+  if (!preflight.ok) {
+    fallback.visible = true;
+    item.mesh_status = preflight.status || 'url_not_served';
+    item.mesh_load_error = `${preflight.reason}; url=${preflight.url || loadUrl}`;
+    setRenderInfo(rendered, rendered.renderInfo?.render_status || 'box_fallback', uri, item.mesh_load_error);
+    appendRuntimeWarning(item, uri, item.mesh_load_error, preflight.code || 'mesh_url_not_served', { mesh_url: preflight.url || loadUrl, http_status: preflight.http_status || null });
+    if (itemRequiresMeshBackedVisual(item)) warnRequiredMeshFallback(item, uri, item.mesh_load_error);
+    refreshMeshLoadUi(rendered);
+    return;
+  }
   try {
-    const ext = uri.split(/[?#]/, 1)[0].slice(uri.split(/[?#]/, 1)[0].lastIndexOf('.') + 1).toLowerCase();
     let loaded;
-    const loadUrl = repoRootRelativeUrl(uri);
     if (ext === 'stl') loaded = await new STLLoader().loadAsync(loadUrl);
     else if (ext === 'dae') loaded = await new ColladaLoader().loadAsync(loadUrl);
     else loaded = await new OBJLoader().loadAsync(loadUrl);
@@ -525,11 +593,11 @@ async function tryLoadMesh(item, rendered, fallback) {
     refreshMeshLoadUi(rendered);
   } catch (err) {
     fallback.visible = true;
-    item.mesh_status = 'load_error';
+    item.mesh_status = 'loader_failure';
     item.mesh_load_error = err?.message || String(err);
-    const reason = `mesh loader failed: ${item.mesh_load_error}`;
+    const reason = `loader_failure: ${loaderName} failed for .${ext || 'unknown'} after fetchable URL ${loadUrl}: ${item.mesh_load_error}`;
     setRenderInfo(rendered, rendered.renderInfo?.render_status || 'box_fallback', uri, reason);
-    appendRuntimeWarning(item, uri, reason);
+    appendRuntimeWarning(item, uri, reason, 'mesh_loader_failure', { extension: ext, loader: loaderName, mesh_url: loadUrl });
     if (itemRequiresMeshBackedVisual(item)) warnRequiredMeshFallback(item, uri, reason);
     refreshMeshLoadUi(rendered);
   }
@@ -1039,6 +1107,17 @@ function safeRelativeSceneUrl(raw) {
   if (typeof raw !== 'string' || !raw.trim()) throw new Error('Empty scene URL parameter.');
   const uri = raw.trim();
   const lower = uri.toLowerCase();
+  const stagedHttpUrl = (() => {
+    if (!lower.startsWith('http://') && !lower.startsWith('https://')) return null;
+    try {
+      const parsed = new URL(uri);
+      const currentOrigin = window.location?.origin || '';
+      const stagedPath = parsed.pathname.replace(/^\/+/, '');
+      if (currentOrigin && currentOrigin !== 'null' && parsed.origin === currentOrigin && STAGED_MESH_ROOTS.some(root => stagedPath.startsWith(root))) return stagedPath + parsed.search + parsed.hash;
+    } catch (_) { /* fall through to unsafe_path below */ }
+    return null;
+  })();
+  if (stagedHttpUrl) return meshUriDiagnostic({ ...item, mesh_uri: stagedHttpUrl });
   if (
     lower.startsWith('http://') ||
     lower.startsWith('https://') ||


### PR DESCRIPTION
### Motivation
- Surface clear, actionable reasons when a mesh URL is unreachable before invoking Three.js loaders so primitive fallback is rare but informative.
- Distinguish network/file/preflight errors from unsupported formats and loader runtime failures to make Product View diagnostics honest and debuggable.
- Preserve existing unsafe-path, package URI, unsupported-format, and invalid-transform guards while adding targeted preflight behavior for staged HTTP assets.

### Description
- Add staged roots constant and same-origin staged-HTTP normalization so browser-served assets under known staged paths are handled safely (`STAGED_MESH_ROOTS` and staged HTTP path handling in `meshUriDiagnostic`).
- Introduce `preflightMeshUrl`, `meshLoaderNameForExtension`, and `meshExtensionFromUri` and call `fetch(..., { method: 'HEAD' })` with a tiny `GET` fallback to verify the URL before calling Three.js loaders.
- Update `tryLoadMesh` to run preflight and, on preflight failure, set `item.mesh_status` to `url_not_served` or `file_access_blocked`, populate `mesh_load_error`, and emit a runtime warning with a concrete code and details; only call `STL/Collada/OBJ` loaders after preflight success.
- Map loader exceptions (post-preflight) to `loader_failure` and emit `mesh_loader_failure` warnings that include the extension and loader name; keep previous `unsupported_format`, `unsafe_path`, `unresolved_package_uri`, and invalid-transform handling intact.
- Extend `appendRuntimeWarning` to accept an explicit `code` and `extra` diagnostics and make `isMissingOrFailedMeshStatus` consider the new failure codes so the scene summary counts them as mesh errors.
- Add a focused unit test (`test_viewer_mesh_preflight_surfaces_distinct_failure_reasons`) and small assertions in the static viewer tests to verify presence and ordering of preflight, URL-not-served, loader-failure, unsupported extension, and invalid-transform tokens.

### Testing
- Ran `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py -q`, which passed.
- Ran `python3 -m pytest tests/test_scene3d_stl_mesh_loader_runtime.py tests/test_workcell_studio_web_viewer_static.py -q`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47a0fa09b48331b835c85ec4351f23)