### PR TITLE
Force baked-visible pose rendering for generated URDF mesh previews in web viewer

### DIFF
--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -490,7 +490,11 @@ def _canonical_generated_transform(raw: Mapping[str, Any]) -> Tuple[Optional[Any
     final render pose; it must not multiply the visual origin a second time.
     """
     baked_source = raw.get("baked_world_visual_transform_source")
-    for field in ("world_from_visual", "final_transform", "baked_world_visual_pose", "expected_visual_pose", "pose", "world_pose"):
+    # Prefer the already-baked visible mesh world pose when present.  Older
+    # generated indexes may also carry link-frame final_transform/world_from_visual
+    # values, and using those first makes the browser re-apply visual_origin and
+    # explode generated URDF meshes.
+    for field in ("baked_world_visual_pose", "expected_visual_pose", "final_transform", "world_from_visual", "pose", "world_pose"):
         value = raw.get(field)
         if value not in (None, "", [], {}):
             return value, str(baked_source or field), field
@@ -1209,7 +1213,7 @@ def _authored_support_surface_defaults(data: Mapping[str, Any]) -> Dict[str, Any
     return defaults
 
 
-def _stl_mesh_dimensions_m(item: Mapping[str, Any]) -> Optional[List[float]]:
+def _stl_mesh_bounds_m(item: Mapping[str, Any]) -> Optional[Dict[str, List[float]]]:
     uri = str(item.get("original_mesh_uri") or item.get("original_source_path") or item.get("mesh_uri") or "")
     if "workbench_description/meshes/visual/table.stl" not in uri:
         return None
@@ -1250,19 +1254,31 @@ def _stl_mesh_dimensions_m(item: Mapping[str, Any]) -> Optional[List[float]]:
     if not vertices:
         return None
     scale = _finite_num3(item.get("scale") or item.get("mesh_scale")) or [1.0, 1.0, 1.0]
-    dims = []
+    minimum: List[float] = []
+    maximum: List[float] = []
+    size: List[float] = []
     for axis in range(3):
         values = [vertex[axis] * scale[axis] for vertex in vertices]
-        dims.append(abs(max(values) - min(values)))
-    if all(v > 0.0 for v in dims):
-        return dims
+        axis_min = min(values)
+        axis_max = max(values)
+        minimum.append(axis_min)
+        maximum.append(axis_max)
+        size.append(abs(axis_max - axis_min))
+    if all(v > 0.0 for v in size):
+        return {"min": minimum, "max": maximum, "size": size}
     return None
+
+
+def _stl_mesh_dimensions_m(item: Mapping[str, Any]) -> Optional[List[float]]:
+    bounds = _stl_mesh_bounds_m(item)
+    return bounds.get("size") if bounds else None
 
 
 def _populate_support_surface_fields(item: Json, category: str, support_defaults: Mapping[str, Any]) -> None:
     if category != "table":
         return
-    mesh_dims = _stl_mesh_dimensions_m(item)
+    mesh_bounds = _stl_mesh_bounds_m(item)
+    mesh_dims = mesh_bounds.get("size") if mesh_bounds else None
     dims = mesh_dims or _finite_num3(item.get("expected_dimensions_m")) or _finite_num3(support_defaults.get("expected_dimensions_m"))
     if mesh_dims is not None and 0.9 <= mesh_dims[0] <= 1.5 and 0.5 <= mesh_dims[1] <= 1.1 and 0.6 <= mesh_dims[2] <= 1.2:
         item.setdefault("support_surface_kind", "workbench_body")
@@ -1275,7 +1291,10 @@ def _populate_support_surface_fields(item: Json, category: str, support_defaults
     if xyz is None and dims is not None:
         xyz = [0.0, 0.0, 0.0]
     if xyz is not None and dims is not None:
-        top_z = xyz[2] + abs(dims[2]) / 2.0
+        # STL workbench meshes may use a floor/local-corner origin rather than
+        # a centered origin.  Use the actual mesh max-Z when available so
+        # support-surface diagnostics match the rendered browser mesh top.
+        top_z = xyz[2] + (float(mesh_bounds["max"][2]) if mesh_bounds else abs(dims[2]) / 2.0)
         item.setdefault("top_surface_z_m", top_z)
         item.setdefault("support_surface_height_m", top_z)
     for key in ("top_surface_z_m", "support_surface_height_m", "expected_support_footprint_m"):

--- a/scripts/run_workcell_web3d_visual_acceptance.py
+++ b/scripts/run_workcell_web3d_visual_acceptance.py
@@ -391,6 +391,52 @@ def _expected_rendered_wrapper_center(diagnostic: Mapping[str, Any]) -> tuple[fl
     return None
 
 
+
+def _has_baked_pose(diagnostic: Mapping[str, Any]) -> bool:
+    for key in ("baked_world_visual_pose", "bakedWorldVisualPose", "expected_visual_pose", "expectedVisualPose", "final_transform", "finalTransform", "world_from_visual", "worldFromVisual"):
+        if _pose_xyz(diagnostic.get(key)) is not None:
+            return True
+    return False
+
+
+def _is_generated_urdf_mesh_diagnostic(diagnostic: Mapping[str, Any]) -> bool:
+    text = _diagnostic_text(diagnostic)
+    mesh_uri = str(diagnostic.get("mesh_uri") or diagnostic.get("meshUri") or "").strip()
+    render_status = _diagnostic_status(diagnostic)
+    has_mesh = bool(mesh_uri) or render_status == "mesh_loaded" or _diagnostic_bool(diagnostic, "mesh_loaded", "meshLoaded")
+    generated = "urdf" in text or "generated" in text or any(token in text for token in ("robot", "gripper", "robotiq", "realsense", "workbench"))
+    visual = any(token in text for token in ("visual", "mesh", "link", "robot", "tool", "gripper", "camera", "table", "workbench"))
+    return has_mesh and generated and visual
+
+
+def baked_pose_render_mode_summary(status: Mapping[str, Any]) -> dict[str, Any]:
+    rows = [d for d in _rendered_mesh_diagnostics_from_status(status) if isinstance(d, Mapping) and _is_generated_urdf_mesh_diagnostic(d) and _has_baked_pose(d)]
+    rendered = []
+    mismatches = []
+    for diagnostic in rows:
+        mode = str(diagnostic.get("workcell_web_render_pose_mode") or diagnostic.get("workcellWebRenderPoseMode") or "").strip()
+        exported_mode = str(diagnostic.get("exported_workcell_web_render_pose_mode") or diagnostic.get("exportedWorkcellWebRenderPoseMode") or "").strip()
+        name = str(diagnostic.get("link") or diagnostic.get("object_name") or diagnostic.get("id") or diagnostic.get("display_name") or "unnamed")
+        if mode == "baked_visible_world_pose":
+            rendered.append(name)
+        else:
+            mismatches.append({"name": name, "mode": mode, "exported_mode": exported_mode})
+    return {
+        "generated_urdf_mesh_rows_with_baked_pose": len(rows),
+        "rows_rendered_in_baked_visible_pose_mode": len(rendered),
+        "rows_with_baked_pose_but_empty_or_legacy_render_mode": mismatches,
+    }
+
+
+def _baked_pose_render_mode_errors(status: Mapping[str, Any]) -> list[str]:
+    summary = baked_pose_render_mode_summary(status)
+    expected = int(summary["generated_urdf_mesh_rows_with_baked_pose"])
+    actual = int(summary["rows_rendered_in_baked_visible_pose_mode"])
+    if expected != actual:
+        missing = ", ".join(row["name"] for row in summary["rows_with_baked_pose_but_empty_or_legacy_render_mode"][:20])
+        return [f"browser viewer baked pose render mode mismatch: generated URDF mesh rows with baked pose={expected}, rendered in baked_visible_world_pose={actual}; missing/legacy rows: {missing or 'unknown'}"]
+    return []
+
 def _euclidean_distance(a: tuple[float, float, float], b: tuple[float, float, float]) -> float:
     return sum((left - right) ** 2 for left, right in zip(a, b)) ** 0.5
 
@@ -519,6 +565,7 @@ def validate_browser_status(status: Mapping[str, Any]) -> list[str]:
     errors.extend(_required_product_fallback_errors(status))
     errors.extend(_table_mesh_contract_errors(status))
     errors.extend(_camera_bounds_errors(status))
+    errors.extend(_baked_pose_render_mode_errors(status))
     return errors
 
 
@@ -714,6 +761,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 1
     status = browser.get("status") if isinstance(browser, Mapping) else None
     if isinstance(status, Mapping):
+        debug_summary = baked_pose_render_mode_summary(status)
+        print("visual_debug_baked_pose_summary: " + json.dumps(debug_summary, sort_keys=True))
         status_errors = validate_browser_status(status)
         if status_errors:
             for error in status_errors:

--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -197,11 +197,12 @@ def test_viewer_generated_urdf_baked_pose_mode_prefers_baked_visual_pose_chain()
     assert "function usesBakedVisibleWorldPose(item)" in js
 
     baked_source_body = js.split("function bakedVisibleWorldPoseSource(item)", 1)[1].split("function usesBakedVisibleWorldPose(item)", 1)[0]
-    assert "item?.baked_world_visual_pose || item?.expected_visual_pose || item?.final_transform || null" in baked_source_body
+    assert "item?.baked_world_visual_pose || item?.expected_visual_pose || item?.final_transform || item?.world_from_visual || null" in baked_source_body
 
-    mode_check_body = js.split("function usesBakedVisibleWorldPose(item)", 1)[1].split("function generatedUrdfFramePoseSource(item)", 1)[0]
+    mode_check_body = js.split("function usesBakedVisibleWorldPose(item)", 1)[1].split("function effectiveWorkcellWebRenderPoseMode(item)", 1)[0]
     assert "item?.workcell_web_render_pose_mode === 'baked_visible_world_pose'" in mode_check_body
     assert "hasFinitePoseBlock(bakedVisibleWorldPoseSource(item))" in mode_check_body
+    assert "return isGeneratedUrdfMeshVisualItem(item);" in mode_check_body
 
     final_pose_body = js.split("function canonicalFinalPose(item)", 1)[1].split("function poseOf(item)", 1)[0]
     assert "if (isGeneratedUrdfItem(item))" in final_pose_body

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -202,8 +202,10 @@ function collectRenderedMeshDiagnostics() {
       debugOverlay: Boolean(isDebugOverlayItem(item)),
       visual_bounds_status: item.visual_bounds_status || '',
       visualBoundsStatus: item.visual_bounds_status || '',
-      workcell_web_render_pose_mode: item.workcell_web_render_pose_mode || '',
-      workcellWebRenderPoseMode: item.workcell_web_render_pose_mode || '',
+      workcell_web_render_pose_mode: effectiveWorkcellWebRenderPoseMode(item),
+      workcellWebRenderPoseMode: effectiveWorkcellWebRenderPoseMode(item),
+      exported_workcell_web_render_pose_mode: item.workcell_web_render_pose_mode || '',
+      exportedWorkcellWebRenderPoseMode: item.workcell_web_render_pose_mode || '',
       baked_world_visual_pose: item.baked_world_visual_pose || null,
       bakedWorldVisualPose: item.baked_world_visual_pose || null,
       expected_visual_pose: item.expected_visual_pose || null,
@@ -372,11 +374,30 @@ function hasFinitePoseBlock(source) {
   return finiteVector(pose.xyz) && finiteVector(pose.rpy);
 }
 function bakedVisibleWorldPoseSource(item) {
-  return item?.baked_world_visual_pose || item?.expected_visual_pose || item?.final_transform || null;
+  return item?.baked_world_visual_pose || item?.expected_visual_pose || item?.final_transform || item?.world_from_visual || null;
+}
+function hasMeshBackedVisualContract(item) {
+  return Boolean(displayMeshUri(item) || item?.mesh_loaded || item?.meshLoaded || item?.mesh_status === 'loaded' || item?.renderInfo?.render_status === 'mesh_loaded');
+}
+function isGeneratedUrdfMeshVisualItem(item) {
+  if (!isGeneratedUrdfItem(item)) return false;
+  if (!hasMeshBackedVisualContract(item)) return false;
+  const identity = viewerGroupIdentity(item);
+  return Boolean(
+    item?.visual !== undefined ||
+    item?.visual_name !== undefined ||
+    item?.visual_index !== undefined ||
+    item?.mesh_uri || item?.package_uri || item?.mesh_path || item?.source_path ||
+    /\b(mesh|visual|link|robot|tool|gripper|camera|table|workbench)\b/.test(identity)
+  );
 }
 function usesBakedVisibleWorldPose(item) {
-  return item?.workcell_web_render_pose_mode === 'baked_visible_world_pose'
-    && hasFinitePoseBlock(bakedVisibleWorldPoseSource(item));
+  if (!hasFinitePoseBlock(bakedVisibleWorldPoseSource(item))) return false;
+  if (item?.workcell_web_render_pose_mode === 'baked_visible_world_pose') return true;
+  return isGeneratedUrdfMeshVisualItem(item);
+}
+function effectiveWorkcellWebRenderPoseMode(item) {
+  return usesBakedVisibleWorldPose(item) ? 'baked_visible_world_pose' : (item?.workcell_web_render_pose_mode || '');
 }
 function generatedUrdfFramePoseSource(item) {
   if (item?.frame_world_pose) return item.frame_world_pose;


### PR DESCRIPTION
### Motivation
- Browser Product View was showing generated URDF robot meshes exploded because the viewer skipped baked visible mesh poses when the exported `workcell_web_render_pose_mode` flag was missing or empty.
- The intent is to make the viewer render generated URDF mesh visuals from their baked visible world pose whenever a finite baked pose exists, while preserving authored/item-specific behavior and diagnostics.

### Description
- Changed baked-pose detection in `workcell_studio_web/viewer/viewer.js` so `bakedVisibleWorldPoseSource` includes `world_from_visual` and `usesBakedVisibleWorldPose` returns true when a finite baked pose exists for generated URDF mesh visuals even if `workcell_web_render_pose_mode` is missing; added `hasMeshBackedVisualContract`, `isGeneratedUrdfMeshVisualItem`, and `effectiveWorkcellWebRenderPoseMode` helpers and made the viewer expose the effective and exported modes separately.
- Updated the render application logic so generated URDF mesh roots use `baked_world_visual_pose || expected_visual_pose || final_transform || world_from_visual` as root pose and treat the mesh local visual-origin as identity when baking is applied (avoid double-applying `visual_origin`).
- Modified `scripts/export_workcell_studio_web_scene.py` to prefer `baked_world_visual_pose` / `expected_visual_pose` before legacy `final_transform`/`world_from_visual` when computing the canonical generated transform, and preserved/annotated `workcell_web_render_pose_mode` and `visual_origin_application` metadata for generated mesh rows.
- Added an acceptance diagnostic in `scripts/run_workcell_web3d_visual_acceptance.py` that counts generated URDF mesh rows with baked pose, counts rows rendered in `baked_visible_world_pose`, lists mismatches, and fails if counts differ; it also prints a `visual_debug_baked_pose_summary` for quick inspection.
- Small exporter improvement for workbench/table STL: compute mesh max-Z from the STL (when available) to derive `top_surface_z_m`/`support_surface_height_m` so table diagnostics compare against actual rendered mesh top rather than an assumed centered box.
- Updated one static test in `tests/test_workcell_studio_web_viewer_static.py` to assert the new inference-based baked-pose path and the new diagnostic/exported-mode fields.
- Preserved safety constraints: no changes to launch files, controllers, MoveIt, or real-hardware flags.

### Testing
- Ran unit/static tests: `python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py tests/test_workcell_studio_web_scene_contract.py tests/test_workcell_web3d_visual_acceptance.py tests/test_export_workcell_studio_web_scene.py` — all tests passed (90 tests).
- Exported and staged the canonical scene with `python3 scripts/ensure_workcell_studio_web_scene_fresh.py --scene scenes/ur5_2f_test --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json --stage-assets --force` — completed successfully.
- Ran browser visual acceptance: `python3 scripts/run_workcell_web3d_visual_acceptance.py --scene scenes/ur5_2f_test --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json --require-browser --port 8765` — the run printed `visual_debug_baked_pose_summary: {"generated_urdf_mesh_rows_with_baked_pose": 18, "rows_rendered_in_baked_visible_pose_mode": 18, "rows_with_baked_pose_but_empty_or_legacy_render_mode": []}` and the acceptance checks passed.
- No automated test or script enabled any real robot execution or changed hardware defaults.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fa1eea45c8331a29096b70ef5cf5c)