### PR TITLE
Open Web 3D viewer via local static server and improve user feedback

### DIFF
--- a/tests/test_workcell_builder_web_viewer_action.py
+++ b/tests/test_workcell_builder_web_viewer_action.py
@@ -29,7 +29,7 @@ def test_web_viewer_action_exports_to_build_not_scenes_or_generated():
     assert 'repo_root / "workcell_studio_web" / "viewer" / "index.html"' in cpp
     assert "QProcess::startDetached" in cpp
     assert "python3 -m http.server 8765 --bind 127.0.0.1" in cpp
-    assert "http://127.0.0.1:8765/workcell_studio_web/viewer/index.html?scene=" in cpp
+    assert "http://localhost:8765/workcell_studio_web/viewer/index.html?scene=" in cpp
 
 
 def test_user_facing_failures_and_local_server_fallback_are_present():
@@ -41,8 +41,12 @@ def test_user_facing_failures_and_local_server_fallback_are_present():
         "Web 3D scene export failed",
         "Viewer file missing",
         "Browser open failed",
+        "reused existing server",
+        "Local static asset server",
+        "Viewer URL opened",
+        "Exported web scene JSON",
         "python3 -m http.server 8765 --bind 127.0.0.1",
-        "http://127.0.0.1:8765/workcell_studio_web/viewer/index.html?scene=",
+        "http://localhost:8765/workcell_studio_web/viewer/index.html?scene=",
     ]:
         assert text in cpp
 

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -3752,7 +3752,7 @@ void SceneSelect::on_export_open_web_3d_viewer_clicked()
   const fs::path viewer_path = repo_root / "workcell_studio_web" / "viewer" / "index.html";
   const QString web_scene_url_path = QString("build/workcell_studio_web_scene/%1.web_scene.json")
     .arg(QString::fromStdString(scene_id));
-  const QString viewer_url = QString("http://127.0.0.1:8765/workcell_studio_web/viewer/index.html?scene=%1")
+  const QString viewer_url = QString("http://localhost:8765/workcell_studio_web/viewer/index.html?scene=%1")
     .arg(QString::fromUtf8(QUrl::toPercentEncoding(web_scene_url_path)));
   fs::create_directories(output_path.parent_path(), ec);
   const QStringList args{
@@ -3780,30 +3780,56 @@ void SceneSelect::on_export_open_web_3d_viewer_clicked()
     return;
   }
 
+  const QString manual_server_command = QString("cd %1 && python3 -m http.server 8765 --bind 127.0.0.1")
+    .arg(QString::fromStdString(repo_root.string()));
+  const auto is_local_server_reachable = []() {
+    const QString probe =
+      "import socket,sys\n"
+      "s=socket.socket()\n"
+      "s.settimeout(0.25)\n"
+      "try:\n"
+      "    s.connect(('127.0.0.1', 8765))\n"
+      "except OSError:\n"
+      "    sys.exit(1)\n"
+      "finally:\n"
+      "    s.close()\n";
+    return QProcess::execute("python3", QStringList{"-c", probe}) == 0;
+  };
+
+  bool server_started = false;
+  bool server_reused = is_local_server_reachable();
   qint64 server_pid = 0;
-  const bool server_started = QProcess::startDetached(
-    "python3",
-    QStringList{"-m", "http.server", "8765", "--bind", "127.0.0.1"},
-    QString::fromStdString(repo_root.string()),
-    &server_pid);
-  if (server_started) {
-    append_info("Started local Web 3D Viewer server from repo root: python3 -m http.server 8765 --bind 127.0.0.1");
+  if (server_reused) {
+    append_info("Reusing existing local Web 3D Viewer static asset server on http://localhost:8765/.");
   } else {
-    append_warning("Could not start local Web 3D Viewer server on 127.0.0.1:8765; opening the repo-root HTTP URL anyway in case a server is already running.");
+    server_started = QProcess::startDetached(
+      "python3",
+      QStringList{"-m", "http.server", "8765", "--bind", "127.0.0.1"},
+      QString::fromStdString(repo_root.string()),
+      &server_pid);
+    if (server_started) {
+      append_info("Started local Web 3D Viewer server from repo root: python3 -m http.server 8765 --bind 127.0.0.1");
+    } else {
+      append_warning("Could not start local Web 3D Viewer server on 127.0.0.1:8765; opening the repo-root HTTP URL anyway in case a server is already running.");
+    }
   }
 
+  const QString server_status = server_started
+    ? QString("started (PID %1)").arg(server_pid)
+    : (server_reused ? QString("reused existing server") : QString("not started"));
   const bool opened = QDesktopServices::openUrl(QUrl(viewer_url));
   const QString fallback = QString(
-    "Viewer URL: %1\n"
-    "Viewer path: %2\n"
-    "Exported JSON path: %3\n\n"
+    "Exported web scene JSON: %3\n"
+    "Viewer URL opened: %1\n"
+    "Local static asset server: %5\n\n"
+    "Viewer path: %2\n\n"
     "The viewer is opened through a repository-root HTTP server so staged meshes resolve under:\n"
     "build/workcell_studio_web_scene/assets/%4/...\n\n"
-    "If the browser cannot connect, run this from the repository root:\n"
-    "python3 -m http.server 8765 --bind 127.0.0.1\n\n"
+    "If the browser cannot connect or the server did not start, run this manually:\n"
+    "%6\n\n"
     "Then open:\n"
     "%1")
-    .arg(viewer_url, QString::fromStdString(viewer_path.string()), QString::fromStdString(output_path.string()), QString::fromStdString(scene_id));
+    .arg(viewer_url, QString::fromStdString(viewer_path.string()), QString::fromStdString(output_path.string()), QString::fromStdString(scene_id), server_status, manual_server_command);
   if (!opened) {
     const QString message = "Browser open failed. Use the local-server URL below.\n\n" + fallback;
     append_error(message.toStdString());

--- a/workcell_studio_web/viewer/README.md
+++ b/workcell_studio_web/viewer/README.md
@@ -16,7 +16,7 @@ Browsers cannot load ROS `package://` URIs directly and cannot read arbitrary pa
 
 ### Workcell Builder action
 
-Workcell Builder also exposes a selected-scene action named **Export & Open Web 3D Viewer** in the Safety / Review flow. The action resolves the selected scene, runs `scripts/export_workcell_studio_web_scene.py --stage-assets`, writes only to `build/workcell_studio_web_scene/<scene_id>.web_scene.json`, starts a repository-root local HTTP server on `127.0.0.1:8765`, and opens `http://127.0.0.1:8765/workcell_studio_web/viewer/index.html?scene=build%2Fworkcell_studio_web_scene%2F<scene_id>.web_scene.json` with Qt/QDesktopServices. Opening through the repository root is important because staged mesh requests resolve as `build/workcell_studio_web_scene/assets/<scene_id>/...`. It does not write under `scenes/`, mutate source YAML, mutate generated scene files, apply edit patches, or change RViz/MoveIt planning truth.
+Workcell Builder also exposes a selected-scene action named **Export & Open Web 3D Viewer** in the Safety / Review flow. The action resolves the selected scene, runs `scripts/export_workcell_studio_web_scene.py --stage-assets`, writes only to `build/workcell_studio_web_scene/<scene_id>.web_scene.json`, starts or reuses a repository-root local HTTP server on `127.0.0.1:8765`, and opens `http://localhost:8765/workcell_studio_web/viewer/index.html?scene=build%2Fworkcell_studio_web_scene%2F<scene_id>.web_scene.json` with Qt/QDesktopServices. The completion/failure dialog reports the exported web scene JSON path, the viewer URL, whether the local static asset server started or an existing server was reused, and the exact `cd <repo> && python3 -m http.server 8765 --bind 127.0.0.1` command to run manually if serving cannot be started automatically. Opening through the repository root is important because staged mesh requests resolve as `build/workcell_studio_web_scene/assets/<scene_id>/...`. It does not write under `scenes/`, mutate source YAML, mutate generated scene files, apply edit patches, or change RViz/MoveIt planning truth.
 
 If direct `file://` loading is blocked or unreliable in your browser, or if you staged mesh assets and want relative mesh URLs to resolve consistently, run this from the repository root and open the URL manually:
 
@@ -24,7 +24,7 @@ If direct `file://` loading is blocked or unreliable in your browser, or if you 
 python3 -m http.server 8765 --bind 127.0.0.1
 ```
 
-URL: `http://127.0.0.1:8765/workcell_studio_web/viewer/index.html?scene=build%2Fworkcell_studio_web_scene%2Fur5_2f_test.web_scene.json`
+URL: `http://localhost:8765/workcell_studio_web/viewer/index.html?scene=build%2Fworkcell_studio_web_scene%2Fur5_2f_test.web_scene.json`
 
 ## Open the viewer
 
@@ -34,7 +34,7 @@ URL: `http://127.0.0.1:8765/workcell_studio_web/viewer/index.html?scene=build%2F
    python3 -m http.server 8765 --bind 127.0.0.1
    ```
 
-2. Open `http://127.0.0.1:8765/workcell_studio_web/viewer/index.html?scene=build%2Fworkcell_studio_web_scene%2Fur5_2f_test.web_scene.json` in a browser. Directly opening `workcell_studio_web/viewer/index.html` can still work for JSON-only review, but served HTTP is the expected path for relative staged mesh assets.
+2. Open `http://localhost:8765/workcell_studio_web/viewer/index.html?scene=build%2Fworkcell_studio_web_scene%2Fur5_2f_test.web_scene.json` in a browser. Directly opening `workcell_studio_web/viewer/index.html` can still work for JSON-only review, but served HTTP is the expected path for relative staged mesh assets.
 3. Use the **Load web_scene.json** file picker.
 4. Select the exported JSON, for example:
    `build/workcell_studio_web_scene/ur5_2f_test.web_scene.json`.


### PR DESCRIPTION
### Motivation
- Make the Workcell Builder "Export & Open Web 3D Viewer" action actually launch a repository-root served viewer URL so staged mesh assets resolve reliably in the browser. 
- Prefer reusing an already-running local static server when available and otherwise attempt to start a simple `python3 -m http.server` instance for a smoother user flow. 
- Surface clear, actionable user-facing feedback after export so operators know which JSON was written, which viewer URL was opened, whether a local server started or was reused, and the manual server command to run if automatic start fails. 

### Description
- Updated `workcell_builder/workcell_builder/gui/scene_select.cpp` to open `http://localhost:8765/...` instead of the `127.0.0.1` literal, probe `127.0.0.1:8765` and reuse an existing server when reachable, and otherwise attempt to start `python3 -m http.server 8765 --bind 127.0.0.1` from the repo root. 
- Added reporting values: `Exported web scene JSON`, `Viewer URL opened`, `Local static asset server` status and an exact manual command string (`cd <repo> && python3 -m http.server 8765 --bind 127.0.0.1`) to the completion/failure dialog and log output. 
- Updated `workcell_studio_web/viewer/README.md` to document the Builder-first served viewer path, server reuse/start behavior, and the manual fallback command. 
- Adjusted `tests/test_workcell_builder_web_viewer_action.py` to expect the `localhost` viewer URL and the new user-facing server/export/fallback status strings. 
- Safety unchanged: no ROS launches, no MoveIt/RViz execution, and no real-hardware commands were added; the action remains an export + static-viewer helper only. 

### Testing
- Ran `pytest tests/test_workcell_builder_web_viewer_action.py` and it passed (4 tests). 
- Ran `pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py` and both tests passed (7 tests total). 
- Ran repository checks including `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47a1c00f248331a7f5eff29a72fc96)