### PR TITLE
Validate Web3D support surface semantics

### DIFF
--- a/scripts/run_workcell_web3d_visual_acceptance.py
+++ b/scripts/run_workcell_web3d_visual_acceptance.py
@@ -217,6 +217,38 @@ def _camera_bounds_errors(status: Mapping[str, Any]) -> list[str]:
     return errors
 
 
+
+
+def _diagnostic_support_surface_kind(diagnostic: Mapping[str, Any]) -> str:
+    for key in (
+        "support_surface_kind",
+        "supportSurfaceKind",
+        "semantic_type",
+        "semanticType",
+        "support_kind",
+        "supportKind",
+        "surface_kind",
+        "surfaceKind",
+        "support_surface_type",
+        "supportSurfaceType",
+    ):
+        value = diagnostic.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip().lower().replace("-", "_").replace(" ", "_")
+    return ""
+
+
+def _diagnostic_float(diagnostic: Mapping[str, Any], *keys: str) -> float | None:
+    for key in keys:
+        value = diagnostic.get(key)
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(number):
+            return number
+    return None
+
 def _diagnostic_up_axis(diagnostic: Mapping[str, Any]) -> tuple[float, float, float] | None:
     for key in ("inferred_up_axis", "inferredUpAxis", "inferred_normal", "inferredNormal", "normal", "up_axis", "upAxis"):
         vector = _diagnostic_vector(diagnostic.get(key))
@@ -237,26 +269,66 @@ def _table_horizontal_errors(status: Mapping[str, Any]) -> list[str]:
         return ["browser viewer canonical table/workbench rendered bounding-box diagnostic is required"]
 
     errors: list[str] = []
+    tabletop_kinds = {"table_surface", "tabletop"}
+    body_kinds = {"workbench_body", "cabinet", "support_surface"}
     for diagnostic in table_diagnostics:
         name = _diagnostic_link_name(diagnostic) or str(diagnostic.get("object_id") or diagnostic.get("id") or "table/workbench")
+        kind = _diagnostic_support_surface_kind(diagnostic)
+        if not kind:
+            errors.append(
+                f"browser viewer table/workbench {name} missing explicit support-surface kind metadata; "
+                "exporter must provide support_surface_kind/supportSurfaceKind or semantic_type/support_kind"
+            )
+            continue
+        if kind not in tabletop_kinds | body_kinds:
+            errors.append(f"browser viewer table/workbench {name} has unsupported support-surface kind {kind!r}")
+            continue
+
         size = _diagnostic_bbox_size(diagnostic)
         if size is None:
             errors.append(f"browser viewer table/workbench {name} missing rendered bounding-box size")
             continue
         x, y, z = size
-        smallest_axis = min(((x, "X"), (y, "Y"), (z, "Z")), key=lambda item: item[0])[1]
-        if smallest_axis != "Z":
-            errors.append(f"browser viewer table/workbench {name} expected thickness/smallest dimension along Z, got size x={x:.3f}, y={y:.3f}, z={z:.3f}")
-        if z >= min(x, y):
-            errors.append(f"browser viewer table/workbench {name} expected largest tabletop dimensions in XY with Z thickness, got size x={x:.3f}, y={y:.3f}, z={z:.3f}")
-        up = _diagnostic_up_axis(diagnostic)
-        if up is None:
-            errors.append(f"browser viewer table/workbench {name} missing inferred up axis/normal")
+
+        if kind in tabletop_kinds:
+            smallest_axis = min(((x, "X"), (y, "Y"), (z, "Z")), key=lambda item: item[0])[1]
+            if smallest_axis != "Z":
+                errors.append(f"browser viewer table/workbench {name} expected thickness/smallest dimension along Z, got size x={x:.3f}, y={y:.3f}, z={z:.3f}")
+            if z >= min(x, y) or z > 0.20:
+                errors.append(f"browser viewer table/workbench {name} expected thin tabletop Z and largest dimensions in XY, got size x={x:.3f}, y={y:.3f}, z={z:.3f}")
+            if min(x, y) < 0.30 or max(x, y) < 0.50:
+                errors.append(f"browser viewer table/workbench {name} expected wide tabletop XY footprint, got size x={x:.3f}, y={y:.3f}, z={z:.3f}")
+            up = _diagnostic_up_axis(diagnostic)
+            if up is None:
+                errors.append(f"browser viewer table/workbench {name} missing inferred up axis/normal")
+                continue
+            dot_world_z = up[2]
+            max_tilt_rad = math.radians(15.0)
+            if dot_world_z < math.cos(max_tilt_rad):
+                errors.append(f"browser viewer table/workbench {name} expected normal/up close to world +Z, got ({up[0]:.3f}, {up[1]:.3f}, {up[2]:.3f})")
             continue
-        dot_world_z = up[2]
-        max_tilt_rad = math.radians(15.0)
-        if dot_world_z < math.cos(max_tilt_rad):
-            errors.append(f"browser viewer table/workbench {name} expected normal/up close to world +Z, got ({up[0]:.3f}, {up[1]:.3f}, {up[2]:.3f})")
+
+        if min(x, y) < 0.30 or max(x, y) < 0.50:
+            errors.append(f"browser viewer table/workbench {name} expected sensible support body XY footprint, got size x={x:.3f}, y={y:.3f}, z={z:.3f}")
+        if not (0.20 <= z <= 1.50):
+            errors.append(f"browser viewer table/workbench {name} expected plausible support body height Z, got size x={x:.3f}, y={y:.3f}, z={z:.3f}")
+        support_height = _diagnostic_float(diagnostic, "top_surface_z_m", "topSurfaceZM", "support_surface_height_m", "supportSurfaceHeightM")
+        if support_height is None:
+            errors.append(
+                f"browser viewer table/workbench {name} kind {kind!r} missing finite top/support height metadata; "
+                "exporter must provide top_surface_z_m or support_surface_height_m"
+            )
+            continue
+        center = _diagnostic_position(diagnostic, "loaded_mesh_bounding_box_center", "loadedMeshBoundingBoxCenter", "bounding_box_center", "boundingBoxCenter")
+        if center is None:
+            errors.append(f"browser viewer table/workbench {name} kind {kind!r} missing loaded bounding-box center needed to validate top/support height")
+            continue
+        loaded_top_z = center[2] + (z / 2.0)
+        if abs(support_height - loaded_top_z) > 0.15:
+            errors.append(
+                f"browser viewer table/workbench {name} kind {kind!r} top/support height {support_height:.3f} m "
+                f"is not plausibly near loaded bbox top {loaded_top_z:.3f} m"
+            )
     return errors
 
 def _diagnostic_link_name(diagnostic: Mapping[str, Any]) -> str:

--- a/tests/test_workcell_web3d_visual_acceptance.py
+++ b/tests/test_workcell_web3d_visual_acceptance.py
@@ -253,6 +253,7 @@ def _valid_table_diagnostic():
         "mesh_loaded": True,
         "fallback_visible": False,
         "mesh_uri": "assets/workbench.stl",
+        "support_surface_kind": "table_surface",
         "expected_dimensions_m": {"x": 1.20, "y": 0.80, "z": 0.05},
         "mesh_local_scale": {"x": 1.0, "y": 1.0, "z": 1.0},
         "bounding_box_size": {"x": 1.20, "y": 0.80, "z": 0.05},
@@ -261,6 +262,28 @@ def _valid_table_diagnostic():
     }
 
 
+
+
+def _workbench_body_diagnostic(with_height=True):
+    diagnostic = _valid_table_diagnostic()
+    diagnostic.update(
+        {
+            "id": "workbench_body",
+            "object_id": "workbench_body",
+            "object_name": "M1 workbench body",
+            "link_name": "workbench_body",
+            "support_surface_kind": "workbench_body",
+            "expected_dimensions_m": {"x": 1.20, "y": 0.80, "z": 0.90},
+            "bounding_box_size": {"x": 1.20, "y": 0.80, "z": 0.90},
+            "loaded_mesh_bounding_box_size": {"x": 1.20, "y": 0.80, "z": 0.90},
+            "bounding_box_center": {"x": 0.40, "y": 0.0, "z": 0.45},
+            "loaded_mesh_bounding_box_center": {"x": 0.40, "y": 0.0, "z": 0.45},
+        }
+    )
+    diagnostic.pop("inferred_up_axis", None)
+    if with_height:
+        diagnostic["top_surface_z_m"] = 0.90
+    return diagnostic
 
 
 def _valid_camera_diagnostic():
@@ -533,3 +556,35 @@ def test_browser_status_validator_rejects_oversized_camera_mesh_in_fit_bounds():
     errors = module.validate_browser_status(status)
 
     assert any("camera/Realsense camera_link loaded mesh bounds are oversized" in error for error in errors)
+
+
+def test_table_horizontal_accepts_tabletop_with_thin_z():
+    assert module._table_horizontal_errors({"renderedMeshDiagnostics": [_valid_table_diagnostic()]}) == []
+
+
+def test_table_horizontal_rejects_tabletop_with_large_z():
+    diagnostic = _valid_table_diagnostic()
+    diagnostic["bounding_box_size"] = {"x": 1.20, "y": 0.80, "z": 0.60}
+
+    errors = module._table_horizontal_errors({"renderedMeshDiagnostics": [diagnostic]})
+
+    assert any("thin tabletop Z" in error for error in errors)
+
+
+def test_table_horizontal_accepts_workbench_body_only_with_support_height_metadata():
+    assert module._table_horizontal_errors({"renderedMeshDiagnostics": [_workbench_body_diagnostic(with_height=True)]}) == []
+
+
+def test_table_horizontal_rejects_workbench_body_without_support_height_metadata():
+    errors = module._table_horizontal_errors({"renderedMeshDiagnostics": [_workbench_body_diagnostic(with_height=False)]})
+
+    assert any("missing finite top/support height metadata" in error for error in errors)
+
+
+def test_table_horizontal_rejects_missing_support_surface_kind_metadata():
+    diagnostic = _valid_table_diagnostic()
+    diagnostic.pop("support_surface_kind", None)
+
+    errors = module._table_horizontal_errors({"renderedMeshDiagnostics": [diagnostic]})
+
+    assert any("missing explicit support-surface kind metadata" in error for error in errors)


### PR DESCRIPTION
### Motivation

- Make table/workbench validation explicit and robust by requiring exporter-provided semantics for support surfaces rather than silently guessing. 
- Allow realistic workbench/body-height support geometry (not just thin tabletops) while ensuring the body has plausible footprint and top/support height metadata. 

### Description

- Added a helper ` _diagnostic_support_surface_kind(diagnostic)` that reads common snake/camel metadata keys such as `support_surface_kind`, `supportSurfaceKind`, `semantic_type`, `support_kind`, and aliases and normalises them to a canonical token. 
- Added `_diagnostic_float(diagnostic, ...)` to robustly parse finite numeric metadata like `top_surface_z_m` / `support_surface_height_m`. 
- Reworked `_table_horizontal_errors()` to branch by explicit kind into `tabletop`/`table_surface` (require thin Z, wide XY, and up axis near world +Z) and `workbench_body`/`cabinet`/`support_surface` (allow body-height Z, require sensible XY footprint and plausible height). 
- For body-kind diagnostics, require a finite `top_surface_z_m` or `support_surface_height_m` and validate it is plausibly near the loaded bounding-box top; fail when these semantics are missing. 
- Updated and added unit tests in `tests/test_workcell_web3d_visual_acceptance.py` and updated `scripts/run_workcell_web3d_visual_acceptance.py` to cover tabletop pass/fail cases, workbench body height metadata acceptance, and explicit-kind missing failures. 

### Testing

- Ran the visual acceptance unit tests with `python3 -m pytest tests/test_workcell_web3d_visual_acceptance.py` and all tests passed (`37 passed`). 
- New tests include `test_table_horizontal_accepts_tabletop_with_thin_z`, `test_table_horizontal_rejects_tabletop_with_large_z`, `test_table_horizontal_accepts_workbench_body_only_with_support_height_metadata`, and `test_table_horizontal_rejects_workbench_body_without_support_height_metadata`, and they passed under the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f9ca6185083318e0aeaef4912ffee)