### PR TITLE
Add dynamic Web 3D visual acceptance

### DIFF
--- a/scripts/run_workcell_web3d_visual_acceptance.py
+++ b/scripts/run_workcell_web3d_visual_acceptance.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Run Web 3D visual acceptance for any Workcell Studio scene.
+
+The acceptance flow keeps all generated browser artifacts under
+``build/workcell_studio_web_scene/`` and validates the same staged JSON that the
+static viewer opens.  Browser collection is best-effort unless
+``--require-browser`` is supplied.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from http.server import ThreadingHTTPServer, SimpleHTTPRequestHandler
+from pathlib import Path
+from threading import Thread
+from typing import Any, Mapping, Sequence
+from urllib.parse import quote
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BUILD_ROOT = REPO_ROOT / "build" / "workcell_studio_web_scene"
+PNG_1X1 = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+)
+
+
+def _load_yaml(path: Path) -> Mapping[str, Any]:
+    if not path.is_file():
+        return {}
+    try:
+        import yaml  # type: ignore
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return data if isinstance(data, Mapping) else {}
+
+
+def _first_text(*values: Any) -> str | None:
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _safe_scene_id(raw: str) -> str:
+    cleaned = "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in raw.strip())
+    return cleaned.strip("._-") or "scene"
+
+
+def derive_scene_id(scene_dir: Path, override: str | None = None) -> str:
+    if override:
+        return _safe_scene_id(override)
+    manifest = _load_yaml(scene_dir / "scene_manifest.yaml")
+    environment = _load_yaml(scene_dir / "environment.yaml")
+    manifest_scene = manifest.get("scene") if isinstance(manifest.get("scene"), Mapping) else {}
+    env_scene = environment.get("scene") if isinstance(environment.get("scene"), Mapping) else {}
+    env_root = environment.get("environment") if isinstance(environment.get("environment"), Mapping) else {}
+    return _safe_scene_id(
+        _first_text(
+            manifest_scene.get("id"), manifest_scene.get("name"),
+            env_scene.get("id"), env_scene.get("name"),
+            env_root.get("scene_id"), env_root.get("id"), env_root.get("name"),
+            scene_dir.name,
+        ) or scene_dir.name
+    )
+
+
+def repo_relative(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def run_step(command: list[str]) -> dict[str, Any]:
+    result = subprocess.run(command, cwd=REPO_ROOT, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+    return {"command": command, "returncode": result.returncode, "stdout": result.stdout, "stderr": result.stderr}
+
+
+def is_port_open(port: int) -> bool:
+    with socket.socket() as sock:
+        sock.settimeout(0.25)
+        try:
+            sock.connect(("127.0.0.1", port))
+            return True
+        except OSError:
+            return False
+
+
+def start_or_reuse_server(port: int) -> tuple[str, ThreadingHTTPServer | None]:
+    if is_port_open(port):
+        return "reused", None
+
+    class Handler(SimpleHTTPRequestHandler):
+        def log_message(self, fmt: str, *args: Any) -> None:  # keep acceptance output concise
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", port), lambda *a, **kw: Handler(*a, directory=str(REPO_ROOT), **kw))
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    deadline = time.time() + 2.0
+    while time.time() < deadline:
+        if is_port_open(port):
+            return "started", server
+        time.sleep(0.05)
+    return "failed", server
+
+
+def browser_command(url: str, screenshot: Path) -> dict[str, Any] | None:
+    for binary in ("chromium", "chromium-browser", "google-chrome", "google-chrome-stable"):
+        exe = shutil.which(binary)
+        if exe:
+            return {
+                "command": [exe, "--headless=new", "--disable-gpu", "--no-sandbox", f"--screenshot={screenshot}", "--window-size=1280,900", url],
+                "kind": binary,
+            }
+    return None
+
+
+def run_browser(url: str, status_path: Path, screenshot_path: Path, require: bool) -> dict[str, Any]:
+    try:
+        from playwright.sync_api import sync_playwright  # type: ignore
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            page = browser.new_page(viewport={"width": 1280, "height": 900})
+            page.goto(url, wait_until="networkidle", timeout=45000)
+            page.wait_for_timeout(1000)
+            status = page.evaluate("window.__WORKCELL_VIEWER_STATUS__ || null")
+            page.screenshot(path=str(screenshot_path), full_page=True)
+            browser.close()
+        return {"available": True, "method": "playwright", "status": status}
+    except Exception as exc:
+        playwright_error = str(exc)
+
+    command_spec = browser_command(url, screenshot_path)
+    if command_spec:
+        result = subprocess.run(command_spec["command"], cwd=REPO_ROOT, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+        return {"available": result.returncode == 0, "method": command_spec["kind"], "status": None, "returncode": result.returncode, "stdout": result.stdout, "stderr": result.stderr, "playwright_error": playwright_error}
+    if require:
+        raise RuntimeError(f"No usable browser found. Playwright error: {playwright_error}")
+    screenshot_path.write_bytes(PNG_1X1)
+    return {"available": False, "method": "skipped", "status": None, "reason": f"No Playwright/chromium/google-chrome browser available. Playwright error: {playwright_error}"}
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run browser visual acceptance for a Workcell Studio Web 3D scene.")
+    parser.add_argument("--scene", required=True, help="Scene directory to export and validate.")
+    parser.add_argument("--output", help="Optional staged web_scene.json output path.")
+    parser.add_argument("--scene-id", help="Override derived scene id used for default output/report names.")
+    parser.add_argument("--require-browser", action="store_true", help="Fail if Playwright/chromium/google-chrome is unavailable or cannot run.")
+    parser.add_argument("--port", type=int, default=8765, help="Repo-root HTTP server port (default: 8765).")
+    args = parser.parse_args(argv)
+
+    scene_dir = Path(args.scene).expanduser()
+    if not scene_dir.is_absolute():
+        scene_dir = (REPO_ROOT / scene_dir).resolve()
+    if not scene_dir.is_dir():
+        print(f"error: --scene must be an existing scene directory: {scene_dir}", file=sys.stderr)
+        return 2
+
+    scene_id = derive_scene_id(scene_dir, args.scene_id)
+    output_path = Path(args.output).expanduser() if args.output else BUILD_ROOT / f"{scene_id}.web_scene.json"
+    if not output_path.is_absolute():
+        output_path = (REPO_ROOT / output_path).resolve()
+    report_path = BUILD_ROOT / f"{scene_id}.visual_acceptance.json"
+    screenshot_path = BUILD_ROOT / f"{scene_id}.visual_acceptance.png"
+    BUILD_ROOT.mkdir(parents=True, exist_ok=True)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    steps = []
+    steps.append(run_step([sys.executable, "scripts/ensure_workcell_studio_web_scene_fresh.py", "--scene", repo_relative(scene_dir), "--output", repo_relative(output_path), "--stage-assets"]))
+    if steps[-1]["returncode"] == 0:
+        steps.append(run_step([sys.executable, "scripts/check_workcell_web_scene_mesh_contract.py", repo_relative(output_path)]))
+    if steps[-1]["returncode"] == 0:
+        steps.append(run_step([sys.executable, "scripts/check_workcell_web_scene_visual_bounds.py", repo_relative(output_path), "--json"]))
+
+    server_status = "not_started"
+    server = None
+    browser = {"available": False, "method": "not_run", "status": None}
+    viewer_url = f"http://localhost:{args.port}/workcell_studio_web/viewer/index.html?scene={quote(repo_relative(output_path))}"
+    if all(step["returncode"] == 0 for step in steps):
+        server_status, server = start_or_reuse_server(args.port)
+        if server_status != "failed":
+            try:
+                browser = run_browser(viewer_url, report_path, screenshot_path, args.require_browser)
+            except Exception as exc:
+                browser = {"available": False, "method": "failed", "status": None, "error": str(exc)}
+        elif args.require_browser:
+            browser = {"available": False, "method": "server_failed", "status": None, "error": f"could not start or reuse HTTP server on port {args.port}"}
+
+    if not screenshot_path.exists():
+        screenshot_path.write_bytes(PNG_1X1)
+
+    report = {
+        "scene_id": scene_id,
+        "scene_dir": repo_relative(scene_dir),
+        "web_scene_json": repo_relative(output_path),
+        "viewer_url": viewer_url,
+        "server_status": server_status,
+        "browser": browser,
+        "steps": steps,
+        "report": repo_relative(report_path),
+        "screenshot": repo_relative(screenshot_path),
+    }
+    report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if server is not None:
+        server.shutdown()
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if any(step["returncode"] != 0 for step in steps):
+        return 1
+    if args.require_browser and not browser.get("available"):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_workcell_builder_web_viewer_action.py
+++ b/tests/test_workcell_builder_web_viewer_action.py
@@ -19,12 +19,13 @@ def test_web_viewer_action_registered_and_wired_to_export_slot():
 
 def test_web_viewer_action_exports_fresh_scene_to_build_before_opening_viewer():
     cpp = CPP.read_text(encoding="utf-8")
-    assert '"scripts" / "ensure_workcell_studio_web_scene_fresh.py"' in cpp
+    assert '"scripts" / "run_workcell_web3d_visual_acceptance.py"' in cpp
     assert 'repo_root / "build" / "workcell_studio_web_scene"' in cpp
     assert 'scene_id + ".web_scene.json"' in cpp
+    assert 'scene_dir_for_current_selection()' in cpp
     assert '"--scene", QString::fromStdString(scene_dir.string())' in cpp
     assert '"--output", QString::fromStdString(output_path.string())' in cpp
-    assert '"--stage-assets"' in cpp
+    assert '"--port", "8765"' in cpp
     assert 'repo_root / "workcell_studio_web" / "viewer" / "index.html"' in cpp
     assert (
         "Web 3D scene export failed; viewer not opened with stale generated artifacts."

--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -53,6 +53,21 @@ def test_viewer_records_render_status_for_inspector():
     assert "rendered.renderInfo" in js
 
 
+def test_viewer_exposes_browser_acceptance_status_hook():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    for token in [
+        "window.__WORKCELL_VIEWER_STATUS__",
+        "scene_name",
+        "renderable_count",
+        "mesh_loaded_count",
+        "required_mesh_failed_count",
+        "fallback_count",
+        "runtime_warnings",
+        "updateViewerStatus",
+    ]:
+        assert token in js
+
+
 def test_viewer_allows_valid_empty_scene_with_empty_message():
     js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
     assert "EMPTY_SCENE_MESSAGE" in js

--- a/tests/test_workcell_web3d_visual_acceptance.py
+++ b/tests/test_workcell_web3d_visual_acceptance.py
@@ -1,0 +1,39 @@
+import importlib.util
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/run_workcell_web3d_visual_acceptance.py"
+spec = importlib.util.spec_from_file_location("web3d_acceptance", SCRIPT)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+def test_derives_scene_id_from_arbitrary_manifest_scene(tmp_path):
+    scene = tmp_path / "not_ur5"
+    scene.mkdir()
+    (scene / "scene_manifest.yaml").write_text(yaml.safe_dump({"scene": {"id": "custom_cell_42"}}), encoding="utf-8")
+    assert module.derive_scene_id(scene) == "custom_cell_42"
+    default_output = module.BUILD_ROOT / f"{module.derive_scene_id(scene)}.web_scene.json"
+    assert default_output == ROOT / "build/workcell_studio_web_scene/custom_cell_42.web_scene.json"
+
+
+def test_derives_scene_id_from_environment_then_folder(tmp_path):
+    scene = tmp_path / "folder_scene"
+    scene.mkdir()
+    (scene / "environment.yaml").write_text(yaml.safe_dump({"environment": {"scene_id": "env_scene"}}), encoding="utf-8")
+    assert module.derive_scene_id(scene) == "env_scene"
+    (scene / "environment.yaml").unlink()
+    assert module.derive_scene_id(scene) == "folder_scene"
+
+
+def test_acceptance_script_has_no_ur5_scene_logic_and_outputs_under_build():
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "scenes/ur5_2f_test" not in text
+    assert "ensure_workcell_studio_web_scene_fresh.py" in text
+    assert "check_workcell_web_scene_mesh_contract.py" in text
+    assert "check_workcell_web_scene_visual_bounds.py" in text
+    assert "build" in text and "workcell_studio_web_scene" in text
+    assert "visual_acceptance.json" in text
+    assert "visual_acceptance.png" in text

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -3717,7 +3717,7 @@ void SceneSelect::on_export_open_web_3d_viewer_clicked()
   }
 
   const std::string scene_id = sanitize_scene_name(workcell.scene_vector[current_index].name);
-  const fs::path scene_dir = scenes_path / workcell.scene_vector[current_index].name;
+  const fs::path scene_dir = scene_dir_for_current_selection();
   if (scene_id.empty()) {
     const QString message = "No scene selected. The selected scene has an empty or invalid scene ID.";
     append_error(message.toStdString());
@@ -3736,11 +3736,11 @@ void SceneSelect::on_export_open_web_3d_viewer_clicked()
   fs::path repo_root = resolve_tool_root(workcell_path, scene_dir);
   fs::path exporter_script;
   if (!repo_root.empty()) {
-    exporter_script = repo_root / "scripts" / "ensure_workcell_studio_web_scene_fresh.py";
+    exporter_script = repo_root / "scripts" / "run_workcell_web3d_visual_acceptance.py";
   }
   if (repo_root.empty() || !fs::exists(exporter_script, ec)) {
     const QString message = QString(
-      "Exporter script missing. Expected scripts/ensure_workcell_studio_web_scene_fresh.py under the Workcell Studio repo root. "
+      "Exporter script missing. Expected visual acceptance script scripts/run_workcell_web3d_visual_acceptance.py under the Workcell Studio repo root. "
       "Set WORKCELL_STUDIO_REPO_ROOT=/path/to/easy_manipulation_deployment. Scene path: %1")
       .arg(QString::fromStdString(scene_dir.string()));
     append_error(message.toStdString());
@@ -3759,9 +3759,9 @@ void SceneSelect::on_export_open_web_3d_viewer_clicked()
     QString::fromStdString(exporter_script.string()),
     "--scene", QString::fromStdString(scene_dir.string()),
     "--output", QString::fromStdString(output_path.string()),
-    "--stage-assets"};
+    "--port", "8765"};
   const QString command_text = "python3 " + args.join(' ');
-  append_info("Export Web 3D Viewer scene: " + command_text.toStdString());
+  append_info("Run Web 3D visual acceptance for selected scene: " + command_text.toStdString());
   QProcess exporter_process;
   exporter_process.setProgram("python3");
   exporter_process.setArguments(args);
@@ -3788,7 +3788,7 @@ void SceneSelect::on_export_open_web_3d_viewer_clicked()
   if (!process_ok || rc != 0 || !output_exists) {
     const QString failure_reason = !process_ok
       ? exporter_process.errorString()
-      : (output_exists ? QString("freshness script exited nonzero") : QString("freshness script did not create the expected output file"));
+      : (output_exists ? QString("visual acceptance script exited nonzero") : QString("visual acceptance script did not create the expected output file"));
     const QString message = QString(
       "Web 3D scene export failed; viewer not opened with stale generated artifacts.\n\n"
       "Reason: %1\n"

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -69,9 +69,28 @@ function computeSceneSummary() {
     editableCount: rendered.filter(obj => canEditItem(obj.item)).length,
   };
 }
-function renderSceneSummary() {
-  if (!el.summary) return;
+function updateViewerStatus() {
   const summary = computeSceneSummary();
+  const warnings = asArray(state.sceneJson?.warnings).concat(asArray(state.sceneJson?.notes_warnings), asArray(state.runtimeWarnings));
+  window.__WORKCELL_VIEWER_STATUS__ = {
+    scene_name: summary.sceneName,
+    sceneName: summary.sceneName,
+    renderable_count: summary.renderableCount,
+    renderableCount: summary.renderableCount,
+    mesh_loaded_count: summary.meshLoadedCount,
+    meshLoadedCount: summary.meshLoadedCount,
+    required_mesh_failed_count: (state.objects || []).filter(obj => obj.renderInfo?.render_status === 'required_mesh_failed_debug_fallback' || obj.item?.renderInfo?.render_status === 'required_mesh_failed_debug_fallback').length,
+    requiredMeshFailedCount: (state.objects || []).filter(obj => obj.renderInfo?.render_status === 'required_mesh_failed_debug_fallback' || obj.item?.renderInfo?.render_status === 'required_mesh_failed_debug_fallback').length,
+    fallback_count: summary.fallbackCount,
+    fallbackCount: summary.fallbackCount,
+    runtime_warnings: warnings,
+    runtimeWarnings: warnings,
+  };
+  return window.__WORKCELL_VIEWER_STATUS__;
+}
+function renderSceneSummary() {
+  const summary = updateViewerStatus();
+  if (!el.summary) return;
   el.summary.classList.toggle('empty', !state.sceneJson);
   const fields = {
     'scene-name': summary.sceneName,
@@ -1495,6 +1514,7 @@ function populateInspector(renderedOrItem) {
 }
 function refreshWarnings(sceneJson = state.sceneJson) {
   const warnings = asArray(sceneJson?.warnings).concat(asArray(sceneJson?.notes_warnings), asArray(state.runtimeWarnings));
+  updateViewerStatus();
   if (!warnings.length) { el.warnings.className = 'warnings state empty'; el.warnings.textContent = 'No JSON or runtime mesh warnings.'; return; }
   el.warnings.className = 'warnings';
   el.warnings.innerHTML = warnings.map(w => {


### PR DESCRIPTION
Summary:
- Added `scripts/run_workcell_web3d_visual_acceptance.py` to export, validate, serve, and optionally browser-check any selected scene without hardcoding `scenes/ur5_2f_test`.
- Added the `window.__WORKCELL_VIEWER_STATUS__` browser hook with scene name, renderable/mesh/fallback counts, required mesh failures, and runtime warnings.
- Updated Workcell Builder’s “Export & Open Web 3D Viewer” action to run the acceptance script for `scene_dir_for_current_selection()` and keep outputs under `build/workcell_studio_web_scene/`.
- Added static/unit coverage for arbitrary scene-id derivation, no hardcoded ur5 script logic, selected-scene GUI command wiring, generated-output policy, and viewer status hook tokens.

Validation:
- `python3 -m pytest -q tests/test_workcell_web3d_visual_acceptance.py tests/test_workcell_builder_web_viewer_action.py tests/test_workcell_studio_web_viewer_static.py tests/test_export_workcell_studio_web_scene.py` passed: 28 tests.
- `python3 scripts/run_workcell_web3d_visual_acceptance.py --scene scenes/ur5_2f_test --port 8765` failed honestly at the existing visual-bounds checker: mesh contract passed, but visual-bounds reported 5 violations in the generated web scene. Browser was not started because the pre-browser checker failed.
- `git diff --check` passed.
- `git ls-files 'scenes/*/generated/*.json' 'build/workcell_studio_web_scene/*.json' 'build/workcell_studio_web_scene/*.png'` returned no tracked generated reports/screenshots.

Safety:
- No ROS launch, robot execution, Gazebo, Isaac, FK rewrite, controller, runtime-service, or hardware-parameter paths were changed.
- Fake-hardware-first and no-real-robot-motion defaults are unaffected.
- Acceptance artifacts are written under `build/workcell_studio_web_scene/`, not committed under `scenes/*/generated/`.

Risks / rollback:
- The new acceptance script gates browser launch on the mesh and visual-bounds checkers. Current `ur5_2f_test` visual-bounds drift is surfaced as a failure rather than hidden.
- Non-Playwright Chromium fallback can capture a screenshot but cannot evaluate `window.__WORKCELL_VIEWER_STATUS__`; Playwright remains the preferred full browser-status path.
- Roll back safely by reverting commit `e18097f`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bc934805c8331951954ba4c1e8389)