### PR TITLE
Validate tool0 presence in viewer frame diagnostics and keep viewer distance checks

### DIFF
--- a/scripts/run_workcell_web3d_visual_acceptance.py
+++ b/scripts/run_workcell_web3d_visual_acceptance.py
@@ -45,8 +45,6 @@ REQUIRED_RENDERED_MESH_ADJACENT_PAIRS = {
     "forearm_link -> wrist_1_link": 0.75,
     "wrist_1_link -> wrist_2_link": 0.75,
     "wrist_2_link -> wrist_3_link": 0.75,
-    "wrist_3_link -> tool0": 0.75,
-    "tool0 -> gripper_base_link": 0.75,
 }
 REQUIRED_PRODUCT_FALLBACK_TOKENS = (
     "required_mesh_failed_debug_fallback",
@@ -67,6 +65,24 @@ def _distance_map_from_status(status: Mapping[str, Any]) -> Mapping[str, Any]:
         if isinstance(value, Mapping):
             return value
     return {}
+
+
+def _resolved_frame_positions_from_status(status: Mapping[str, Any]) -> Mapping[str, Any]:
+    for key in ("resolved_frame_positions", "resolvedFramePositions"):
+        value = status.get(key)
+        if isinstance(value, Mapping):
+            return value
+    return {}
+
+
+def _frame_diagnostics_from_status(status: Mapping[str, Any]) -> Sequence[Any] | Mapping[str, Any]:
+    for key in ("frame_diagnostics", "frameDiagnostics"):
+        value = status.get(key)
+        if isinstance(value, Mapping):
+            return value
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            return value
+    return []
 
 
 def _rendered_mesh_diagnostics_from_status(status: Mapping[str, Any]) -> Sequence[Any]:
@@ -251,6 +267,14 @@ def _diagnostic_link_name(diagnostic: Mapping[str, Any]) -> str:
     return ""
 
 
+def _frame_diagnostic_name(diagnostic: Mapping[str, Any]) -> str:
+    for key in ("frame_name", "frameName", "frame", "link_name", "linkName", "link", "id", "name"):
+        value = diagnostic.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
 def _diagnostic_vector(value: Any) -> tuple[float, float, float] | None:
     if isinstance(value, Mapping):
         raw = (value.get("x"), value.get("y"), value.get("z"))
@@ -376,6 +400,28 @@ def _rendered_mesh_adjacency_errors(status: Mapping[str, Any]) -> list[str]:
     return errors
 
 
+def _tool0_frame_contract_errors(status: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+
+    resolved_positions = _resolved_frame_positions_from_status(status)
+    if "tool0" not in resolved_positions:
+        errors.append("browser viewer resolvedFramePositions/resolved_frame_positions must include tool0")
+
+    frame_diagnostics = _frame_diagnostics_from_status(status)
+    tool0_diagnostic_seen = False
+    if isinstance(frame_diagnostics, Mapping):
+        tool0_diagnostic_seen = "tool0" in frame_diagnostics
+    else:
+        for raw in frame_diagnostics:
+            if isinstance(raw, Mapping) and _frame_diagnostic_name(raw) == "tool0":
+                tool0_diagnostic_seen = True
+                break
+    if not tool0_diagnostic_seen:
+        errors.append("browser viewer frameDiagnostics/frame_diagnostics must include tool0")
+
+    return errors
+
+
 def validate_browser_status(status: Mapping[str, Any]) -> list[str]:
     errors: list[str] = []
     mesh_loaded_count = _status_int(status, "mesh_loaded_count", "meshLoadedCount")
@@ -394,6 +440,7 @@ def validate_browser_status(status: Mapping[str, Any]) -> list[str]:
             distance = float("nan")
         if not (0.0 <= distance <= max_distance_m):
             errors.append(f"browser viewer resolved distance {pair} expected <= {max_distance_m:.3f} m, got {raw!r}")
+    errors.extend(_tool0_frame_contract_errors(status))
     errors.extend(_rendered_mesh_adjacency_errors(status))
     errors.extend(_mesh_backing_errors(status))
     errors.extend(_table_horizontal_errors(status))

--- a/tests/test_workcell_web3d_visual_acceptance.py
+++ b/tests/test_workcell_web3d_visual_acceptance.py
@@ -114,14 +114,20 @@ def test_acceptance_script_preserves_canonical_mesh_count_expectations():
 def test_acceptance_script_requires_viewer_side_resolved_tool_chain_distances():
     text = SCRIPT.read_text(encoding="utf-8")
     assert "REQUIRED_VIEWER_RESOLVED_DISTANCE_PAIRS" in text
+    assert "REQUIRED_RENDERED_MESH_ADJACENT_PAIRS" in text
     for pair in [
         "wrist_3_link -> tool0",
         "tool0 -> gripper_base_link",
         "wrist_3_link -> gripper_base_link",
     ]:
         assert pair in text
+        assert pair not in module.REQUIRED_RENDERED_MESH_ADJACENT_PAIRS
     assert "viewer_resolved_distances_m" in text
     assert "resolved_distances_m" in text
+    assert "resolved_frame_positions" in text
+    assert "resolvedFramePositions" in text
+    assert "frame_diagnostics" in text
+    assert "frameDiagnostics" in text
     assert "browser viewer resolved distance {pair} expected <=" in text
 
 
@@ -148,12 +154,16 @@ def test_browser_status_validator_accepts_expected_meshes_and_tool_chain_distanc
         "meshLoadedCount": 18,
         "requiredMeshFailedCount": 0,
         "viewer_resolved_distances_m": distance_pairs,
+        "resolvedFramePositions": _valid_resolved_frame_positions(),
+        "frameDiagnostics": _valid_frame_diagnostics(),
         "renderedMeshDiagnostics": _valid_rendered_mesh_diagnostics(),
     }
     snake_status = {
         "mesh_loaded_count": 18,
         "required_mesh_failed_count": 0,
         "viewer_resolved_distances_m": distance_pairs,
+        "resolved_frame_positions": _valid_resolved_frame_positions(),
+        "frame_diagnostics": _valid_frame_diagnostics(),
         "rendered_mesh_diagnostics": _valid_rendered_mesh_diagnostics(),
     }
 
@@ -178,6 +188,8 @@ def test_browser_status_validator_rejects_missing_viewer_side_tool_chain_distanc
         "mesh_loaded_count": 18,
         "required_mesh_failed_count": 0,
         "viewer_resolved_distances_m": reported_distances,
+        "resolved_frame_positions": _valid_resolved_frame_positions(),
+        "frame_diagnostics": _valid_frame_diagnostics(),
         "rendered_mesh_diagnostics": _valid_rendered_mesh_diagnostics(),
     }
 
@@ -189,6 +201,8 @@ def test_browser_status_validator_rejects_missing_viewer_side_distance_map():
     status = {
         "mesh_loaded_count": 18,
         "required_mesh_failed_count": 0,
+        "resolved_frame_positions": _valid_resolved_frame_positions(),
+        "frame_diagnostics": _valid_frame_diagnostics(),
         "rendered_mesh_diagnostics": _valid_rendered_mesh_diagnostics(),
     }
 
@@ -280,11 +294,29 @@ def _valid_viewer_distances():
     }
 
 
+def _valid_resolved_frame_positions():
+    return {
+        "wrist_3_link": {"x": 0.30, "y": 0.0, "z": 0.0},
+        "tool0": {"x": 0.301, "y": 0.0, "z": 0.0},
+        "gripper_base_link": {"x": 0.40, "y": 0.0, "z": 0.0},
+    }
+
+
+def _valid_frame_diagnostics():
+    return [
+        {"frame_name": "wrist_3_link", "resolved": True},
+        {"frame_name": "tool0", "resolved": True},
+        {"frame_name": "gripper_base_link", "resolved": True},
+    ]
+
+
 def _valid_browser_status_with_rendered_diagnostics():
     return {
         "meshLoadedCount": 18,
         "requiredMeshFailedCount": 0,
         "viewer_resolved_distances_m": _valid_viewer_distances(),
+        "resolvedFramePositions": _valid_resolved_frame_positions(),
+        "frameDiagnostics": _valid_frame_diagnostics(),
         "renderedMeshDiagnostics": _valid_rendered_mesh_diagnostics(),
     }
 
@@ -294,6 +326,8 @@ def test_browser_status_validator_rejects_missing_rendered_mesh_diagnostics():
         "mesh_loaded_count": 18,
         "required_mesh_failed_count": 0,
         "viewer_resolved_distances_m": _valid_viewer_distances(),
+        "resolved_frame_positions": _valid_resolved_frame_positions(),
+        "frame_diagnostics": _valid_frame_diagnostics(),
     }
 
     errors = module.validate_browser_status(status)
@@ -331,10 +365,61 @@ def test_browser_status_validator_accepts_valid_rendered_mesh_diagnostics_snake_
         "mesh_loaded_count": 18,
         "required_mesh_failed_count": 0,
         "viewer_resolved_distances_m": _valid_viewer_distances(),
+        "resolved_frame_positions": _valid_resolved_frame_positions(),
+        "frame_diagnostics": _valid_frame_diagnostics(),
         "rendered_mesh_diagnostics": _valid_rendered_mesh_diagnostics(),
     }
 
     assert module.validate_browser_status(status) == []
+
+
+def test_browser_status_validator_accepts_tool0_in_frame_diagnostics_but_not_rendered_mesh_diagnostics():
+    status = _valid_browser_status_with_rendered_diagnostics()
+    status["renderedMeshDiagnostics"] = [
+        diagnostic for diagnostic in status["renderedMeshDiagnostics"] if diagnostic.get("link_name") != "tool0"
+    ]
+
+    assert module.validate_browser_status(status) == []
+
+
+def test_browser_status_validator_rejects_missing_tool0_frame_diagnostics():
+    status = _valid_browser_status_with_rendered_diagnostics()
+    status["frameDiagnostics"] = [
+        diagnostic for diagnostic in status["frameDiagnostics"] if diagnostic.get("frame_name") != "tool0"
+    ]
+
+    errors = module.validate_browser_status(status)
+
+    assert any("frameDiagnostics/frame_diagnostics must include tool0" in error for error in errors)
+
+
+def test_browser_status_validator_rejects_missing_tool0_resolved_frame_position():
+    status = _valid_browser_status_with_rendered_diagnostics()
+    status["resolvedFramePositions"] = {
+        key: value for key, value in status["resolvedFramePositions"].items() if key != "tool0"
+    }
+
+    errors = module.validate_browser_status(status)
+
+    assert any("resolvedFramePositions/resolved_frame_positions must include tool0" in error for error in errors)
+
+
+def test_browser_status_validator_rejects_implausible_wrist_to_tool0_distance():
+    status = _valid_browser_status_with_rendered_diagnostics()
+    status["viewer_resolved_distances_m"]["wrist_3_link -> tool0"] = 99.0
+
+    errors = module.validate_browser_status(status)
+
+    assert any("wrist_3_link -> tool0" in error and "expected <=" in error for error in errors)
+
+
+def test_browser_status_validator_rejects_implausible_tool0_to_gripper_distance():
+    status = _valid_browser_status_with_rendered_diagnostics()
+    status["viewer_resolved_distances_m"]["tool0 -> gripper_base_link"] = 99.0
+
+    errors = module.validate_browser_status(status)
+
+    assert any("tool0 -> gripper_base_link" in error and "expected <=" in error for error in errors)
 
 
 def test_browser_status_validator_accepts_horizontal_table_diagnostic():


### PR DESCRIPTION
### Motivation
- Ensure the Web3D visual acceptance validator requires `tool0` presence in viewer-resolved frame positions and frame diagnostics even when `tool0` is not mesh-backed in the rendered diagnostics. 
- Keep viewer-side resolved-frame distance checks for the wrist/tool/gripper chain while restricting rendered-mesh adjacency checks to actual UR5 mesh-backed link pairs.

### Description
- Removed `"wrist_3_link -> tool0"` and `"tool0 -> gripper_base_link"` from `REQUIRED_RENDERED_MESH_ADJACENT_PAIRS` so only mesh-backed UR5 adjacency checks remain. 
- Added helpers to read `resolved_frame_positions` / `resolvedFramePositions` (`_resolved_frame_positions_from_status`) and `frame_diagnostics` / `frameDiagnostics` (`_frame_diagnostics_from_status`).
- Added `_frame_diagnostic_name` helper to extract names from frame diagnostics.
- Added `_tool0_frame_contract_errors` which fails with clear errors when `tool0` is absent from resolved frame positions or frame diagnostics, and integrated this check into `validate_browser_status` while preserving `REQUIRED_VIEWER_RESOLVED_DISTANCE_PAIRS` checks.
- Updated and added unit tests in `tests/test_workcell_web3d_visual_acceptance.py` covering presence of `tool0` in frame diagnostics (allowed to be absent from rendered mesh diagnostics), failures when `tool0` frame diagnostics or resolved positions are missing, and failures for implausible `wrist_3_link -> tool0` or `tool0 -> gripper_base_link` distances.

### Testing
- Ran `python3 -m pytest tests/test_workcell_web3d_visual_acceptance.py` and all tests passed (`32 passed`).
- Unit tests added exercise both camelCase and snake_case viewer status forms and assert proper failure messages for missing `tool0` frame data and implausible resolved distances.
- No changes touch launch files, controllers, runtime services, or real-hardware paths; fake-hardware defaults are unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f9a52165c8331b9d98c64347ed483)