### PR TITLE
Guard mesh unit autoscale for viewer assets

### DIFF
--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -938,6 +938,7 @@ def _populate_visual_bounds_item_fields(payload: Json) -> None:
     for section, item in _all_scene_items(payload):
         if not _is_mesh_item(item):
             continue
+        had_explicit_expected_dimensions = _finite_num3(item.get("expected_dimensions_m")) is not None
         local = _item_local_bounds(item)
         if local is not None:
             item["expected_dimensions_m"] = _bounds_dimensions(_scaled_bounds(local, item))
@@ -952,7 +953,12 @@ def _populate_visual_bounds_item_fields(payload: Json) -> None:
         item.setdefault("mesh_load_required", category in {"robot_link", "gripper", "table", "camera", "object"})
         # Unit autoscale is a browser-side asset convenience only.  Generated URDF
         # previews and robot links must keep authored units exactly as exported.
-        item["allow_mesh_unit_autoscale"] = bool(item.get("source_kind") != "generated_preview" and category not in {"robot_link", "zone"})
+        item["allow_mesh_unit_autoscale"] = bool(
+            had_explicit_expected_dimensions
+            and item.get("source_kind") != "generated_preview"
+            and section in {"assets", "sensors"}
+            and category in {"table", "camera", "object"}
+        )
 
 
 def _visual_bounds_contract(payload: Json, data: Mapping[str, Any]) -> Json:

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -705,6 +705,8 @@ async function tryLoadMesh(item, rendered, fallback) {
     applyMeshLocalTransform(meshObject, item);
     meshObject.updateMatrixWorld(true);
     const nativeBounds = new THREE.Box3().setFromObject(meshObject);
+    const autoscaled = maybeApplyMeshUnitAutoscale(item, meshObject, nativeBounds, uri);
+    const validationBounds = autoscaled ? new THREE.Box3().setFromObject(meshObject) : nativeBounds;
     fallback.visible = false;
     rendered.object3d.add(meshObject);
     rendered.meshObject = meshObject;
@@ -712,7 +714,7 @@ async function tryLoadMesh(item, rendered, fallback) {
     item.mesh_load_error = '';
     trackMeshLoadAttempt(item, 'loaded', loadUrl, '');
     setRenderInfo(rendered, 'mesh_loaded', uri, '');
-    diagnoseLoadedMeshBounds(item, meshObject, rendered, nativeBounds);
+    diagnoseLoadedMeshBounds(item, meshObject, rendered, validationBounds);
     const bounds = computeRenderedBounds();
     if (bounds) frameScene(bounds);
     refreshMeshLoadUi(rendered);
@@ -864,11 +866,75 @@ function meshContractCategoryOf(item) {
   if (/\b(table|workbench|bench)\b/.test(identity)) return 'table';
   if (/\b(camera|sensor|realsense|rgbd|vision)\b/.test(identity)) return 'camera';
   if (/\b(object|part|product|item)\b/.test(identity)) return 'object';
-  if (/\b(robot|arm|manipulator|ur3|ur5|ur10)\b/.test(identity)) return 'robot';
+  if (/\b(environment|asset|fixture)\b/.test(identity)) return 'environment';
+  if (/\b(robot|arm|manipulator|ur3|ur5|ur10|ur_|universal_robot)\b/.test(identity)) return 'robot';
   if (/\b(tool|gripper|eef|suction|robotiq|airpick)\b/.test(identity)) return 'tool';
   if (/\b(zone|overlay|helper|diagnostic|fov|bounds|reachability|collision)\b/.test(identity)) return 'helper';
   return 'core';
 }
+
+function meshUnitAutoscaleAllowed(item) {
+  if (!item || item.allow_mesh_unit_autoscale !== true || !item.expected_dimensions_m) return false;
+  if (item.source_kind === 'generated_preview' || item.active_visual_source === 'generated_preview') return false;
+  const category = meshContractCategoryOf(item);
+  if (!['table', 'camera', 'object', 'environment'].includes(category)) return false;
+  const identity = [
+    item.source_layer,
+    item.active_visual_source,
+    item.role,
+    item.category,
+    item.type,
+    item.id,
+    item.link,
+    item.object_name,
+    item.display_name,
+    item.source_path,
+    item.mesh_path,
+    item.package_uri,
+    item.original_mesh_uri,
+    itemLabel(item || {}),
+  ].map(value => String(value || '').toLowerCase()).join(' ');
+  return !/\b(robot|arm|manipulator|ur3|ur5|ur10|ur_|universal_robot|robotiq|gripper|suction|airpick|tool|eef|end_effector)\b/.test(identity);
+}
+function meshUnitCorrectionPayload(source, confidence, nativeBounds, correctedBounds, scale, axisRatios, targetRatio) {
+  return {
+    source,
+    confidence,
+    native_bounds: box3ToJson(nativeBounds),
+    corrected_bounds: box3ToJson(correctedBounds),
+    scale,
+    axis_ratios: axisRatios,
+    target_ratio: targetRatio,
+  };
+}
+function maybeApplyMeshUnitAutoscale(item, meshObject, nativeBounds, meshUri) {
+  if (!meshUnitAutoscaleAllowed(item)) return false;
+  const expected = expectedDimensionsOf(item);
+  const finiteNative = finiteBox3(nativeBounds);
+  const dims = finiteNative ? box3Dimensions(finiteNative) : null;
+  const axes = ['x', 'y', 'z'];
+  if (!expected || !dims || axes.some(axis => dims[axis] <= 1e-9 || expected[axis] <= 1e-9)) return false;
+  const axisRatios = Object.fromEntries(axes.map(axis => [axis, dims[axis] / expected[axis]]));
+  const ratioValues = Object.values(axisRatios);
+  const maxRatio = Math.max(...ratioValues);
+  const minRatio = Math.min(...ratioValues);
+  const uniformRatio = minRatio > 0 ? maxRatio / minRatio : Infinity;
+  const targetRatio = [1000, 100].find(target => Math.abs(maxRatio - target) / target <= 0.2 && Math.abs(minRatio - target) / target <= 0.2 && uniformRatio <= 1.25);
+  if (!targetRatio) {
+    item.mesh_unit_correction = meshUnitCorrectionPayload('viewer_expected_dimensions_m', 'rejected_non_uniform_or_unclear_ratio', finiteNative, finiteNative, 1.0, axisRatios, null);
+    appendRuntimeWarning(item, meshUri, `mesh unit autoscale rejected: native bounds do not have a clear uniform 100x or 1000x ratio to expected_dimensions_m (uniform_ratio=${uniformRatio.toFixed(3)})`, 'mesh_unit_autoscale_rejected', item.mesh_unit_correction);
+    return false;
+  }
+  const scale = targetRatio === 1000 ? 0.001 : 0.01;
+  meshObject.scale.multiplyScalar(scale);
+  meshObject.updateMatrixWorld(true);
+  const correctedBounds = finiteBox3(new THREE.Box3().setFromObject(meshObject));
+  item.mesh_unit_correction = meshUnitCorrectionPayload('viewer_expected_dimensions_m', 'clear_uniform_ratio', finiteNative, correctedBounds, scale, axisRatios, targetRatio);
+  item.visual_bounds_status = 'corrected_by_local_unit_scale';
+  appendRuntimeWarning(item, meshUri, `mesh unit autoscale applied: native bounds matched a clear ${targetRatio}x ratio to expected_dimensions_m`, 'mesh_unit_autoscale_applied', item.mesh_unit_correction);
+  return true;
+}
+
 function isCoreMeshContractItem(item) {
   return !['helper'].includes(meshContractCategoryOf(item)) && !isZone(item);
 }
@@ -889,7 +955,7 @@ function diagnoseLoadedMeshBounds(item, meshObject, rendered, nativeBounds = nul
   const worldBounds = finiteBox3(new THREE.Box3().setFromObject(meshObject));
   item.loaded_mesh_bounds = box3ToJson(localBounds);
   item.loaded_mesh_world_bounds = box3ToJson(worldBounds);
-  item.visual_bounds_status = 'valid';
+  item.visual_bounds_status = item.mesh_unit_correction?.scale && item.mesh_unit_correction.scale !== 1.0 ? 'corrected_by_local_unit_scale' : 'valid';
   const expected = expectedDimensionsOf(item);
   const dims = localBounds ? box3Dimensions(localBounds) : null;
   const worldDims = worldBounds ? box3Dimensions(worldBounds) : null;


### PR DESCRIPTION
### Motivation
- Prevent incorrect automatic unit scaling of robot and tool meshes by restricting browser-side autoscale to authored environment/assets that already include explicit size expectations. 
- Make Product View more honest about mesh units by applying only high-confidence uniform corrections (1000x or 100x) and otherwise surface diagnostics for manual resolution. 
- Preserve authored robot/gripper/tool units and generated preview fidelity so generated URDF previews and robot links are never autoscaled by the viewer. 

### Description
- Exporter change: `scripts/export_workcell_studio_web_scene.py` now sets `allow_mesh_unit_autoscale` only when an item already had explicit `expected_dimensions_m`, `source_kind != 'generated_preview'`, `section` is one of `assets`/`sensors`, and `category` is `table`/`camera`/`object` (previously more permissive). 
- Viewer changes: added `meshUnitAutoscaleAllowed`, `meshUnitCorrectionPayload`, and `maybeApplyMeshUnitAutoscale` to gate autoscale eligibility and compute/record corrections. 
- Autoscale logic: when eligible, compares native mesh bounds to `expected_dimensions_m` and applies `scale=0.001` for ~1000x or `scale=0.01` for ~100x uniform ratios, otherwise rejects autoscale and emits diagnostics. 
- Integration and metadata: autoscale is applied before final bounds validation so `diagnoseLoadedMeshBounds` uses corrected bounds when a scale was applied, and items receive `mesh_unit_correction` (with `source`, `confidence`, `native_bounds`, `corrected_bounds`, `scale`, `axis_ratios`, `target_ratio`) and runtime warnings `mesh_unit_autoscale_applied` or `mesh_unit_autoscale_rejected`; robot/tool/gripper/generated previews remain excluded. 

### Testing
- Static checks: `node --check workcell_studio_web/viewer/viewer.js` and `python3 -m py_compile scripts/export_workcell_studio_web_scene.py` both passed. 
- Unit/regression: `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py` passed (7 tests). 
- Safety: no runtime or hardware configuration was changed and robot/gripper/tool meshes remain explicitly excluded from viewer autoscaling (no real-hardware paths enabled).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bc3945680833197a0cd229726baf9)