### PR TITLE
Report camera_framing_blockers as strict violations in visual-bounds checker

### DIFF
--- a/scripts/check_workcell_web_scene_visual_bounds.py
+++ b/scripts/check_workcell_web_scene_visual_bounds.py
@@ -144,6 +144,22 @@ def check(payload: Mapping[str, Any]) -> tuple[Json, list[str]]:
             errors.append("metadata.visual_bounds_contract.status is absent even though visual_bounds_contract is present")
         elif str(status).strip().lower() not in PASS_STATUSES:
             errors.append(f"metadata.visual_bounds_contract.status must be pass or passed, got {status!r}")
+
+        camera_framing_blockers = visual_contract.get("camera_framing_blockers")
+        if isinstance(camera_framing_blockers, list) and camera_framing_blockers:
+            for index, blocker in enumerate(camera_framing_blockers):
+                if isinstance(blocker, Mapping):
+                    blocker_id = blocker.get("id", "<unknown>")
+                    category = blocker.get("category", "<unknown>")
+                    reason = blocker.get("reason", "<unknown>")
+                else:
+                    blocker_id = f"<invalid blocker #{index}>"
+                    category = "<unknown>"
+                    reason = "blocker entry is not an object"
+                errors.append(
+                    "metadata.visual_bounds_contract.camera_framing_blockers "
+                    f"contains blocker id={blocker_id!r}, category={category!r}, reason={reason!r}"
+                )
     # If the entire visual_bounds_contract object is absent, treat the file as a
     # pre-viewer/runtime-validation export and do not fail solely for that reason.
 

--- a/tests/test_check_workcell_web_scene_visual_bounds.py
+++ b/tests/test_check_workcell_web_scene_visual_bounds.py
@@ -62,7 +62,6 @@ def test_checker_accepts_visual_bounds_contract_payload():
     assert summary["core_mesh_item_count"] == 3
 
 
-
 def test_checker_rejects_visual_bounds_contract_failed_status_with_blockers():
     payload = _valid_payload()
     payload["metadata"]["visual_bounds_contract"] = {
@@ -77,6 +76,38 @@ def test_checker_rejects_visual_bounds_contract_failed_status_with_blockers():
     assert summary["contract_status"] == "failed"
     assert any("metadata.visual_bounds_contract.status must be pass or passed" in error for error in errors)
 
+
+def test_checker_cli_reports_camera_framing_blocker_as_violation(tmp_path):
+    web_scene = tmp_path / "scene.web_scene.json"
+    payload = _valid_payload()
+    payload["metadata"]["visual_bounds_contract"] = {
+        "status": "passed",
+        "camera_framing_blockers": [
+            {
+                "id": "helper_bounds_box",
+                "category": "bounds_box",
+                "reason": "helper_overlay_would_dominate_product_view",
+            }
+        ],
+    }
+    web_scene.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(web_scene), "--json"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 1
+    summary = json.loads(result.stdout)
+    assert summary["contract_status"] == "failed"
+    assert any(
+        "helper_bounds_box" in error
+        and "bounds_box" in error
+        and "helper_overlay_would_dominate_product_view" in error
+        for error in summary["violations"]
+    )
 
 def test_checker_rejects_missing_dimensions_mesh_contract_and_robot_autoscale():
     payload = _valid_payload()


### PR DESCRIPTION
### Motivation
- The web-scene visual-bounds contract must fail when the viewer reports camera framing blockers so exported scenes do not silently pass with overlays that dominate Product View.
- Preserve existing status validation so a non-`pass` `metadata.visual_bounds_contract.status` still causes failure.
- Add coverage to ensure CLI JSON output and exit codes reflect blocker-driven failures.

### Description
- Updated `check(payload)` in `scripts/check_workcell_web_scene_visual_bounds.py` to inspect `metadata.visual_bounds_contract.camera_framing_blockers` and append one readable violation per blocker including the blocker `id`, `category`, and `reason` when the list is non-empty. 
- Kept the existing status validation: a non-`pass`/`passed` `status` still produces a failure entry and does not get overridden by blocker handling. 
- Added a targeted test `tests/test_check_workcell_web_scene_visual_bounds.py::test_checker_cli_reports_camera_framing_blocker_as_violation` that writes a web scene with one blocker and asserts the CLI JSON summary includes the blocker in `violations` and that the checker exits as failed.

### Testing
- Ran `python3 -m pytest tests/test_check_workcell_web_scene_visual_bounds.py` which executed the suite (including the new blocker test) and all tests passed. 
- The CLI invocation used in tests calls the script with `--json` and asserts `contract_status` is `failed` and the `violations` list contains the blocker details. 
- No other automated tests were modified and the change is limited to static metadata validation with strict handling of blockers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bcccc69348331a4a4f782e1585d16)