### PR TITLE
Exclude helper zones from required item summary

### DIFF
--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -910,16 +910,18 @@ def _viewer_summary(payload: Json) -> Json:
             scene_min = item_min if scene_min is None else [min(scene_min[i], item_min[i]) for i in range(3)]
             scene_max = item_max if scene_max is None else [max(scene_max[i], item_max[i]) for i in range(3)]
 
-        text = _identity_text(item)
         categories: List[str] = []
-        if "robot" in text or str(item.get("category", "")).lower() == "robot":
-            categories.append("robot")
-        if any(token in text for token in ("tool", "gripper", "robotiq", "end_effector", "suction")):
-            categories.append("tool")
-        if any(token in text for token in ("table", "workbench", "support_surface")):
-            categories.append("table")
-        if any(token in text for token in ("camera", "realsense")):
-            categories.append("camera")
+        is_helper_or_zone = _section == "zones" or _is_helper(item)
+        if not is_helper_or_zone:
+            text = _identity_text(item)
+            if "robot" in text or str(item.get("category", "")).lower() == "robot":
+                categories.append("robot")
+            if any(token in text for token in ("tool", "gripper", "robotiq", "end_effector", "suction")):
+                categories.append("tool")
+            if any(token in text for token in ("table", "workbench", "support_surface")):
+                categories.append("table")
+            if any(token in text for token in ("camera", "realsense")):
+                categories.append("camera")
         for category in categories:
             entry = required[category]
             entry["present"] = True

--- a/tests/test_workcell_studio_web_scene_contract.py
+++ b/tests/test_workcell_studio_web_scene_contract.py
@@ -225,6 +225,8 @@ def test_ur5_2f_web_scene_stages_required_product_meshes_without_required_fallba
         assert summary["required_item_status"][category]["present"] is True
         assert summary["required_item_status"][category]["status"] in {"mesh_backed", "missing_or_failed_mesh"}
         assert summary["required_item_status"][category]["item_ids"]
+    assert any(item["id"] == "safety_zone_keepout" for item in payload["zones"])
+    assert "safety_zone_keepout" not in summary["required_item_status"]["robot"]["item_ids"]
 
     required_identity_expectations = {
         "ur5": ("robots", "robot", "ur5", ("category", "role", "id", "source_kind", "source_layer", "active_visual_source", "link", "original_mesh_uri", "mesh_uri")),


### PR DESCRIPTION
### Motivation
- Prevent helper/zone items from being misclassified as required physical items in the viewer summary so overlay/safety zones (e.g. `safety_zone_keepout`) do not appear in `required_item_status` for `robot`, `tool`, `table`, or `camera` while still contributing to renderable and mesh counts.

### Description
- Modify `_viewer_summary()` in `scripts/export_workcell_studio_web_scene.py` to compute `is_helper_or_zone = _section == "zones" or _is_helper(item)` and skip adding `robot`/`tool`/`table`/`camera` categories when true, preserving all renderable, mesh-backed, fallback, and bounds calculations.
- Extend `tests/test_workcell_studio_web_scene_contract.py` to assert that `safety_zone_keepout` is present in `payload["zones"]` and is not included in `viewer_summary["required_item_status"]["robot"]["item_ids"]`.

### Testing
- Ran `pytest tests/test_workcell_studio_web_scene_contract.py -q` and the suite passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a83a3aac88331970ccd43663238c5)