### PR TITLE
Prefer tool0 frame for gripper fallback and avoid using wrist visual poses

### DIFF
--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -653,7 +653,7 @@ def _set_item_pose(item: Json, pose: Json, source: str) -> None:
     item.setdefault("provenance", {})["transform_source"] = source
 
 
-def _apply_web_scene_transform_parity_fallbacks(data: Dict[str, Any], generated: Dict[str, List[Json]]) -> None:
+def _apply_web_scene_transform_parity_fallbacks(data: Dict[str, Any], generated: Dict[str, List[Json]], warnings: List[Json]) -> None:
     """Keep browser export transforms plausible when flattened URDF metadata is stale.
 
     Some generated static visual indexes include correct mesh identity but leave
@@ -662,21 +662,62 @@ def _apply_web_scene_transform_parity_fallbacks(data: Dict[str, Any], generated:
     applies conservative scene-metadata fallbacks only when the generated mesh
     pose is effectively collapsed at the world origin.
     """
-    wrist_pose = None
-    for item in generated.get("robots", []):
-        if "wrist_3" in str(item.get("link", "")):
-            wrist_pose = item.get("final_transform") or item.get("world_from_visual") or item.get("pose")
-            break
-    wrist_xyz = _pose_xyz(wrist_pose)
-    if wrist_xyz is not None:
+    generated_items = [
+        item
+        for section in GENERATED_OUTPUT_SECTIONS
+        for item in generated.get(section, [])
+        if isinstance(item, Mapping)
+    ]
+
+    def _link_key(item: Mapping[str, Any]) -> str:
+        return str(item.get("link") or item.get("link_name") or item.get("frame") or item.get("object_name") or "")
+
+    def _frame_pose(item: Mapping[str, Any], *, prefer_frame: bool = False) -> Optional[Json]:
+        # Parent-frame composition must use explicit frame/link world metadata only.
+        # Render-only visual poses such as final_transform/world_from_visual/pose/
+        # baked_world_visual_pose may include visual_origin and must not affect
+        # gripper attachment.
+        fields = ("frame_world_pose", "link_world_pose") if prefer_frame else ("link_world_pose", "frame_world_pose")
+        for field in fields:
+            value = item.get(field)
+            if isinstance(value, Mapping):
+                return dict(value)
+        return None
+
+    frame_pose_by_link: Dict[str, Json] = {}
+    for item in generated_items:
+        link = _link_key(item)
+        if not link:
+            continue
+        pose = _frame_pose(item, prefer_frame=(link == "tool0"))
+        if pose is not None:
+            frame_pose_by_link[link] = pose
+
+    tool_parent_pose = frame_pose_by_link.get("tool0")
+    transform_source = "web_export_tool0_frame_transform_parity_fallback"
+    if tool_parent_pose is None and "wrist_3_link" in frame_pose_by_link:
+        tool_parent_pose = frame_pose_by_link["wrist_3_link"]
+        transform_source = "web_export_wrist_3_link_link_pose_transform_parity_fallback"
+        _warn(
+            warnings,
+            "tool0_frame_missing_using_wrist_3_link_fallback",
+            "tool0 frame/link world pose metadata is missing from generated/scene_visual_mesh_index.json; "
+            "using wrist_3_link.link_world_pose only as a temporary gripper parent fallback. "
+            "Regenerate the scene visual mesh index so tool0.frame_world_pose or tool0.link_world_pose is available.",
+            INPUTS["visual_mesh_index"],
+        )
+
+    parent_xyz = _pose_xyz(tool_parent_pose)
+    if parent_xyz is not None:
         for item in generated.get("tools", []):
             pose = item.get("final_transform") or item.get("world_from_visual") or item.get("pose")
             xyz = _pose_xyz(pose)
             chain = " ".join(str(v) for v in _as_list(item.get("transform_chain")))
-            if xyz is not None and sum(v * v for v in xyz) < 0.05 and ("wrist_3" in chain or "tool0" in chain):
+            parent_link = str(item.get("joint_parent_link") or item.get("parent_link") or "")
+            if xyz is not None and sum(v * v for v in xyz) < 0.05 and ("wrist_3" in chain or "tool0" in chain or parent_link in {"tool0", "wrist_3_link"}):
                 adjusted = dict(pose) if isinstance(pose, Mapping) else {"rpy": [0.0, 0.0, 0.0]}
-                adjusted["xyz"] = [wrist_xyz[i] + xyz[i] for i in range(3)]
-                _set_item_pose(item, adjusted, "web_export_wrist_transform_parity_fallback")
+                adjusted["xyz"] = [parent_xyz[i] + xyz[i] for i in range(3)]
+                _set_item_pose(item, adjusted, transform_source)
 
     env = _as_map(data.get("environment"))
     authored_camera_pose = None
@@ -1327,7 +1368,7 @@ def build_web_scene(scene_dir: Path, *, stage_assets: bool = False, output_path:
 
     generated = _generated_preview_items(_as_map(data.get("visual_mesh_index")), scene_dir, warnings) if data.get("visual_mesh_index") is not None else {section: [] for section in GENERATED_OUTPUT_SECTIONS}
     _supplement_missing_tool_meshes(data, generated)
-    _apply_web_scene_transform_parity_fallbacks(data, generated)
+    _apply_web_scene_transform_parity_fallbacks(data, generated, warnings)
     _suppress_unresolved_placeholder_robot_visuals(generated, warnings)
     authored = _authored_sections(data, scene_dir, warnings)
     top_robots, top_tools, top_sensors = _top_level_entities(data, warnings)

--- a/tests/test_export_workcell_studio_web_scene.py
+++ b/tests/test_export_workcell_studio_web_scene.py
@@ -413,6 +413,68 @@ def test_robotiq_fallback_uses_tool0_frame_not_wrist_visual_pose(tmp_path):
     assert gripper_base["final_transform"]["xyz"] != [0.7, 0.2, 0.6]
 
 
+def test_gripper_parent_fallback_ignores_wrist_visual_origin_when_tool0_missing(tmp_path):
+    scene = tmp_path / "scene"
+    (scene / "layout").mkdir(parents=True)
+    (scene / "generated").mkdir()
+    (scene / "scene_manifest.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "scene": {"name": "missing_tool0_frame_regression"},
+                "end_effector": {"id": "robotiq_85", "model": "robotiq_85"},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    (scene / "cell_definition.yaml").write_text("{}", encoding="utf-8")
+    (scene / "environment.yaml").write_text("{}", encoding="utf-8")
+    (scene / "layout/workcell_studio_layout.yaml").write_text(yaml.safe_dump({"items": []}), encoding="utf-8")
+    (scene / "generated/scene_visual_mesh_index.json").write_text(
+        json.dumps(
+            {
+                "visual_items": [
+                    {
+                        "id": "generated_urdf::wrist_3_link::visual_0",
+                        "category": "robot",
+                        "role": "robot",
+                        "link": "wrist_3_link",
+                        "mesh_uri": "package://ur_description/meshes/ur5/visual/wrist3.dae",
+                        "link_world_pose": {"xyz": [0.4, 0.2, 0.6], "rpy": [0.0, 0.0, 0.0]},
+                        "visual_origin": {"xyz": [0.3, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]},
+                        "baked_world_visual_pose": {"xyz": [0.7, 0.2, 0.6], "rpy": [0.0, 0.0, 0.0]},
+                    },
+                    {
+                        "id": "generated_urdf::gripper_base_link::visual_0",
+                        "category": "tool",
+                        "role": "gripper",
+                        "link": "gripper_base_link",
+                        "parent_link": "tool0",
+                        "joint_parent_link": "tool0",
+                        "mesh_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+                        "final_transform": {"xyz": [0.0, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]},
+                        "transform_chain": ["wrist_3_link", "tool0", "gripper_base_link"],
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    out = tmp_path / "build/scene.web_scene.json"
+    subprocess.run([sys.executable, str(SCRIPT), "--scene", str(scene), "--output", str(out)], check=True)
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    wrist = next(item for item in payload["robots"] if item["link"] == "wrist_3_link")
+    gripper_base = next(item for item in payload["tools"] if item["link"] == "gripper_base_link")
+    warning_codes = {warning["code"] for warning in payload["warnings"]}
+
+    assert wrist["visual_origin"] == {"xyz": [0.3, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]}
+    assert gripper_base["final_transform"]["xyz"] == [0.4, 0.2, 0.6]
+    assert gripper_base["final_transform"]["xyz"] != wrist["baked_world_visual_pose"]["xyz"]
+    assert "tool0_frame_missing_using_wrist_3_link_fallback" in warning_codes
+
+
 def test_ur5_2f_web_scene_preserves_tool0_transform_anchor_metadata(tmp_path):
     extract = subprocess.run(
         [


### PR DESCRIPTION
### Motivation
- Render-only visual poses in generated preview indexes were being used as parent frames for grippers, causing incorrect gripper placement when `tool0` metadata was missing.
- The exporter must prefer explicit frame/link world metadata for parent composition and emit a clear diagnostic when falling back to a less-preferred source.

### Description
- Updated `_apply_web_scene_transform_parity_fallbacks()` to build a `frame_pose_by_link` map from all generated preview items and anchors and to use only explicit `frame_world_pose`/`link_world_pose` for parent-frame composition. 
- Prefer `tool0.frame_world_pose` / `tool0.link_world_pose` for gripper correction and only fall back to `wrist_3_link.link_world_pose` when `tool0` metadata is genuinely absent. 
- Explicitly avoid using render-only poses (`final_transform`, `world_from_visual`, `pose`, `baked_world_visual_pose`) as parent frames for gripper attachment, and use the composed frame-only pose for adjustments. 
- Thread the `warnings` list into the fallback function and emit a clear `tool0_frame_missing_using_wrist_3_link_fallback` warning when the `tool0` frame is absent. 
- Added `test_gripper_parent_fallback_ignores_wrist_visual_origin_when_tool0_missing` to ensure `wrist_3_link.visual_origin` remains present for rendering while it does not influence `gripper_base_link` parent composition.

### Testing
- Ran the web-scene tests with `python3 -m pytest tests/test_export_workcell_studio_web_scene.py -q` and observed `10 passed` (all tests in that module passed). 
- The new unit test verifies that `wrist_3_link.visual_origin` is preserved for rendering while the gripper uses the explicit link/frame fallback and that the fallback warning is emitted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cf55927988331b1dd28d28ae68471)