### PR TITLE
Add resolved frame pose mocks and distance assertions to static viewer status test

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -465,6 +465,17 @@ resetView = () => {};
 renderSceneSummary = () => updateViewerStatus();
 state.sceneJson = { scene: { id: 'status_test' } };
 state.runtimeWarnings = [{ code: 'camera_framing_blocker_excluded', reason: 'hidden helper excluded' }];
+class MockVector3 {
+  constructor(x = 0, y = 0, z = 0) {
+    this.x = x;
+    this.y = y;
+    this.z = z;
+  }
+}
+THREE = { Vector3: MockVector3 };
+state.resolvedFramePoses.set('wrist_3_link', { xyz: new MockVector3(0, 0, 0), rpy: new MockVector3(0, 0, 0) });
+state.resolvedFramePoses.set('tool0', { xyz: new MockVector3(0.10, 0, 0), rpy: new MockVector3(0, 0, 0) });
+state.resolvedFramePoses.set('gripper_base_link', { xyz: new MockVector3(0.10, 0.20, 0), rpy: new MockVector3(0, 0, 0) });
 state.objects = [
   { item: { id: 'robot_link', role: 'robot' }, renderInfo: { render_status: 'mesh_loaded' }, object3d: { visible: true } },
   { item: { id: 'workbench', category: 'environment' }, renderInfo: { render_status: 'mesh_loaded' }, object3d: { visible: true } },
@@ -476,6 +487,16 @@ assert.strictEqual(status.meshLoadedCount, 2);
 assert.strictEqual(status.mesh_loaded_count, 2);
 assert.strictEqual(status.requiredMeshFailedCount, 0);
 assert.strictEqual(status.required_mesh_failed_count, 0);
+assert.deepStrictEqual(status.resolvedFramePositions.wrist_3_link, [0, 0, 0]);
+assert.deepStrictEqual(status.resolvedFramePositions.tool0, [0.10, 0, 0]);
+assert.deepStrictEqual(status.resolvedFramePositions.gripper_base_link, [0.10, 0.20, 0]);
+assert.deepStrictEqual(status.resolved_frame_positions, status.resolvedFramePositions);
+assert.strictEqual(typeof status.viewer_resolved_distances_m['wrist_3_link -> tool0'], 'number');
+assert.strictEqual(typeof status.viewer_resolved_distances_m['tool0 -> gripper_base_link'], 'number');
+assert.strictEqual(typeof status.viewer_resolved_distances_m['wrist_3_link -> gripper_base_link'], 'number');
+assert.strictEqual(status.viewer_resolved_distances_m['wrist_3_link -> tool0'], 0.10);
+assert.strictEqual(status.viewer_resolved_distances_m['tool0 -> gripper_base_link'], 0.20);
+assert.strictEqual(status.viewer_resolved_distances_m['wrist_3_link -> gripper_base_link'], Math.hypot(0.10, 0.20, 0));
 assert.strictEqual(status.runtimeWarnings.length, 1);
 assert.strictEqual(status.runtimeWarnings[0].code, 'camera_framing_blocker_excluded');
 assert.strictEqual(isUserFacingWarning(status.runtimeWarnings[0]), false);


### PR DESCRIPTION
### Motivation
- Ensure the static Node VM status harness exercises the resolved-frame plumbing and that `updateViewerStatus()` reports deterministic frame positions and inter-frame distances for key robot frames.

### Description
- Added a `MockVector3` and set `THREE.Vector3` in the Node VM harness used by the static viewer test to provide deterministic `state.resolvedFramePoses` for `wrist_3_link`, `tool0`, and `gripper_base_link`.
- Called the existing `updateViewerStatus()` harness and added assertions that `resolvedFramePositions` (both camelCase and snake_case) are populated and that `viewer_resolved_distances_m` contains numeric entries for `wrist_3_link -> tool0`, `tool0 -> gripper_base_link`, and `wrist_3_link -> gripper_base_link` with the expected numeric values.
- Preserved and did not alter existing assertions that hidden helper/debug overlays do not count toward physical mesh counts and that required-mesh failure counts remain zero for hidden items.
- Modified file: `tests/test_workcell_studio_web_viewer_static.py`.

### Testing
- Ran `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py` and observed all tests in the file pass (25 passed).
- This change is test-only and does not affect runtime, launch files, hardware parameters, or fake-hardware defaults.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d0c8296108331adc687e16fe7353a)