### PR TITLE
Validate rendered Web3D UR5 mesh adjacency

### DIFF
--- a/scripts/run_workcell_web3d_visual_acceptance.py
+++ b/scripts/run_workcell_web3d_visual_acceptance.py
@@ -37,6 +37,16 @@ REQUIRED_VIEWER_RESOLVED_DISTANCE_PAIRS = {
     "tool0 -> gripper_base_link": 0.35,
     "wrist_3_link -> gripper_base_link": 0.45,
 }
+REQUIRED_RENDERED_MESH_ADJACENT_PAIRS = {
+    "base_link_inertia -> shoulder_link": 0.75,
+    "shoulder_link -> upper_arm_link": 0.75,
+    "upper_arm_link -> forearm_link": 0.75,
+    "forearm_link -> wrist_1_link": 0.75,
+    "wrist_1_link -> wrist_2_link": 0.75,
+    "wrist_2_link -> wrist_3_link": 0.75,
+    "wrist_3_link -> tool0": 0.75,
+    "tool0 -> gripper_base_link": 0.75,
+}
 
 
 def _status_int(status: Mapping[str, Any], snake: str, camel: str) -> int:
@@ -49,6 +59,89 @@ def _distance_map_from_status(status: Mapping[str, Any]) -> Mapping[str, Any]:
         if isinstance(value, Mapping):
             return value
     return {}
+
+
+def _rendered_mesh_diagnostics_from_status(status: Mapping[str, Any]) -> Sequence[Any]:
+    for key in ("rendered_mesh_diagnostics", "renderedMeshDiagnostics"):
+        value = status.get(key)
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            return value
+    return []
+
+
+def _diagnostic_link_name(diagnostic: Mapping[str, Any]) -> str:
+    for key in ("link_name", "linkName", "link", "frame", "id", "display_name", "displayName"):
+        value = diagnostic.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _diagnostic_vector(value: Any) -> tuple[float, float, float] | None:
+    if isinstance(value, Mapping):
+        raw = (value.get("x"), value.get("y"), value.get("z"))
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)) and len(value) >= 3:
+        raw = (value[0], value[1], value[2])
+    else:
+        return None
+    try:
+        vector = (float(raw[0]), float(raw[1]), float(raw[2]))
+    except (TypeError, ValueError):
+        return None
+    if not all(component == component for component in vector):
+        return None
+    return vector
+
+
+def _diagnostic_positions(diagnostic: Mapping[str, Any]) -> list[tuple[float, float, float]]:
+    positions: list[tuple[float, float, float]] = []
+    for key in (
+        "loaded_mesh_bounding_box_center",
+        "loadedMeshBoundingBoxCenter",
+        "visual_wrapper_world_position",
+        "visualWrapperWorldPosition",
+    ):
+        vector = _diagnostic_vector(diagnostic.get(key))
+        if vector is not None:
+            positions.append(vector)
+    return positions
+
+
+def _euclidean_distance(a: tuple[float, float, float], b: tuple[float, float, float]) -> float:
+    return sum((left - right) ** 2 for left, right in zip(a, b)) ** 0.5
+
+
+def _rendered_mesh_adjacency_errors(status: Mapping[str, Any]) -> list[str]:
+    diagnostics = _rendered_mesh_diagnostics_from_status(status)
+    if not diagnostics:
+        return ["browser viewer renderedMeshDiagnostics/rendered_mesh_diagnostics is required for rendered UR5 mesh adjacency checks"]
+
+    by_link: dict[str, Mapping[str, Any]] = {}
+    for raw in diagnostics:
+        if not isinstance(raw, Mapping):
+            continue
+        link_name = _diagnostic_link_name(raw)
+        if link_name and link_name not in by_link:
+            by_link[link_name] = raw
+
+    errors: list[str] = []
+    for pair, max_distance_m in REQUIRED_RENDERED_MESH_ADJACENT_PAIRS.items():
+        left, right = [part.strip() for part in pair.split("->", 1)]
+        left_diag = by_link.get(left)
+        right_diag = by_link.get(right)
+        if left_diag is None or right_diag is None:
+            missing = [link for link, diag in ((left, left_diag), (right, right_diag)) if diag is None]
+            errors.append(f"browser viewer rendered mesh adjacency {pair} missing required link diagnostics: {', '.join(missing)}")
+            continue
+        left_positions = _diagnostic_positions(left_diag)
+        right_positions = _diagnostic_positions(right_diag)
+        if not left_positions or not right_positions:
+            errors.append(f"browser viewer rendered mesh adjacency {pair} missing rendered bounding-box center or wrapper position diagnostics")
+            continue
+        distance = min(_euclidean_distance(a, b) for a in left_positions for b in right_positions)
+        if distance > max_distance_m:
+            errors.append(f"browser viewer rendered mesh adjacency {pair} expected <= {max_distance_m:.3f} m, got {distance:.3f} m")
+    return errors
 
 
 def validate_browser_status(status: Mapping[str, Any]) -> list[str]:
@@ -69,6 +162,7 @@ def validate_browser_status(status: Mapping[str, Any]) -> list[str]:
             distance = float("nan")
         if not (0.0 <= distance <= max_distance_m):
             errors.append(f"browser viewer resolved distance {pair} expected <= {max_distance_m:.3f} m, got {raw!r}")
+    errors.extend(_rendered_mesh_adjacency_errors(status))
     return errors
 
 

--- a/tests/test_workcell_web3d_visual_acceptance.py
+++ b/tests/test_workcell_web3d_visual_acceptance.py
@@ -139,11 +139,13 @@ def test_browser_status_validator_accepts_expected_meshes_and_tool_chain_distanc
         "meshLoadedCount": 18,
         "requiredMeshFailedCount": 0,
         "viewer_resolved_distances_m": distance_pairs,
+        "renderedMeshDiagnostics": _valid_rendered_mesh_diagnostics(),
     }
     snake_status = {
         "mesh_loaded_count": 18,
         "required_mesh_failed_count": 0,
         "viewer_resolved_distances_m": distance_pairs,
+        "rendered_mesh_diagnostics": _valid_rendered_mesh_diagnostics(),
     }
 
     assert camel_status["meshLoadedCount"] == module.EXPECTED_MESH_LOADED_COUNT == 18
@@ -167,6 +169,7 @@ def test_browser_status_validator_rejects_missing_viewer_side_tool_chain_distanc
         "mesh_loaded_count": 18,
         "required_mesh_failed_count": 0,
         "viewer_resolved_distances_m": reported_distances,
+        "rendered_mesh_diagnostics": _valid_rendered_mesh_diagnostics(),
     }
 
     errors = module.validate_browser_status(status)
@@ -177,8 +180,97 @@ def test_browser_status_validator_rejects_missing_viewer_side_distance_map():
     status = {
         "mesh_loaded_count": 18,
         "required_mesh_failed_count": 0,
+        "rendered_mesh_diagnostics": _valid_rendered_mesh_diagnostics(),
     }
 
     errors = module.validate_browser_status(status)
     for pair in module.REQUIRED_VIEWER_RESOLVED_DISTANCE_PAIRS:
         assert any(pair in error for error in errors)
+
+
+def _valid_rendered_mesh_diagnostics(spacing=0.05):
+    diagnostics = []
+    for index, link in enumerate([
+        "base_link_inertia",
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link",
+        "wrist_1_link",
+        "wrist_2_link",
+        "wrist_3_link",
+        "tool0",
+        "gripper_base_link",
+    ]):
+        diagnostics.append(
+            {
+                "link_name": link,
+                "loaded_mesh_bounding_box_center": {"x": index * spacing, "y": 0.0, "z": 0.0},
+                "visual_wrapper_world_position": {"x": index * spacing, "y": 0.0, "z": 0.0},
+            }
+        )
+    return diagnostics
+
+
+def _valid_viewer_distances():
+    return {
+        "wrist_3_link -> tool0": 0.001,
+        "tool0 -> gripper_base_link": 0.10,
+        "wrist_3_link -> gripper_base_link": 0.10,
+    }
+
+
+def _valid_browser_status_with_rendered_diagnostics():
+    return {
+        "meshLoadedCount": 18,
+        "requiredMeshFailedCount": 0,
+        "viewer_resolved_distances_m": _valid_viewer_distances(),
+        "renderedMeshDiagnostics": _valid_rendered_mesh_diagnostics(),
+    }
+
+
+def test_browser_status_validator_rejects_missing_rendered_mesh_diagnostics():
+    status = {
+        "mesh_loaded_count": 18,
+        "required_mesh_failed_count": 0,
+        "viewer_resolved_distances_m": _valid_viewer_distances(),
+    }
+
+    errors = module.validate_browser_status(status)
+
+    assert any("renderedMeshDiagnostics/rendered_mesh_diagnostics is required" in error for error in errors)
+
+
+def test_browser_status_validator_rejects_missing_required_rendered_links():
+    status = _valid_browser_status_with_rendered_diagnostics()
+    status["renderedMeshDiagnostics"] = [
+        diagnostic for diagnostic in status["renderedMeshDiagnostics"] if diagnostic["link_name"] != "forearm_link"
+    ]
+
+    errors = module.validate_browser_status(status)
+
+    assert any("upper_arm_link -> forearm_link" in error and "forearm_link" in error for error in errors)
+    assert any("forearm_link -> wrist_1_link" in error and "forearm_link" in error for error in errors)
+
+
+def test_browser_status_validator_rejects_excessive_adjacent_rendered_mesh_separation():
+    status = _valid_browser_status_with_rendered_diagnostics()
+    for diagnostic in status["renderedMeshDiagnostics"]:
+        if diagnostic["link_name"] == "upper_arm_link":
+            diagnostic["loaded_mesh_bounding_box_center"] = {"x": 10.0, "y": 0.0, "z": 0.0}
+            diagnostic["visual_wrapper_world_position"] = {"x": 10.0, "y": 0.0, "z": 0.0}
+
+    errors = module.validate_browser_status(status)
+
+    assert any("shoulder_link -> upper_arm_link" in error and "expected <=" in error for error in errors)
+    assert any("upper_arm_link -> forearm_link" in error and "expected <=" in error for error in errors)
+
+
+def test_browser_status_validator_accepts_valid_rendered_mesh_diagnostics_snake_case():
+    status = {
+        "mesh_loaded_count": 18,
+        "required_mesh_failed_count": 0,
+        "viewer_resolved_distances_m": _valid_viewer_distances(),
+        "rendered_mesh_diagnostics": _valid_rendered_mesh_diagnostics(),
+    }
+
+    assert module.validate_browser_status(status) == []


### PR DESCRIPTION
### Motivation
- Ensure the Web3D visual acceptance uses browser-provided rendered mesh diagnostics to verify the UR5 rendered chain is present and plausibly adjacent in Product View. 
- Rely on rendered bounding-box centres and visual wrapper positions (browser diagnostics) rather than only resolved-frame distances to detect mesh/preview regressions. 
- Preserve existing mesh-count expectations (`meshLoadedCount == 18`, `requiredMeshFailedCount == 0`) while tightening physical rendered adjacency checks for the canonical UR5 chain.

### Description
- Added `REQUIRED_RENDERED_MESH_ADJACENT_PAIRS` for the UR5 adjacent link chain (`base_link_inertia -> shoulder_link` through `tool0 -> gripper_base_link`).
- Implemented helpers to consume diagnostics and compute adjacency: `_rendered_mesh_diagnostics_from_status`, `_diagnostic_link_name`, `_diagnostic_vector`, `_diagnostic_positions`, `_euclidean_distance`, and `_rendered_mesh_adjacency_errors` in `scripts/run_workcell_web3d_visual_acceptance.py` and hooked them into `validate_browser_status()`.
- Validation failures include missing diagnostics, missing required link entries, missing positional evidence, or excessive separation between adjacent rendered meshes; existing resolved-distance checks remain unchanged.
- Updated `tests/test_workcell_web3d_visual_acceptance.py` to add fixtures and tests asserting that (1) missing rendered diagnostics fail, (2) missing required links fail, (3) excessive adjacent separation fails, and (4) valid rendered diagnostics (both snake/camel cases) pass.

### Testing
- Ran `python3 -m pytest tests/test_workcell_web3d_visual_acceptance.py`, which completed successfully with all tests passing.
- The updated test run included the new adjacency tests and existing resolved-distance / mesh-count expectations and passed (17 tests).
- No runtime, launch, controller, or hardware-default behavior was changed by this PR; the acceptance gate is stricter for viewer diagnostics only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d129be3c48331be19e4fcc1e9a08a)