### PR TITLE
Bake web preview poses for generated URDF meshes

### DIFF
--- a/scripts/ensure_workcell_studio_web_scene_fresh.py
+++ b/scripts/ensure_workcell_studio_web_scene_fresh.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import copy
 import json
 import os
 import shutil
@@ -214,18 +215,52 @@ def _pose_has_finite_xyz(pose: object) -> bool:
 
 
 def _visual_world_pose(item: dict) -> Optional[dict]:
-    """Return the visible mesh-world pose while keeping link/frame pose untouched.
+    """Return the finite visible mesh-world pose baked by the URDF extractor.
 
-    Generated URDF browser placement uses ``frame_world_pose``/``link_world_pose``
-    for the link root, then applies ``visual_origin`` locally to the mesh wrapper.
-    The parity contract also needs a stable diagnostic pose for visible mesh
-    separation; ``baked_world_visual_pose`` is exactly that link*visual-origin pose.
+    Generated URDF browser placement can use ``frame_world_pose``/``link_world_pose``
+    as the link root plus a local ``visual_origin`` wrapper. Rows flagged with
+    ``workcell_web_render_pose_mode=baked_visible_world_pose`` instead render from
+    this baked link*visual-origin pose so Product View matches the visible mesh
+    placement directly.
     """
     for field in ("baked_world_visual_pose", "expected_visual_pose"):
         pose = item.get(field)
         if _pose_has_finite_xyz(pose):
-            return dict(pose)
+            return copy.deepcopy(pose)
     return None
+
+
+def _is_generated_urdf_mesh_row(item: dict) -> bool:
+    if str(item.get("geometry_type") or "").lower() != "mesh":
+        return False
+    source_text = " ".join(
+        str(item.get(field) or "")
+        for field in (
+            "source",
+            "source_kind",
+            "source_layer",
+            "active_visual_source",
+            "transform_source",
+            "baked_world_visual_transform_source",
+            "primary_pose_source",
+        )
+    ).lower()
+    return "urdf" in source_text
+
+
+def _baked_visible_pose_fields(item: dict, visible_pose: dict) -> dict:
+    fields = {
+        "final_transform": copy.deepcopy(visible_pose),
+        "world_from_visual": copy.deepcopy(visible_pose),
+        "workcell_web_visible_mesh_pose_source": "baked_world_visual_pose",
+        "workcell_web_render_pose_mode": "baked_visible_world_pose",
+        "visual_origin_application": "baked_into_web_preview_pose",
+    }
+    if "link_world_pose" in item:
+        fields["original_link_world_pose"] = copy.deepcopy(item.get("link_world_pose"))
+    if "frame_world_pose" in item:
+        fields["original_frame_world_pose"] = copy.deepcopy(item.get("frame_world_pose"))
+    return fields
 
 
 def normalize_ur5_mesh_preview_rows(mesh_index: Path) -> bool:
@@ -255,54 +290,56 @@ def normalize_ur5_mesh_preview_rows(mesh_index: Path) -> bool:
     for item in raw_items:
         if not isinstance(item, dict):
             continue
-        link = str(item.get("link") or item.get("link_name") or item.get("object_name") or "")
-        if link not in UR5_REQUIRED_LINKS:
-            continue
-        if str(item.get("geometry_type") or "").lower() != "mesh":
-            continue
-        if not any(UR5_VISUAL_MESH_URI_TOKEN in value for value in _mesh_uri_values(item)):
+        link = str(
+            item.get("link") or item.get("link_name") or item.get("object_name") or ""
+        )
+        if not _is_generated_urdf_mesh_row(item):
             continue
 
-        desired = {
-            "category": "robot_static_mesh_visual",
-            "role": "robot",
-            "source_layer": "locked_generated_urdf_visual",
-            "active_visual_source": "mesh_preview",
-            "primitive_geometry_type": "mesh",
-            "mesh_available": True,
-            "render_expected": True,
-            "primitive_fallback": False,
-            "fallback_reason": "",
-        }
-        visible_pose = _visual_world_pose(item)
-        if visible_pose is not None:
-            # Keep link_world_pose/frame_world_pose as the viewer's primary root pose.
-            # These legacy final/visual fields are diagnostics used by exporter
-            # contracts to detect visibly collapsed meshes.
+        desired = {}
+        if link in UR5_REQUIRED_LINKS and any(
+            UR5_VISUAL_MESH_URI_TOKEN in value for value in _mesh_uri_values(item)
+        ):
             desired.update(
                 {
-                    "final_transform": visible_pose,
-                    "world_from_visual": visible_pose,
-                    "workcell_web_visible_mesh_pose_source": "baked_world_visual_pose",
+                    "category": "robot_static_mesh_visual",
+                    "role": "robot",
+                    "source_layer": "locked_generated_urdf_visual",
+                    "active_visual_source": "mesh_preview",
+                    "primitive_geometry_type": "mesh",
+                    "mesh_available": True,
+                    "render_expected": True,
+                    "primitive_fallback": False,
+                    "fallback_reason": "",
                 }
             )
+            normalized_links.add(link)
+
+        visible_pose = _visual_world_pose(item)
+        if visible_pose is not None:
+            # Flag generated URDF mesh rows to render from the baked visible
+            # world pose instead of using link_world_pose/frame_world_pose as
+            # the viewer's primary root pose plus a local visual-origin wrapper.
+            desired.update(_baked_visible_pose_fields(item, visible_pose))
             visible_pose_links.add(link)
+
         for key, value in desired.items():
             if item.get(key) != value:
                 item[key] = value
                 changed = True
-        normalized_links.add(link)
 
     if normalized_links:
         payload["workcell_web_ur5_mesh_preview_normalized"] = True
         payload["workcell_web_ur5_mesh_preview_links"] = sorted(normalized_links)
+        changed = True
+    if visible_pose_links:
         payload["workcell_web_ur5_visible_mesh_pose_links"] = sorted(visible_pose_links)
         changed = True
     if changed:
         mesh_index.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         print(
-            "[workcell_web_scene_fresh] normalized UR5 mesh preview rows: "
-            + ",".join(sorted(normalized_links))
+            "[workcell_web_scene_fresh] normalized mesh preview rows: "
+            + ",".join(sorted(normalized_links | visible_pose_links))
         )
     return changed
 

--- a/tests/test_ensure_workcell_studio_web_scene_fresh.py
+++ b/tests/test_ensure_workcell_studio_web_scene_fresh.py
@@ -207,6 +207,58 @@ def test_sourced_real_xacro_requires_real_expansion_status(tmp_path, monkeypatch
     ]
 
 
+def test_normalize_ur5_mesh_preview_rows_flags_all_generated_urdf_baked_mesh_rows(tmp_path):
+    mesh_index = tmp_path / "scene_visual_mesh_index.json"
+    link_pose = {"xyz": [1, 2, 3], "rpy": [0.1, 0.2, 0.3]}
+    frame_pose = {"xyz": [4, 5, 6], "rpy": [0.4, 0.5, 0.6]}
+    baked_pose = {"xyz": [7, 8, 9], "rpy": [0.7, 0.8, 0.9]}
+    tool_baked_pose = {"xyz": [0.1, 0.2, 0.3], "rpy": [1.0, 1.1, 1.2]}
+    payload = {
+        "visual_items": [
+            {
+                "id": "ur5_shoulder",
+                "source": "urdf_flattened",
+                "link": "shoulder_link",
+                "geometry_type": "mesh",
+                "mesh_uri": "package://ur_description/meshes/ur5/visual/shoulder.dae",
+                "link_world_pose": link_pose,
+                "frame_world_pose": frame_pose,
+                "baked_world_visual_pose": baked_pose,
+                "visual_origin_application": "viewer_applies_visual_origin_to_mesh_wrapper",
+            },
+            {
+                "id": "robotiq_finger",
+                "source": "urdf_flattened",
+                "link": "robotiq_85_left_finger_link",
+                "geometry_type": "mesh",
+                "mesh_uri": "package://robotiq_85_description/meshes/visual/finger.dae",
+                "link_world_pose": {"xyz": [0, 0, 0], "rpy": [0, 0, 0]},
+                "expected_visual_pose": tool_baked_pose,
+                "visual_origin_application": "viewer_applies_visual_origin_to_mesh_wrapper",
+            },
+        ]
+    }
+    mesh_index.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert ensure.normalize_ur5_mesh_preview_rows(mesh_index) is True
+
+    normalized = json.loads(mesh_index.read_text(encoding="utf-8"))
+    ur5_item, tool_item = normalized["visual_items"]
+    assert ur5_item["workcell_web_render_pose_mode"] == "baked_visible_world_pose"
+    assert ur5_item["original_link_world_pose"] == link_pose
+    assert ur5_item["original_frame_world_pose"] == frame_pose
+    assert ur5_item["visual_origin_application"] == "baked_into_web_preview_pose"
+    assert ur5_item["final_transform"] == baked_pose
+    assert ur5_item["world_from_visual"] == baked_pose
+    assert ur5_item["category"] == "robot_static_mesh_visual"
+    assert tool_item["workcell_web_render_pose_mode"] == "baked_visible_world_pose"
+    assert tool_item["original_link_world_pose"] == {"xyz": [0, 0, 0], "rpy": [0, 0, 0]}
+    assert "original_frame_world_pose" not in tool_item
+    assert tool_item["visual_origin_application"] == "baked_into_web_preview_pose"
+    assert tool_item["final_transform"] == tool_baked_pose
+    assert tool_item["world_from_visual"] == tool_baked_pose
+    assert tool_item.get("category") is None
+
 def test_ur5_mesh_index_regeneration_has_no_legacy_static_fallback_transform_statuses(tmp_path):
     scene = Path("scenes/ur5_2f_test")
     mesh_index = scene / "generated" / "scene_visual_mesh_index.json"


### PR DESCRIPTION
### Motivation
- Product View should render generated URDF visuals from the extractor-baked visible world pose so the browser preview matches the visible mesh placement directly.
- Preserve legacy `link_world_pose`/`frame_world_pose` diagnostics before overriding preview pose fields to avoid losing provenance information.

### Description
- Update `_visual_world_pose` to return a deep-copied finite baked visible pose when present and adjust its docstring to explain baked pose rendering.
- Add helper functions `_is_generated_urdf_mesh_row` and `_baked_visible_pose_fields`, and use them in `normalize_ur5_mesh_preview_rows` to detect generated URDF mesh rows and produce the baked-pose metadata.
- When a finite baked visible pose exists, set `workcell_web_render_pose_mode` to `"baked_visible_world_pose"`, set `visual_origin_application` to `"baked_into_web_preview_pose"`, and copy the baked pose into both `final_transform` and `world_from_visual` so the web preview renders from the baked pose.
- Preserve diagnostics by copying existing `link_world_pose`/`frame_world_pose` into `original_link_world_pose`/`original_frame_world_pose` when present.
- Keep the existing UR5 link classification (category/role/source_layer/etc.) for required UR5 links while applying baked-pose metadata to all generated URDF mesh rows (including Robotiq/tool rows), and update the normalization metadata keys written to the mesh index.
- Add a regression test that verifies UR5 arm and a Robotiq/tool generated URDF mesh row are flagged with the baked preview metadata and that original poses are preserved.

### Testing
- Ran `python3 -m pytest tests/test_ensure_workcell_studio_web_scene_fresh.py -q` and all tests passed.
- Ran `python3 -m pytest tests/test_workcell_studio_web_scene_contract.py::test_ur5_2f_web_scene_stages_required_product_meshes_without_required_fallbacks -q` and the targeted contract test passed.
- Verified syntax with `python3 -m py_compile scripts/ensure_workcell_studio_web_scene_fresh.py` and no errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f7aa19234833186a0be349421de1d)