### PR TITLE
Guard viewer mesh diagnostics object methods

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -507,6 +507,8 @@ assert.strictEqual(status.viewer_resolved_distances_m['wrist_3_link -> gripper_b
 assert.strictEqual(status.runtimeWarnings.length, 1);
 assert.strictEqual(status.runtimeWarnings[0].code, 'camera_framing_blocker_excluded');
 assert.strictEqual(isUserFacingWarning(status.runtimeWarnings[0]), false);
+assert.deepStrictEqual(status.renderedMeshDiagnostics, []);
+assert.deepStrictEqual(status.rendered_mesh_diagnostics, []);
 setDebugOverlaysVisible(true);
 assert.strictEqual(window.__WORKCELL_VIEWER_STATUS__.meshLoadedCount, 2);
 assert.strictEqual(window.__WORKCELL_VIEWER_STATUS__.requiredMeshFailedCount, 0);

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -147,6 +147,9 @@ function collectRenderedMeshDiagnostics() {
     const item = rendered?.item || {};
     const category = meshContractCategoryOf(item);
     if (!rendered?.object3d || (!isGeneratedUrdfItem(item) && !['table', 'environment'].includes(category))) continue;
+    if (typeof rendered.object3d.updateMatrixWorld !== 'function') continue;
+    if (typeof rendered.object3d.getWorldPosition !== 'function') continue;
+    if (typeof rendered.object3d.getWorldQuaternion !== 'function') continue;
     rendered.object3d.updateMatrixWorld(true);
     rendered.meshObject?.updateMatrixWorld?.(true);
     rendered.loadedMeshObject?.updateMatrixWorld?.(true);


### PR DESCRIPTION
### Motivation
- Prevent runtime exceptions during status collection when `state.objects` contains mocked or static `object3d` values that do not implement Three.js APIs. 
- Ensure diagnostics collection is resilient in static/test harnesses while preserving diagnostics for real Three.js objects.

### Description
- Added method guards in `collectRenderedMeshDiagnostics()` to `continue` unless `typeof rendered.object3d.updateMatrixWorld === 'function'`, `typeof rendered.object3d.getWorldPosition === 'function'`, and `typeof rendered.object3d.getWorldQuaternion === 'function'` are true. 
- Kept optional chaining for `rendered.meshObject?.updateMatrixWorld?.(true)` and `rendered.loadedMeshObject?.updateMatrixWorld?.(true)` so non-essential mocked mesh roots remain safe. 
- Updated `tests/test_workcell_studio_web_viewer_static.py` to assert that a mocked `object3d` without those methods results in empty `renderedMeshDiagnostics` (`status.renderedMeshDiagnostics === []`) rather than throwing.
- Files changed: `workcell_studio_web/viewer/viewer.js`, `tests/test_workcell_studio_web_viewer_static.py`.

### Testing
- Ran `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py` which passed all tests (26 passed). 
- Verified that the static Node.js-based harness used by the test still produces a valid `window.__WORKCELL_VIEWER_STATUS__` and that diagnostics are empty for mocked objects without Three.js methods.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e4314a53c8331a1fc854dff217f1d)