### PR TITLE
Fix generated URDF viewer mesh hierarchy

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -161,7 +161,7 @@ def test_viewer_includes_mesh_loader_references_and_safe_mesh_uri_logic():
         assert unsafe_token in js
 
 
-def test_viewer_applies_mesh_local_transform_only_to_loaded_meshes():
+def test_viewer_applies_mesh_local_transform_only_below_object_roots():
     js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
     for token in [
         "meshLocalTransformOf",
@@ -172,13 +172,17 @@ def test_viewer_applies_mesh_local_transform_only_to_loaded_meshes():
         "meshLocalVector(scaleSource",
         "Number.isFinite(number)",
         "applyMeshLocalTransform",
+        "applyLoadedMeshScaleHandling",
         "invalid_mesh_local_transform",
         "applied_mesh_local_transform",
     ]:
         assert token in js
+    make_visual_body = js.split("function makeMeshVisualRoot", 1)[1].split("function applyMeshLocalTransform", 1)[0]
+    assert make_visual_body.index("applyMeshLocalTransform(visualRoot, item)") < make_visual_body.index("applyLoadedMeshScaleHandling(meshObject, item)")
+    assert make_visual_body.index("applyLoadedMeshScaleHandling(meshObject, item)") < make_visual_body.index("visualRoot.add(meshObject)")
     try_load_body = js.split("async function tryLoadMesh", 1)[1].split("function collectItems", 1)[0]
-    assert try_load_body.index("materializeLoadedMesh(item, uri, loaded)") < try_load_body.index("applyMeshLocalTransform(meshObject, item)")
-    assert try_load_body.index("applyMeshLocalTransform(meshObject, item)") < try_load_body.index("rendered.object3d.add(meshObject)")
+    assert try_load_body.index("materializeLoadedMesh(item, uri, loaded)") < try_load_body.index("makeMeshVisualRoot(item, meshObject)")
+    assert try_load_body.index("makeMeshVisualRoot(item, meshObject)") < try_load_body.index("rendered.object3d.add(visualRoot)")
     apply_pose_body = js.split("function applyPose", 1)[1].split("function assignItemUserData", 1)[0]
     assert "mesh_local_transform" not in apply_pose_body
     assert "visual_local_transform" not in apply_pose_body
@@ -201,8 +205,11 @@ def test_viewer_places_generated_urdf_roots_at_frame_pose_and_visuals_at_origin(
     pose_body = js.split("function poseOf(item)", 1)[1].split("function scaleOf", 1)[0]
     assert "if (isGeneratedUrdfItem(item)) return framePoseOf(item)" in pose_body
     mesh_transform_body = js.split("function applyMeshLocalTransform", 1)[1].split("async function tryLoadMesh", 1)[0]
-    assert "isGeneratedUrdfItem(item) ? visualOriginOf(item) : transform.pose" in mesh_transform_body
+    assert "const generatedUrdf = isGeneratedUrdfItem(item);" in mesh_transform_body
+    assert "const visualOrigin = generatedUrdf ? visualOriginOf(item) : transform.pose" in mesh_transform_body
     assert "meshObject.position.copy(visualOrigin.xyz)" in mesh_transform_body
+    assert "if (generatedUrdf) meshObject.scale.set(1, 1, 1);" in mesh_transform_body
+    assert "function applyLoadedMeshScaleHandling" in mesh_transform_body
 
 
 def test_generated_urdf_link_placement_does_not_primarily_use_legacy_visual_world_pose():

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -398,7 +398,7 @@ function warnMissingGeneratedUrdfFramePose(item) {
   if (state._generatedUrdfFramePoseWarnings.has(key)) return;
   state._generatedUrdfFramePoseWarnings.add(key);
   const meshUri = displayMeshUri(item);
-  appendViewerDiagnosticWarning(item, 'missing_generated_urdf_frame_pose', `generated URDF item lacks both frame_world_pose and link_world_pose; using legacy visual-world fallback only for diagnostics/compatibility (mesh_uri=${meshUri || 'none'})`, {
+  appendViewerDiagnosticWarning(item, 'missing_generated_urdf_frame_pose', `generated URDF item lacks both frame_world_pose and link_world_pose; placing generated URDF link at identity and reporting legacy visual-world fields only for diagnostics (mesh_uri=${meshUri || 'none'})`, {
     mesh_uri: meshUri,
     legacy_fallback_pose: item?.final_transform || item?.world_from_visual || item?.baked_world_visual_pose || item?.pose || item?.world_pose || null,
   });
@@ -881,18 +881,22 @@ function makeMeshVisualRoot(item, meshObject) {
   visualRoot.up.copy(THREE.Object3D.DEFAULT_UP);
   applyMeshLocalTransform(visualRoot, item);
   // Keep loader-provided scene hierarchies, especially Collada .dae internal
-  // transforms, intact below the visual-origin root.  Generated URDF visual
-  // world/baked transforms belong to the posed link root, never the mesh child.
+  // transforms, intact below the visual-origin root. Generated URDF visual
+  // world/baked transforms belong to the posed link root, and mesh scale/unit
+  // corrections stay on the raw loader output instead of the visual wrapper.
+  applyLoadedMeshScaleHandling(meshObject, item);
   visualRoot.add(meshObject);
   assignItemUserData(visualRoot, item);
   return visualRoot;
 }
 function applyMeshLocalTransform(meshObject, item) {
   const transform = meshLocalTransformOf(item);
-  const visualOrigin = isGeneratedUrdfItem(item) ? visualOriginOf(item) : transform.pose;
+  const generatedUrdf = isGeneratedUrdfItem(item);
+  const visualOrigin = generatedUrdf ? visualOriginOf(item) : transform.pose;
   meshObject.position.copy(visualOrigin.xyz);
   meshObject.rotation.set(visualOrigin.rpy.x, visualOrigin.rpy.y, visualOrigin.rpy.z, 'XYZ');
-  meshObject.scale.set(transform.scale.x, transform.scale.y, transform.scale.z);
+  if (generatedUrdf) meshObject.scale.set(1, 1, 1);
+  else meshObject.scale.set(transform.scale.x, transform.scale.y, transform.scale.z);
   if (!transform.valid) {
     appendViewerDiagnosticWarning(item, 'invalid_mesh_local_transform', transform.reason, {
       mesh_local_transform: item?.mesh_local_transform,
@@ -907,6 +911,11 @@ function applyMeshLocalTransform(meshObject, item) {
     });
   }
   return transform.valid;
+}
+function applyLoadedMeshScaleHandling(meshObject, item) {
+  if (!isGeneratedUrdfItem(item)) return;
+  const transform = meshLocalTransformOf(item);
+  meshObject.scale.set(transform.scale.x, transform.scale.y, transform.scale.z);
 }
 async function tryLoadMesh(item, rendered, fallback) {
   const diagnostic = meshUriDiagnostic(item);
@@ -963,7 +972,7 @@ async function tryLoadMesh(item, rendered, fallback) {
     const visualRoot = makeMeshVisualRoot(item, meshObject);
     visualRoot.updateMatrixWorld(true);
     const nativeBounds = new THREE.Box3().setFromObject(visualRoot);
-    const autoscaled = maybeApplyMeshUnitAutoscale(item, visualRoot, nativeBounds, uri);
+    const autoscaled = maybeApplyMeshUnitAutoscale(item, meshObject, nativeBounds, uri);
     const validationBounds = autoscaled ? new THREE.Box3().setFromObject(visualRoot) : nativeBounds;
     fallback.visible = false;
     rendered.object3d.add(visualRoot);


### PR DESCRIPTION
### Motivation
- Ensure generated URDF links are positioned only by the canonical frame/link world pose (`frame_world_pose`/`link_world_pose`) and never by legacy visual-world fields for placement. 
- Keep visual wrapper transforms limited to the visual origin/local transform, and preserve raw loader hierarchies (especially Collada `.dae`) without reparenting or rotating children. 
- Apply mesh unit/scale corrections to the raw loader output instead of the visual wrapper and improve diagnostics when generated-URDF frame poses are missing.

### Description
- Updated `workcell_studio_web/viewer/viewer.js` to clarify diagnostics in `warnMissingGeneratedUrdfFramePose()` so legacy visual-world fields are reported only for diagnostics and not used for placement. 
- Changed `applyMeshLocalTransform()` so generated URDF visuals use `visualOriginOf(item)` for position/rotation and do not apply local scale there (scale is set to identity for generated URDFs). 
- Added `applyLoadedMeshScaleHandling(meshObject, item)` and call it from `makeMeshVisualRoot()` so unit/scale handling is applied on the raw loaded mesh object (preserving Collada scene hierarchies). 
- Adjusted `tryLoadMesh()` to compute autoscale against the raw loaded mesh and to attach `visualRoot` (the visual wrapper) under the posed link root while keeping `rendered.meshObject` as the wrapper and `rendered.loadedMeshObject` as the loader output. 
- Updated static test `tests/test_workcell_studio_web_viewer_static.py` to assert the new ordering and separation of visual-origin wrapper vs loaded mesh scale handling.

### Testing
- Ran `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py` and it passed (all tests in that file). 
- Ran `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py` and both passed. 
- No runtime/ROS launch or hardware-related code was changed and fake-hardware defaults remain unaffected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d147f64f08331a7af18d630f3c7ce)