### PR TITLE
Preserve Web3D transform anchors in exported `frames` section

### DIFF
--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -87,6 +87,8 @@ HELPER_TOKENS = (
     "bounds_box",
     "bounding_box",
 )
+GENERATED_OUTPUT_SECTIONS = ("robots", "tools", "assets", "sensors", "zones", "frames")
+RENDERABLE_OUTPUT_SECTIONS = ("robots", "tools", "assets", "sensors", "zones")
 
 Json = Dict[str, Any]
 
@@ -299,7 +301,7 @@ def _stage_visual_meshes(payload: Json, scene_dir: Path, output_path: Path) -> N
     scene_id = str(payload.get("scene", {}).get("id") or scene_dir.name)
     asset_root = (repo_root / "build" / "workcell_studio_web_scene" / "assets" / scene_id).resolve()
     asset_root.mkdir(parents=True, exist_ok=True)
-    sections: Sequence[str] = ("robots", "tools", "assets", "sensors", "zones")
+    sections: Sequence[str] = RENDERABLE_OUTPUT_SECTIONS
     for section in sections:
         for item in payload.get(section, []):
             if not isinstance(item, dict):
@@ -391,7 +393,13 @@ def _is_helper(item: Mapping[str, Any]) -> bool:
     return any(token in text for token in HELPER_TOKENS)
 
 
+def _is_transform_anchor(item: Mapping[str, Any]) -> bool:
+    return str(item.get("type", "")).lower() == "transform_anchor" or str(item.get("role", "")).lower() == "transform_anchor"
+
+
 def _section_from_item(item: Mapping[str, Any]) -> str:
+    if _is_transform_anchor(item):
+        return "frames"
     text = _identity_text(item)
     category = str(item.get("category", "")).lower()
     role = str(item.get("role", "")).lower()
@@ -435,7 +443,7 @@ def _pose_with_xyz_offset(base_pose: Any, offset: Sequence[float]) -> Json:
 
 
 def _generated_preview_items(index: Mapping[str, Any], scene_dir: Path, warnings: List[Json]) -> Dict[str, List[Json]]:
-    sections = {"robots": [], "tools": [], "assets": [], "sensors": [], "zones": []}
+    sections = {section: [] for section in GENERATED_OUTPUT_SECTIONS}
     items = _as_list(index.get("visual_items") or index.get("items"))
     if not items:
         _warn(warnings, "visual_mesh_index_items_missing", "Visual mesh index has no visual_items/items list.", INPUTS["visual_mesh_index"])
@@ -471,6 +479,17 @@ def _generated_preview_items(index: Mapping[str, Any], scene_dir: Path, warnings
         item["editable"] = False
         item["source_kind"] = "generated_preview"
         item["provenance"].update({"locked": INPUTS["visual_mesh_index"], "editable": INPUTS["visual_mesh_index"], "source_kind": INPUTS["visual_mesh_index"]})
+        if _is_transform_anchor(raw):
+            item["render_expected"] = False
+            item["mesh_available"] = False
+            item["mesh_load_required"] = False
+            item.setdefault("active_visual_source", "frame_anchor")
+            item["provenance"].update({
+                "render_expected": INPUTS["visual_mesh_index"],
+                "mesh_available": INPUTS["visual_mesh_index"],
+                "mesh_load_required": INPUTS["visual_mesh_index"],
+                "active_visual_source": INPUTS["visual_mesh_index"],
+            })
         if final_transform is not None:
             item["provenance"].update({
                 "final_transform": INPUTS["visual_mesh_index"],
@@ -531,7 +550,7 @@ def _supplement_missing_tool_meshes(data: Dict[str, Any], generated: Dict[str, L
 
     preview_items = [
         item
-        for section in ("robots", "tools", "assets", "sensors", "zones")
+        for section in GENERATED_OUTPUT_SECTIONS
         for item in generated.get(section, [])
         if isinstance(item, Mapping)
     ]
@@ -911,7 +930,7 @@ def _core_mesh_category(item: Mapping[str, Any], section: str) -> Optional[str]:
 
 
 def _all_scene_items(payload: Mapping[str, Any]) -> Iterable[Tuple[str, Json]]:
-    for section in ("robots", "tools", "assets", "sensors", "zones"):
+    for section in GENERATED_OUTPUT_SECTIONS:
         for item in payload.get(section, []):
             if isinstance(item, dict):
                 yield section, item
@@ -1052,7 +1071,7 @@ def _visual_bounds_contract(payload: Json, data: Mapping[str, Any]) -> Json:
     blockers: List[Json] = []
 
     for section, item in _all_scene_items(payload):
-        if section == "zones" or _is_helper(item):
+        if section == "zones" or _is_helper(item) or not _is_render_expected(item):
             continue
         item_id = str(item.get("id"))
         category = str(item.get("mesh_contract_category") or _visual_contract_category(item, section))
@@ -1225,7 +1244,7 @@ def _viewer_item_status(item: Mapping[str, Any]) -> str:
 
 
 def _viewer_summary(payload: Json) -> Json:
-    sections: Sequence[str] = ("robots", "tools", "assets", "sensors", "zones")
+    sections: Sequence[str] = RENDERABLE_OUTPUT_SECTIONS
     renderable: List[Tuple[str, Json]] = []
     for section in sections:
         for item in payload.get(section, []):
@@ -1306,7 +1325,7 @@ def build_web_scene(scene_dir: Path, *, stage_assets: bool = False, output_path:
     env_scene = _as_map(_as_map(data.get("environment")).get("scene"))
     scene_name = _first_present(scene_meta.get("name"), cell_scene.get("name"), cell_scene.get("id"), env_scene.get("name"), env_scene.get("id"), scene_dir.name)
 
-    generated = _generated_preview_items(_as_map(data.get("visual_mesh_index")), scene_dir, warnings) if data.get("visual_mesh_index") is not None else {"robots": [], "tools": [], "assets": [], "sensors": [], "zones": []}
+    generated = _generated_preview_items(_as_map(data.get("visual_mesh_index")), scene_dir, warnings) if data.get("visual_mesh_index") is not None else {section: [] for section in GENERATED_OUTPUT_SECTIONS}
     _supplement_missing_tool_meshes(data, generated)
     _apply_web_scene_transform_parity_fallbacks(data, generated)
     _suppress_unresolved_placeholder_robot_visuals(generated, warnings)
@@ -1346,6 +1365,7 @@ def build_web_scene(scene_dir: Path, *, stage_assets: bool = False, output_path:
         "assets": _sort_items(assets),
         "sensors": _sort_items(sensors),
         "zones": _sort_items(zones),
+        "frames": _sort_items(generated["frames"]),
         "warnings": sorted(warnings, key=lambda w: (str(w.get("source", "")), str(w.get("code", "")), str(w.get("message", "")))),
         "backend_actions": [
             {

--- a/tests/test_export_workcell_studio_web_scene.py
+++ b/tests/test_export_workcell_studio_web_scene.py
@@ -7,6 +7,8 @@ import yaml
 
 
 SCRIPT = Path("scripts/export_workcell_studio_web_scene.py")
+ROOT = Path(__file__).resolve().parents[1]
+EXTRACT_INDEX_SCRIPT = ROOT / "scripts" / "extract_scene_urdf_visual_mesh_index.py"
 
 
 def test_export_web_scene_contract_and_determinism(tmp_path):
@@ -409,3 +411,60 @@ def test_robotiq_fallback_uses_tool0_frame_not_wrist_visual_pose(tmp_path):
     assert gripper_base["link_world_pose"]["xyz"] == [0.4, 0.2, 0.6]
     assert gripper_base["final_transform"]["xyz"] == [0.4, 0.2, 0.6]
     assert gripper_base["final_transform"]["xyz"] != [0.7, 0.2, 0.6]
+
+
+def test_ur5_2f_web_scene_preserves_tool0_transform_anchor_metadata(tmp_path):
+    extract = subprocess.run(
+        [
+            sys.executable,
+            str(EXTRACT_INDEX_SCRIPT),
+            "--scene",
+            "ur5_2f_test",
+            "--allow-xacro-lite-fallback",
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert extract.returncode == 0, extract.stdout + extract.stderr
+
+    out = tmp_path / "ur5_2f_test.web_scene.json"
+    subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / SCRIPT),
+            "--scene",
+            str(ROOT / "scenes" / "ur5_2f_test"),
+            "--output",
+            str(out),
+            "--no-stage-assets",
+        ],
+        cwd=ROOT,
+        check=True,
+    )
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    anchors = [
+        item
+        for item in payload.get("frames", [])
+        if item.get("link") == "tool0" and item.get("role") == "transform_anchor"
+    ]
+    assert anchors, "expected exported Web3D scene to preserve the non-rendered tool0 frame anchor"
+
+    anchor = anchors[0]
+    assert anchor["id"] == "urdf_frame_anchor_tool0"
+    assert anchor["type"] == "transform_anchor"
+    assert anchor["render_expected"] is False
+    assert anchor["mesh_available"] is False
+    assert anchor["mesh_load_required"] is False
+    assert "mesh_uri" not in anchor
+    assert anchor["parent_link"]
+    assert anchor["joint_parent_link"] == anchor["parent_link"]
+    assert isinstance(anchor["joint_origin"], dict)
+    assert isinstance(anchor["link_world_pose"], dict)
+    assert anchor["frame_world_pose"] == anchor["link_world_pose"]
+    assert anchor["world_pose"] == anchor["link_world_pose"]
+    assert anchor["pose"] == anchor["link_world_pose"]
+    assert anchor["source_layer"]
+    assert anchor["active_visual_source"]


### PR DESCRIPTION
### Motivation
- Ensure generated, non-rendered frame/anchor items (e.g. `tool0` transform anchors) survive the Web3D export so the browser/product view can consume authoritative frame poses and joint metadata without requiring a mesh.
- Carry through key pose/link/joint/source fields from the generated visual index so downstream tooling and fallback heuristics (tool mounting, framing, grasp plumbing) see the same metadata as the Scene3D index.

### Description
- Route items where `type == "transform_anchor"` or `role == "transform_anchor"` into a new top-level `frames` section by adding `GENERATED_OUTPUT_SECTIONS` and `_is_transform_anchor` and returning `"frames"` from `_section_from_item` for anchors.
- In `_generated_preview_items` copy anchor metadata fields and force anchors to be non-rendered and non-mesh-required by setting `render_expected: False`, `mesh_available: False`, and `mesh_load_required: False`, and provide a stable `active_visual_source` fallback when missing.
- Include `frames` in the final output payload (`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cf45bcedc8331b5c2f5dbb4c6b5eb)