### PR TITLE
Restore visual mesh index repair compatibility API

### DIFF
--- a/scripts/generate_scene_visual_mesh_index.py
+++ b/scripts/generate_scene_visual_mesh_index.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -14,16 +15,80 @@ if str(Path(__file__).resolve().parents[1]) not in sys.path:
 from scripts.scene3d_visual_index_report import run_visual_index_postprocess  # noqa: E402
 
 
-def _repair_scene_index(scene_dir: Path) -> int:
-    result = run_visual_index_postprocess(scene_dir)
+def _list_value(data: dict, key: str) -> list:
+    value = data.get(key)
+    return value if isinstance(value, list) else []
+
+
+def _format_repair_detail(index_path: Path, changed: bool, added_links: list[str] | tuple[str, ...] | None) -> str:
+    data = json.loads(index_path.read_text(encoding="utf-8")) if index_path.exists() else {}
+    added_arm = list(added_links) if added_links else _list_value(data, "ur5_runtime_repair_added_links")
+    added_eef = _list_value(data, "ur5_runtime_repair_added_end_effector_links")
+    if changed and added_arm:
+        return "ur5_links=" + ",".join(str(v) for v in added_arm)
+    if changed and added_eef:
+        return "end_effector_links=" + ",".join(str(v) for v in added_eef)
+    if changed:
+        return "visual_rows_normalized"
+    return "already_safe"
+
+
+def _print_repair_result(result: dict) -> int:
     if result.get("postprocess_error"):
         print("visual mesh index repair failed: " + str(result["postprocess_error"]), file=sys.stderr)
         return 2
     if result.get("postprocess_changed"):
-        print("[generate_scene_visual_mesh_index] UR5 repair applied: " + str(result.get("postprocess_detail") or "visual rows normalized"), flush=True)
+        print(
+            "[generate_scene_visual_mesh_index] UR5 repair applied: "
+            + str(result.get("postprocess_detail") or "visual rows normalized"),
+            flush=True,
+        )
     else:
         print("[generate_scene_visual_mesh_index] existing index already safe for preview", flush=True)
     return 0
+
+
+def _repair_existing_index(index_path: Path) -> int:
+    """Repair one existing visual index file.
+
+    This compatibility entry point is intentionally kept for older tests and
+    callers that repair a concrete ``scene_visual_mesh_index.json`` path rather
+    than a full scene directory.
+    """
+    try:
+        from scripts.repair_ur5_scene3d_visual_index import repair_index  # noqa: PLC0415
+    except Exception as exc:  # pragma: no cover
+        return _print_repair_result(
+            {
+                "postprocess_changed": False,
+                "postprocess_error": f"repair module unavailable: {exc}",
+                "postprocess_detail": "",
+            }
+        )
+
+    try:
+        changed, added_links = repair_index(index_path)
+        detail = _format_repair_detail(index_path, bool(changed), added_links)
+        return _print_repair_result(
+            {
+                "postprocess_changed": bool(changed),
+                "postprocess_error": "",
+                "postprocess_detail": detail,
+            }
+        )
+    except Exception as exc:  # pragma: no cover
+        return _print_repair_result(
+            {
+                "postprocess_changed": False,
+                "postprocess_error": str(exc),
+                "postprocess_detail": "",
+            }
+        )
+
+
+def _repair_scene_index(scene_dir: Path) -> int:
+    result = run_visual_index_postprocess(scene_dir)
+    return _print_repair_result(result)
 
 
 def main() -> int:


### PR DESCRIPTION
### Motivation

The latest local test run failed before collecting the requested Web3D test files because `tests/test_generate_scene_visual_mesh_index_repair_output.py` imports `_repair_existing_index` from `scripts/generate_scene_visual_mesh_index.py`, but that compatibility function no longer exists on `main`.

### Description

- Restores `_repair_existing_index(index_path)` as a compatibility entry point for callers/tests that repair a concrete `scene_visual_mesh_index.json` file instead of a full scene directory.
- Factors common repair-result printing into `_print_repair_result()` so both scene-directory repair and direct-index repair produce the same user-facing messages.
- Adds detail formatting for repaired UR5 links and repaired Robotiq/2F end-effector preview links by reading the repaired index metadata.
- Keeps the existing CLI behavior unchanged: `--repair-existing-only` still repairs `scenes/<scene>/generated/scene_visual_mesh_index.json` through the scene postprocess path.

### Testing

Please run in the ROS Humble workspace:

```bash
python3 -m pytest -q tests/test_generate_scene_visual_mesh_index_repair_output.py
python3 -m pytest -q \
  tests/test_workcell_studio_web_viewer_static.py \
  tests/test_workcell_web3d_visual_acceptance.py \
  tests/test_export_workcell_studio_web_scene.py \
  tests/test_workcell_studio_web_scene_contract.py
```

No launch, robot motion, or real-hardware path is touched.