### PR TITLE
Add web viewer mesh scale regression tests

### DIFF
--- a/tests/test_workcell_studio_web_scene_contract.py
+++ b/tests/test_workcell_studio_web_scene_contract.py
@@ -446,6 +446,32 @@ def _assert_browser_safe_staged_mesh(item: dict) -> None:
     assert item.get("mesh_resolve_warning") in (None, "")
 
 
+
+def test_ur5_2f_table_mesh_contract_keeps_mesh_backing_and_uniform_scale(tmp_path):
+    payload = _ensure_ur5_2f_web_scene_fresh(tmp_path / "out" / "ur5_2f_test.table_mesh.web_scene.json")
+
+    tables = _items_with_original_mesh(payload, "assets", "workbench_description/meshes/visual/table.stl")
+    assert tables
+    for table in tables:
+        _assert_pose_is_finite(table)
+        _assert_browser_safe_staged_mesh(table)
+        scale = _finite_vector(table.get("scale") or table.get("mesh_scale"), length=3, label=f"{table.get('id')}.scale")
+        assert table.get("primitive_geometry_type") in (None, "mesh")
+        assert table.get("mesh_uri"), f"{table.get('id')} must remain mesh-backed"
+        assert table.get("mesh_staging_status") == "staged"
+        assert table.get("mesh_load_required") is True
+        assert "workbench_description/meshes/visual/table.stl" in str(table.get("original_mesh_uri"))
+        assert table.get("fallback_reason") in (None, "")
+        assert scale[0] == scale[1] == scale[2], "table/workbench mesh scale must remain uniform"
+        assert scale == [0.001, 0.001, 0.001]
+        assert all(0.0001 <= value <= 10.0 for value in scale)
+        assert table.get("expected_dimensions_m") != scale
+        if "expected_dimensions_m" in table:
+            expected = _finite_vector(table["expected_dimensions_m"], length=3, label=f"{table.get('id')}.expected_dimensions_m")
+            assert len(set(round(v, 9) for v in expected)) > 1, "fixture should catch per-axis fitting attempts"
+            assert scale != expected, "expected_dimensions_m must not be copied into render scale"
+
+
 def test_ur5_2f_web_scene_export_transform_parity_for_product_meshes(tmp_path):
     payload = _ensure_ur5_2f_web_scene_fresh(tmp_path / "out" / "ur5_2f_test.parity.web_scene.json")
 

--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -373,6 +373,176 @@ def test_viewer_visual_bounds_diagnostics_and_fit_bounds_contract_are_source_gua
     assert "auto_detected_cm_to_m" in unit_autoscale_body
 
 
+
+def test_viewer_does_not_apply_expected_dimensions_as_per_axis_render_scale():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+
+    assert "maybeApplyExpectedDimensionScale" not in js
+
+    render_scale_bodies = [
+        js.split("function scaleOf(item)", 1)[1].split("function transformOf", 1)[0],
+        js.split("function meshLocalTransformOf(item)", 1)[1].split("function cloneTransform", 1)[0],
+        js.split("function applyMeshLocalTransform", 1)[1].split("async function tryLoadMesh", 1)[0],
+        js.split("function applyLoadedMeshScaleHandling", 1)[1].split("async function tryLoadMesh", 1)[0],
+    ]
+    for body in render_scale_bodies:
+        assert "expected_dimensions_m" not in body
+        assert "expected_dimensions" not in body
+        assert "dimensions_m" not in body
+
+    for forbidden in [
+        ".scale.set(expected",
+        ".scale.set(dimensions",
+        ".scale.set(dims",
+        "scale.x = expected",
+        "scale.y = expected",
+        "scale.z = expected",
+        "meshObject.scale.set(axisRatios",
+        "meshObject.scale.set(scale.x, scale.y, scale.z)",
+    ]:
+        assert forbidden not in js
+
+
+def test_viewer_expected_dimensions_are_limited_to_diagnostics_and_uniform_unit_correction():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+
+    assert "function expectedDimensionsOf(item)" in js
+    assert "function maybeApplyMeshUnitAutoscale" in js
+    unit_autoscale_body = js.split("function maybeApplyMeshUnitAutoscale", 1)[1].split("function isCoreMeshContractItem", 1)[0]
+    assert "expected_dimensions_m" in unit_autoscale_body
+    assert "axisRatios" in unit_autoscale_body
+    assert "uniformRatio" in unit_autoscale_body
+    assert "[1000, 100].find" in unit_autoscale_body
+    assert "uniformRatio <= 1.25" in unit_autoscale_body
+    assert "meshObject.scale.multiplyScalar(scale);" in unit_autoscale_body
+    assert "meshObject.scale.set" not in unit_autoscale_body
+    assert "targetRatio === 1000 ? 0.001 : 0.01" in unit_autoscale_body
+    assert "rejected_non_uniform_or_unclear_ratio" in unit_autoscale_body
+
+    expected_dimension_references = [line for line in js.splitlines() if "expected_dimensions_m" in line]
+    assert expected_dimension_references
+    allowed_context_tokens = (
+        "expectedDimensionsOf",
+        "item?.expected_dimensions_m",
+        "meshUnitAutoscaleAllowed",
+        "maybeApplyMeshUnitAutoscale",
+        "viewer_expected_dimensions_m",
+        "appendRuntimeWarning",
+        "warnLoadedMeshBounds",
+        "loaded_mesh_oversized",
+        "mesh_unit_autoscale",
+        "expected_dimensions_m:",
+        "to expected_dimensions_m",
+    )
+    for line in expected_dimension_references:
+        assert any(token in line for token in allowed_context_tokens), line
+
+
+def test_viewer_unit_autoscale_is_uniform_only_for_clear_100_or_1000_ratios():
+    js_path = VIEWER / "viewer.js"
+    harness = r'''
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+let source = fs.readFileSync(process.argv[1], 'utf8').replace(/boot\(\);\s*$/, '');
+class MockVector3 {
+  constructor(x = 0, y = 0, z = 0) { this.x = x; this.y = y; this.z = z; }
+}
+class MockBox3 {
+  constructor(size) {
+    this.min = { x: 0, y: 0, z: 0 };
+    this.max = { x: size?.x || 0, y: size?.y || 0, z: size?.z || 0 };
+  }
+  isEmpty() { return false; }
+  getSize(target) {
+    target.x = this.max.x - this.min.x;
+    target.y = this.max.y - this.min.y;
+    target.z = this.max.z - this.min.z;
+    return target;
+  }
+  getCenter(target) {
+    target.x = (this.min.x + this.max.x) / 2;
+    target.y = (this.min.y + this.max.y) / 2;
+    target.z = (this.min.z + this.max.z) / 2;
+    return target;
+  }
+  setFromObject(object) { return new MockBox3(object.mockCorrectedSize || object.mockSize || { x: 1, y: 1, z: 1 }); }
+}
+const element = () => ({
+  hidden: false,
+  checked: false,
+  disabled: false,
+  textContent: '',
+  className: '',
+  innerHTML: '',
+  classList: { toggle() {} },
+  setAttribute() {},
+  querySelector() { return { textContent: '' }; },
+  appendChild() {},
+  addEventListener() {},
+  getBoundingClientRect() { return { width: 800, height: 600, left: 0, top: 0 }; },
+});
+const sandbox = {
+  console,
+  assert,
+  MockVector3,
+  MockBox3,
+  window: { location: { search: '' } },
+  document: { getElementById() { return element(); }, createElement() { return element(); } },
+  URLSearchParams,
+  requestAnimationFrame() { return 0; },
+};
+vm.createContext(sandbox);
+vm.runInContext(source + `
+THREE = { Vector3: MockVector3, Box3: MockBox3 };
+state.runtimeWarnings = [];
+function meshObject(size) {
+  return {
+    mockSize: size,
+    mockCorrectedSize: size,
+    updateMatrixWorld() {},
+    scale: {
+      scalar: 1,
+      setCalled: false,
+      multiplyScalar(value) { this.scalar *= value; },
+      set() { this.setCalled = true; throw new Error('per-axis scale must not be used for unit correction'); },
+    },
+  };
+}
+let mmItem = { id: 'metric_table', category: 'table', allow_mesh_unit_autoscale: true, expected_dimensions_m: [1, 0.5, 0.25] };
+let mmMesh = meshObject({ x: 1000, y: 500, z: 250 });
+assert.strictEqual(maybeApplyMeshUnitAutoscale(mmItem, mmMesh, new MockBox3(mmMesh.mockSize), 'table.stl'), true);
+assert.strictEqual(mmMesh.scale.scalar, 0.001);
+assert.strictEqual(mmMesh.scale.setCalled, false);
+assert.strictEqual(mmItem.mesh_unit_correction.target_ratio, 1000);
+
+let cmItem = { id: 'cm_table', category: 'table', allow_mesh_unit_autoscale: true, expected_dimensions_m: [1, 0.5, 0.25] };
+let cmMesh = meshObject({ x: 100, y: 50, z: 25 });
+assert.strictEqual(maybeApplyMeshUnitAutoscale(cmItem, cmMesh, new MockBox3(cmMesh.mockSize), 'table.stl'), true);
+assert.strictEqual(cmMesh.scale.scalar, 0.01);
+assert.strictEqual(cmMesh.scale.setCalled, false);
+assert.strictEqual(cmItem.mesh_unit_correction.target_ratio, 100);
+
+let fittedItem = { id: 'bad_fit_table', category: 'table', allow_mesh_unit_autoscale: true, expected_dimensions_m: [1, 0.5, 0.25] };
+let fittedMesh = meshObject({ x: 4, y: 7, z: 11 });
+assert.strictEqual(maybeApplyMeshUnitAutoscale(fittedItem, fittedMesh, new MockBox3(fittedMesh.mockSize), 'table.stl'), false);
+assert.strictEqual(fittedMesh.scale.scalar, 1);
+assert.strictEqual(fittedMesh.scale.setCalled, false);
+assert.strictEqual(fittedItem.mesh_unit_correction.confidence, 'rejected_non_uniform_or_unclear_ratio');
+assert.strictEqual(fittedItem.mesh_unit_correction.scale, 1.0);
+assert.strictEqual(fittedItem.mesh_unit_correction.target_ratio, null);
+`, sandbox);
+'''
+    result = subprocess.run(
+        ["node", "-e", harness, str(js_path)],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert result.stderr == ""
+
 def test_viewer_hides_camera_framing_exclusions_from_user_warning_panel_but_keeps_status_raw():
     js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
     for token in [


### PR DESCRIPTION
### Motivation

- Prevent regressions where `expected_dimensions_m` is accidentally used to apply non-uniform per-axis render scale in the browser viewer and ensure unit-correction remains diagnostics-only or strictly uniform-only.
- Ensure authored table/workbench product meshes remain mesh-backed (not replaced by primitive/slab fallbacks) and retain uniform scale behavior in exported web scenes.

### Description

- Added static viewer assertions to `tests/test_workcell_studio_web_viewer_static.py` that verify `workcell_studio_web/viewer/viewer.js` does not define or call `maybeApplyExpectedDimensionScale` and does not apply per-axis scaling from `expected_dimensions_m` in render paths.
- Added tests that assert `expected_dimensions_m` is only used in diagnostics/warnings or in the strict unit-autoscale flow, and that unit autoscale is uniform-only and limited to clear 100x or 1000x ratios (no arbitrary per-axis fitting). The unit-autoscale behavior is exercised with a Node-based VM harness to validate runtime logic in `viewer.js`.
- Added a focused scene-contract regression test in `tests/test_workcell_studio_web_scene_contract.py` that validates `ur5_2f_test` table/workbench items remain mesh-backed, staged, required (mesh load required), and uniformly scaled rather than being fitted per-axis to `expected_dimensions_m`.
- Tests-only change; no runtime, launch, or hardware-related code altered.

### Testing

- Ran `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py -q` and observed all tests in that file passed (`29 passed`).
- Ran the new focused scene-contract test with `python3 -m pytest tests/test_workcell_studio_web_scene_contract.py::test_ur5_2f_table_mesh_contract_keeps_mesh_backing_and_uniform_scale -q` and it passed.
- Running the entire `tests/test_workcell_studio_web_scene_contract.py -q` in this checkout surfaced existing unrelated failures (schema rejects an extra top-level `frames` field and an existing UR5 transform parity test reported an implausible 0.0 distance between links); these are pre-existing product/test issues and are not caused by these test additions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f5e9d0e7c8331818f3cb1589d78df)