### PR TITLE
Add Web 3D URDF placement acceptance guards and stricter viewer-status validation

### DIFF
--- a/scripts/run_workcell_web3d_visual_acceptance.py
+++ b/scripts/run_workcell_web3d_visual_acceptance.py
@@ -30,6 +30,47 @@ PNG_1X1 = base64.b64decode(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
 )
 
+EXPECTED_MESH_LOADED_COUNT = 18
+EXPECTED_REQUIRED_MESH_FAILED_COUNT = 0
+REQUIRED_VIEWER_RESOLVED_DISTANCE_PAIRS = {
+    "wrist_3_link -> tool0": 0.20,
+    "tool0 -> gripper_base_link": 0.35,
+    "wrist_3_link -> gripper_base_link": 0.45,
+}
+
+
+def _status_int(status: Mapping[str, Any], snake: str, camel: str) -> int:
+    return int(status.get(snake) if status.get(snake) is not None else status.get(camel) or 0)
+
+
+def _distance_map_from_status(status: Mapping[str, Any]) -> Mapping[str, Any]:
+    for key in ("viewer_resolved_distances_m", "resolved_distances_m", "resolvedFrameDistancesM", "resolved_frame_distances_m"):
+        value = status.get(key)
+        if isinstance(value, Mapping):
+            return value
+    return {}
+
+
+def validate_browser_status(status: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    mesh_loaded_count = _status_int(status, "mesh_loaded_count", "meshLoadedCount")
+    required_mesh_failed_count = _status_int(status, "required_mesh_failed_count", "requiredMeshFailedCount")
+    if mesh_loaded_count != EXPECTED_MESH_LOADED_COUNT:
+        errors.append(f"browser viewer meshLoadedCount expected {EXPECTED_MESH_LOADED_COUNT}, got {mesh_loaded_count}")
+    if required_mesh_failed_count != EXPECTED_REQUIRED_MESH_FAILED_COUNT:
+        errors.append(f"browser viewer requiredMeshFailedCount expected {EXPECTED_REQUIRED_MESH_FAILED_COUNT}, got {required_mesh_failed_count}")
+
+    distances = _distance_map_from_status(status)
+    for pair, max_distance_m in REQUIRED_VIEWER_RESOLVED_DISTANCE_PAIRS.items():
+        raw = distances.get(pair)
+        try:
+            distance = float(raw) if raw is not None else float("nan")
+        except (TypeError, ValueError):
+            distance = float("nan")
+        if not (0.0 <= distance <= max_distance_m):
+            errors.append(f"browser viewer resolved distance {pair} expected <= {max_distance_m:.3f} m, got {raw!r}")
+    return errors
+
 
 def _load_yaml(path: Path) -> Mapping[str, Any]:
     if not path.is_file():
@@ -223,13 +264,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 1
     status = browser.get("status") if isinstance(browser, Mapping) else None
     if isinstance(status, Mapping):
-        mesh_loaded_count = int(status.get("mesh_loaded_count") or status.get("meshLoadedCount") or 0)
-        required_mesh_failed_count = int(status.get("required_mesh_failed_count") or status.get("requiredMeshFailedCount") or 0)
-        if mesh_loaded_count == 0:
-            print("error: browser viewer loaded zero mesh-backed visuals (mesh_loaded_count == 0)", file=sys.stderr)
-            return 1
-        if required_mesh_failed_count > 0:
-            print(f"error: browser viewer reported required mesh failures (required_mesh_failed_count == {required_mesh_failed_count})", file=sys.stderr)
+        status_errors = validate_browser_status(status)
+        if status_errors:
+            for error in status_errors:
+                print(f"error: {error}", file=sys.stderr)
             return 1
     elif args.require_browser:
         print("error: browser viewer did not expose window.__WORKCELL_VIEWER_STATUS__", file=sys.stderr)

--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -204,6 +204,47 @@ def test_viewer_places_generated_urdf_roots_at_frame_pose_and_visuals_at_origin(
     assert "isGeneratedUrdfItem(item) ? visualOriginOf(item) : transform.pose" in mesh_transform_body
     assert "meshObject.position.copy(visualOrigin.xyz)" in mesh_transform_body
 
+
+def test_generated_urdf_link_placement_does_not_primarily_use_legacy_visual_world_pose():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    pose_body = js.split("function poseOf(item)", 1)[1].split("function scaleOf", 1)[0]
+    generated_branch = pose_body.split("const pose = canonicalFinalPose(item);", 1)[0]
+
+    assert "if (isGeneratedUrdfItem(item)) return framePoseOf(item)" in generated_branch
+    for legacy_pose in ["baked_world_visual_pose", "world_from_visual", "final_transform"]:
+        assert legacy_pose not in generated_branch
+
+
+def test_generated_urdf_link_placement_consumes_link_or_frame_world_pose():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    frame_source_body = js.split("function generatedUrdfFramePoseSource(item)", 1)[1].split("function framePoseOf(item)", 1)[0]
+    pose_body = js.split("function poseOf(item)", 1)[1].split("function scaleOf", 1)[0]
+
+    assert "if (item?.frame_world_pose) return item.frame_world_pose;" in frame_source_body
+    assert "if (item?.link_world_pose) return item.link_world_pose;" in frame_source_body
+    assert "if (isGeneratedUrdfItem(item)) return framePoseOf(item)" in pose_body
+
+
+def test_viewer_declares_explicit_ros_z_up_convention():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    init_body = js.split("function initThree()", 1)[1].split("function animate()", 1)[0]
+
+    assert "const ROS_Z_UP = new THREE.Vector3(0, 0, 1);" in init_body
+    assert "THREE.Object3D.DEFAULT_UP.copy(ROS_Z_UP);" in init_body
+    assert "scene.up.copy(ROS_Z_UP);" in init_body
+    assert "camera.up.copy(ROS_Z_UP);" in init_body
+
+
+def test_viewer_ground_grid_is_ros_xy_not_threejs_default_xz_y_up():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    init_body = js.split("function initThree()", 1)[1].split("function animate()", 1)[0]
+
+    assert "new THREE.GridHelper" in init_body
+    assert "grid.name = 'ros_xy_ground_grid';" in init_body
+    assert "grid.up.copy(ROS_Z_UP);" in init_body
+    assert "grid.rotation.x = Math.PI / 2;" in init_body
+
+
 def test_repository_does_not_track_generated_web_scene_outputs_under_source_paths():
     result = subprocess.run(
         ["git", "ls-files", "*.web_scene.json"],

--- a/tests/test_workcell_web3d_visual_acceptance.py
+++ b/tests/test_workcell_web3d_visual_acceptance.py
@@ -95,8 +95,59 @@ def test_acceptance_script_supports_playwright_browser_status_path():
     assert "p.chromium.launch" in text
     assert "window.__WORKCELL_VIEWER_STATUS__" in text
     assert "page.wait_for_function" in text
-    assert "mesh_loaded_count == 0" in text
-    assert "required_mesh_failed_count > 0" in text
+    assert "validate_browser_status(status)" in text
+    assert "EXPECTED_MESH_LOADED_COUNT = 18" in text
+    assert "EXPECTED_REQUIRED_MESH_FAILED_COUNT = 0" in text
     assert "viewer_url:" in text
     assert "screenshot_path:" in text
     assert "report_path:" in text
+
+
+def test_acceptance_script_preserves_canonical_mesh_count_expectations():
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "EXPECTED_MESH_LOADED_COUNT = 18" in text
+    assert "EXPECTED_REQUIRED_MESH_FAILED_COUNT = 0" in text
+    assert "meshLoadedCount expected {EXPECTED_MESH_LOADED_COUNT}" in text
+    assert "requiredMeshFailedCount expected {EXPECTED_REQUIRED_MESH_FAILED_COUNT}" in text
+
+
+def test_acceptance_script_requires_viewer_side_resolved_tool_chain_distances():
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "REQUIRED_VIEWER_RESOLVED_DISTANCE_PAIRS" in text
+    for pair in [
+        "wrist_3_link -> tool0",
+        "tool0 -> gripper_base_link",
+        "wrist_3_link -> gripper_base_link",
+    ]:
+        assert pair in text
+    assert "viewer_resolved_distances_m" in text
+    assert "resolved_distances_m" in text
+    assert "browser viewer resolved distance {pair} expected <=" in text
+
+
+def test_browser_status_validator_accepts_expected_meshes_and_tool_chain_distances():
+    status = {
+        "meshLoadedCount": 18,
+        "requiredMeshFailedCount": 0,
+        "viewer_resolved_distances_m": {
+            "wrist_3_link -> tool0": 0.001,
+            "tool0 -> gripper_base_link": 0.10,
+            "wrist_3_link -> gripper_base_link": 0.10,
+        },
+    }
+
+    assert module.validate_browser_status(status) == []
+
+
+def test_browser_status_validator_rejects_missing_viewer_side_tool_chain_distance():
+    status = {
+        "mesh_loaded_count": 18,
+        "required_mesh_failed_count": 0,
+        "viewer_resolved_distances_m": {
+            "wrist_3_link -> tool0": 0.001,
+            "tool0 -> gripper_base_link": 0.10,
+        },
+    }
+
+    errors = module.validate_browser_status(status)
+    assert any("wrist_3_link -> gripper_base_link" in error for error in errors)


### PR DESCRIPTION
### Motivation
- Prevent generated URDF visuals/links from relying on legacy visual-world fallbacks (`baked_world_visual_pose`, `world_from_visual`, `final_transform`) instead of authoritative `frame_world_pose` / `link_world_pose` for placement.
- Make the static Web 3D viewer explicitly ROS-convention aware by asserting a Z-up convention and ensuring the ground grid is ROS XY rather than Three.js default XZ/Y-up.
- Preserve canonical visual-acceptance expectations (`meshLoadedCount == 18`, `requiredMeshFailedCount == 0`) and add a deterministic check that the viewer resolves short tool-chain distances for key links.

### Description
- Added static assertions to `tests/test_workcell_studio_web_viewer_static.py` that verify generated URDF placement uses `frame_world_pose`/`link_world_pose` and does not primarily use legacy visual-world pose fields, and that the viewer declares ROS Z-up and a ROS XY ground grid.
- Extended `scripts/run_workcell_web3d_visual_acceptance.py` with `EXPECTED_MESH_LOADED_COUNT`, `EXPECTED_REQUIRED_MESH_FAILED_COUNT`, `REQUIRED_VIEWER_RESOLVED_DISTANCE_PAIRS`, and a `validate_browser_status` function that enforces mesh counts and viewer-resolved distances, and replaced the previous looser mesh checks with the stricter validator.
- Added tests in `tests/test_workcell_web3d_visual_acceptance.py` that assert the acceptance script contains the new expectations and exercise the `validate_browser_status` logic with positive and negative cases.
- Hardened numeric parsing for resolved distances to avoid crashes on unexpected types and kept all changes limited to viewer/static acceptance and tests.

### Testing
- Ran `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py tests/test_workcell_web3d_visual_acceptance.py` and all tests passed (`37 passed`).
- The new unit/static assertions cover the viewer JS tokens and the acceptance script validator logic and succeeded locally during the test run.
- No runtime launch, hardware, or fake-hardware defaults were modified and existing acceptance expectations for mesh counts remained enforced by the new validator.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cff87128c83319a2adc83ba2c8e74)