### PR TITLE
Ignore Workcell Studio generated artifacts and web 3D exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,10 @@ tesseract_external/
 src/boost_plugin_loader/
 src/ros_industrial_cmake_boilerplate/
 
-# Workcell Studio generated scene outputs
-scenes/*/generated/*
+# Workcell Studio generated scene cache/artifacts
+scenes/*/generated/
 !scenes/*/generated/.gitkeep
+
+# Workcell Studio Web 3D exports
+*.web_scene.json
+workcell_studio_web_scene/


### PR DESCRIPTION
### Motivation
- Prevent committing generated scene cache/artifacts and Web 3D export files while keeping a `.gitkeep` placeholder so generated directories remain in repo history.

### Description
- Updated `.gitignore` to replace the broad `scenes/*/generated/*` rule with `scenes/*/generated/` and preserve `!scenes/*/generated/.gitkeep`, and added ignore rules for `*.web_scene.json` and `workcell_studio_web_scene/`.

### Testing
- Ran `git diff --check` which passed, and ran `git check-ignore -v` against tracked scene source files which returned no ignored matches (status `1`), confirming source files like `scene_manifest.yaml` and `urdf/*.xacro` remain tracked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bb1373f7083318ab370dc61f12d7c)