### PR TITLE
Web3D viewer: exclude debug/helper overlays from mesh status counts and add status tests

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -341,6 +341,7 @@ def test_viewer_load_contract_keeps_selection_empty_until_manual_pick():
     load_url_body = _viewer_function_body(js, "async function loadSceneUrl(rawUrl)", "if (el.resetView)")
     render_scene_body = _viewer_function_body(js, "function renderScene(items)", "function createLabelElement")
     object_list_body = _viewer_function_body(js, "function populateObjectList()", "function selectObject(id)")
+    append_object_list_body = _viewer_function_body(js, "function appendObjectListRow(rendered, group)", "function populateObjectList()")
     select_body = _viewer_function_body(js, "function selectObject(id)", "function pickObject(event)")
     pick_body = _viewer_function_body(js, "function pickObject(event)", "function attachTransformGizmo")
 
@@ -357,8 +358,95 @@ def test_viewer_load_contract_keeps_selection_empty_until_manual_pick():
     assert "populateObjectList();" in render_scene_body
     assert "frameScene(bounds);" in render_scene_body
 
-    assert "li.addEventListener('click', () => selectObject(rendered.item.id));" in object_list_body
+    assert "li.addEventListener('click', () => selectObject(rendered.item.id));" in append_object_list_body
     assert "const selected = rendered.item.id === id;" in select_body
     assert "rendered.item.locked" not in select_body
     assert "canEditItem(rendered.item)" not in select_body
     assert "if (item?.id) selectObject(item.id);" in pick_body
+
+
+def test_viewer_status_reporting_ignores_hidden_helper_overlay_counters(tmp_path):
+    js_path = VIEWER / "viewer.js"
+    harness = r"""
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+let source = fs.readFileSync(process.argv[1], 'utf8').replace(/boot\(\);\s*$/, '');
+const element = () => ({
+  hidden: false,
+  checked: false,
+  disabled: false,
+  textContent: '',
+  className: '',
+  innerHTML: '',
+  classList: { toggle() {} },
+  setAttribute() {},
+  querySelector() { return { textContent: '' }; },
+  appendChild() {},
+  addEventListener() {},
+  getBoundingClientRect() { return { width: 800, height: 600, left: 0, top: 0 }; },
+});
+const context = {
+  console,
+  assert,
+  window: { location: { search: '' } },
+  document: { getElementById() { return element(); }, createElement() { return element(); } },
+  URLSearchParams,
+  requestAnimationFrame() { return 0; },
+};
+vm.createContext(context);
+vm.runInContext(source + `
+populateObjectList = () => {};
+updateLabels = () => {};
+resetView = () => {};
+renderSceneSummary = () => updateViewerStatus();
+state.sceneJson = { scene: { id: 'status_test' } };
+state.runtimeWarnings = [{ code: 'camera_framing_blocker_excluded', reason: 'hidden helper excluded' }];
+state.objects = [
+  { item: { id: 'robot_link', role: 'robot' }, renderInfo: { render_status: 'mesh_loaded' }, object3d: { visible: true } },
+  { item: { id: 'workbench', category: 'environment' }, renderInfo: { render_status: 'mesh_loaded' }, object3d: { visible: true } },
+  { item: { id: 'camera_fov_helper', role: 'camera_fov', category: 'overlay' }, renderInfo: { render_status: 'mesh_loaded' }, object3d: { visible: false } },
+  { item: { id: 'pick_zone_bounds', role: 'pick_zone', category: 'safety_zone', renderInfo: { render_status: 'required_mesh_failed_debug_fallback' } }, renderInfo: { render_status: 'required_mesh_failed_debug_fallback' }, object3d: { visible: false } },
+];
+let status = updateViewerStatus();
+assert.strictEqual(status.meshLoadedCount, 2);
+assert.strictEqual(status.mesh_loaded_count, 2);
+assert.strictEqual(status.requiredMeshFailedCount, 0);
+assert.strictEqual(status.required_mesh_failed_count, 0);
+assert.strictEqual(status.runtimeWarnings.length, 1);
+assert.strictEqual(status.runtimeWarnings[0].code, 'camera_framing_blocker_excluded');
+assert.strictEqual(isUserFacingWarning(status.runtimeWarnings[0]), false);
+setDebugOverlaysVisible(true);
+assert.strictEqual(window.__WORKCELL_VIEWER_STATUS__.meshLoadedCount, 2);
+assert.strictEqual(window.__WORKCELL_VIEWER_STATUS__.requiredMeshFailedCount, 0);
+setDebugOverlaysVisible(false);
+assert.strictEqual(window.__WORKCELL_VIEWER_STATUS__.meshLoadedCount, 2);
+assert.strictEqual(window.__WORKCELL_VIEWER_STATUS__.requiredMeshFailedCount, 0);
+`, context);
+"""
+    result = subprocess.run(
+        ["node", "-e", harness, str(js_path)],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert result.stderr == ""
+
+
+def test_viewer_status_static_contract_counts_physical_not_debug_overlay_visibility():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    summary_body = js.split("function computeSceneSummary", 1)[1].split("function isUserFacingWarning", 1)[0]
+    status_body = js.split("function updateViewerStatus", 1)[1].split("function renderSceneSummary", 1)[0]
+    debug_toggle_body = js.split("function setDebugOverlaysVisible", 1)[1].split("function updateLabels", 1)[0]
+
+    assert "function statusCountedRenderables()" in js
+    assert "!isDebugOverlayItem(obj.item)" in js
+    assert "const statusRendered = statusCountedRenderables();" in summary_body
+    assert "meshLoadedCount: statusRendered.filter" in summary_body
+    assert "fallbackCount: statusRendered.filter" in summary_body
+    assert "meshFailedCount: statusRendered.filter" in summary_body
+    assert "requiredMeshFailedCount: statusCountedRenderables().filter(isRequiredMeshFailureStatus).length" in status_body
+    assert "renderSceneSummary();" in debug_toggle_body
+    assert "rendered.object3d.visible = state.debugOverlaysVisible" in debug_toggle_body

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -56,16 +56,23 @@ function isMissingOrFailedMeshStatus(status) {
   return ['missing_file', 'unresolved_package_uri', 'unsafe_path', 'unsupported_format', 'load_error', 'url_not_served', 'file_access_blocked', 'loader_failure']
     .includes(String(status || '').toLowerCase());
 }
+function statusCountedRenderables() {
+  return (state.objects || []).filter(obj => !isDebugOverlayItem(obj.item));
+}
+function isRequiredMeshFailureStatus(obj) {
+  return obj?.renderInfo?.render_status === 'required_mesh_failed_debug_fallback' || obj?.item?.renderInfo?.render_status === 'required_mesh_failed_debug_fallback';
+}
 function computeSceneSummary() {
   const rendered = state.objects || [];
+  const statusRendered = statusCountedRenderables();
   return {
     sceneName: sceneDisplayName(),
     renderableCount: rendered.length,
-    meshLoadedCount: rendered.filter(obj => obj.renderInfo?.render_status === 'mesh_loaded').length,
-    meshVisuallyInvalidCount: rendered.filter(obj => obj.item?.visual_bounds_status && !['valid', 'corrected_by_local_unit_scale'].includes(obj.item.visual_bounds_status)).length,
-    meshUnitScaleCorrectedCount: rendered.filter(obj => obj.item?.visual_bounds_status === 'corrected_by_local_unit_scale').length,
-    fallbackCount: rendered.filter(obj => isRuntimeFallbackStatus(obj.renderInfo?.render_status || obj.item?.renderInfo?.render_status)).length,
-    meshFailedCount: rendered.filter(obj => isMissingOrFailedMeshStatus(obj.item?.mesh_status)).length,
+    meshLoadedCount: statusRendered.filter(obj => obj.renderInfo?.render_status === 'mesh_loaded').length,
+    meshVisuallyInvalidCount: statusRendered.filter(obj => obj.item?.visual_bounds_status && !['valid', 'corrected_by_local_unit_scale'].includes(obj.item.visual_bounds_status)).length,
+    meshUnitScaleCorrectedCount: statusRendered.filter(obj => obj.item?.visual_bounds_status === 'corrected_by_local_unit_scale').length,
+    fallbackCount: statusRendered.filter(obj => isRuntimeFallbackStatus(obj.renderInfo?.render_status || obj.item?.renderInfo?.render_status)).length,
+    meshFailedCount: statusRendered.filter(obj => isMissingOrFailedMeshStatus(obj.item?.mesh_status)).length,
     generatedLockedCount: rendered.filter(obj => isGeneratedOrLockedItem(obj.item)).length,
     editableCount: rendered.filter(obj => canEditItem(obj.item)).length,
   };
@@ -104,8 +111,8 @@ function updateViewerStatus() {
     renderableCount: summary.renderableCount,
     mesh_loaded_count: summary.meshLoadedCount,
     meshLoadedCount: summary.meshLoadedCount,
-    required_mesh_failed_count: (state.objects || []).filter(obj => obj.renderInfo?.render_status === 'required_mesh_failed_debug_fallback' || obj.item?.renderInfo?.render_status === 'required_mesh_failed_debug_fallback').length,
-    requiredMeshFailedCount: (state.objects || []).filter(obj => obj.renderInfo?.render_status === 'required_mesh_failed_debug_fallback' || obj.item?.renderInfo?.render_status === 'required_mesh_failed_debug_fallback').length,
+    required_mesh_failed_count: statusCountedRenderables().filter(isRequiredMeshFailureStatus).length,
+    requiredMeshFailedCount: statusCountedRenderables().filter(isRequiredMeshFailureStatus).length,
     fallback_count: summary.fallbackCount,
     fallbackCount: summary.fallbackCount,
     runtime_warnings: warnings,
@@ -1319,6 +1326,7 @@ function setDebugOverlaysVisible(visible) {
   }
   populateObjectList();
   updateLabels();
+  renderSceneSummary();
   resetView();
 }
 


### PR DESCRIPTION
### Motivation
- Prevent debug/helper/zone overlays from distorting product mesh status metrics such as `meshLoadedCount` and mesh-failed counters. 
- Preserve raw runtime diagnostics like `camera_framing_blocker_excluded` in runtime status while keeping them out of normal user-facing warnings. 
- Ensure toggling debug overlay visibility does not stale or zero viewer status so browser acceptance hooks remain reliable. 

### Description
- Add `statusCountedRenderables()` and `isRequiredMeshFailureStatus()` and change `computeSceneSummary()` to compute `meshLoadedCount`, fallback and failed-mesh counters using only physical/product renderables (i.e. excluding debug overlay items). 
- Change `updateViewerStatus()` to derive `requiredMeshFailedCount` from the filtered renderable set and keep `runtimeWarnings` intact in the raw status payload. 
- Refresh the rendered summary when debug overlays visibility changes by calling `renderSceneSummary()` from `setDebugOverlaysVisible()` so status consumers observe consistent counts after toggles. 
- Add focused static tests in `tests/test_workcell_studio_web_viewer_static.py` that exercise `meshLoadedCount`, `requiredMeshFailedCount`, `runtimeWarnings` visibility for `camera_framing_blocker_excluded`, and that hidden helper/zone overlays do not affect physical mesh counters. 
- Modified files: `workcell_studio_web/viewer/viewer.js` and `tests/test_workcell_studio_web_viewer_static.py`. 

### Testing
- Ran the focused static test file with `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py -q` and all tests passed. 
- Ran combined acceptance/static tests with `python3 -m pytest tests/test_workcell_web3d_visual_acceptance.py tests/test_workcell_studio_web_viewer_static.py -q` and the full suite passed. 
- All automated tests mentioned above succeeded (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ced17be34833185e4c1aee568019d)