### PR TITLE
Suppress unresolved generated mesh placeholders when real robot meshes exist

### DIFF
--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -694,6 +694,95 @@ def _top_level_entities(data: Dict[str, Any], warnings: List[Json]) -> Tuple[Lis
     return robots, tools, sensors
 
 
+
+def _contains_unresolved_substitution(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    text = value.strip()
+    return text == "${mesh}" or ("${" in text and "}" in text)
+
+
+def _has_unresolved_placeholder_mesh_reference(item: Mapping[str, Any]) -> bool:
+    return any(_contains_unresolved_substitution(item.get(field)) for field in MESH_URI_FIELDS)
+
+
+def _supported_mesh_uri(value: Any) -> bool:
+    if not isinstance(value, str) or _contains_unresolved_substitution(value):
+        return False
+    parsed = urlparse(value)
+    path = unquote(parsed.path if parsed.scheme else value)
+    return Path(path).suffix.lower() in SUPPORTED_MESH_SUFFIXES
+
+
+def _robot_family_from_item(item: Mapping[str, Any]) -> Optional[str]:
+    text = " ".join(str(item.get(field, "")) for field in MESH_URI_FIELDS + ("id", "role", "category", "display_name", "link")).lower()
+    for family in ("ur3", "ur5", "ur10"):
+        if f"/meshes/{family}/" in text or family in text:
+            return family
+    return None
+
+
+def _normalized_robot_link(item: Mapping[str, Any]) -> str:
+    link = str(item.get("link") or item.get("object_name") or "").lower()
+    return link.removesuffix("_inertia")
+
+
+def _is_robot_like_generated_item(item: Mapping[str, Any]) -> bool:
+    text = _identity_text(item)
+    role = str(item.get("role", "")).lower()
+    category = str(item.get("category", "")).lower()
+    return (
+        item.get("source_kind") == "generated_preview"
+        and (role == "robot" or category == "robot" or "robot" in text or _robot_family_from_item(item) is not None)
+    )
+
+
+def _has_generated_robot_mesh_replacements(generated: Mapping[str, List[Json]]) -> Tuple[set[Tuple[str, str]], set[str]]:
+    replacement_keys: set[Tuple[str, str]] = set()
+    replacement_families: set[str] = set()
+    for section in ("robots", "assets"):
+        for item in generated.get(section, []):
+            if not isinstance(item, Mapping) or not _is_robot_like_generated_item(item):
+                continue
+            uri = _first_present(*(item.get(field) for field in MESH_URI_FIELDS))
+            if not _supported_mesh_uri(uri):
+                continue
+            family = _robot_family_from_item(item)
+            link = _normalized_robot_link(item)
+            if family:
+                replacement_families.add(family)
+                if link:
+                    replacement_keys.add((family, link))
+    return replacement_keys, replacement_families
+
+
+def _suppress_unresolved_placeholder_robot_visuals(generated: Dict[str, List[Json]], warnings: List[Json]) -> None:
+    replacement_keys, replacement_families = _has_generated_robot_mesh_replacements(generated)
+    if not replacement_keys and not replacement_families:
+        return
+    for section in ("robots", "assets"):
+        kept: List[Json] = []
+        for item in generated.get(section, []):
+            if not _has_unresolved_placeholder_mesh_reference(item):
+                kept.append(item)
+                continue
+            family = _robot_family_from_item(item)
+            link = _normalized_robot_link(item)
+            should_suppress = (family and ((family, link) in replacement_keys or family in replacement_families))
+            if not should_suppress and link and any((replacement_family, link) in replacement_keys for replacement_family in replacement_families):
+                should_suppress = True
+            if not should_suppress:
+                kept.append(item)
+                continue
+            item_id = str(item.get("id") or "<unknown>")
+            _warn(
+                warnings,
+                "unresolved_placeholder_visual_suppressed",
+                f"Suppressed generated visual-index item {item_id} because its mesh reference contains an unresolved xacro substitution and a generated robot mesh replacement exists.",
+                INPUTS["visual_mesh_index"],
+            )
+        generated[section] = kept
+
 def _sort_items(items: List[Json]) -> List[Json]:
     return sorted(items, key=lambda x: (str(x.get("source_kind", "")), str(x.get("category", "")), str(x.get("role", "")), str(x.get("id", ""))))
 
@@ -864,6 +953,7 @@ def build_web_scene(scene_dir: Path, *, stage_assets: bool = False, output_path:
     generated = _generated_preview_items(_as_map(data.get("visual_mesh_index")), scene_dir, warnings) if data.get("visual_mesh_index") is not None else {"robots": [], "tools": [], "assets": [], "sensors": [], "zones": []}
     _supplement_missing_tool_meshes(data, generated)
     _apply_web_scene_transform_parity_fallbacks(data, generated)
+    _suppress_unresolved_placeholder_robot_visuals(generated, warnings)
     authored = _authored_sections(data, scene_dir, warnings)
     top_robots, top_tools, top_sensors = _top_level_entities(data, warnings)
 

--- a/tests/test_workcell_studio_web_scene_contract.py
+++ b/tests/test_workcell_studio_web_scene_contract.py
@@ -197,10 +197,27 @@ def test_ur5_2f_web_scene_stages_required_product_meshes_without_required_fallba
     assert required["table"]
     assert required["camera"]
 
+    renderable_items = [
+        item
+        for bucket in ("robots", "tools", "assets", "sensors", "zones")
+        for item in payload[bucket]
+        if item.get("render_expected", True) is not False
+    ]
+    for item in renderable_items:
+        for field in ("mesh_uri", "mesh_path", "source_path", "package_uri", "resolved_source_path"):
+            value = item.get(field)
+            assert value != "${mesh}", (item.get("id"), field)
+            assert not (isinstance(value, str) and "${" in value and "}" in value), (item.get("id"), field, value)
+    assert any(
+        warning.get("code") == "unresolved_placeholder_visual_suppressed"
+        and warning.get("source") == "generated/scene_visual_mesh_index.json"
+        for warning in payload["warnings"]
+    )
+
     summary = payload["viewer_summary"]
     assert summary["renderable_count"] >= 20
     assert summary["mesh_backed_count"] >= len(required["ur5"]) + len(required["robotiq"]) + len(required["table"]) + len(required["camera"])
-    assert summary["missing_or_failed_mesh_count"] >= 1
+    assert summary["missing_or_failed_mesh_count"] == 0
     assert summary["scene_bounds"]["source_count"] == summary["renderable_count"]
     for axis in range(3):
         assert summary["scene_bounds"]["min"][axis] <= summary["scene_bounds"]["max"][axis]


### PR DESCRIPTION
### Motivation
- Generated visual-index rows sometimes contain unresolved xacro placeholders like `${mesh}` which produce primitive/placeholder visuals that shadow real mesh-backed robot visuals in Product View.
- Remove those placeholder generated visuals when a repaired/static mesh-backed visual exists for the same robot family/link so the viewer and summary counts reflect real mesh-backed geometry.

### Description
- Added helpers to detect unresolved xacro-style substitutions and mesh-bearing URIs (`_contains_unresolved_substitution`, `_has_unresolved_placeholder_mesh_reference`, `_supported_mesh_uri`).
- Added robot-family/link heuristics and replacement detection (`_robot_family_from_item`, `_normalized_robot_link`, `_is_robot_like_generated_item`, `_has_generated_robot_mesh_replacements`).
- Implemented `_suppress_unresolved_placeholder_robot_visuals` which drops generated `robots`/`assets` items whose mesh fields contain unresolved `${...}` placeholders when a generated/static mesh-backed replacement exists, and it emits `unresolved_placeholder_visual_suppressed` warnings sourced to `generated/scene_visual_mesh_index.json`.
- Wire suppression into `build_web_scene()` immediately after generated preview items are prepared and transform fallbacks are applied, and added a targeted regression test asserting no exported renderable has unresolved `${...}` mesh references while UR5, Robotiq, table, and camera mesh-backed rows remain.

### Testing
- Ran the targeted regression: `python3 -m pytest tests/test_workcell_studio_web_scene_contract.py::test_ur5_2f_web_scene_stages_required_product_meshes_without_required_fallbacks` — passed.
- Ran the contract suite: `python3 -m pytest tests/test_workcell_studio_web_scene_contract.py` — passed (6 passed).
- Ran additional smoke/unit checks: `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py` — passed (7 passed).
- Ran CLI smoke export: `python3 scripts/export_workcell_studio_web_scene.py --scene scenes/ur5_2f_test --output /tmp/ur5_2f_test.web_scene.json` and inspected the JSON — no unresolved `${...}` mesh references remained and suppression warnings were emitted.
- Note: an unrelated viewer-JS string-policy assertion surfaced during prior combined runs and is external to this exporter change; the tests exercised for this PR all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a8148b678833188c023ddb0bea2c0)