### PR TITLE
Document Web 3D generated artifact policy

### DIFF
--- a/docs/WORKCELL_STUDIO_WEB_3D_SCENE_CONTRACT.md
+++ b/docs/WORKCELL_STUDIO_WEB_3D_SCENE_CONTRACT.md
@@ -30,7 +30,9 @@ Workcell Studio source-of-truth scene data remains in the existing authored and 
 - `layout/workcell_studio_layout.yaml` for Workcell Builder editor state where applicable;
 - `cell_definition.yaml` for the generated exchange model and canonical generated cell definition;
 - `scene_manifest.yaml` for scene package indexing and contract summaries; and
-- generated backend metadata such as visual mesh indexes, validation outputs, readiness metadata, and generated package metadata.
+- generated package artifacts such as validation outputs, readiness metadata, and package indexes.
+
+Generated cache/build artifacts are not source-of-truth. In particular, `generated/scene_visual_mesh_index.json` is a regenerated visual cache produced by the mesh-index extractor for Scene3D/Web preview flows. It should not be committed under `scenes/*/generated/`; the GUI/Web viewer refresh path regenerates it automatically when it is missing, stale, or produced by an older extractor. Source-of-truth scene files remain the tracked YAML, xacro, URDF, and layout inputs (`environment.yaml`, `layout/workcell_studio_layout.yaml`, `cell_definition.yaml`, `scene_manifest.yaml`, task/config YAML, and scene URDF/xacro files).
 
 The browser UI reads and writes scene state through the web scene contract. The contract is the browser-facing interchange layer, not the canonical owner of the full workcell model.
 
@@ -68,7 +70,7 @@ Generated scene files = regenerated from source-of-truth data.
 
 ## Exporter behavior
 
-The exporter should produce deterministic, browser-readable JSON from existing Workcell Studio scene inputs. Exported web scene output belongs under `build/` by default or under an explicit user-specified output path.
+The exporter should produce deterministic, browser-readable JSON from existing Workcell Studio scene inputs. Exported web scene output belongs under `build/workcell_studio_web_scene/` by default, or under another explicitly ignored output location. Do not write or commit web scene JSON exports under `scenes/*/generated/`; those exports are viewer/build products, not canonical scene state.
 
 Exporter behavior must remain side-effect-light:
 
@@ -112,7 +114,7 @@ python3 scripts/export_workcell_studio_web_scene.py \
   --stage-assets
 ```
 
-The exporter reads only optional scene inputs (`scene_manifest.yaml`, `cell_definition.yaml`, `environment.yaml`, `layout/workcell_studio_layout.yaml`, and `generated/scene_visual_mesh_index.json`) and writes one deterministic JSON file. The payload includes `inputs` presence metadata, per-item provenance, editability/lock state, ROS world Z-up units, and backend action descriptors that are requests for backend workflows rather than frontend-side execution hooks.
+The exporter reads only optional scene inputs (`scene_manifest.yaml`, `cell_definition.yaml`, `environment.yaml`, `layout/workcell_studio_layout.yaml`, and the regenerated cache `generated/scene_visual_mesh_index.json`) and writes one deterministic JSON file under the requested ignored output path. The payload includes `inputs` presence metadata, per-item provenance, editability/lock state, ROS world Z-up units, and backend action descriptors that are requests for backend workflows rather than frontend-side execution hooks.
 
 Browsers cannot load ROS `package://` URIs directly. When `--stage-assets` is used, the exporter resolves and copies supported meshes into `build/workcell_studio_web_scene/assets/<scene_id>/...`, rewrites each staged item's `mesh_uri` to a browser-safe relative URL, and preserves the ROS/source URI in `original_mesh_uri`. Serve the repository root with `python3 -m http.server 8765` and load `http://localhost:8765/workcell_studio_web/viewer/index.html`; then choose the exported `build/workcell_studio_web_scene/<scene_id>.web_scene.json`. For `ur5_2f_test`, the expected browser result is that robot, table/workbench, camera, and gripper/tool meshes are recognizable when the source meshes exist and use supported formats.
 

--- a/docs/architecture/SCENE3D_CANVAS_CONTRACT.md
+++ b/docs/architecture/SCENE3D_CANVAS_CONTRACT.md
@@ -10,7 +10,7 @@ This document defines the non-optional stability contract for Workcell Builder S
    - Editability: editable (`editable=true`).
 
 2. `mesh_preview`
-   - Owns: mesh-backed visual preview loaded from `generated/scene_visual_mesh_index.json` when safe.
+   - Owns: mesh-backed visual preview loaded from `generated/scene_visual_mesh_index.json` when safe. This JSON file is generated cache/build output, not tracked source-of-truth, and must not be committed under `scenes/*/generated/`.
    - Must never own: authoring state unless explicitly mapped by user workflow.
    - Editability: selectable/inspectable, not authoring source.
 
@@ -34,6 +34,13 @@ This document defines the non-optional stability contract for Workcell Builder S
 - Authoring source-of-truth is `editable_layout` only.
 - `mesh_preview` and `locked_generated_urdf_visual` are preview layers and must not mutate layout YAML/environment YAML implicitly.
 - `overlay` is visual-only and cannot become data ownership.
+
+## Generated cache and web export placement
+
+- `generated/scene_visual_mesh_index.json` is generated cache/build output used by Scene3D/Web preview refresh, not canonical scene state.
+- Do not commit `generated/scene_visual_mesh_index.json` under `scenes/*/generated/`; the GUI/Web viewer refresh path regenerates it automatically when the file is missing, stale, or produced by an older extractor.
+- Source-of-truth scene state remains in tracked YAML, xacro, URDF, layout, task/config, and manifest inputs.
+- Web scene JSON exports should be written under `build/workcell_studio_web_scene/` or another ignored output location, never as committed scene artifacts under `scenes/*/generated/`.
 
 ## Fallback Rules
 
@@ -79,7 +86,6 @@ Additional invariants:
 - Editable layout items remain `editable=true`.
 - Primitive fallback cannot be deleted solely because mesh index exists.
 - If a higher-fidelity visual supersedes fallback rendering, diagnostics must retain fallback relationship metadata.
-
 
 ## Camera, FOV, and perception overlay contract
 

--- a/docs/manuals/WORKCELL_STUDIO_SCENE_READINESS.md
+++ b/docs/manuals/WORKCELL_STUDIO_SCENE_READINESS.md
@@ -27,6 +27,11 @@ The command reads `scenes/supported_scenes.yaml` as the supported-scene catalog
 and writes the readiness report artifacts under
 `build/workcell_studio_scene_readiness`.
 
+## Generated visual cache and Web 3D export policy
+
+`generated/scene_visual_mesh_index.json` is generated cache/build output for Scene3D/Web preview paths. It should not be committed under `scenes/*/generated/`; the GUI/Web viewer refresh path regenerates it automatically when needed. Keep canonical scene state in tracked source-of-truth inputs such as YAML, xacro, URDF, layout, manifest, and task/config files.
+
+Web scene JSON exports are also build/viewer outputs. Write them under `build/workcell_studio_web_scene/` or another ignored output location instead of `scenes/*/generated/`. Readiness evidence may cite regenerated outputs from a real workspace, but those generated cache/export files should not become canonical scene files.
 
 ## `ur5_2f_test` fake-hardware-only canary readiness
 
@@ -135,7 +140,6 @@ fake-hardware RViz/MoveIt readiness by itself. Treat it as debug/legacy evidence
 that may complement, but never replace, generated scene validation, package build
 checks, the broader scene readiness matrix, or fake-hardware RViz/MoveIt launch
 validation. RViz/MoveIt remains the planning and visual truth.
-
 
 ## Local `ur5_2f_test` real-workspace evidence runner
 

--- a/scripts/ensure_workcell_studio_web_scene_fresh.py
+++ b/scripts/ensure_workcell_studio_web_scene_fresh.py
@@ -5,6 +5,12 @@ The web scene consumed by browser/Product View flows depends on both scene-local
 source files and generator/configuration files.  This helper checks the expected
 outputs and refreshes them when missing, stale, or when the mesh-index extractor
 version changed.
+
+``generated/scene_visual_mesh_index.json`` is generated cache/build output for
+preview refresh, not canonical scene state, and should not be committed under
+``scenes/*/generated/``.  Web scene JSON exports should be written under
+``build/workcell_studio_web_scene/`` (or another ignored output location), while
+tracked YAML/xacro/URDF/layout inputs remain the source of truth.
 """
 
 from __future__ import annotations

--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -2,8 +2,16 @@
 """Export a dependency-light Workcell Studio scene description for web viewers.
 
 This exporter is intentionally read-only with respect to scene inputs. It only
-loads authoring/generated metadata files, normalizes the small subset needed by a
-browser preview, and writes one deterministic JSON document to --output.
+loads authoring metadata plus generated preview cache files, normalizes the small
+subset needed by a browser preview, and writes one deterministic JSON document to
+--output.
+
+``generated/scene_visual_mesh_index.json`` is treated as generated cache/build
+output that the GUI/Web refresh path can regenerate automatically; it is not a
+tracked source-of-truth scene file and should not be committed under
+``scenes/*/generated/``.  Write web scene JSON exports under
+``build/workcell_studio_web_scene/`` or another ignored output location, not as
+committed scene artifacts.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
### Motivation
- Clarify the intended ownership and placement of Scene3D/Web preview artifacts so generated cache files are not treated as source-of-truth and do not get committed into scene packages. 
- Make the web-scene exporter and freshness helper explicitly document that `generated/scene_visual_mesh_index.json` is a regenerated cache and that web JSON exports belong under `build/workcell_studio_web_scene/` or another ignored output location. 

### Description
- Updated `docs/WORKCELL_STUDIO_WEB_3D_SCENE_CONTRACT.md` to state that `generated/scene_visual_mesh_index.json` is a regenerated cache/build artifact, must not be committed under `scenes/*/generated/`, and that web scene JSON exports should go under `build/workcell_studio_web_scene/` or an ignored output path. 
- Added matching placement and cache-policy notes to `docs/architecture/SCENE3D_CANVAS_CONTRACT.md` and `docs/manuals/WORKCELL_STUDIO_SCENE_READINESS.md` to keep Scene3D, readiness, and export expectations consistent. 
- Expanded docstrings/comments in `scripts/ensure_workcell_studio_web_scene_fresh.py` and `scripts/export_workcell_studio_web_scene.py` to document the same cache vs source-of-truth guidance near the relevant tooling. 
- The changes are documentation and comment updates only; no runtime behavior, launch files, controllers, or safety defaults were modified. 
- Files changed: `docs/WORKCELL_STUDIO_WEB_3D_SCENE_CONTRACT.md`, `docs/architecture/SCENE3D_CANVAS_CONTRACT.md`, `docs/manuals/WORKCELL_STUDIO_SCENE_READINESS.md`, `scripts/ensure_workcell_studio_web_scene_fresh.py`, and `scripts/export_workcell_studio_web_scene.py`. 

### Testing
- Ran `git diff --check` to validate no whitespace/patch issues, which passed. 
- Ran `python3 -m py_compile scripts/ensure_workcell_studio_web_scene_fresh.py scripts/export_workcell_studio_web_scene.py` to check script syntax, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bb34c25d0833183614876d4568395)