### PR TITLE
Add Web3D visual fallback/status checks and richer viewer diagnostics

### DIFF
--- a/scripts/run_workcell_web3d_visual_acceptance.py
+++ b/scripts/run_workcell_web3d_visual_acceptance.py
@@ -48,6 +48,13 @@ REQUIRED_RENDERED_MESH_ADJACENT_PAIRS = {
     "wrist_3_link -> tool0": 0.75,
     "tool0 -> gripper_base_link": 0.75,
 }
+REQUIRED_PRODUCT_FALLBACK_TOKENS = (
+    "required_mesh_failed_debug_fallback",
+    "primitive_fallback",
+    "box_fallback",
+    "debug_fallback",
+    "fallback_geometry",
+)
 
 
 def _status_int(status: Mapping[str, Any], snake: str, camel: str) -> int:
@@ -86,6 +93,112 @@ def _diagnostic_bbox_size(diagnostic: Mapping[str, Any]) -> tuple[float, float, 
         if vector is not None:
             return tuple(abs(component) for component in vector)
     return None
+
+
+def _diagnostic_status(diagnostic: Mapping[str, Any]) -> str:
+    return str(diagnostic.get("render_status") or diagnostic.get("renderStatus") or diagnostic.get("mesh_status") or "").lower()
+
+
+def _diagnostic_bool(diagnostic: Mapping[str, Any], *keys: str) -> bool:
+    for key in keys:
+        value = diagnostic.get(key)
+        if isinstance(value, bool):
+            return value
+    return False
+
+
+def _diagnostic_expected_dimensions(diagnostic: Mapping[str, Any]) -> tuple[float, float, float] | None:
+    for key in ("expected_dimensions_m", "expectedDimensionsM", "expected_dimensions", "expectedDimensions"):
+        vector = _diagnostic_vector(diagnostic.get(key))
+        if vector is not None:
+            return tuple(abs(component) for component in vector)
+    return None
+
+
+def _diagnostic_scale(diagnostic: Mapping[str, Any]) -> tuple[float, float, float] | None:
+    for key in ("mesh_local_scale", "meshLocalScale", "scale", "mesh_scale", "meshScale"):
+        vector = _diagnostic_vector(diagnostic.get(key))
+        if vector is not None:
+            return tuple(abs(component) for component in vector)
+    correction = diagnostic.get("mesh_unit_correction") or diagnostic.get("meshUnitCorrection")
+    if isinstance(correction, Mapping):
+        raw = correction.get("scale")
+        try:
+            scale = abs(float(raw))
+        except (TypeError, ValueError):
+            return None
+        return (scale, scale, scale)
+    return None
+
+
+def _is_non_uniform(vector: tuple[float, float, float], tolerance: float = 0.05) -> bool:
+    finite = [component for component in vector if component > 0 and math.isfinite(component)]
+    if len(finite) != 3:
+        return False
+    return max(finite) / min(finite) > (1.0 + tolerance)
+
+
+def _is_required_product_diagnostic(diagnostic: Mapping[str, Any]) -> bool:
+    text = _diagnostic_text(diagnostic)
+    category = str(diagnostic.get("category") or "").lower()
+    return (
+        category in {"robot", "tool", "table", "environment"}
+        or any(token in text for token in ("ur5", "robot", "base-link", "shoulder-link", "upper-arm", "forearm", "wrist", "tool0", "gripper", "robotiq", "table", "workbench", "bench"))
+    )
+
+
+def _required_product_fallback_errors(status: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for diagnostic in _rendered_mesh_diagnostics_from_status(status):
+        if not isinstance(diagnostic, Mapping) or not _is_required_product_diagnostic(diagnostic):
+            continue
+        render_status = _diagnostic_status(diagnostic)
+        fallback_visible = _diagnostic_bool(diagnostic, "fallback_visible", "fallbackVisible")
+        if fallback_visible and any(token in render_status for token in REQUIRED_PRODUCT_FALLBACK_TOKENS):
+            name = _diagnostic_link_name(diagnostic) or str(diagnostic.get("id") or diagnostic.get("object_id") or "required product")
+            errors.append(f"browser viewer required product {name} has visible fallback/debug geometry render_status={render_status!r}")
+    return errors
+
+
+def _table_mesh_contract_errors(status: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for diagnostic in _rendered_mesh_diagnostics_from_status(status):
+        if not isinstance(diagnostic, Mapping):
+            continue
+        if not any(token in _diagnostic_text(diagnostic) for token in ("table", "workbench", "work-bench", "bench")):
+            continue
+        name = _diagnostic_link_name(diagnostic) or str(diagnostic.get("object_id") or diagnostic.get("id") or "table/workbench")
+        render_status = _diagnostic_status(diagnostic)
+        expected = _diagnostic_expected_dimensions(diagnostic)
+        mesh_uri = str(diagnostic.get("mesh_uri") or diagnostic.get("meshUri") or "")
+        if expected and mesh_uri and render_status != "mesh_loaded":
+            errors.append(f"browser viewer table/workbench {name} expected a loaded mesh but got render_status={render_status!r}")
+        if expected:
+            scale = _diagnostic_scale(diagnostic)
+            if scale and _is_non_uniform(scale):
+                errors.append(f"browser viewer table/workbench {name} has non-uniform mesh scale derived from expected_dimensions_m: x={scale[0]:.3f}, y={scale[1]:.3f}, z={scale[2]:.3f}")
+    return errors
+
+
+def _camera_bounds_errors(status: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for diagnostic in _rendered_mesh_diagnostics_from_status(status):
+        if not isinstance(diagnostic, Mapping):
+            continue
+        if not any(token in _diagnostic_text(diagnostic) for token in ("camera", "realsense", "sensor")):
+            continue
+        if _diagnostic_status(diagnostic) != "mesh_loaded":
+            continue
+        size = _diagnostic_bbox_size(diagnostic)
+        expected = _diagnostic_expected_dimensions(diagnostic)
+        excluded = _diagnostic_bool(diagnostic, "exclude_from_fit_bounds", "excludeFromFitBounds", "debug_overlay", "debugOverlay")
+        if not size or not expected:
+            continue
+        ratios = [size[index] / expected[index] for index in range(3) if expected[index] > 0]
+        if ratios and max(ratios) > 3.0 and not excluded:
+            name = _diagnostic_link_name(diagnostic) or str(diagnostic.get("object_id") or diagnostic.get("id") or "camera")
+            errors.append(f"browser viewer camera/Realsense {name} loaded mesh bounds are oversized and still included in normal product/fit bounds")
+    return errors
 
 
 def _diagnostic_up_axis(diagnostic: Mapping[str, Any]) -> tuple[float, float, float] | None:
@@ -225,6 +338,9 @@ def validate_browser_status(status: Mapping[str, Any]) -> list[str]:
             errors.append(f"browser viewer resolved distance {pair} expected <= {max_distance_m:.3f} m, got {raw!r}")
     errors.extend(_rendered_mesh_adjacency_errors(status))
     errors.extend(_table_horizontal_errors(status))
+    errors.extend(_required_product_fallback_errors(status))
+    errors.extend(_table_mesh_contract_errors(status))
+    errors.extend(_camera_bounds_errors(status))
     return errors
 
 

--- a/tests/test_workcell_web3d_visual_acceptance.py
+++ b/tests/test_workcell_web3d_visual_acceptance.py
@@ -125,6 +125,15 @@ def test_acceptance_script_requires_viewer_side_resolved_tool_chain_distances():
     assert "browser viewer resolved distance {pair} expected <=" in text
 
 
+def test_viewer_status_reports_loaded_mesh_vs_fallback_geometry():
+    text = (ROOT / "workcell_studio_web/viewer/viewer.js").read_text(encoding="utf-8")
+    assert "renderedObjectStatuses" in text
+    assert "rendered_object_statuses" in text
+    assert "mesh_loaded: renderStatus === 'mesh_loaded'" in text
+    assert "fallback_visible" in text
+    assert "required_mesh_failed_debug_fallback" in text
+
+
 def test_browser_status_validator_accepts_expected_meshes_and_tool_chain_distances():
     distance_pairs = {
         "wrist_3_link -> tool0": 0.001,
@@ -204,6 +213,10 @@ def _valid_rendered_mesh_diagnostics(spacing=0.05):
         diagnostics.append(
             {
                 "link_name": link,
+                "category": "tool" if link in {"tool0", "gripper_base_link"} else "robot",
+                "render_status": "mesh_loaded",
+                "mesh_loaded": True,
+                "fallback_visible": False,
                 "loaded_mesh_bounding_box_center": {"x": index * spacing, "y": 0.0, "z": 0.0},
                 "visual_wrapper_world_position": {"x": index * spacing, "y": 0.0, "z": 0.0},
             }
@@ -219,6 +232,12 @@ def _valid_table_diagnostic():
         "object_name": "M1 workbench",
         "category": "table",
         "link_name": "workbench",
+        "render_status": "mesh_loaded",
+        "mesh_loaded": True,
+        "fallback_visible": False,
+        "mesh_uri": "assets/workbench.stl",
+        "expected_dimensions_m": {"x": 1.20, "y": 0.80, "z": 0.05},
+        "mesh_local_scale": {"x": 1.0, "y": 1.0, "z": 1.0},
         "bounding_box_size": {"x": 1.20, "y": 0.80, "z": 0.05},
         "bounding_box_center": {"x": 0.40, "y": 0.0, "z": 0.75},
         "inferred_up_axis": {"x": 0.0, "y": 0.0, "z": 1.0},
@@ -314,3 +333,60 @@ def test_browser_status_validator_rejects_90_degree_rotated_table_diagnostic():
 
     assert any("thickness/smallest dimension along Z" in error for error in errors)
     assert any("normal/up close to world +Z" in error for error in errors)
+
+
+def test_browser_status_validator_rejects_required_product_visible_fallbacks():
+    status = _valid_browser_status_with_rendered_diagnostics()
+    for diagnostic in status["renderedMeshDiagnostics"]:
+        if diagnostic["link_name"] == "gripper_base_link":
+            diagnostic["render_status"] = "required_mesh_failed_debug_fallback"
+            diagnostic["fallback_visible"] = True
+
+    errors = module.validate_browser_status(status)
+
+    assert any("required product gripper_base_link" in error and "visible fallback/debug geometry" in error for error in errors)
+
+
+def test_browser_status_validator_rejects_table_expected_mesh_rendered_as_primitive_fallback():
+    status = _valid_browser_status_with_rendered_diagnostics()
+    for diagnostic in status["renderedMeshDiagnostics"]:
+        if diagnostic.get("category") == "table":
+            diagnostic["render_status"] = "primitive_fallback"
+            diagnostic["fallback_visible"] = True
+
+    errors = module.validate_browser_status(status)
+
+    assert any("table/workbench workbench expected a loaded mesh" in error for error in errors)
+
+
+def test_browser_status_validator_rejects_table_non_uniform_scale_from_expected_dimensions():
+    status = _valid_browser_status_with_rendered_diagnostics()
+    for diagnostic in status["renderedMeshDiagnostics"]:
+        if diagnostic.get("category") == "table":
+            diagnostic["mesh_local_scale"] = {"x": 1.0, "y": 0.5, "z": 2.0}
+
+    errors = module.validate_browser_status(status)
+
+    assert any("non-uniform mesh scale derived from expected_dimensions_m" in error for error in errors)
+
+
+def test_browser_status_validator_rejects_oversized_camera_mesh_in_fit_bounds():
+    status = _valid_browser_status_with_rendered_diagnostics()
+    status["renderedMeshDiagnostics"].append(
+        {
+            "id": "camera_realsense",
+            "object_id": "camera_realsense",
+            "display_name": "Intel RealSense camera",
+            "category": "camera",
+            "link_name": "camera_link",
+            "render_status": "mesh_loaded",
+            "mesh_loaded": True,
+            "exclude_from_fit_bounds": False,
+            "expected_dimensions_m": {"x": 0.08, "y": 0.08, "z": 0.06},
+            "loaded_mesh_bounding_box_size": {"x": 4.0, "y": 4.0, "z": 3.0},
+        }
+    )
+
+    errors = module.validate_browser_status(status)
+
+    assert any("camera/Realsense camera_link loaded mesh bounds are oversized" in error for error in errors)

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -146,7 +146,7 @@ function collectRenderedMeshDiagnostics() {
   for (const rendered of state.objects || []) {
     const item = rendered?.item || {};
     const category = meshContractCategoryOf(item);
-    if (!rendered?.object3d || (!isGeneratedUrdfItem(item) && !['table', 'environment'].includes(category))) continue;
+    if (!rendered?.object3d || (!isGeneratedUrdfItem(item) && !['table', 'environment', 'camera', 'tool', 'robot'].includes(category))) continue;
     if (typeof rendered.object3d.updateMatrixWorld !== 'function') continue;
     if (typeof rendered.object3d.getWorldPosition !== 'function') continue;
     if (typeof rendered.object3d.getWorldQuaternion !== 'function') continue;
@@ -166,10 +166,14 @@ function collectRenderedMeshDiagnostics() {
 
     const boundsSource = rendered.loadedMeshObject || rendered.meshObject || rendered.object3d;
     const bounds = box3DiagnosticsForObject(boundsSource);
+    const itemBounds = box3DiagnosticsForObject(rendered.object3d);
     const worldQuaternion = new THREE.Quaternion();
     rendered.object3d.getWorldQuaternion(worldQuaternion);
     const worldEuler = new THREE.Euler().setFromQuaternion(worldQuaternion, 'XYZ');
     const inferredUpAxis = worldUpDiagnosticsForObject(rendered.object3d);
+    const expectedDimensions = expectedDimensionsOf(item);
+    const meshLocal = meshLocalTransformOf(item);
+    const renderStatus = rendered.renderInfo?.render_status || item.renderInfo?.render_status || item.mesh_status || '';
     diagnostics.push({
       id: item.id || '',
       object_id: item.id || item.object_name || item.name || '',
@@ -179,8 +183,30 @@ function collectRenderedMeshDiagnostics() {
       link_name: item.link_name || item.link || item.object_name || '',
       frame: item.frame || item.frame_id || item.link || item.link_name || '',
       display_name: item.display_name || item.label || item.name || item.object_name || item.link || item.id || '',
-      render_status: rendered.renderInfo?.render_status || item.renderInfo?.render_status || item.mesh_status || '',
+      source_layer: item.source_layer || '',
+      active_visual_source: item.active_visual_source || '',
+      role: item.role || '',
+      status: item.status || '',
+      render_status: renderStatus,
+      renderStatus,
+      mesh_loaded: renderStatus === 'mesh_loaded',
+      meshLoaded: renderStatus === 'mesh_loaded',
+      fallback_visible: Boolean(rendered.fallback?.visible),
+      fallbackVisible: Boolean(rendered.fallback?.visible),
+      exclude_from_fit_bounds: Boolean(item.exclude_from_fit_bounds || rendered.object3d.userData?.exclude_from_fit_bounds),
+      excludeFromFitBounds: Boolean(item.exclude_from_fit_bounds || rendered.object3d.userData?.exclude_from_fit_bounds),
+      debug_overlay: Boolean(isDebugOverlayItem(item)),
+      debugOverlay: Boolean(isDebugOverlayItem(item)),
+      visual_bounds_status: item.visual_bounds_status || '',
+      visualBoundsStatus: item.visual_bounds_status || '',
+      mesh_unit_correction: item.mesh_unit_correction || null,
+      meshUnitCorrection: item.mesh_unit_correction || null,
+      expected_dimensions_m: expectedDimensions ? vector3ToDiagnostics(expectedDimensions) : null,
+      expectedDimensionsM: expectedDimensions ? vector3ToDiagnostics(expectedDimensions) : null,
+      mesh_local_scale: vector3ToDiagnostics(meshLocal.scale),
+      meshLocalScale: vector3ToDiagnostics(meshLocal.scale),
       mesh_uri: rendered.renderInfo?.mesh_uri || displayMeshUri(item),
+      fallback_reason: rendered.renderInfo?.fallback_reason || '',
       linkFrameWorldPosition: vector3ToDiagnostics(linkFrameWorldPosition),
       link_frame_world_position: vector3ToDiagnostics(linkFrameWorldPosition),
       visualWrapperWorldPosition,
@@ -193,6 +219,10 @@ function collectRenderedMeshDiagnostics() {
       bounding_box_center: bounds.center,
       boundingBoxSize: bounds.size,
       bounding_box_size: bounds.size,
+      itemBoundingBoxCenter: itemBounds.center,
+      item_bounding_box_center: itemBounds.center,
+      itemBoundingBoxSize: itemBounds.size,
+      item_bounding_box_size: itemBounds.size,
       worldQuaternion: quaternionToDiagnostics(worldQuaternion),
       world_quaternion: quaternionToDiagnostics(worldQuaternion),
       worldEuler: eulerToDiagnostics(worldEuler),
@@ -220,6 +250,25 @@ function updateViewerStatus() {
   const warnings = asArray(state.sceneJson?.warnings).concat(asArray(state.sceneJson?.notes_warnings), asArray(state.runtimeWarnings));
   const resolvedFrameStatus = buildResolvedFrameStatus();
   const renderedMeshDiagnostics = collectRenderedMeshDiagnostics();
+  const renderedObjectStatuses = statusCountedRenderables().map(obj => {
+    const item = obj?.item || {};
+    const renderStatus = obj?.renderInfo?.render_status || item?.renderInfo?.render_status || item?.mesh_status || '';
+    return {
+      id: item.id || '',
+      display_name: item.display_name || item.label || item.name || item.object_name || item.link || item.id || '',
+      category: meshContractCategoryOf(item),
+      render_status: renderStatus,
+      renderStatus,
+      mesh_loaded: renderStatus === 'mesh_loaded',
+      meshLoaded: renderStatus === 'mesh_loaded',
+      fallback_visible: Boolean(obj?.fallback?.visible),
+      fallbackVisible: Boolean(obj?.fallback?.visible),
+      mesh_uri: obj?.renderInfo?.mesh_uri || displayMeshUri(item),
+      fallback_reason: obj?.renderInfo?.fallback_reason || '',
+      visual_bounds_status: item.visual_bounds_status || '',
+      visualBoundsStatus: item.visual_bounds_status || '',
+    };
+  });
   window.__WORKCELL_VIEWER_STATUS__ = {
     scene_name: summary.sceneName,
     sceneName: summary.sceneName,
@@ -239,6 +288,8 @@ function updateViewerStatus() {
     resolvedFrameDistancesM: resolvedFrameStatus.resolvedFrameDistancesM,
     renderedMeshDiagnostics,
     rendered_mesh_diagnostics: renderedMeshDiagnostics,
+    renderedObjectStatuses,
+    rendered_object_statuses: renderedObjectStatuses,
   };
   return window.__WORKCELL_VIEWER_STATUS__;
 }


### PR DESCRIPTION
### Motivation
- Improve Web3D visual acceptance by surfacing real failures when required product meshes are missing and fallback/debug geometry is visible. 
- Detect table, camera, and generated-URDF mesh contract problems (primitive fallback used instead of real mesh, non-uniform scaling, oversized camera bounds) that break Product View framing and validation.

### Description
- Added runtime validators in `scripts/run_workcell_web3d_visual_acceptance.py` to detect visible required-product fallback/debug geometry, table mesh-contract mismatches (expected mesh rendered as a primitive/fallback and non-uniform mesh-local scale derived from `expected_dimensions_m`), and oversized camera/Realsense meshes included in normal fit bounds. 
- Introduced helper diagnostic accessors (`_diagnostic_status`, `_diagnostic_bool`, `_diagnostic_expected_dimensions`, `_diagnostic_scale`, `_is_non_uniform`, `_is_required_product_diagnostic`) and new error collectors (`_required_product_fallback_errors`, `_table_mesh_contract_errors`, `_camera_bounds_errors`) and wired them into `validate_browser_status`.
- Expanded the browser-side status payload in `workcell_studio_web/viewer/viewer.js` to include per-object properties such as `render_status`/`renderStatus`, `mesh_loaded`/`meshLoaded`, `fallback_visible`/`fallbackVisible`, `expected_dimensions_m`, `mesh_local_scale`, `visual_bounds_status`, `mesh_unit_correction`, `exclude_from_fit_bounds`, debug-overlay flags, and item-local bounding-box diagnostics, and added `renderedObjectStatuses`/`rendered_object_statuses` summarising per-object render state.
- Added regression tests in `tests/test_workcell_web3d_visual_acceptance.py` covering the new failure modes and asserting the viewer script exposes the new diagnostics.

### Testing
- Ran `pytest tests/test_workcell_web3d_visual_acceptance.py` and all tests passed (`24 passed`).
- Performed browser script validation with `node --check workcell_studio_web/viewer/viewer.js` which passed without errors.
- Verified Python script syntax with `python3 -m py_compile scripts/run_workcell_web3d_visual_acceptance.py` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f5d0abfd083319740777ebe87a067)