### PR TITLE
Add Web 3D visual-acceptance CI (Playwright Chromium + artifacts)

### DIFF
--- a/.github/workflows/web3d-visual-acceptance.yml
+++ b/.github/workflows/web3d-visual-acceptance.yml
@@ -1,0 +1,93 @@
+name: Web 3D Visual Acceptance
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - scripts/run_workcell_web3d_visual_acceptance.py
+      - scripts/export_workcell_studio_web_scene.py
+      - scripts/check_workcell_web_scene_mesh_contract.py
+      - scripts/check_workcell_web_scene_visual_bounds.py
+      - workcell_studio_web/**
+      - tests/test_workcell_web3d_visual_acceptance.py
+      - tests/test_workcell_studio_web_viewer_static.py
+      - scenes/ur5_2f_test/**
+
+jobs:
+  browser-proof:
+    name: Browser render ur5_2f_test
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python test and browser tooling
+        run: python3 -m pip install --upgrade pip pytest playwright pyyaml
+
+      - name: Install Playwright Chromium
+        run: python3 -m playwright install --with-deps chromium
+
+      - name: Run Web 3D browser visual acceptance
+        run: |
+          python3 scripts/run_workcell_web3d_visual_acceptance.py \
+            --scene scenes/ur5_2f_test \
+            --port 8765 \
+            --require-browser
+
+      - name: Add Web 3D artifact summary
+        if: always()
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          report_path = Path('build/workcell_studio_web_scene/ur5_2f_test.visual_acceptance.json')
+          screenshot_name = 'ur5_2f_test.visual_acceptance.png'
+          report_name = 'ur5_2f_test.visual_acceptance.json'
+          if report_path.is_file():
+              report = json.loads(report_path.read_text(encoding='utf-8'))
+              status = (report.get('browser') or {}).get('status') or {}
+              browser_status = (report.get('browser') or {}).get('method', 'unknown')
+              rows = [
+                  ('scene id', report.get('scene_id', 'ur5_2f_test')),
+                  ('browser_runtime_status', browser_status),
+                  ('mesh_loaded_count', status.get('mesh_loaded_count', 0)),
+                  ('required_mesh_failed_count', status.get('required_mesh_failed_count', 0)),
+                  ('fallback_count', status.get('fallback_count', 0)),
+                  ('screenshot artifact name', screenshot_name),
+                  ('report artifact name', report_name),
+              ]
+          else:
+              rows = [
+                  ('scene id', 'ur5_2f_test'),
+                  ('browser_runtime_status', 'report missing'),
+                  ('mesh_loaded_count', 'n/a'),
+                  ('required_mesh_failed_count', 'n/a'),
+                  ('fallback_count', 'n/a'),
+                  ('screenshot artifact name', screenshot_name),
+                  ('report artifact name', report_name),
+              ]
+          summary = Path(__import__('os').environ['GITHUB_STEP_SUMMARY'])
+          with summary.open('a', encoding='utf-8') as fh:
+              fh.write('## Web 3D visual acceptance\n\n')
+              fh.write('| Field | Value |\n| --- | --- |\n')
+              for key, value in rows:
+                  fh.write(f'| {key} | {value} |\n')
+          PY
+
+      - name: Upload Web 3D visual acceptance artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ur5_2f_test-web3d-visual-acceptance
+          if-no-files-found: error
+          path: |
+            build/workcell_studio_web_scene/ur5_2f_test.visual_acceptance.json
+            build/workcell_studio_web_scene/ur5_2f_test.visual_acceptance.png
+            build/workcell_studio_web_scene/ur5_2f_test.web_scene.json

--- a/scripts/run_workcell_web3d_visual_acceptance.py
+++ b/scripts/run_workcell_web3d_visual_acceptance.py
@@ -131,7 +131,8 @@ def run_browser(url: str, status_path: Path, screenshot_path: Path, require: boo
             browser = p.chromium.launch(headless=True)
             page = browser.new_page(viewport={"width": 1280, "height": 900})
             page.goto(url, wait_until="networkidle", timeout=45000)
-            page.wait_for_timeout(1000)
+            page.wait_for_function("window.__WORKCELL_VIEWER_STATUS__ && typeof window.__WORKCELL_VIEWER_STATUS__ === 'object'", timeout=45000)
+            page.wait_for_function("() => { const s = window.__WORKCELL_VIEWER_STATUS__ || {}; return (s.renderable_count || s.renderableCount || 0) === 0 || (s.mesh_loaded_count || s.meshLoadedCount || 0) > 0 || (s.required_mesh_failed_count || s.requiredMeshFailedCount || 0) > 0 || (s.fallback_count || s.fallbackCount || 0) > 0; }", timeout=45000)
             status = page.evaluate("window.__WORKCELL_VIEWER_STATUS__ || null")
             page.screenshot(path=str(screenshot_path), full_page=True)
             browser.close()
@@ -213,9 +214,25 @@ def main(argv: Sequence[str] | None = None) -> int:
     if server is not None:
         server.shutdown()
     print(json.dumps(report, indent=2, sort_keys=True))
+    print(f"viewer_url: {viewer_url}")
+    print(f"screenshot_path: {repo_relative(screenshot_path)}")
+    print(f"report_path: {repo_relative(report_path)}")
     if any(step["returncode"] != 0 for step in steps):
         return 1
     if args.require_browser and not browser.get("available"):
+        return 1
+    status = browser.get("status") if isinstance(browser, Mapping) else None
+    if isinstance(status, Mapping):
+        mesh_loaded_count = int(status.get("mesh_loaded_count") or status.get("meshLoadedCount") or 0)
+        required_mesh_failed_count = int(status.get("required_mesh_failed_count") or status.get("requiredMeshFailedCount") or 0)
+        if mesh_loaded_count == 0:
+            print("error: browser viewer loaded zero mesh-backed visuals (mesh_loaded_count == 0)", file=sys.stderr)
+            return 1
+        if required_mesh_failed_count > 0:
+            print(f"error: browser viewer reported required mesh failures (required_mesh_failed_count == {required_mesh_failed_count})", file=sys.stderr)
+            return 1
+    elif args.require_browser:
+        print("error: browser viewer did not expose window.__WORKCELL_VIEWER_STATUS__", file=sys.stderr)
         return 1
     return 0
 

--- a/tests/test_workcell_web3d_visual_acceptance.py
+++ b/tests/test_workcell_web3d_visual_acceptance.py
@@ -37,3 +37,66 @@ def test_acceptance_script_has_no_ur5_scene_logic_and_outputs_under_build():
     assert "build" in text and "workcell_studio_web_scene" in text
     assert "visual_acceptance.json" in text
     assert "visual_acceptance.png" in text
+
+WORKFLOW = ROOT / ".github/workflows/web3d-visual-acceptance.yml"
+
+
+def test_web3d_visual_acceptance_workflow_exists():
+    assert WORKFLOW.is_file()
+
+
+def test_web3d_visual_acceptance_workflow_requires_browser_runtime():
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "scripts/run_workcell_web3d_visual_acceptance.py" in text
+    assert "--require-browser" in text
+    assert "python3 -m playwright install --with-deps chromium" in text
+
+
+def test_web3d_visual_acceptance_workflow_uploads_screenshot_report_and_scene_artifacts():
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "actions/upload-artifact@v4" in text
+    assert "build/workcell_studio_web_scene/ur5_2f_test.visual_acceptance.json" in text
+    assert "build/workcell_studio_web_scene/ur5_2f_test.visual_acceptance.png" in text
+    assert "build/workcell_studio_web_scene/ur5_2f_test.web_scene.json" in text
+    assert "GITHUB_STEP_SUMMARY" in text
+    for token in [
+        "scene id",
+        "browser_runtime_status",
+        "mesh_loaded_count",
+        "required_mesh_failed_count",
+        "fallback_count",
+        "screenshot artifact name",
+        "report artifact name",
+    ]:
+        assert token in text
+
+
+def test_web3d_visual_acceptance_workflow_does_not_commit_generated_outputs():
+    result = __import__("subprocess").run(
+        [
+            "git",
+            "ls-files",
+            "scenes/*/generated/*.json",
+            "build/workcell_studio_web_scene/*.json",
+            "build/workcell_studio_web_scene/*.png",
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=__import__("subprocess").PIPE,
+        stderr=__import__("subprocess").PIPE,
+    )
+    assert result.stdout.splitlines() == []
+
+
+def test_acceptance_script_supports_playwright_browser_status_path():
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "from playwright.sync_api import sync_playwright" in text
+    assert "p.chromium.launch" in text
+    assert "window.__WORKCELL_VIEWER_STATUS__" in text
+    assert "page.wait_for_function" in text
+    assert "mesh_loaded_count == 0" in text
+    assert "required_mesh_failed_count > 0" in text
+    assert "viewer_url:" in text
+    assert "screenshot_path:" in text
+    assert "report_path:" in text


### PR DESCRIPTION
### Motivation
- Provide repeatable, reviewable browser-based proof that the Workcell Studio Web 3D viewer renders the canonical `ur5_2f_test` scene in CI and surface visual artifacts for review.
- Previous runs skipped browser rendering when Playwright/Chromium was unavailable, preventing visual verification from CI.

### Description
- Add a focused GitHub Actions workflow at `.github/workflows/web3d-visual-acceptance.yml` that triggers on `workflow_dispatch` and `pull_request` path filters for the viewer, export/check scripts, tests, and `scenes/ur5_2f_test`, and which checks out the repo, sets up Python, installs `pytest`/`playwright`/`pyyaml`, runs `python3 -m playwright install --with-deps chromium`, runs the acceptance script with `--require-browser`, writes a step Markdown summary to `GITHUB_STEP_SUMMARY`, and uploads the JSON report, PNG screenshot, and staged web-scene JSON as artifacts.
- Make the acceptance runner `scripts/run_workcell_web3d_visual_acceptance.py` CI-friendly by using Playwright when available, waiting for `window.__WORKCELL_VIEWER_STATUS__` via `page.wait_for_function`, taking the screenshot after the viewer exposes status, printing `viewer_url`, `screenshot_path`, and `report_path` to stdout, and failing clearly when `mesh_loaded_count == 0` or `required_mesh_failed_count > 0` (or when the `__WORKCELL_VIEWER_STATUS__` hook is missing while `--require-browser` is set).
- Add/extend tests in `tests/test_workcell_web3d_visual_acceptance.py` to assert the new workflow file exists, that the workflow installs Playwright Chromium and invokes the acceptance script with `--require-browser`, that artifact upload paths are present, and that generated web_scene outputs are not tracked in the repository.

### Testing
- Ran `python3 -m pytest -q tests/test_workcell_web3d_visual_acceptance.py tests/test_workcell_studio_web_viewer_static.py`, and all tests passed (`24 passed`).
- Verified the new workflow file exists at `.github/workflows/web3d-visual-acceptance.yml` and contains `python3 -m playwright install --with-deps chromium` and `--require-browser` usage.
- Verified repository does not track generated web scene outputs via `git ls-files 'scenes/*/generated/*.json' 'build/workcell_studio_web_scene/*.json' 'build/workcell_studio_web_scene/*.png'` which returned no tracked files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bd02d39308331849522884e630690)