### PR TITLE
Export baked generated preview pose metadata

### DIFF
--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -482,7 +482,7 @@ def _annotate_mesh_unit_evidence(item: Json, scene_dir: Path) -> None:
             return
 
 
-def _canonical_generated_transform(raw: Mapping[str, Any]) -> Tuple[Optional[Any], Optional[str]]:
+def _canonical_generated_transform(raw: Mapping[str, Any]) -> Tuple[Optional[Any], Optional[str], Optional[str]]:
     """Return the browser-ready world-from-visual pose and its source field.
 
     Generated mesh rows may carry link-frame, visual-origin, and already-baked
@@ -490,11 +490,11 @@ def _canonical_generated_transform(raw: Mapping[str, Any]) -> Tuple[Optional[Any
     final render pose; it must not multiply the visual origin a second time.
     """
     baked_source = raw.get("baked_world_visual_transform_source")
-    for field in ("world_from_visual", "final_transform", "baked_world_visual_pose", "pose", "world_pose"):
+    for field in ("world_from_visual", "final_transform", "baked_world_visual_pose", "expected_visual_pose", "pose", "world_pose"):
         value = raw.get(field)
         if value not in (None, "", [], {}):
-            return value, str(baked_source or field)
-    return None, None
+            return value, str(baked_source or field), field
+    return None, None, None
 
 
 def _pose_with_xyz_offset(base_pose: Any, offset: Sequence[float]) -> Json:
@@ -515,7 +515,7 @@ def _generated_preview_items(index: Mapping[str, Any], scene_dir: Path, warnings
     fields = (
         "id", "type", "category", "role", "display_name", "link", "object_name", "visual", "pose", "world_pose",
         "final_transform", "world_from_visual", "transform_source",
-        "baked_world_visual_pose", "link_world_pose", "frame_world_pose", "visual_origin", "baked_world_visual_matrix",
+        "baked_world_visual_pose", "expected_visual_pose", "link_world_pose", "frame_world_pose", "visual_origin", "baked_world_visual_matrix",
         "baked_world_visual_quaternion", "baked_world_visual_transform_source", "geometry_type",
         "parent_link", "immediate_parent_link", "root_link", "link_chain", "joint_parent_link",
         "parent_joint", "parent_joint_name", "parent_joint_type", "parent_joint_origin",
@@ -533,11 +533,18 @@ def _generated_preview_items(index: Mapping[str, Any], scene_dir: Path, warnings
             continue
         item = _copy_fields(raw, fields, INPUTS["visual_mesh_index"], scene_dir)
         item.setdefault("id", _stable_id("generated_preview", i))
-        final_transform, transform_source = _canonical_generated_transform(raw)
+        final_transform, transform_source, transform_field = _canonical_generated_transform(raw)
         if final_transform is not None:
             item["final_transform"] = final_transform
             item["world_from_visual"] = final_transform
             item["transform_source"] = transform_source
+            if transform_field in {"baked_world_visual_pose", "expected_visual_pose"}:
+                item["workcell_web_render_pose_mode"] = "baked_visible_world_pose"
+                item["visual_origin_application"] = "baked_into_web_preview_pose"
+                if "link_world_pose" in raw:
+                    item["original_link_world_pose"] = raw.get("link_world_pose")
+                if "frame_world_pose" in raw:
+                    item["original_frame_world_pose"] = raw.get("frame_world_pose")
         elif raw.get("baked_world_visual_transform_source"):
             item["transform_source"] = raw.get("baked_world_visual_transform_source")
         item["locked"] = True
@@ -561,6 +568,15 @@ def _generated_preview_items(index: Mapping[str, Any], scene_dir: Path, warnings
                 "world_from_visual": INPUTS["visual_mesh_index"],
                 "transform_source": INPUTS["visual_mesh_index"],
             })
+            if transform_field in {"baked_world_visual_pose", "expected_visual_pose"}:
+                item["provenance"].update({
+                    "workcell_web_render_pose_mode": INPUTS["visual_mesh_index"],
+                    "visual_origin_application": INPUTS["visual_mesh_index"],
+                })
+                if "original_link_world_pose" in item:
+                    item["provenance"]["original_link_world_pose"] = INPUTS["visual_mesh_index"]
+                if "original_frame_world_pose" in item:
+                    item["provenance"]["original_frame_world_pose"] = INPUTS["visual_mesh_index"]
         if any(token in _identity_text(raw) for token in ("camera", "realsense", "d435")):
             _annotate_mesh_unit_evidence(item, scene_dir)
         sections[_section_from_item(raw)].append(item)

--- a/tests/test_export_workcell_studio_web_scene.py
+++ b/tests/test_export_workcell_studio_web_scene.py
@@ -55,6 +55,15 @@ def test_export_web_scene_contract_and_determinism(tmp_path):
                         "baked_world_visual_quaternion": [0, 0, 0, 1],
                         "mesh_scale": [1, 1, 1],
                     },
+                    {
+                        "id": "robotiq_finger",
+                        "category": "gripper",
+                        "role": "tool",
+                        "link": "robotiq_85_left_finger_link",
+                        "mesh_path": str(scene / "meshes/robotiq_finger.dae"),
+                        "expected_visual_pose": {"xyz": [0.4, 0.5, 0.6], "rpy": [0.7, 0.8, 0.9]},
+                        "link_world_pose": {"xyz": [0.1, 0.2, 0.3], "rpy": [0.0, 0.0, 0.0]},
+                    },
                     {"id": "camera_mesh", "category": "camera", "role": "camera", "package_uri": "package://camera/mesh.dae"},
                 ]
             }
@@ -106,11 +115,23 @@ def test_export_web_scene_contract_and_determinism(tmp_path):
     assert payload["robots"][-1]["final_transform"] == {"xyz": [1.1, 2.2, 3.3], "rpy": [0.1, 0.2, 1.87]}
     assert payload["robots"][-1]["world_from_visual"] == payload["robots"][-1]["final_transform"]
     assert payload["robots"][-1]["transform_source"] == "baked_world_visual_pose"
+    assert payload["robots"][-1]["workcell_web_render_pose_mode"] == "baked_visible_world_pose"
+    assert payload["robots"][-1]["visual_origin_application"] == "baked_into_web_preview_pose"
     assert payload["robots"][-1]["link_world_pose"] == {"xyz": [1, 2, 3], "rpy": [0.1, 0.2, 0.3]}
+    assert payload["robots"][-1]["original_link_world_pose"] == payload["robots"][-1]["link_world_pose"]
     assert payload["robots"][-1]["visual_origin"] == {"xyz": [0.1, 0.2, 0.3], "rpy": [0, 0, 1.57]}
     assert payload["robots"][-1]["mesh_scale"] == [1, 1, 1]
     assert payload["robots"][-1]["baked_world_visual_matrix"] == [[1, 0, 0, 1.1], [0, 1, 0, 2.2], [0, 0, 1, 3.3], [0, 0, 0, 1]]
     assert payload["robots"][-1]["baked_world_visual_quaternion"] == [0, 0, 0, 1]
+    tool_mesh = next(item for item in payload["tools"] if item["id"] == "robotiq_finger")
+    assert tool_mesh["final_transform"] == {"xyz": [0.4, 0.5, 0.6], "rpy": [0.7, 0.8, 0.9]}
+    assert tool_mesh["workcell_web_render_pose_mode"] == "baked_visible_world_pose"
+    assert tool_mesh["visual_origin_application"] == "baked_into_web_preview_pose"
+    assert tool_mesh["original_link_world_pose"] == {"xyz": [0.1, 0.2, 0.3], "rpy": [0.0, 0.0, 0.0]}
+    assert tool_mesh["link_world_pose"] == {"xyz": [0.1, 0.2, 0.3], "rpy": [0.0, 0.0, 0.0]}
+    assert tool_mesh["provenance"]["workcell_web_render_pose_mode"] == "generated/scene_visual_mesh_index.json"
+    assert tool_mesh["provenance"]["visual_origin_application"] == "generated/scene_visual_mesh_index.json"
+    assert tool_mesh["provenance"]["original_link_world_pose"] == "generated/scene_visual_mesh_index.json"
     camera_mesh = next(item for item in payload["sensors"] if item["id"] == "camera_mesh")
     assert camera_mesh["package_uri"] == "package://camera/mesh.dae"
     assert payload["robots"][-1]["provenance"]["mesh_path"] == "generated/scene_visual_mesh_index.json"


### PR DESCRIPTION
### Motivation
- Ensure the web scene exporter marks generated-preview rows that already carry a baked visible pose so the viewer uses the baked pose without reapplying the visual origin. 
- Preserve diagnostic pose data (`link_world_pose` / `frame_world_pose`) while exporting original copies and clear provenance for robot and tool (including Robotiq) preview rows.

### Description
- Extend `_canonical_generated_transform` to detect `expected_visual_pose` and return the field name of the canonical transform. 
- When a generated-preview row's canonical transform field is `baked_world_visual_pose` or `expected_visual_pose`, add `workcell_web_render_pose_mode: "baked_visible_world_pose"` and `visual_origin_application: "baked_into_web_preview_pose"` to the exported item. 
- Copy `original_link_world_pose` and `original_frame_world_pose` from the raw `link_world_pose` / `frame_world_pose` when present while keeping the original diagnostic fields intact. 
- Add provenance entries for the new fields using `INPUTS["visual_mesh_index"]` and include test coverage updating `tests/test_export_workcell_studio_web_scene.py` to include a Robotiq/tool preview row and assertions for the new behavior.

### Testing
- Ran `python3 -m pytest tests/test_export_workcell_studio_web_scene.py` and all tests passed (`11 passed`).
- Ran `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py` and both test modules passed (`7 passed`).
- Verified `python3 -m py_compile scripts/export_workcell_studio_web_scene.py` and `git diff --check` for syntax/format checks with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f7d0811388331bcc0e885f57c112d)