### PR TITLE
Validate Web3D table orientation diagnostics

### DIFF
--- a/scripts/run_workcell_web3d_visual_acceptance.py
+++ b/scripts/run_workcell_web3d_visual_acceptance.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import base64
 import json
+import math
 import os
 import shutil
 import socket
@@ -68,6 +69,66 @@ def _rendered_mesh_diagnostics_from_status(status: Mapping[str, Any]) -> Sequenc
             return value
     return []
 
+
+
+def _diagnostic_text(diagnostic: Mapping[str, Any]) -> str:
+    values = []
+    for key in ("id", "object_id", "objectId", "object_name", "objectName", "display_name", "displayName", "name", "label", "category", "role", "type"):
+        value = diagnostic.get(key)
+        if isinstance(value, str):
+            values.append(value)
+    return " ".join(values).lower().replace("_", "-")
+
+
+def _diagnostic_bbox_size(diagnostic: Mapping[str, Any]) -> tuple[float, float, float] | None:
+    for key in ("bounding_box_size", "boundingBoxSize", "loaded_mesh_bounding_box_size", "loadedMeshBoundingBoxSize"):
+        vector = _diagnostic_vector(diagnostic.get(key))
+        if vector is not None:
+            return tuple(abs(component) for component in vector)
+    return None
+
+
+def _diagnostic_up_axis(diagnostic: Mapping[str, Any]) -> tuple[float, float, float] | None:
+    for key in ("inferred_up_axis", "inferredUpAxis", "inferred_normal", "inferredNormal", "normal", "up_axis", "upAxis"):
+        vector = _diagnostic_vector(diagnostic.get(key))
+        if vector is not None:
+            length = _euclidean_distance(vector, (0.0, 0.0, 0.0))
+            if length > 0.0:
+                return tuple(component / length for component in vector)
+    return None
+
+
+def _table_horizontal_errors(status: Mapping[str, Any]) -> list[str]:
+    diagnostics = _rendered_mesh_diagnostics_from_status(status)
+    table_diagnostics = [
+        raw for raw in diagnostics
+        if isinstance(raw, Mapping) and any(token in _diagnostic_text(raw) for token in ("table", "workbench", "work-bench", "bench"))
+    ]
+    if not table_diagnostics:
+        return ["browser viewer canonical table/workbench rendered bounding-box diagnostic is required"]
+
+    errors: list[str] = []
+    for diagnostic in table_diagnostics:
+        name = _diagnostic_link_name(diagnostic) or str(diagnostic.get("object_id") or diagnostic.get("id") or "table/workbench")
+        size = _diagnostic_bbox_size(diagnostic)
+        if size is None:
+            errors.append(f"browser viewer table/workbench {name} missing rendered bounding-box size")
+            continue
+        x, y, z = size
+        smallest_axis = min(((x, "X"), (y, "Y"), (z, "Z")), key=lambda item: item[0])[1]
+        if smallest_axis != "Z":
+            errors.append(f"browser viewer table/workbench {name} expected thickness/smallest dimension along Z, got size x={x:.3f}, y={y:.3f}, z={z:.3f}")
+        if z >= min(x, y):
+            errors.append(f"browser viewer table/workbench {name} expected largest tabletop dimensions in XY with Z thickness, got size x={x:.3f}, y={y:.3f}, z={z:.3f}")
+        up = _diagnostic_up_axis(diagnostic)
+        if up is None:
+            errors.append(f"browser viewer table/workbench {name} missing inferred up axis/normal")
+            continue
+        dot_world_z = up[2]
+        max_tilt_rad = math.radians(15.0)
+        if dot_world_z < math.cos(max_tilt_rad):
+            errors.append(f"browser viewer table/workbench {name} expected normal/up close to world +Z, got ({up[0]:.3f}, {up[1]:.3f}, {up[2]:.3f})")
+    return errors
 
 def _diagnostic_link_name(diagnostic: Mapping[str, Any]) -> str:
     for key in ("link_name", "linkName", "link", "frame", "id", "display_name", "displayName"):
@@ -163,6 +224,7 @@ def validate_browser_status(status: Mapping[str, Any]) -> list[str]:
         if not (0.0 <= distance <= max_distance_m):
             errors.append(f"browser viewer resolved distance {pair} expected <= {max_distance_m:.3f} m, got {raw!r}")
     errors.extend(_rendered_mesh_adjacency_errors(status))
+    errors.extend(_table_horizontal_errors(status))
     return errors
 
 

--- a/tests/test_workcell_web3d_visual_acceptance.py
+++ b/tests/test_workcell_web3d_visual_acceptance.py
@@ -208,7 +208,28 @@ def _valid_rendered_mesh_diagnostics(spacing=0.05):
                 "visual_wrapper_world_position": {"x": index * spacing, "y": 0.0, "z": 0.0},
             }
         )
+    diagnostics.append(_valid_table_diagnostic())
     return diagnostics
+
+
+def _valid_table_diagnostic():
+    return {
+        "id": "workbench",
+        "object_id": "workbench",
+        "object_name": "M1 workbench",
+        "category": "table",
+        "link_name": "workbench",
+        "bounding_box_size": {"x": 1.20, "y": 0.80, "z": 0.05},
+        "bounding_box_center": {"x": 0.40, "y": 0.0, "z": 0.75},
+        "inferred_up_axis": {"x": 0.0, "y": 0.0, "z": 1.0},
+    }
+
+
+def _rotated_table_diagnostic():
+    diagnostic = _valid_table_diagnostic()
+    diagnostic["bounding_box_size"] = {"x": 1.20, "y": 0.05, "z": 0.80}
+    diagnostic["inferred_up_axis"] = {"x": 0.0, "y": 1.0, "z": 0.0}
+    return diagnostic
 
 
 def _valid_viewer_distances():
@@ -274,3 +295,22 @@ def test_browser_status_validator_accepts_valid_rendered_mesh_diagnostics_snake_
     }
 
     assert module.validate_browser_status(status) == []
+
+
+def test_browser_status_validator_accepts_horizontal_table_diagnostic():
+    status = _valid_browser_status_with_rendered_diagnostics()
+
+    assert module.validate_browser_status(status) == []
+
+
+def test_browser_status_validator_rejects_90_degree_rotated_table_diagnostic():
+    status = _valid_browser_status_with_rendered_diagnostics()
+    status["renderedMeshDiagnostics"] = [
+        _rotated_table_diagnostic() if diagnostic.get("category") == "table" else diagnostic
+        for diagnostic in status["renderedMeshDiagnostics"]
+    ]
+
+    errors = module.validate_browser_status(status)
+
+    assert any("thickness/smallest dimension along Z" in error for error in errors)
+    assert any("normal/up close to world +Z" in error for error in errors)

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -117,6 +117,14 @@ function vector3ToDiagnostics(value) {
   const xyz = finiteXyzArrayFromVector(value);
   return xyz ? { x: xyz[0], y: xyz[1], z: xyz[2] } : null;
 }
+function quaternionToDiagnostics(q) { return q ? { x: q.x, y: q.y, z: q.z, w: q.w } : null; }
+function eulerToDiagnostics(e) { return e ? { x: e.x, y: e.y, z: e.z, order: e.order || 'XYZ' } : null; }
+function worldUpDiagnosticsForObject(object) {
+  if (!object || !THREE?.Vector3) return null;
+  object.updateMatrixWorld(true);
+  const up = new THREE.Vector3(0, 0, 1).transformDirection(object.matrixWorld).normalize();
+  return vector3ToDiagnostics(up);
+}
 function box3DiagnosticsForObject(object) {
   if (!object || !THREE?.Box3) return { center: null, size: null };
   object.updateMatrixWorld(true);
@@ -137,7 +145,8 @@ function collectRenderedMeshDiagnostics() {
   const diagnostics = [];
   for (const rendered of state.objects || []) {
     const item = rendered?.item || {};
-    if (!rendered?.object3d || !isGeneratedUrdfItem(item)) continue;
+    const category = meshContractCategoryOf(item);
+    if (!rendered?.object3d || (!isGeneratedUrdfItem(item) && !['table', 'environment'].includes(category))) continue;
     rendered.object3d.updateMatrixWorld(true);
     rendered.meshObject?.updateMatrixWorld?.(true);
     rendered.loadedMeshObject?.updateMatrixWorld?.(true);
@@ -152,10 +161,17 @@ function collectRenderedMeshDiagnostics() {
       visualWrapperWorldPosition = vector3ToDiagnostics(visualWrapperWorld);
     }
 
-    const boundsSource = rendered.loadedMeshObject || rendered.meshObject;
+    const boundsSource = rendered.loadedMeshObject || rendered.meshObject || rendered.object3d;
     const bounds = box3DiagnosticsForObject(boundsSource);
+    const worldQuaternion = new THREE.Quaternion();
+    rendered.object3d.getWorldQuaternion(worldQuaternion);
+    const worldEuler = new THREE.Euler().setFromQuaternion(worldQuaternion, 'XYZ');
+    const inferredUpAxis = worldUpDiagnosticsForObject(rendered.object3d);
     diagnostics.push({
       id: item.id || '',
+      object_id: item.id || item.object_name || item.name || '',
+      object_name: item.object_name || item.name || item.display_name || item.label || item.id || '',
+      category,
       link: item.link || item.object_name || item.visual || '',
       link_name: item.link_name || item.link || item.object_name || '',
       frame: item.frame || item.frame_id || item.link || item.link_name || '',
@@ -170,6 +186,18 @@ function collectRenderedMeshDiagnostics() {
       loaded_mesh_bounding_box_center: bounds.center,
       loadedMeshBoundingBoxSize: bounds.size,
       loaded_mesh_bounding_box_size: bounds.size,
+      boundingBoxCenter: bounds.center,
+      bounding_box_center: bounds.center,
+      boundingBoxSize: bounds.size,
+      bounding_box_size: bounds.size,
+      worldQuaternion: quaternionToDiagnostics(worldQuaternion),
+      world_quaternion: quaternionToDiagnostics(worldQuaternion),
+      worldEuler: eulerToDiagnostics(worldEuler),
+      world_euler: eulerToDiagnostics(worldEuler),
+      inferredUpAxis: inferredUpAxis,
+      inferred_up_axis: inferredUpAxis,
+      inferredNormal: inferredUpAxis,
+      inferred_normal: inferredUpAxis,
     });
   }
   const expectedOrder = new Map(EXPECTED_GENERATED_URDF_DIAGNOSTIC_LINKS.map((name, index) => [name, index]));


### PR DESCRIPTION
### Motivation

- Ensure table/workbench items are included in the viewer's rendered diagnostics so automated acceptance can deterministically validate table geometry and orientation.
- Add a browser-side acceptance gate that verifies canonical `ur5_2f_test` table is horizontal in ROS Z-up to catch regressions where a table gets rotated into a vertical orientation.

### Description

- Extended `collectRenderedMeshDiagnostics` in `workcell_studio_web/viewer/viewer.js` to emit table/environment items and added deterministic fields: `object_id`, `object_name`, `category`, `boundingBoxCenter`/`bounding_box_center`, `boundingBoxSize`/`bounding_box_size`, `worldQuaternion`/`world_quaternion`, `worldEuler`/`world_euler`, and `inferredUpAxis`/`inferred_up_axis`.
- Added helper conversions in `viewer.js` (`quaternionToDiagnostics`, `eulerToDiagnostics`, `worldUpDiagnosticsForObject`) and broadened the bounds source fallback to ensure tables produce reliable bounding-box diagnostics.
- Added table-orientation validation helpers in `scripts/run_workcell_web3d_visual_acceptance.py` (`_diagnostic_text`, `_diagnostic_bbox_size`, `_diagnostic_up_axis`, `_table_horizontal_errors`) and integrated them into `validate_browser_status` to require a table/workbench diagnostic, verify XY are the largest axes, Z is the smallest (thickness), and that the inferred up vector is within 15° of world +Z.
- Added tests in `tests/test_workcell_web3d_visual_acceptance.py` including `_valid_table_diagnostic`, `_rotated_table_diagnostic`, `test_browser_status_validator_accepts_horizontal_table_diagnostic`, and `test_browser_status_validator_rejects_90_degree_rotated_table_diagnostic` to cover accepted and rejected table cases.

### Testing

- Ran `python3 -m pytest tests/test_workcell_web3d_visual_acceptance.py` and all tests passed (`19 passed`).
- Ran `node --check workcell_studio_web/viewer/viewer.js` with no syntax errors and `python3 -m py_compile scripts/run_workcell_web3d_visual_acceptance.py` with no syntax errors.
- Ran `git diff --check` with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d13dd14a08331941608907fee3e61)