### PR TITLE
Hide camera framing exclusions from Warnings panel while preserving diagnostics

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -297,3 +297,31 @@ def test_viewer_visual_bounds_diagnostics_and_fit_bounds_contract_are_source_gua
     assert "mesh_unit_correction" in unit_autoscale_body
     assert "auto_detected_mm_to_m" in unit_autoscale_body
     assert "auto_detected_cm_to_m" in unit_autoscale_body
+
+
+def test_viewer_hides_camera_framing_exclusions_from_user_warning_panel_but_keeps_status_raw():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    for token in [
+        "function isUserFacingWarning(w)",
+        "w.code === 'camera_framing_blocker_excluded'",
+        "return false",
+        "required_mesh_failed",
+        "invalid_dimension",
+        "visual_contract",
+        "unsafe_path",
+        "unsupported_format",
+        "missing_file",
+        "loader_failure",
+        "load_error",
+    ]:
+        assert token in js
+
+    refresh_body = js.split("function refreshWarnings", 1)[1].split("function populateWarnings", 1)[0]
+    assert "const userFacingWarnings = warnings.filter(isUserFacingWarning);" in refresh_body
+    assert "userFacingWarnings.map" in refresh_body
+    assert "warnings.map" not in refresh_body
+
+    status_body = js.split("function updateViewerStatus", 1)[1].split("function renderSceneSummary", 1)[0]
+    assert "runtime_warnings: warnings" in status_body
+    assert "runtimeWarnings: warnings" in status_body
+    assert "filter(isUserFacingWarning)" not in status_body

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -70,6 +70,30 @@ function computeSceneSummary() {
     editableCount: rendered.filter(obj => canEditItem(obj.item)).length,
   };
 }
+function isUserFacingWarning(w) {
+  if (!w) return false;
+  if (w.code === 'camera_framing_blocker_excluded') return false;
+  if (w.mesh_load_error || w.mesh_load_warning) return true;
+  if (Array.isArray(w.missing_files) && w.missing_files.length) return true;
+  if (w.missing_file) return true;
+  const fields = [
+    w.code, w.status, w.source, w.reason, w.message, w.mesh_status, w.mesh_load_status, w.render_status,
+    w.visual_bounds_status, w.fallback_or_skip_reason,
+  ];
+  const text = fields.map(value => Array.isArray(value) ? value.join(' ') : String(value || '')).join(' ').toLowerCase();
+  const realFailureTokens = [
+    'mesh_load_error', 'mesh load error', 'mesh_load_warning', 'mesh load warning',
+    'required_mesh_failed', 'required mesh failed', 'required_mesh_failed_debug_fallback',
+    'invalid_dimension', 'invalid_dimensions', 'invalid dimensions', 'invalid_renderable_transform', 'invalid_mesh_local_transform',
+    'loaded_mesh_bounds_invalid', 'loaded_mesh_collapsed', 'loaded_mesh_oversized',
+    'visual_contract', 'visual bounds', 'visual_bounds_status',
+    'unsafe_path', 'unsafe path', 'unsupported_format', 'unsupported format',
+    'missing_file', 'missing file', 'missing files', 'not found',
+    'loader_failure', 'loader failure', 'mesh_loader_failure', 'load_error', 'load error',
+    'url_not_served', 'file_access_blocked', 'unresolved_package_uri',
+  ];
+  return realFailureTokens.some(token => text.includes(token));
+}
 function updateViewerStatus() {
   const summary = computeSceneSummary();
   const warnings = asArray(state.sceneJson?.warnings).concat(asArray(state.sceneJson?.notes_warnings), asArray(state.runtimeWarnings));
@@ -1575,10 +1599,11 @@ function populateInspector(renderedOrItem) {
 }
 function refreshWarnings(sceneJson = state.sceneJson) {
   const warnings = asArray(sceneJson?.warnings).concat(asArray(sceneJson?.notes_warnings), asArray(state.runtimeWarnings));
+  const userFacingWarnings = warnings.filter(isUserFacingWarning);
   updateViewerStatus();
-  if (!warnings.length) { el.warnings.className = 'warnings state empty'; el.warnings.textContent = 'No JSON or runtime mesh warnings.'; return; }
+  if (!userFacingWarnings.length) { el.warnings.className = 'warnings state empty'; el.warnings.textContent = 'No user-facing JSON or runtime mesh warnings.'; return; }
   el.warnings.className = 'warnings';
-  el.warnings.innerHTML = warnings.map(w => {
+  el.warnings.innerHTML = userFacingWarnings.map(w => {
     const label = w.code || w.source || 'warning';
     const details = w.message || w.reason || JSON.stringify(w);
     const objectDetails = w.object_id || w.mesh_uri ? `<br><code>object=${escapeHtml(w.object_id)} link=${escapeHtml(w.link || w.object_name || '')} original=${escapeHtml(w.original_mesh_uri || '')} mesh=${escapeHtml(w.mesh_uri)}</code>` : '';


### PR DESCRIPTION
### Motivation
- Keep `camera_framing_blocker_excluded` present in runtime diagnostics/status payloads for browser acceptance and debugging while preventing it from polluting the normal Warnings panel shown to users.
- Ensure the Warnings panel surfaces only real user-facing failures (mesh load errors, required-mesh failures, invalid dimensions/transforms, visual contract failures, unsafe paths, unsupported formats, missing files, loader failures) so that users see actionable problems.

### Description
- Added a new helper `isUserFacingWarning(w)` in `workcell_studio_web/viewer/viewer.js` that returns `false` for `w.code === 'camera_framing_blocker_excluded'` and returns `true` for real failure indicators including `mesh_load_error`, `mesh_load_warning`, `missing_files`, `missing_file`, and a set of failure tokens for required-mesh, loader, visual-bounds, unsafe/unsupported URIs, and similar errors.
- Updated `refreshWarnings()` to filter warnings with `isUserFacingWarning(w)` before rendering the Warnings panel so camera-framing exclusions are hidden from the normal UI.
- Left `updateViewerStatus()` unchanged so `runtime_warnings` / `runtimeWarnings` in the exported status JSON continue to include the full raw warning list for browser-acceptance and debug reporting.
- Added a static regression test in `tests/test_workcell_studio_web_viewer_static.py` that verifies the presence of the new helper, the panel filter usage, and that the status payload remains unfiltered.

### Testing
- Ran `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py -q` and the suite passed (17 tests) confirming the new test and existing static checks succeeded.
- Ran `node --check workcell_studio_web/viewer/viewer.js` with no syntax errors reported.
- Ran `git diff --check` as part of pre-commit validation with no whitespace/errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cea7481e88331b49f8b2b84938680)