### PR TITLE
Fix Robotiq fallback tool frame pose lookup

### DIFF
--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -443,7 +443,7 @@ def _generated_preview_items(index: Mapping[str, Any], scene_dir: Path, warnings
     fields = (
         "id", "type", "category", "role", "display_name", "link", "object_name", "visual", "pose", "world_pose",
         "final_transform", "world_from_visual", "transform_source",
-        "baked_world_visual_pose", "link_world_pose", "visual_origin", "baked_world_visual_matrix",
+        "baked_world_visual_pose", "link_world_pose", "frame_world_pose", "visual_origin", "baked_world_visual_matrix",
         "baked_world_visual_quaternion", "baked_world_visual_transform_source", "geometry_type",
         "parent_link", "immediate_parent_link", "root_link", "link_chain", "joint_parent_link",
         "parent_joint", "parent_joint_name", "parent_joint_type", "parent_joint_origin",
@@ -508,13 +508,53 @@ def _supplement_missing_tool_meshes(data: Dict[str, Any], generated: Dict[str, L
     expected_links = [str(v) for v in _as_list(tool_meta.get("visual_links"))]
     if not expected_links:
         expected_links = list(ROBOTIQ_85_VISUAL_MESHES)
-    robot_items = generated.get("robots", [])
-    wrist_pose = None
-    for item in robot_items:
-        if "wrist_3" in str(item.get("link", "")):
-            wrist_pose = item.get("pose") or item.get("world_pose") or item.get("baked_world_visual_pose")
-            break
-    link_poses: Dict[str, Json] = {"tool0": dict(wrist_pose) if isinstance(wrist_pose, Mapping) else {"xyz": [0, 0, 0], "rpy": [0, 0, 0]}}
+    def _frame_pose(item: Mapping[str, Any]) -> Optional[Json]:
+        """Return explicit link/frame world pose metadata, never render poses."""
+        for field in ("link_world_pose", "frame_world_pose"):
+            value = item.get(field)
+            if isinstance(value, Mapping):
+                return dict(value)
+        return None
+
+    def _link_name(item: Mapping[str, Any]) -> str:
+        return str(item.get("link") or item.get("link_name") or item.get("frame") or item.get("object_name") or "")
+
+    def _is_non_rendered_anchor(item: Mapping[str, Any]) -> bool:
+        if item.get("render_expected") is False:
+            return True
+        if item.get("mesh_available") is False or item.get("resolved") is False:
+            return True
+        if not any(item.get(field) for field in MESH_URI_FIELDS):
+            geometry = str(item.get("geometry_type") or item.get("primitive_geometry_type") or "").lower()
+            return geometry in {"", "frame", "anchor", "none"}
+        return False
+
+    preview_items = [
+        item
+        for section in ("robots", "tools", "assets", "sensors", "zones")
+        for item in generated.get(section, [])
+        if isinstance(item, Mapping)
+    ]
+    link_poses: Dict[str, Json] = {}
+    for item in preview_items:
+        link = _link_name(item)
+        pose = _frame_pose(item)
+        if link and pose is not None and (link not in link_poses or _is_non_rendered_anchor(item)):
+            link_poses[link] = pose
+    tool0_anchor_pose = next(
+        (
+            pose
+            for item in preview_items
+            if _link_name(item) == "tool0" and _is_non_rendered_anchor(item)
+            for pose in [_frame_pose(item)]
+            if pose is not None
+        ),
+        None,
+    )
+    if tool0_anchor_pose is not None:
+        link_poses["tool0"] = tool0_anchor_pose
+    elif "tool0" not in link_poses:
+        link_poses["tool0"] = {"xyz": [0, 0, 0], "rpy": [0, 0, 0]}
     for link in expected_links:
         mesh_name = ROBOTIQ_85_VISUAL_MESHES.get(link)
         if not mesh_name:
@@ -523,8 +563,9 @@ def _supplement_missing_tool_meshes(data: Dict[str, Any], generated: Dict[str, L
         joint_origin = _as_map(transform_meta.get("joint_origin"))
         parent_link = str(transform_meta.get("parent_link") or "tool0")
         parent_pose = link_poses.get(parent_link) or link_poses["tool0"]
-        final_transform = _pose_with_xyz_offset(parent_pose, _as_list(joint_origin.get("xyz") or [0.0, 0.0, 0.0]))
-        link_poses[link] = final_transform
+        link_world_pose = _pose_with_xyz_offset(parent_pose, _as_list(joint_origin.get("xyz") or [0.0, 0.0, 0.0]))
+        final_transform = dict(link_world_pose)
+        link_poses[link] = link_world_pose
         item: Json = {
             "id": f"generated_tool::{link}::visual_0",
             "type": "mesh",
@@ -538,7 +579,8 @@ def _supplement_missing_tool_meshes(data: Dict[str, Any], generated: Dict[str, L
             "world_pose": final_transform,
             "final_transform": final_transform,
             "world_from_visual": final_transform,
-            "link_world_pose": final_transform,
+            "link_world_pose": link_world_pose,
+            "frame_world_pose": link_world_pose,
             "parent_link": parent_link,
             "joint_parent_link": parent_link,
             "joint_origin": joint_origin,
@@ -563,8 +605,8 @@ def _supplement_missing_tool_meshes(data: Dict[str, Any], generated: Dict[str, L
             "source_kind": "generated_preview",
             "provenance": _provenance(
                 ("id", "link", "mesh_uri", "package_uri", "pose", "world_pose", "final_transform",
-                 "world_from_visual", "parent_link", "joint_origin", "visual_origin", "transform_source",
-                 "locked", "editable", "source_kind"),
+                 "world_from_visual", "link_world_pose", "frame_world_pose", "parent_link", "joint_origin",
+                 "visual_origin", "transform_source", "locked", "editable", "source_kind"),
                 "scene_manifest.yaml|generated/scene_visual_mesh_index.json",
             ),
         }

--- a/tests/test_export_workcell_studio_web_scene.py
+++ b/tests/test_export_workcell_studio_web_scene.py
@@ -351,3 +351,61 @@ def test_web_viewer_prefers_canonical_final_transform_without_visual_origin_reco
     pose_block = viewer.split("function poseOf(item)", 1)[1].split("function scaleOf", 1)[0]
     assert "item.final_transform || item.world_from_visual || item.baked_world_visual_pose" in pose_block
     assert "visual_origin" not in pose_block
+
+
+def test_robotiq_fallback_uses_tool0_frame_not_wrist_visual_pose(tmp_path):
+    scene = tmp_path / "scene"
+    (scene / "layout").mkdir(parents=True)
+    (scene / "generated").mkdir()
+    (scene / "scene_manifest.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "scene": {"name": "tool0_frame_regression"},
+                "end_effector": {"id": "robotiq_85", "model": "robotiq_85"},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    (scene / "cell_definition.yaml").write_text("{}", encoding="utf-8")
+    (scene / "environment.yaml").write_text("{}", encoding="utf-8")
+    (scene / "layout/workcell_studio_layout.yaml").write_text(yaml.safe_dump({"items": []}), encoding="utf-8")
+    (scene / "generated/scene_visual_mesh_index.json").write_text(
+        json.dumps(
+            {
+                "visual_items": [
+                    {
+                        "id": "generated_urdf::wrist_3_link::visual_0",
+                        "category": "robot",
+                        "role": "robot",
+                        "link": "wrist_3_link",
+                        "mesh_uri": "package://ur_description/meshes/ur5/visual/wrist3.dae",
+                        "link_world_pose": {"xyz": [0.4, 0.2, 0.6], "rpy": [0.0, 0.0, 0.0]},
+                        "visual_origin": {"xyz": [0.3, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]},
+                        "baked_world_visual_pose": {"xyz": [0.7, 0.2, 0.6], "rpy": [0.0, 0.0, 0.0]},
+                    },
+                    {
+                        "id": "generated_urdf::tool0::frame",
+                        "category": "tool",
+                        "role": "frame_anchor",
+                        "link": "tool0",
+                        "render_expected": False,
+                        "geometry_type": "frame",
+                        "link_world_pose": {"xyz": [0.4, 0.2, 0.6], "rpy": [0.0, 0.0, 0.0]},
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    out = tmp_path / "build/scene.web_scene.json"
+    subprocess.run([sys.executable, str(SCRIPT), "--scene", str(scene), "--output", str(out)], check=True)
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    gripper_base = next(item for item in payload["tools"] if item["link"] == "gripper_base_link")
+    assert gripper_base["parent_link"] == "tool0"
+    assert gripper_base["joint_parent_link"] == "tool0"
+    assert gripper_base["link_world_pose"]["xyz"] == [0.4, 0.2, 0.6]
+    assert gripper_base["final_transform"]["xyz"] == [0.4, 0.2, 0.6]
+    assert gripper_base["final_transform"]["xyz"] != [0.7, 0.2, 0.6]


### PR DESCRIPTION
### Motivation
- Prevent supplemented Robotiq tool meshes from being positioned using rendered/baked visual poses (which include `visual_origin`) and instead compose tool geometry from explicit frame/link-frame metadata. 
- Prefer a non-rendered `tool0` anchor when present so tool composition follows authored frame anchors rather than inferred render visuals. 
- Ensure `gripper_base_link` and its joint-parenting stay attached to `tool0` and are not displaced by wrist visual offsets.

### Description
- Export now preserves `frame_world_pose` on generated preview rows by adding it to the copied fields so frame pose metadata is available for fallback logic. (`scripts/export_workcell_studio_web_scene.py`)
- `_supplement_missing_tool_meshes()` now builds a frame-pose lookup from explicit `link_world_pose` / `frame_world_pose` only (never from `pose`/`world_pose`/`baked_world_visual_pose`), and prefers non-rendered anchor rows for resolving `tool0`. (`scripts/export_workcell_studio_web_scene.py`)
- When composing fallback Robotiq links, the code uses `link_world_pose` / `frame_world_pose` for parent-child composition while keeping `final_transform` / `world_from_visual` as the render pose for mesh placement, and `parent_link` / `joint_parent_link` remain `tool0`. (`scripts/export_workcell_studio_web_scene.py`)
- Updated provenance fields to include `link_world_pose`/`frame_world_pose` and added a regression test that verifies `gripper_base_link` is anchored to `tool0` and not displaced by a `wrist_3_link` visual/baked offset. (`tests/test_export_workcell_studio_web_scene.py`)

### Testing
- Ran `python3 -m pytest tests/test_export_workcell_studio_web_scene.py -q` and the suite passed (8 tests). 
- Ran `python3 -m pytest tests/test_export_workcell_studio_web_scene.py tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py -q` and all tests passed (15 tests in that run).
- The new regression test asserts `gripper_base_link.parent_link` and `joint_parent_link` are `tool0` and that its `final_transform` uses the `tool0` frame pose rather than the `wrist_3_link` baked visual pose.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cf2a9e3f08331b84920a87e37e445)