### PR TITLE
test: tighten Web3D browser status acceptance tests

### DIFF
--- a/tests/test_workcell_web3d_visual_acceptance.py
+++ b/tests/test_workcell_web3d_visual_acceptance.py
@@ -126,28 +126,59 @@ def test_acceptance_script_requires_viewer_side_resolved_tool_chain_distances():
 
 
 def test_browser_status_validator_accepts_expected_meshes_and_tool_chain_distances():
-    status = {
+    distance_pairs = {
+        "wrist_3_link -> tool0": 0.001,
+        "tool0 -> gripper_base_link": 0.10,
+        "wrist_3_link -> gripper_base_link": 0.10,
+    }
+    assert set(distance_pairs) == set(module.REQUIRED_VIEWER_RESOLVED_DISTANCE_PAIRS)
+    for pair, distance in distance_pairs.items():
+        assert distance <= module.REQUIRED_VIEWER_RESOLVED_DISTANCE_PAIRS[pair]
+
+    camel_status = {
         "meshLoadedCount": 18,
         "requiredMeshFailedCount": 0,
-        "viewer_resolved_distances_m": {
-            "wrist_3_link -> tool0": 0.001,
-            "tool0 -> gripper_base_link": 0.10,
-            "wrist_3_link -> gripper_base_link": 0.10,
-        },
+        "viewer_resolved_distances_m": distance_pairs,
+    }
+    snake_status = {
+        "mesh_loaded_count": 18,
+        "required_mesh_failed_count": 0,
+        "viewer_resolved_distances_m": distance_pairs,
     }
 
-    assert module.validate_browser_status(status) == []
+    assert camel_status["meshLoadedCount"] == module.EXPECTED_MESH_LOADED_COUNT == 18
+    assert camel_status["requiredMeshFailedCount"] == module.EXPECTED_REQUIRED_MESH_FAILED_COUNT == 0
+    assert snake_status["mesh_loaded_count"] == module.EXPECTED_MESH_LOADED_COUNT == 18
+    assert snake_status["required_mesh_failed_count"] == module.EXPECTED_REQUIRED_MESH_FAILED_COUNT == 0
+    assert module.validate_browser_status(camel_status) == []
+    assert module.validate_browser_status(snake_status) == []
 
 
 def test_browser_status_validator_rejects_missing_viewer_side_tool_chain_distance():
+    missing_pair = "wrist_3_link -> gripper_base_link"
+    reported_distances = {
+        "wrist_3_link -> tool0": 0.001,
+        "tool0 -> gripper_base_link": 0.10,
+    }
+    assert missing_pair in module.REQUIRED_VIEWER_RESOLVED_DISTANCE_PAIRS
+    assert missing_pair not in reported_distances
+
     status = {
         "mesh_loaded_count": 18,
         "required_mesh_failed_count": 0,
-        "viewer_resolved_distances_m": {
-            "wrist_3_link -> tool0": 0.001,
-            "tool0 -> gripper_base_link": 0.10,
-        },
+        "viewer_resolved_distances_m": reported_distances,
     }
 
     errors = module.validate_browser_status(status)
-    assert any("wrist_3_link -> gripper_base_link" in error for error in errors)
+    assert any(missing_pair in error for error in errors)
+
+
+def test_browser_status_validator_rejects_missing_viewer_side_distance_map():
+    status = {
+        "mesh_loaded_count": 18,
+        "required_mesh_failed_count": 0,
+    }
+
+    errors = module.validate_browser_status(status)
+    for pair in module.REQUIRED_VIEWER_RESOLVED_DISTANCE_PAIRS:
+        assert any(pair in error for error in errors)


### PR DESCRIPTION
### Motivation

- Ensure the browser-side viewer status contract is strict: canonical mesh counts must be exact and required viewer-resolved tool-chain distances must be present and under thresholds.  
- Prevent `validate_browser_status()` from silently accepting missing distance data by making tests assert explicit failures when distances are omitted.  
- Make tests verify both camelCase and snake_case status field styles so the validator continues to handle both expected payload shapes.

### Description

- Updated `tests/test_workcell_web3d_visual_acceptance.py` to assert the three `viewer_resolved_distances_m` pairs exactly match `module.REQUIRED_VIEWER_RESOLVED_DISTANCE_PAIRS` and that each reported value is <= the validator threshold.  
- Strengthened the passing-case test to verify both camelCase and snake_case mesh status fields and that they equal `module.EXPECTED_MESH_LOADED_COUNT` (`18`) and `module.EXPECTED_REQUIRED_MESH_FAILED_COUNT` (`0`).  
- Added negative-case coverage that omits a single required distance pair and asserts the validator error mentions the missing pair, and added a case where the entire distance map is absent and asserts every required pair is reported as missing.

### Testing

- Ran the focused test module with `python3 -m pytest tests/test_workcell_web3d_visual_acceptance.py` and all tests in that file passed (13 tests).  
- The changes are test-only and no runtime/launch/ROS files or real-hardware behaviors were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d0ea0b5e083319301e59d1a937d5c)