### PR TITLE
Expose frame-level diagnostics in viewer status (include non-rendered tool0)

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -653,7 +653,8 @@ populateObjectList = () => {};
 updateLabels = () => {};
 resetView = () => {};
 renderSceneSummary = () => updateViewerStatus();
-state.sceneJson = { scene: { id: 'status_test' } };
+state.sceneJson = { scene: { id: 'status_test' }, frames: [{ name: 'tool0', link: 'tool0', parent_link: 'wrist_3_link', role: 'transform_anchor', type: 'frame', source_layer: 'generated_urdf', provenance: { source: 'payload.frames' }, world_pose: { xyz: [0.10, 0, 0], rpy: [0, 0, 0] } }] };
+state.frameLookup = parseSceneFrames(state.sceneJson);
 state.runtimeWarnings = [{ code: 'camera_framing_blocker_excluded', reason: 'hidden helper excluded' }];
 class MockVector3 {
   constructor(x = 0, y = 0, z = 0) {
@@ -692,6 +693,15 @@ assert.strictEqual(status.runtimeWarnings[0].code, 'camera_framing_blocker_exclu
 assert.strictEqual(isUserFacingWarning(status.runtimeWarnings[0]), false);
 assert.deepStrictEqual(status.renderedMeshDiagnostics, []);
 assert.deepStrictEqual(status.rendered_mesh_diagnostics, []);
+assert.strictEqual(status.frameDiagnostics, status.frame_diagnostics);
+const toolFrameDiagnostic = status.frameDiagnostics.find(entry => entry.name === 'tool0');
+assert.ok(toolFrameDiagnostic, 'expected tool0 frame diagnostic even without rendered object');
+assert.strictEqual(toolFrameDiagnostic.link, 'tool0');
+assert.strictEqual(toolFrameDiagnostic.parent_link, 'wrist_3_link');
+assert.strictEqual(toolFrameDiagnostic.role, 'transform_anchor');
+assert.strictEqual(toolFrameDiagnostic.render_expected, false);
+assert.strictEqual(toolFrameDiagnostic.mesh_available, false);
+assert.deepStrictEqual(toolFrameDiagnostic.resolved_world_position, [0.10, 0, 0]);
 setDebugOverlaysVisible(true);
 assert.strictEqual(window.__WORKCELL_VIEWER_STATUS__.meshLoadedCount, 2);
 assert.strictEqual(window.__WORKCELL_VIEWER_STATUS__.requiredMeshFailedCount, 0);
@@ -765,3 +775,6 @@ def test_viewer_status_exports_generated_urdf_mesh_diagnostics():
     assert "const renderedMeshDiagnostics = collectRenderedMeshDiagnostics();" in status_body
     assert "renderedMeshDiagnostics" in status_body
     assert "rendered_mesh_diagnostics: renderedMeshDiagnostics" in status_body
+    assert "const frameDiagnostics = collectFrameDiagnostics();" in status_body
+    assert "frameDiagnostics" in status_body
+    assert "frame_diagnostics: frameDiagnostics" in status_body

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -260,6 +260,7 @@ function updateViewerStatus() {
   const warnings = asArray(state.sceneJson?.warnings).concat(asArray(state.sceneJson?.notes_warnings), asArray(state.runtimeWarnings));
   const resolvedFrameStatus = buildResolvedFrameStatus();
   const renderedMeshDiagnostics = collectRenderedMeshDiagnostics();
+  const frameDiagnostics = collectFrameDiagnostics();
   const renderedObjectStatuses = statusCountedRenderables().map(obj => {
     const item = obj?.item || {};
     const renderStatus = obj?.renderInfo?.render_status || item?.renderInfo?.render_status || item?.mesh_status || '';
@@ -298,6 +299,8 @@ function updateViewerStatus() {
     resolvedFrameDistancesM: resolvedFrameStatus.resolvedFrameDistancesM,
     renderedMeshDiagnostics,
     rendered_mesh_diagnostics: renderedMeshDiagnostics,
+    frameDiagnostics,
+    frame_diagnostics: frameDiagnostics,
     renderedObjectStatuses,
     rendered_object_statuses: renderedObjectStatuses,
   };
@@ -1248,6 +1251,54 @@ function distanceMetersBetweenXyz(a, b) {
   const distance = Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
   return Number.isFinite(distance) ? distance : null;
 }
+
+function renderedObjectForFrame(name) {
+  if (!name) return null;
+  for (const rendered of state.objects || []) {
+    const item = rendered?.item;
+    if (!item || !renderedObjectFrameNames(item, rendered?.object3d).has(String(name))) continue;
+    return rendered;
+  }
+  return null;
+}
+function collectFrameDiagnostics() {
+  const names = new Set();
+  for (const name of state.frameLookup?.keys?.() || []) names.add(String(name));
+  for (const name of state.resolvedFramePoses?.keys?.() || []) names.add(String(name));
+  const diagnostics = [];
+  for (const name of names) {
+    const frame = state.frameLookup?.get?.(name) || {};
+    const pose = state.resolvedFramePoses.get(name) || resolveFrameWorldPose(name);
+    const rendered = renderedObjectForFrame(name);
+    const item = rendered?.item || {};
+    const renderStatus = rendered?.renderInfo?.render_status || item?.renderInfo?.render_status || item?.mesh_status || '';
+    const sourceLayer = frame.source_layer || item.source_layer || '';
+    const provenance = frame.provenance || item.provenance || null;
+    const worldPose = frame.world_pose || frame.world_transform || null;
+    const xyz = finiteXyzArrayFromVector(pose?.xyz);
+    diagnostics.push({
+      id: frame.id || item.id || name,
+      name: frame.name || name,
+      frame: frame.frame || frame.frame_id || item.frame || item.frame_id || name,
+      link: frame.link || frame.link_name || item.link || item.link_name || name,
+      parent: frame.parent || frame.parent_frame || frame.parent_frame_id || item.parent || item.parent_frame || '',
+      parent_link: frame.parent_link || frame.parent_link_name || item.parent_link || item.parent_link_name || frameParentNameOf(frame) || '',
+      role: frame.role || item.role || '',
+      type: frame.type || item.type || '',
+      render_expected: Boolean((frame.render_expected ?? item.render_expected) || displayMeshUri(frame) || displayMeshUri(item) || rendered),
+      mesh_available: Boolean(renderStatus === 'mesh_loaded' || displayMeshUri(frame) || displayMeshUri(item)),
+      source_layer: sourceLayer,
+      provenance,
+      world_pose: worldPose,
+      xyz: xyz,
+      rpy: pose?.rpy ? finiteXyzArrayFromVector(pose.rpy) : null,
+      resolved_world_position: xyz,
+    });
+  }
+  diagnostics.sort((a, b) => String(a.name || a.frame || a.id).localeCompare(String(b.name || b.frame || b.id)));
+  return diagnostics;
+}
+
 function buildResolvedFrameStatus() {
   const frameNames = ['wrist_3_link', 'tool0', 'gripper_base_link'];
   const pairs = [


### PR DESCRIPTION
### Motivation
- Provide richer frame-level diagnostics to the viewer status so consumers can inspect frames (including non-rendered transform anchors like `tool0`) and their resolved poses.
- Ensure both snake_case and camelCase consumers can read the status payload without changing existing mesh-only diagnostics.
- Avoid creating any fake `THREE.Mesh` or selectable objects for frames that have no real visual.

### Description
- Added `collectFrameDiagnostics()` which iterates `state.frameLookup` and `state.resolvedFramePoses` to emit per-frame diagnostics including `id`, `name`, `frame`, `link`, `parent`, `parent_link`, `role`, `type`, `render_expected`, `mesh_available`, `source_layer`, `provenance`, `world_pose`/`xyz`/`rpy`, and a stable `resolved_world_position` in `workcell_studio_web/viewer/viewer.js`.
- Added `renderedObjectForFrame()` helper used by the diagnostics collector to detect rendered objects associated with a frame.
- Updated `updateViewerStatus()` to include both `frameDiagnostics` and `frame_diagnostics` in the exported `window.__WORKCELL_VIEWER_STATUS__`, while preserving `renderedMeshDiagnostics` / `rendered_mesh_diagnostics` as mesh-only outputs.
- Ensured `tool0` is included when present in `payload.frames` via `parseSceneFrames()` and `collectFrameDiagnostics()` without creating any fake `THREE.Mesh` or selectable object when no real visual exists.
- Updated static unit coverage in `tests/test_workcell_studio_web_viewer_static.py` to assert `tool0` frame diagnostics are present and the new status fields are emitted.

### Testing
- Ran `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py -q` and it passed (`30 passed`).
- Ran `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py tests/test_workcell_studio_web_viewer_static.py -q` and it passed (`37 passed`).
- No failures observed and no runtime/hardware or launch configuration changes were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f982dc49883318158382c390a9d86)