### PR TITLE
Add visual-bounds tests and viewer mesh-unit correction labels

### DIFF
--- a/tests/test_check_workcell_web_scene_visual_bounds.py
+++ b/tests/test_check_workcell_web_scene_visual_bounds.py
@@ -1,0 +1,97 @@
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check_workcell_web_scene_visual_bounds.py"
+
+spec = importlib.util.spec_from_file_location("check_workcell_web_scene_visual_bounds", SCRIPT)
+checker = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(checker)
+
+
+def _valid_payload():
+    return {
+        "schema_version": "workcell_studio_web_scene/v1",
+        "metadata": {"visual_bounds_contract": {"status": "passed"}},
+        "robots": [
+            {
+                "id": "ur5_base_link",
+                "category": "robot",
+                "mesh_contract_category": "robot_link",
+                "mesh_load_required": True,
+                "mesh_uri": "assets/ur5/base.dae",
+                "expected_dimensions_m": [0.2, 0.2, 0.1],
+                "allow_mesh_unit_autoscale": False,
+            }
+        ],
+        "tools": [],
+        "assets": [
+            {
+                "id": "workbench",
+                "role": "support_surface",
+                "mesh_contract_category": "table",
+                "mesh_uri": "assets/table.stl",
+                "expected_dimensions_m": [1.2, 0.8, 0.08],
+                "allow_mesh_unit_autoscale": True,
+            }
+        ],
+        "sensors": [
+            {
+                "id": "realsense_camera",
+                "role": "camera",
+                "mesh_contract_category": "camera",
+                "mesh_uri": "assets/realsense.stl",
+                "expected_dimensions_m": [0.08, 0.08, 0.06],
+                "allow_mesh_unit_autoscale": True,
+            }
+        ],
+        "zones": [],
+    }
+
+
+def test_checker_accepts_visual_bounds_contract_payload():
+    summary, errors = checker.check(_valid_payload())
+    assert errors == []
+    assert summary["contract_status"] == "passed"
+    assert summary["table_item_count"] == 1
+    assert summary["camera_item_count"] == 1
+    assert summary["core_mesh_item_count"] == 3
+
+
+def test_checker_rejects_missing_dimensions_mesh_contract_and_robot_autoscale():
+    payload = _valid_payload()
+    del payload["assets"][0]["expected_dimensions_m"]
+    del payload["sensors"][0]["mesh_contract_category"]
+    payload["robots"][0]["allow_mesh_unit_autoscale"] = True
+    payload["robots"][0]["mesh_unit_correction"] = {"scale": 0.001}
+
+    summary, errors = checker.check(payload)
+
+    assert summary["contract_status"] == "failed"
+    assert any("table/workbench item but lacks expected_dimensions_m" in error for error in errors)
+    assert any("required/core mesh item but lacks mesh_contract_category" in error for error in errors)
+    assert any("allow_mesh_unit_autoscale: true" in error for error in errors)
+    assert any("contains mesh_unit_correction" in error for error in errors)
+
+
+def test_checker_cli_returns_json_summary_and_nonzero_for_violations(tmp_path):
+    web_scene = tmp_path / "scene.web_scene.json"
+    payload = _valid_payload()
+    payload["assets"][0]["expected_dimensions_m"] = [1200, 0.8, 0.08]
+    web_scene.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(web_scene), "--json"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 1
+    summary = json.loads(result.stdout)
+    assert summary["contract_status"] == "failed"
+    assert any("obviously impossible expected_dimensions_m.x" in error for error in summary["violations"])

--- a/tests/test_export_workcell_studio_web_scene.py
+++ b/tests/test_export_workcell_studio_web_scene.py
@@ -23,14 +23,14 @@ def test_export_web_scene_contract_and_determinism(tmp_path):
     )
     (scene / "environment.yaml").write_text(
         yaml.safe_dump(
-            {"environment": {"assets": [{"id": "bin", "type": "target_bin", "pose_xyz": [1, 2, 3]}]}},
+            {"environment": {"assets": [{"id": "bin", "type": "target_bin", "pose_xyz": [1, 2, 3]}], "sensors": [{"id": "realsense_camera", "role": "camera", "category": "camera", "dimensions": [0.08, 0.08, 0.06], "pose_xyz": [0.4, 0.0, 0.8], "mesh_uri": "meshes/realsense.stl"}]}},
             sort_keys=False,
         ),
         encoding="utf-8",
     )
     (scene / "layout/workcell_studio_layout.yaml").write_text(
         yaml.safe_dump(
-            {"schema_version": "workcell_studio_layout/v1", "items": [{"id": "table", "role": "support_surface", "mesh_path": str(scene / "meshes/table.stl")}]},
+            {"schema_version": "workcell_studio_layout/v1", "items": [{"id": "table", "role": "support_surface", "dimensions": [1.2, 0.8, 0.08], "mesh_path": str(scene / "meshes/table.stl")}]},
             sort_keys=False,
         ),
         encoding="utf-8",
@@ -77,6 +77,27 @@ def test_export_web_scene_contract_and_determinism(tmp_path):
     assert table["locked"] is False
     assert table["editable"] is True
     assert table["mesh_path"] == "meshes/table.stl"
+    assert table["expected_dimensions_m"] == [1.2, 0.8, 0.08]
+    assert table["mesh_contract_category"] == "table"
+    camera = next(item for item in payload["sensors"] if item["id"] == "realsense_camera")
+    assert camera["expected_dimensions_m"] == [0.08, 0.08, 0.06]
+    assert camera["mesh_contract_category"] == "camera"
+    mesh_backed_items = [
+        item
+        for section in ("robots", "tools", "assets", "sensors", "zones")
+        for item in payload[section]
+        if item.get("mesh_uri") or item.get("mesh_path") or item.get("package_uri") or item.get("mesh_url")
+    ]
+    assert mesh_backed_items
+    assert all(item.get("mesh_contract_category") for item in mesh_backed_items)
+    robot_or_generated_link_items = [
+        item
+        for section in ("robots", "tools")
+        for item in payload[section]
+        if item.get("source_kind") == "generated_preview" or item.get("link") or item.get("category") == "robot"
+    ]
+    assert robot_or_generated_link_items
+    assert all(item.get("allow_mesh_unit_autoscale") is not True for item in robot_or_generated_link_items)
     assert payload["robots"][-1]["mesh_path"] == "meshes/robot.dae"
     assert payload["robots"][-1]["final_transform"] == {"xyz": [1.1, 2.2, 3.3], "rpy": [0.1, 0.2, 1.87]}
     assert payload["robots"][-1]["world_from_visual"] == payload["robots"][-1]["final_transform"]
@@ -86,7 +107,8 @@ def test_export_web_scene_contract_and_determinism(tmp_path):
     assert payload["robots"][-1]["mesh_scale"] == [1, 1, 1]
     assert payload["robots"][-1]["baked_world_visual_matrix"] == [[1, 0, 0, 1.1], [0, 1, 0, 2.2], [0, 0, 1, 3.3], [0, 0, 0, 1]]
     assert payload["robots"][-1]["baked_world_visual_quaternion"] == [0, 0, 0, 1]
-    assert payload["sensors"][-1]["package_uri"] == "package://camera/mesh.dae"
+    camera_mesh = next(item for item in payload["sensors"] if item["id"] == "camera_mesh")
+    assert camera_mesh["package_uri"] == "package://camera/mesh.dae"
     assert payload["robots"][-1]["provenance"]["mesh_path"] == "generated/scene_visual_mesh_index.json"
     assert payload["robots"][-1]["provenance"]["final_transform"] == "generated/scene_visual_mesh_index.json"
 

--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -236,3 +236,49 @@ def test_viewer_mesh_preflight_surfaces_distinct_failure_reasons():
     assert try_load_body.index("await preflightMeshUrl") < try_load_body.index("new STLLoader().loadAsync")
     assert "item.mesh_status = preflight.status || 'url_not_served'" in try_load_body
     assert "item.mesh_status = 'loader_failure'" in try_load_body
+
+
+def test_viewer_local_mesh_transform_is_applied_to_mesh_object_not_parent_pose():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    for token in [
+        "mesh_local_transform",
+        "visual_local_transform",
+        "function applyMeshLocalTransform",
+        "applyMeshLocalTransform(meshObject, item)",
+    ]:
+        assert token in js
+
+    local_transform_body = js.split("function applyMeshLocalTransform", 1)[1].split("async function tryLoadMesh", 1)[0]
+    assert "meshObject" in local_transform_body
+    assert ".position" in local_transform_body
+    assert ".rotation" in local_transform_body
+    assert ".scale" in local_transform_body
+
+    apply_pose_body = js.split("function applyPose", 1)[1].split("function assignItemUserData", 1)[0]
+    assert "mesh_local_transform" not in apply_pose_body
+    assert "visual_local_transform" not in apply_pose_body
+    assert "applyMeshLocalTransform" not in apply_pose_body
+
+
+def test_viewer_visual_bounds_diagnostics_and_fit_bounds_contract_are_source_guarded():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    for token in [
+        "loaded_mesh_oversized",
+        "loaded_mesh_bounds_invalid",
+        "required_mesh_failed_debug_fallback",
+        "mesh_unit_correction",
+        "auto_detected_mm_to_m",
+        "auto_detected_cm_to_m",
+    ]:
+        assert token in js
+
+    fit_bounds_body = js.split("function computeFitBounds", 1)[1].split("function computeRenderedBounds", 1)[0]
+    assert "required_mesh_failed_debug_fallback" in fit_bounds_body
+    assert "includeDebugFallbacks" in fit_bounds_body
+    assert "continue" in fit_bounds_body
+    assert "excluded from normal camera fit bounds" in fit_bounds_body
+
+    unit_autoscale_body = js.split("function maybeApplyMeshUnitAutoscale", 1)[1].split("function isCoreMeshContractItem", 1)[0]
+    assert "mesh_unit_correction" in unit_autoscale_body
+    assert "auto_detected_mm_to_m" in unit_autoscale_body
+    assert "auto_detected_cm_to_m" in unit_autoscale_body

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -1033,7 +1033,8 @@ function maybeApplyMeshUnitAutoscale(item, meshObject, nativeBounds, meshUri) {
   meshObject.scale.multiplyScalar(scale);
   meshObject.updateMatrixWorld(true);
   const correctedBounds = finiteBox3(new THREE.Box3().setFromObject(meshObject));
-  item.mesh_unit_correction = meshUnitCorrectionPayload('viewer_expected_dimensions_m', 'clear_uniform_ratio', finiteNative, correctedBounds, scale, axisRatios, targetRatio);
+  const confidence = targetRatio === 1000 ? 'auto_detected_mm_to_m' : 'auto_detected_cm_to_m';
+  item.mesh_unit_correction = meshUnitCorrectionPayload('viewer_expected_dimensions_m', confidence, finiteNative, correctedBounds, scale, axisRatios, targetRatio);
   item.visual_bounds_status = 'corrected_by_local_unit_scale';
   appendRuntimeWarning(item, meshUri, `mesh unit autoscale applied: native bounds matched a clear ${targetRatio}x ratio to expected_dimensions_m`, 'mesh_unit_autoscale_applied', item.mesh_unit_correction);
   return true;


### PR DESCRIPTION
### Motivation

- Ensure exported web scene metadata provides actionable visual-bounds information for tables and cameras and that core/robot mesh items carry contract metadata rather than allowing unsafe autoscaling. 
- Provide a lightweight, dependency-free checker and static viewer tests to guard browser framing behavior and mesh-unit-detection logic without requiring ROS or a browser.

### Description

- Extended `tests/test_export_workcell_studio_web_scene.py` to assert table/support-surface `expected_dimensions_m` is `[1.2, 0.8, 0.08]`, Realsense/camera `expected_dimensions_m` is `[0.08, 0.08, 0.06]`, mesh-backed items include `mesh_contract_category`, and robot/generated link items do not set `allow_mesh_unit_autoscale: true`.
- Added `tests/test_check_workcell_web_scene_visual_bounds.py` which imports and exercises `scripts/check_workcell_web_scene_visual_bounds.py` with a passing payload, targeted failure payloads, and a CLI `--json` case that returns a nonzero exit code on violations.
- Added static/source tests in `tests/test_workcell_studio_web_viewer_static.py` to assert presence and correct placement of `mesh_local_transform`/`visual_local_transform` handling, that the local transform is applied to the loaded mesh object (not the parent group), that `required_mesh_failed_debug_fallback` is excluded from normal fit bounds, and that mesh unit-correction provenance tokens including `auto_detected_mm_to_m` and `auto_detected_cm_to_m` are present.
- Updated `workcell_studio_web/viewer/viewer.js` to annotate successful mesh unit autoscale corrections with a confidence label of either `auto_detected_mm_to_m` or `auto_detected_cm_to_m` so the viewer emits clearer diagnostic provenance when converting units.

### Testing

- Ran `python3 -m pytest tests/test_export_workcell_studio_web_scene.py tests/test_check_workcell_web_scene_visual_bounds.py tests/test_workcell_studio_web_viewer_static.py -q` and all tests passed (`23 passed`).
- Ran `git diff --check` to validate no whitespace/patch issues and committed the changes; no lint-level diffs were reported.
- Tests are dependency-light and designed to run without ROS or a browser, using only the local scripts and static viewer source.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bc6eb4d5c8331b13c00da58825288)