### PR TITLE
Classify camera helpers as overlays and preserve camera mesh unit evidence/bounds in web export

### DIFF
--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -22,6 +22,7 @@ import json
 import os
 import shutil
 import sys
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from urllib.parse import unquote, urlparse
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
@@ -403,6 +404,8 @@ def _section_from_item(item: Mapping[str, Any]) -> str:
     text = _identity_text(item)
     category = str(item.get("category", "")).lower()
     role = str(item.get("role", "")).lower()
+    if _is_helper(item):
+        return "zones"
     if category == "robot" or role == "robot":
         return "robots"
     if (
@@ -413,9 +416,70 @@ def _section_from_item(item: Mapping[str, Any]) -> str:
         return "tools"
     if "camera" in text or "realsense" in text:
         return "sensors"
-    if _is_helper(item):
-        return "zones"
     return "assets"
+
+
+def _mesh_unit_evidence_from_path(path: Path) -> Optional[Json]:
+    """Return non-rendering mesh unit evidence for exporter diagnostics.
+
+    COLLADA files can declare their authored linear unit in ``asset/unit``.
+    The D435 asset used by the canonical scene declares ``meter=1`` and has
+    vertex coordinates in the expected physical camera range, so the exporter
+    records that evidence rather than applying an implicit scale.
+    """
+    if path.suffix.lower() != ".dae" or not path.is_file():
+        return None
+    try:
+        root = ET.parse(path).getroot()
+    except Exception:  # noqa: BLE001 - unit evidence is diagnostic only
+        return None
+    unit = None
+    for elem in root.iter():
+        if elem.tag.rsplit("}", 1)[-1] == "unit":
+            unit = elem
+            break
+    if unit is None:
+        return {"source": "collada_asset_unit", "declared_unit": "unspecified", "unit_scale_to_m": None}
+    meter_raw = unit.attrib.get("meter")
+    try:
+        meter = float(meter_raw) if meter_raw is not None else None
+    except ValueError:
+        meter = None
+    name = unit.attrib.get("name") or "unspecified"
+    if meter == 1.0:
+        interpretation = "mesh_vertices_already_meters_no_exporter_unit_conversion_applied"
+    elif meter == 0.01:
+        interpretation = "mesh_vertices_declared_centimeters"
+    elif meter == 0.001:
+        interpretation = "mesh_vertices_declared_millimeters"
+    else:
+        interpretation = "mesh_vertices_declared_custom_or_unknown_unit"
+    return {
+        "source": "collada_asset_unit",
+        "declared_unit": name,
+        "unit_scale_to_m": meter,
+        "interpretation": interpretation,
+    }
+
+
+def _annotate_mesh_unit_evidence(item: Json, scene_dir: Path) -> None:
+    if item.get("mesh_unit_evidence"):
+        return
+    repo_root = Path.cwd().resolve()
+    for _field, uri in _mesh_candidates(item):
+        resolved: Optional[Path]
+        if uri.startswith("package://"):
+            resolved, _source_root, _dest_rel, _warning = _resolve_package_uri(uri, repo_root)
+        else:
+            resolved, _source_root, _dest_rel, _warning = _resolve_local_mesh_uri(uri, scene_dir, repo_root)
+        if resolved is None:
+            continue
+        evidence = _mesh_unit_evidence_from_path(resolved)
+        if evidence:
+            evidence["source_path"] = os.path.relpath(resolved, repo_root).replace(os.sep, "/") if _is_relative_to(resolved, repo_root) else str(resolved)
+            item["mesh_unit_evidence"] = evidence
+            item.setdefault("mesh_unit_conversion", {"applied": False, "scale": [1.0, 1.0, 1.0], "reason": evidence.get("interpretation")})
+            return
 
 
 def _canonical_generated_transform(raw: Mapping[str, Any]) -> Tuple[Optional[Any], Optional[str]]:
@@ -460,6 +524,7 @@ def _generated_preview_items(index: Mapping[str, Any], scene_dir: Path, warnings
         "joint_value_source", "applied_joint_value_source", "transform_chain",
         "primitive_geometry_type", "package_uri", "mesh_uri", "source_path", "mesh_path",
         "resolved_source_path", "scale", "mesh_scale", "source_layer", "active_visual_source",
+        "mesh_bounds", "local_bounds", "bounds", "dimensions", "size",
         "render_expected", "mesh_available", "resolved", "warning",
     )
     for i, raw in enumerate(items):
@@ -496,6 +561,8 @@ def _generated_preview_items(index: Mapping[str, Any], scene_dir: Path, warnings
                 "world_from_visual": INPUTS["visual_mesh_index"],
                 "transform_source": INPUTS["visual_mesh_index"],
             })
+        if any(token in _identity_text(raw) for token in ("camera", "realsense", "d435")):
+            _annotate_mesh_unit_evidence(item, scene_dir)
         sections[_section_from_item(raw)].append(item)
     return sections
 

--- a/tests/test_export_workcell_studio_web_scene.py
+++ b/tests/test_export_workcell_studio_web_scene.py
@@ -214,6 +214,85 @@ def test_export_visual_bounds_contract_ignores_helper_zones_outside_workspace(tm
     assert all("camera_fov_overlay" not in source for source in payload["metadata"]["visual_bounds_contract"]["scene_bounds_m"]["sources"])
 
 
+def test_export_fails_oversized_physical_camera_bounds_but_excludes_camera_helpers(tmp_path):
+    scene = tmp_path / "scene"
+    (scene / "layout").mkdir(parents=True)
+    (scene / "generated").mkdir()
+    (scene / "scene_manifest.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "scene": {
+                    "name": "camera_bounds_regression",
+                    "expected_workspace_bounds_m": {"min": [-1.0, -1.0, 0.0], "max": [1.0, 1.0, 1.8]},
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    (scene / "cell_definition.yaml").write_text("{}", encoding="utf-8")
+    (scene / "environment.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "environment": {
+                    "sensors": [
+                        {
+                            "id": "realsense_d435",
+                            "role": "camera",
+                            "category": "camera",
+                            "dimensions": [0.08, 0.08, 0.06],
+                        }
+                    ]
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    (scene / "layout/workcell_studio_layout.yaml").write_text(yaml.safe_dump({"items": []}), encoding="utf-8")
+    (scene / "generated/scene_visual_mesh_index.json").write_text(
+        json.dumps(
+            {
+                "visual_items": [
+                    {
+                        "id": "generated_urdf::camera_link::visual_0",
+                        "category": "camera",
+                        "role": "camera",
+                        "link": "camera_link",
+                        "mesh_uri": "package://realsense2_description/meshes/d435.dae",
+                        "pose": {"xyz": [0.0, 0.0, 0.6], "rpy": [0.0, 0.0, 0.0]},
+                        "mesh_bounds": {"min": [-50.0, -50.0, -50.0], "max": [50.0, 50.0, 50.0]},
+                    },
+                    {
+                        "id": "camera_fov_overlay",
+                        "category": "camera",
+                        "role": "camera_fov",
+                        "source_layer": "overlay",
+                        "active_visual_source": "camera_fov",
+                        "pose": {"xyz": [0.0, 0.0, 0.6], "rpy": [0.0, 0.0, 0.0]},
+                        "dimensions": [100.0, 100.0, 100.0],
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    out = tmp_path / "build/scene.web_scene.json"
+    subprocess.run([sys.executable, str(SCRIPT), "--scene", str(scene), "--output", str(out)], check=True)
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    contract = payload["metadata"]["visual_bounds_contract"]
+    assert contract["status"] == "failed"
+    assert any(
+        blocker["id"] == "generated_urdf::camera_link::visual_0"
+        and blocker["reason"] == "oversized_item_can_break_camera_framing"
+        for blocker in contract["camera_framing_blockers"]
+    )
+    assert all("camera_fov_overlay" not in source for source in contract["scene_bounds_m"]["sources"])
+    assert any(item["id"] == "camera_fov_overlay" for item in payload["zones"])
+
+
 def test_export_carries_authored_fixture_dimensions_to_generated_table_camera_meshes(tmp_path):
     scene = tmp_path / "scene"
     (scene / "layout").mkdir(parents=True)
@@ -472,7 +551,7 @@ def test_gripper_parent_fallback_ignores_wrist_visual_origin_when_tool0_missing(
     assert wrist["visual_origin"] == {"xyz": [0.3, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]}
     assert gripper_base["final_transform"]["xyz"] == [0.4, 0.2, 0.6]
     assert gripper_base["final_transform"]["xyz"] != wrist["baked_world_visual_pose"]["xyz"]
-    assert "tool0_frame_missing_using_wrist_3_link_fallback" in warning_codes
+    assert "tool0_frame_missing_or_collapsed_using_wrist_3_link_fallback" in warning_codes
 
 
 def test_ur5_2f_web_scene_preserves_tool0_transform_anchor_metadata(tmp_path):


### PR DESCRIPTION
### Motivation
- Prevent camera FOV/frustum helper rows from polluting physical product fit bounds while keeping the authored camera body mesh visible and sized correctly.
- Ensure generated camera meshes (D435/Realsense) carry explicit unit evidence so accidental unit mismatches are not silently hidden by global suppression.
- Surface genuinely oversized physical meshes as visual-bounds failures so real regressions are detected by the visual contract.

### Description
- Classify helper/overlay identities before sensor detection in `_section_from_item` so `camera_fov`/frustum helpers are routed to the `zones`/overlay handling rather than `sensors` (file: `scripts/export_workcell_studio_web_scene.py`).
- Preserve generated preview mesh bound fields (`mesh_bounds`, `local_bounds`, `bounds`, `dimensions`, `size`) in the exported web-scene payload so physical camera meshes contribute to the visual bounds contract.
- Add COLLADA unit evidence extraction (`asset/unit`) via `_mesh_unit_evidence_from_path` and annotate camera/Realsense/D435 preview items with `mesh_unit_evidence` and a default `mesh_unit_conversion` payload (no conversion applied when `meter=1`).
- Wire camera-item annotation in `_generated_preview_items` for identities containing `camera`, `realsense`, or `d435` and set `mesh_unit_conversion` metadata to indicate exporter decisions.
- Add a test that verifies an oversized physical camera mesh triggers a visual-bounds failure while a `camera_fov` overlay is excluded from fit bounds, and update a stale test assertion to match current warning codes (file: `tests/test_export_workcell_studio_web_scene.py`).

### Testing
- Ran `python3 -m pytest tests/test_export_workcell_studio_web_scene.py tests/test_workcell_studio_web_viewer_static.py tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py -q` and observed `47 passed` across the modified/related suites.
- Ran `python3 scripts/regenerate_scene_visual_mesh_indexes.py --scene ur5_2f_test --portable` and `python3 scripts/export_workcell_studio_web_scene.py --scene scenes/ur5_2f_test --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json` and confirmed the D435 `.dae` reports `meter=1` evidence and the exporter applied no unit conversion (evidence present on exported camera item).
- Ran the visual-bounds checker `python3 scripts/check_workcell_web_scene_visual_bounds.py build/workcell_studio_web_scene/ur5_2f_test.web_scene.json` which reported pre-existing gripper/tool fallback items outside workspace (these are existing scene/tool fallback issues surfaced by the preserved generated bounds and not caused by the camera unit change).
- Focused new test assertions verifying that (1) oversized physical camera meshes produce camera framing blockers and (2) `camera_fov` helper rows are excluded from product fit-bounds passed (tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f600e1c048331a5e585cc3df6929b)