### PR TITLE
Fix web scene frames schema and UR5 mesh export

### DIFF
--- a/schemas/workcell_studio_web_scene_v1.schema.json
+++ b/schemas/workcell_studio_web_scene_v1.schema.json
@@ -1,169 +1,465 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://workcell-studio.local/schemas/workcell_studio_web_scene_v1.schema.json",
-  "title": "Workcell Studio Web Scene v1",
-  "description": "Browser-facing, dependency-light scene JSON exported from Workcell Studio authored and generated scene inputs.",
-  "type": "object",
-  "additionalProperties": false,
-  "required": ["schema_version", "scene", "inputs", "robots", "tools", "assets", "sensors", "zones", "metadata", "viewer_summary", "warnings", "backend_actions"],
-  "properties": {
-    "schema_version": {"const": "workcell_studio_web_scene/v1"},
-    "scene": {"$ref": "#/$defs/scene"},
-    "inputs": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["cell_definition", "environment", "layout", "scene_manifest", "visual_mesh_index"],
-      "properties": {
-        "cell_definition": {"$ref": "#/$defs/input"},
-        "environment": {"$ref": "#/$defs/input"},
-        "layout": {"$ref": "#/$defs/input"},
-        "scene_manifest": {"$ref": "#/$defs/input"},
-        "visual_mesh_index": {"$ref": "#/$defs/input"}
-      }
-    },
-    "robots": {"type": "array", "items": {"$ref": "#/$defs/item"}},
-    "tools": {"type": "array", "items": {"$ref": "#/$defs/item"}},
-    "assets": {"type": "array", "items": {"$ref": "#/$defs/item"}},
-    "sensors": {"type": "array", "items": {"$ref": "#/$defs/item"}},
-    "zones": {"type": "array", "items": {"$ref": "#/$defs/item"}},
-    "metadata": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["mesh_contract"],
-      "properties": {
-        "mesh_contract": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["required_mesh_count", "staged_mesh_count", "missing_required_meshes", "fallback_primitive_count", "core_mesh_failures", "mesh_contract_status"],
-          "properties": {
-            "required_mesh_count": {"type": "integer", "minimum": 0},
-            "staged_mesh_count": {"type": "integer", "minimum": 0},
-            "missing_required_meshes": {"type": "array", "items": {"type": "object", "additionalProperties": true}},
-            "fallback_primitive_count": {"type": "integer", "minimum": 0},
-            "core_mesh_failures": {"type": "array", "items": {"type": "object", "additionalProperties": true}},
-            "mesh_contract_status": {"enum": ["passed", "failed"]}
-          }
-        }
-      }
-    },
-    "viewer_summary": {"$ref": "#/$defs/viewerSummary"},
-    "warnings": {"type": "array", "items": {"$ref": "#/$defs/warning"}},
-    "backend_actions": {"type": "array", "items": {"$ref": "#/$defs/backendAction"}}
-  },
-  "$defs": {
-    "scene": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["id", "name", "source_dir", "provenance", "units", "coordinate_system"],
-      "properties": {
-        "id": {"type": "string", "minLength": 1},
-        "name": {"type": "string", "minLength": 1},
-        "source_dir": {"type": "string", "minLength": 1},
-        "provenance": {"$ref": "#/$defs/provenance"},
-        "units": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["distance", "angle"],
-          "properties": {"distance": {"const": "metre"}, "angle": {"const": "radian"}}
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://workcell-studio.local/schemas/workcell_studio_web_scene_v1.schema.json",
+    "title": "Workcell Studio Web Scene v1",
+    "description": "Browser-facing, dependency-light scene JSON exported from Workcell Studio authored and generated scene inputs.",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "schema_version",
+        "scene",
+        "inputs",
+        "robots",
+        "tools",
+        "assets",
+        "sensors",
+        "zones",
+        "metadata",
+        "viewer_summary",
+        "warnings",
+        "backend_actions"
+    ],
+    "properties": {
+        "schema_version": {
+            "const": "workcell_studio_web_scene/v1"
         },
-        "coordinate_system": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["frame", "up_axis", "convention", "pose_reference"],
-          "properties": {
-            "frame": {"const": "world"},
-            "up_axis": {"const": "z"},
-            "convention": {"const": "ros_world_z_up"},
-            "pose_reference": {"type": "string"}
-          }
-        }
-      }
-    },
-    "input": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["path", "present"],
-      "properties": {"path": {"type": "string", "minLength": 1}, "present": {"type": "boolean"}}
-    },
-    "item": {
-      "type": "object",
-      "additionalProperties": true,
-      "required": ["id", "provenance"],
-      "properties": {
-        "id": {"type": "string", "minLength": 1},
-        "editable": {"type": "boolean"},
-        "locked": {"type": "boolean"},
-        "source_kind": {"enum": ["user_authored", "generated_preview"]},
-        "provenance": {"$ref": "#/$defs/provenance"}
-      }
-    },
-    "provenance": {"type": "object", "additionalProperties": {"type": "string"}},
-    "warning": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["code", "message"],
-      "properties": {
-        "code": {"type": "string", "minLength": 1},
-        "message": {"type": "string", "minLength": 1},
-        "source": {"type": "string", "minLength": 1}
-      }
-    },
-    "backendAction": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["id", "label", "enabled", "request_kind"],
-      "properties": {
-        "id": {"type": "string", "minLength": 1},
-        "label": {"type": "string", "minLength": 1},
-        "enabled": {"type": "boolean"},
-        "request_kind": {"enum": ["backend_request"]},
-        "description": {"type": "string"},
-        "safety_note": {"type": "string"}
-      }
-    },
-    "viewerSummary": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["scene_bounds", "renderable_count", "mesh_backed_count", "fallback_count", "missing_or_failed_mesh_count", "required_item_status"],
-      "properties": {
-        "scene_bounds": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["min", "max", "source_count", "sources"],
-          "properties": {
-            "min": {"$ref": "#/$defs/number3"},
-            "max": {"$ref": "#/$defs/number3"},
-            "source_count": {"type": "integer", "minimum": 0},
-            "sources": {"type": "array", "items": {"type": "string"}}
-          }
+        "scene": {
+            "$ref": "#/$defs/scene"
         },
-        "renderable_count": {"type": "integer", "minimum": 0},
-        "mesh_backed_count": {"type": "integer", "minimum": 0},
-        "fallback_count": {"type": "integer", "minimum": 0},
-        "missing_or_failed_mesh_count": {"type": "integer", "minimum": 0},
-        "required_item_status": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["robot", "tool", "table", "camera"],
-          "properties": {
-            "robot": {"$ref": "#/$defs/requiredItemStatus"},
-            "tool": {"$ref": "#/$defs/requiredItemStatus"},
-            "table": {"$ref": "#/$defs/requiredItemStatus"},
-            "camera": {"$ref": "#/$defs/requiredItemStatus"}
-          }
+        "inputs": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "cell_definition",
+                "environment",
+                "layout",
+                "scene_manifest",
+                "visual_mesh_index"
+            ],
+            "properties": {
+                "cell_definition": {
+                    "$ref": "#/$defs/input"
+                },
+                "environment": {
+                    "$ref": "#/$defs/input"
+                },
+                "layout": {
+                    "$ref": "#/$defs/input"
+                },
+                "scene_manifest": {
+                    "$ref": "#/$defs/input"
+                },
+                "visual_mesh_index": {
+                    "$ref": "#/$defs/input"
+                }
+            }
+        },
+        "robots": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/item"
+            }
+        },
+        "tools": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/item"
+            }
+        },
+        "assets": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/item"
+            }
+        },
+        "sensors": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/item"
+            }
+        },
+        "zones": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/item"
+            }
+        },
+        "frames": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/item"
+            }
+        },
+        "metadata": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "mesh_contract"
+            ],
+            "properties": {
+                "mesh_contract": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "required_mesh_count",
+                        "staged_mesh_count",
+                        "missing_required_meshes",
+                        "fallback_primitive_count",
+                        "core_mesh_failures",
+                        "mesh_contract_status"
+                    ],
+                    "properties": {
+                        "required_mesh_count": {
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "staged_mesh_count": {
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "missing_required_meshes": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": true
+                            }
+                        },
+                        "fallback_primitive_count": {
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "core_mesh_failures": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": true
+                            }
+                        },
+                        "mesh_contract_status": {
+                            "enum": [
+                                "passed",
+                                "failed"
+                            ]
+                        }
+                    }
+                },
+                "visual_bounds_contract": {
+                    "type": "object",
+                    "additionalProperties": true
+                }
+            }
+        },
+        "viewer_summary": {
+            "$ref": "#/$defs/viewerSummary"
+        },
+        "warnings": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/warning"
+            }
+        },
+        "backend_actions": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/backendAction"
+            }
         }
-      }
     },
-    "requiredItemStatus": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["present", "status", "item_ids"],
-      "properties": {
-        "present": {"type": "boolean"},
-        "status": {"enum": ["missing", "mesh_backed", "primitive_fallback", "missing_or_failed_mesh"]},
-        "item_ids": {"type": "array", "items": {"type": "string"}}
-      }
-    },
-    "number3": {"type": "array", "minItems": 3, "maxItems": 3, "items": {"type": "number"}}
-  }
+    "$defs": {
+        "scene": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "id",
+                "name",
+                "source_dir",
+                "provenance",
+                "units",
+                "coordinate_system"
+            ],
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "name": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "source_dir": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "provenance": {
+                    "$ref": "#/$defs/provenance"
+                },
+                "units": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "distance",
+                        "angle"
+                    ],
+                    "properties": {
+                        "distance": {
+                            "const": "metre"
+                        },
+                        "angle": {
+                            "const": "radian"
+                        }
+                    }
+                },
+                "coordinate_system": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "frame",
+                        "up_axis",
+                        "convention",
+                        "pose_reference"
+                    ],
+                    "properties": {
+                        "frame": {
+                            "const": "world"
+                        },
+                        "up_axis": {
+                            "const": "z"
+                        },
+                        "convention": {
+                            "const": "ros_world_z_up"
+                        },
+                        "pose_reference": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "input": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "path",
+                "present"
+            ],
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "present": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "item": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": [
+                "id",
+                "provenance"
+            ],
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "editable": {
+                    "type": "boolean"
+                },
+                "locked": {
+                    "type": "boolean"
+                },
+                "source_kind": {
+                    "enum": [
+                        "user_authored",
+                        "generated_preview"
+                    ]
+                },
+                "provenance": {
+                    "$ref": "#/$defs/provenance"
+                }
+            }
+        },
+        "provenance": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "warning": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "code",
+                "message"
+            ],
+            "properties": {
+                "code": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "message": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "source": {
+                    "type": "string",
+                    "minLength": 1
+                }
+            }
+        },
+        "backendAction": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "id",
+                "label",
+                "enabled",
+                "request_kind"
+            ],
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "label": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "request_kind": {
+                    "enum": [
+                        "backend_request"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "safety_note": {
+                    "type": "string"
+                }
+            }
+        },
+        "viewerSummary": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "scene_bounds",
+                "renderable_count",
+                "mesh_backed_count",
+                "fallback_count",
+                "missing_or_failed_mesh_count",
+                "required_item_status"
+            ],
+            "properties": {
+                "scene_bounds": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "min",
+                        "max",
+                        "source_count",
+                        "sources"
+                    ],
+                    "properties": {
+                        "min": {
+                            "$ref": "#/$defs/number3"
+                        },
+                        "max": {
+                            "$ref": "#/$defs/number3"
+                        },
+                        "source_count": {
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "sources": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "renderable_count": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "mesh_backed_count": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "fallback_count": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "missing_or_failed_mesh_count": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "required_item_status": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "robot",
+                        "tool",
+                        "table",
+                        "camera"
+                    ],
+                    "properties": {
+                        "robot": {
+                            "$ref": "#/$defs/requiredItemStatus"
+                        },
+                        "tool": {
+                            "$ref": "#/$defs/requiredItemStatus"
+                        },
+                        "table": {
+                            "$ref": "#/$defs/requiredItemStatus"
+                        },
+                        "camera": {
+                            "$ref": "#/$defs/requiredItemStatus"
+                        }
+                    }
+                }
+            }
+        },
+        "requiredItemStatus": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "present",
+                "status",
+                "item_ids"
+            ],
+            "properties": {
+                "present": {
+                    "type": "boolean"
+                },
+                "status": {
+                    "enum": [
+                        "missing",
+                        "mesh_backed",
+                        "primitive_fallback",
+                        "missing_or_failed_mesh"
+                    ]
+                },
+                "item_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "number3": {
+            "type": "array",
+            "minItems": 3,
+            "maxItems": 3,
+            "items": {
+                "type": "number"
+            }
+        }
+    }
 }

--- a/scripts/ensure_workcell_studio_web_scene_fresh.py
+++ b/scripts/ensure_workcell_studio_web_scene_fresh.py
@@ -51,6 +51,17 @@ GENERATOR_INPUT_RELS = (
     "assets/robots/universal_robot/ur5_moveit_config/config/initial_positions.yaml",
 )
 
+UR5_VISUAL_MESH_URI_TOKEN = "ur_description/meshes/ur5/visual/"
+UR5_REQUIRED_LINKS = {
+    "base_link_inertia",
+    "shoulder_link",
+    "upper_arm_link",
+    "forearm_link",
+    "wrist_1_link",
+    "wrist_2_link",
+    "wrist_3_link",
+}
+
 
 def _is_relative_to(path: Path, root: Path) -> bool:
     try:
@@ -173,6 +184,79 @@ def require_real_xacro_mesh_index(mesh_index: Path) -> None:
     )
 
 
+def _mesh_uri_values(item: dict) -> List[str]:
+    values: List[str] = []
+    for field in ("mesh_uri", "package_uri", "mesh_path", "source_path", "resolved_source_path", "repo_relative_source_path", "asset_relative_source_path"):
+        value = item.get(field)
+        if isinstance(value, str) and value:
+            values.append(value)
+    return values
+
+
+def normalize_ur5_mesh_preview_rows(mesh_index: Path) -> bool:
+    """Mark real-xacro UR5 mesh rows as browser robot preview rows.
+
+    The real URDF extractor can emit correct UR5 mesh rows without the static
+    fallback classification fields.  The web exporter buckets generated rows by
+    role/category before staging assets, so unclassified real-xacro UR5 rows land
+    in generic assets and the browser scene loses the required robot mesh contract.
+    Normalize only resolved UR5 visual mesh rows; do not fabricate geometry.
+    """
+    if not mesh_index.exists():
+        return False
+    try:
+        payload = json.loads(mesh_index.read_text(encoding="utf-8"))
+    except Exception:
+        return False
+    if not isinstance(payload, dict):
+        return False
+    raw_items = payload.get("visual_items") or payload.get("items")
+    if not isinstance(raw_items, list):
+        return False
+
+    changed = False
+    normalized_links: set[str] = set()
+    for item in raw_items:
+        if not isinstance(item, dict):
+            continue
+        link = str(item.get("link") or item.get("link_name") or item.get("object_name") or "")
+        if link not in UR5_REQUIRED_LINKS:
+            continue
+        if str(item.get("geometry_type") or "").lower() != "mesh":
+            continue
+        if not any(UR5_VISUAL_MESH_URI_TOKEN in value for value in _mesh_uri_values(item)):
+            continue
+
+        desired = {
+            "category": "robot_static_mesh_visual",
+            "role": "robot",
+            "source_layer": "locked_generated_urdf_visual",
+            "active_visual_source": "mesh_preview",
+            "primitive_geometry_type": "mesh",
+            "mesh_available": True,
+            "render_expected": True,
+            "primitive_fallback": False,
+            "fallback_reason": "",
+        }
+        for key, value in desired.items():
+            if item.get(key) != value:
+                item[key] = value
+                changed = True
+        normalized_links.add(link)
+
+    if normalized_links:
+        payload["workcell_web_ur5_mesh_preview_normalized"] = True
+        payload["workcell_web_ur5_mesh_preview_links"] = sorted(normalized_links)
+        changed = True
+    if changed:
+        mesh_index.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        print(
+            "[workcell_web_scene_fresh] normalized UR5 mesh preview rows: "
+            + ",".join(sorted(normalized_links))
+        )
+    return changed
+
+
 def run_checked(command: Sequence[str]) -> None:
     result = subprocess.run(command, cwd=REPO_ROOT, text=True, capture_output=True, check=False)
     if result.returncode != 0:
@@ -241,6 +325,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         require_real_xacro_mesh_index(mesh_index)
         web_stale = True
         web_reason = "mesh index was refreshed"
+
+    if normalize_ur5_mesh_preview_rows(mesh_index):
+        web_stale = True
+        web_reason = "mesh index UR5 preview rows were normalized for web export"
+        if args.stage_assets:
+            assets_stale = True
+            assets_reason = "mesh index UR5 preview rows were normalized for web export"
 
     if args.force or web_stale or assets_stale:
         reasons = []


### PR DESCRIPTION
### Motivation
The focused Web3D/export test run is now down to real contract failures: the exporter emits top-level `frames`, but the v1 schema rejects it, and real-xacro UR5 mesh rows are generated but do not survive into the web scene `robots` bucket as required mesh-backed robot rows.

### Description
- Updates the web scene v1 schema to allow the exporter-owned top-level `frames` array.
- Allows `metadata.visual_bounds_contract` in the schema so the current exporter diagnostics remain schema-valid.
- Normalizes resolved UR5 visual mesh rows in `generated/scene_visual_mesh_index.json` before web-scene export so real-xacro rows with `ur_description/meshes/ur5/visual/...` are explicitly marked as generated robot mesh preview rows.
- Forces web-scene/staged-asset refresh when this normalization changes the mesh index.

### Testing
- Verified syntax locally for the modified freshness helper with `python3 -m py_compile`.
- User-provided pre-fix focused run still failed with 4 failures: schema rejected `frames`, and UR5 mesh-backed rows were missing from `payload["robots"]`. fileciteturn40file0

After merging, rerun:

```bash
python3 -m pytest -q \
  tests/test_workcell_studio_web_viewer_static.py \
  tests/test_workcell_studio_web_scene_contract.py
```

No real robot motion is involved; this stays within generated metadata/web export and fake-hardware-safe preview flow.