### PR TITLE
Export web scene support surface metadata

### DIFF
--- a/schemas/workcell_studio_web_scene_v1.schema.json
+++ b/schemas/workcell_studio_web_scene_v1.schema.json
@@ -276,6 +276,23 @@
                         "generated_preview"
                     ]
                 },
+                "support_surface_kind": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "top_surface_z_m": {
+                    "type": "number"
+                },
+                "support_surface_height_m": {
+                    "type": "number"
+                },
+                "expected_support_footprint_m": {
+                    "type": "array",
+                    "minItems": 2,
+                    "items": {
+                        "type": "number"
+                    }
+                },
                 "provenance": {
                     "$ref": "#/$defs/provenance"
                 }

--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -525,6 +525,8 @@ def _generated_preview_items(index: Mapping[str, Any], scene_dir: Path, warnings
         "primitive_geometry_type", "package_uri", "mesh_uri", "source_path", "mesh_path",
         "resolved_source_path", "scale", "mesh_scale", "source_layer", "active_visual_source",
         "mesh_bounds", "local_bounds", "bounds", "dimensions", "size",
+        "support_surface_kind", "support_kind", "semantic_type", "top_surface_z_m", "topSurfaceZM", "support_surface_height_m", "supportSurfaceHeightM",
+        "expected_support_footprint_m", "support_footprint_m", "footprint_m", "footprint",
         "render_expected", "mesh_available", "resolved", "warning",
     )
     for i, raw in enumerate(items):
@@ -838,6 +840,8 @@ def _authored_item(raw: Mapping[str, Any], source: str, index: int, scene_dir: P
         "id", "type", "role", "category", "display_name", "frame", "pose", "pose_xyz", "pose_rpy", "dimensions",
         "geometry_type", "primitive_geometry_type", "mesh_uri", "package_uri", "source_path", "mesh_path", "material",
         "layout_item_ref", "support_surface_ref", "task_zone_ref", "scale", "mesh_scale", "perception_mode", "runtime_enforced", "runtime_commanded",
+        "support_surface_kind", "support_kind", "semantic_type", "top_surface_z_m", "topSurfaceZM", "support_surface_height_m", "supportSurfaceHeightM",
+        "expected_support_footprint_m", "support_footprint_m", "footprint_m", "footprint", "table_height", "table_top_z", "surface_height_m",
     )
     item = _copy_fields(raw, fields, source, scene_dir)
     item.setdefault("id", _stable_id("authored", index))
@@ -1160,8 +1164,128 @@ def _authored_physical_dimension_defaults(data: Mapping[str, Any]) -> Dict[str, 
     return defaults
 
 
+def _authored_support_surface_defaults(data: Mapping[str, Any]) -> Dict[str, Any]:
+    defaults: Dict[str, Any] = {}
+    env = _as_map(data.get("environment"))
+    env_root = _as_map(env.get("environment"))
+    cell = _as_map(data.get("cell_definition"))
+    cell_env = _as_map(cell.get("environment"))
+    candidates = (
+        _as_list(env_root.get("support_surfaces"))
+        + _as_list(env.get("support_surfaces"))
+        + _as_list(cell_env.get("support_surfaces"))
+    )
+    for raw in candidates:
+        if not isinstance(raw, Mapping):
+            continue
+        text = _identity_text(raw)
+        if not any(token in text for token in ("table", "workbench", "support_surface")):
+            continue
+        dims = _finite_num3(raw.get("dimensions") or raw.get("size"))
+        pose = _finite_num3(raw.get("pose_xyz"))
+        if pose is None:
+            pose = _pose_xyz(raw.get("pose"))
+        if dims is not None:
+            defaults.setdefault("expected_support_footprint_m", [abs(dims[0]), abs(dims[1])])
+            defaults.setdefault("expected_dimensions_m", dims)
+        for source_key, target_key in (
+            ("support_surface_kind", "support_surface_kind"),
+            ("support_kind", "support_surface_kind"),
+            ("semantic_type", "support_surface_kind"),
+            ("top_surface_z_m", "top_surface_z_m"),
+            ("topSurfaceZM", "top_surface_z_m"),
+            ("support_surface_height_m", "support_surface_height_m"),
+            ("supportSurfaceHeightM", "support_surface_height_m"),
+            ("table_top_z", "top_surface_z_m"),
+            ("table_height", "support_surface_height_m"),
+            ("surface_height_m", "support_surface_height_m"),
+        ):
+            if raw.get(source_key) not in (None, ""):
+                defaults.setdefault(target_key, raw.get(source_key))
+        if pose is not None and dims is not None:
+            top_z = pose[2] + abs(dims[2]) / 2.0
+            defaults.setdefault("top_surface_z_m", top_z)
+            defaults.setdefault("support_surface_height_m", top_z)
+    return defaults
+
+
+def _stl_mesh_dimensions_m(item: Mapping[str, Any]) -> Optional[List[float]]:
+    uri = str(item.get("original_mesh_uri") or item.get("original_source_path") or item.get("mesh_uri") or "")
+    if "workbench_description/meshes/visual/table.stl" not in uri:
+        return None
+    resolved = item.get("resolved_source_path")
+    if not isinstance(resolved, str) or not resolved:
+        return None
+    path = Path(resolved)
+    if not path.is_absolute():
+        path = Path.cwd() / path
+    if not path.is_file():
+        return None
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        return None
+    vertices: List[List[float]] = []
+    try:
+        text = raw.decode("utf-8", errors="ignore")
+        for line in text.splitlines():
+            parts = line.strip().split()
+            if len(parts) == 4 and parts[0].lower() == "vertex":
+                vertices.append([float(parts[1]), float(parts[2]), float(parts[3])])
+    except ValueError:
+        vertices = []
+    if not vertices and len(raw) >= 84:
+        import struct
+
+        try:
+            tri_count = struct.unpack_from("<I", raw, 80)[0]
+            expected = 84 + tri_count * 50
+            if expected <= len(raw):
+                for offset in range(84, expected, 50):
+                    for vertex_index in range(3):
+                        vertex_offset = offset + 12 + vertex_index * 12
+                        vertices.append(list(struct.unpack_from("<fff", raw, vertex_offset)))
+        except (struct.error, ValueError):
+            return None
+    if not vertices:
+        return None
+    scale = _finite_num3(item.get("scale") or item.get("mesh_scale")) or [1.0, 1.0, 1.0]
+    dims = []
+    for axis in range(3):
+        values = [vertex[axis] * scale[axis] for vertex in vertices]
+        dims.append(abs(max(values) - min(values)))
+    if all(v > 0.0 for v in dims):
+        return dims
+    return None
+
+
+def _populate_support_surface_fields(item: Json, category: str, support_defaults: Mapping[str, Any]) -> None:
+    if category != "table":
+        return
+    mesh_dims = _stl_mesh_dimensions_m(item)
+    dims = mesh_dims or _finite_num3(item.get("expected_dimensions_m")) or _finite_num3(support_defaults.get("expected_dimensions_m"))
+    if mesh_dims is not None and 0.9 <= mesh_dims[0] <= 1.5 and 0.5 <= mesh_dims[1] <= 1.1 and 0.6 <= mesh_dims[2] <= 1.2:
+        item.setdefault("support_surface_kind", "workbench_body")
+        item["expected_dimensions_m"] = mesh_dims
+    else:
+        item.setdefault("support_surface_kind", support_defaults.get("support_surface_kind") or "support_surface")
+    if dims is not None:
+        item.setdefault("expected_support_footprint_m", [abs(dims[0]), abs(dims[1])])
+    xyz = _item_pose_xyz(item)
+    if xyz is None and dims is not None:
+        xyz = [0.0, 0.0, 0.0]
+    if xyz is not None and dims is not None:
+        top_z = xyz[2] + abs(dims[2]) / 2.0
+        item.setdefault("top_surface_z_m", top_z)
+        item.setdefault("support_surface_height_m", top_z)
+    for key in ("top_surface_z_m", "support_surface_height_m", "expected_support_footprint_m"):
+        if key not in item and key in support_defaults:
+            item[key] = support_defaults[key]
+
+
 def _populate_visual_bounds_item_fields(payload: Json, data: Mapping[str, Any]) -> None:
     dimension_defaults = _authored_physical_dimension_defaults(data)
+    support_defaults = _authored_support_surface_defaults(data)
     for section, item in _all_scene_items(payload):
         if not _is_mesh_item(item):
             continue
@@ -1179,6 +1303,7 @@ def _populate_visual_bounds_item_fields(payload: Json, data: Mapping[str, Any]) 
         item["mesh_contract_category"] = category
         if "expected_dimensions_m" not in item and category in dimension_defaults:
             item["expected_dimensions_m"] = dimension_defaults[category]
+        _populate_support_surface_fields(item, category, support_defaults)
         item.setdefault("mesh_load_required", category in {"robot_link", "gripper", "table", "camera", "object"})
         # Unit autoscale is a browser-side asset convenience only.  Generated URDF
         # previews and robot links must keep authored units exactly as exported.

--- a/tests/test_export_workcell_studio_web_scene.py
+++ b/tests/test_export_workcell_studio_web_scene.py
@@ -92,6 +92,10 @@ def test_export_web_scene_contract_and_determinism(tmp_path):
     assert table["mesh_path"] == "meshes/table.stl"
     assert table["expected_dimensions_m"] == [1.2, 0.8, 0.08]
     assert table["mesh_contract_category"] == "table"
+    assert table["support_surface_kind"] == "support_surface"
+    assert table["top_surface_z_m"] == 0.04
+    assert table["support_surface_height_m"] == 0.04
+    assert table["expected_support_footprint_m"] == [1.2, 0.8]
     camera = next(item for item in payload["sensors"] if item["id"] == "realsense_camera")
     assert camera["expected_dimensions_m"] == [0.08, 0.08, 0.06]
     assert camera["mesh_contract_category"] == "camera"
@@ -381,7 +385,17 @@ def test_export_carries_authored_fixture_dimensions_to_generated_table_camera_me
     table = next(item for item in payload["assets"] if item["id"] == "urdf_visual_table")
     camera = next(item for item in payload["sensors"] if item["id"] == "urdf_visual_camera")
     assert table["mesh_contract_category"] == "table"
-    assert table["expected_dimensions_m"] == [1.2, 0.8, 0.08]
+    assert table["support_surface_kind"] == "workbench_body"
+    assert 1.1 < table["expected_dimensions_m"][0] < 1.3
+    assert 0.7 < table["expected_dimensions_m"][1] < 0.9
+    assert 0.8 < table["expected_dimensions_m"][2] < 1.0
+    assert 1.1 < table["expected_support_footprint_m"][0] < 1.3
+    assert 0.7 < table["expected_support_footprint_m"][1] < 0.9
+    assert isinstance(table["top_surface_z_m"], float)
+    assert isinstance(table["support_surface_height_m"], float)
+    assert table["original_mesh_uri"] == "package://workbench_description/meshes/visual/table.stl"
+    assert table["mesh_staging_status"] == "staged"
+    assert table["mesh_staged_path"] == table["mesh_uri"]
     assert camera["mesh_contract_category"] == "camera"
     assert camera["expected_dimensions_m"] == [0.08, 0.08, 0.06]
 

--- a/tests/test_workcell_studio_web_scene_contract.py
+++ b/tests/test_workcell_studio_web_scene_contract.py
@@ -461,6 +461,12 @@ def test_ur5_2f_table_mesh_contract_keeps_mesh_backing_and_uniform_scale(tmp_pat
         assert table.get("mesh_staging_status") == "staged"
         assert table.get("mesh_load_required") is True
         assert "workbench_description/meshes/visual/table.stl" in str(table.get("original_mesh_uri"))
+        assert table.get("mesh_staged_path") == table.get("mesh_uri")
+        assert table.get("support_surface_kind") == "workbench_body"
+        footprint = _finite_vector(table.get("expected_support_footprint_m"), length=2, label=f"{table.get('id')}.expected_support_footprint_m")
+        assert footprint[0] > 0.5 and footprint[1] > 0.3
+        assert math.isfinite(float(table.get("top_surface_z_m")))
+        assert math.isfinite(float(table.get("support_surface_height_m")))
         assert table.get("fallback_reason") in (None, "")
         assert scale[0] == scale[1] == scale[2], "table/workbench mesh scale must remain uniform"
         assert scale == [0.001, 0.001, 0.001]


### PR DESCRIPTION
### Motivation
- Ensure authored and generated table/workbench items include explicit support-surface metadata (kind, top/support height, XY footprint) so the Product View and browser diagnostics can validate framing and support assumptions.
- Populate sensible defaults for tables/workbenches from authored `environment.yaml`/`cell_definition.yaml` or from actual staged mesh bounds (especially `workbench_description/meshes/visual/table.stl`) to avoid missing/ambiguous viewer diagnostics.
- Preserve existing mesh provenance and staging information while making support-surface data available to downstream viewers and validators.

### Description
- Extended field copying for authored and generated-preview items to carry support-surface aliases and height/footprint keys in `_authored_item` and `_generated_preview_items`.
- Added `_authored_support_surface_defaults`, `_stl_mesh_dimensions_m`, and `_populate_support_surface_fields` to compute defaults from `environment.yaml`/`cell_definition.yaml` and to infer dimensions/top height from staged table STL geometry when resolvable.
- Wired support-surface population into the existing bounds pipeline by calling `_populate_support_surface_fields` from `_populate_visual_bounds_item_fields` while preserving `original_mesh_uri`, `mesh_uri`, `mesh_staged_path`, and `mesh_staging_status` set by mesh staging.
- Updated the JSON schema `schemas/workcell_studio_web_scene_v1.schema.json` to allow `support_surface_kind`, `top_surface_z_m`, `support_surface_height_m`, and `expected_support_footprint_m`, and adjusted tests in `tests/test_export_workcell_studio_web_scene.py` and `tests/test_workcell_studio_web_scene_contract.py` to assert the new contract for authored and generated table/workbench items.

### Testing
- Ran `python3 -m pytest tests/test_export_workcell_studio_web_scene.py tests/test_workcell_studio_web_scene_contract.py` and all tests passed (`21 passed`).
- The updated contract tests exercise the `ur5_2f_test` workbench mesh path and assert presence of `support_surface_kind`, finite `top_surface_z_m`/`support_surface_height_m`, `expected_support_footprint_m`, and preservation of original/staged mesh URIs/paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f9dd0d7d8833185a53fc81cc2b2f7)