### PR TITLE
Fix Web3D Robotiq parent transforms

### DIFF
--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -839,6 +839,110 @@ def _apply_web_scene_transform_parity_fallbacks(data: Dict[str, Any], generated:
             if xyz is not None and sum(v * v for v in xyz) < 0.05 and ("camera" in _identity_text(item) or "realsense" in _identity_text(item)):
                 _set_item_pose(item, authored_camera_pose, "web_export_authored_camera_transform_fallback")
 
+
+def _rpy_xyz_matrix(rpy: Sequence[float]) -> List[List[float]]:
+    import math
+    r = float(rpy[0] if len(rpy) > 0 else 0.0)
+    p = float(rpy[1] if len(rpy) > 1 else 0.0)
+    y = float(rpy[2] if len(rpy) > 2 else 0.0)
+    cr, sr = math.cos(r), math.sin(r)
+    cp, sp = math.cos(p), math.sin(p)
+    cy, sy = math.cos(y), math.sin(y)
+    # Match THREE.Euler(..., 'XYZ') composition used by the browser: Rz * Ry * Rx.
+    return [
+        [cy * cp, cy * sp * sr - sy * cr, cy * sp * cr + sy * sr],
+        [sy * cp, sy * sp * sr + cy * cr, sy * sp * cr - cy * sr],
+        [-sp, cp * sr, cp * cr],
+    ]
+
+
+def _matrix_transpose(m: Sequence[Sequence[float]]) -> List[List[float]]:
+    return [[float(m[j][i]) for j in range(3)] for i in range(3)]
+
+
+def _matrix_multiply(a: Sequence[Sequence[float]], b: Sequence[Sequence[float]]) -> List[List[float]]:
+    return [[sum(float(a[i][k]) * float(b[k][j]) for k in range(3)) for j in range(3)] for i in range(3)]
+
+
+def _matrix_vec_multiply(m: Sequence[Sequence[float]], v: Sequence[float]) -> List[float]:
+    return [sum(float(m[i][k]) * float(v[k]) for k in range(3)) for i in range(3)]
+
+
+def _rpy_from_xyz_matrix(m: Sequence[Sequence[float]]) -> List[float]:
+    import math
+    # Inverse of the Rz * Ry * Rx matrix above for THREE Euler order XYZ.
+    sy = -float(m[2][0])
+    if abs(sy) < 0.999999:
+        pitch = math.asin(sy)
+        roll = math.atan2(float(m[2][1]), float(m[2][2]))
+        yaw = math.atan2(float(m[1][0]), float(m[0][0]))
+    else:
+        pitch = math.copysign(math.pi / 2.0, sy)
+        roll = math.atan2(-float(m[1][2]), float(m[1][1]))
+        yaw = 0.0
+    return [roll, pitch, yaw]
+
+
+def _parent_to_child_pose(parent_world_pose: Any, child_world_pose: Any) -> Optional[Json]:
+    parent_xyz = _pose_xyz(parent_world_pose)
+    child_xyz = _pose_xyz(child_world_pose)
+    if parent_xyz is None or child_xyz is None:
+        return None
+    parent_rpy = _as_list(_as_map(parent_world_pose).get("rpy") or [0.0, 0.0, 0.0])
+    child_rpy = _as_list(_as_map(child_world_pose).get("rpy") or [0.0, 0.0, 0.0])
+    try:
+        parent_rot = _rpy_xyz_matrix([float(v) for v in parent_rpy[:3]])
+        child_rot = _rpy_xyz_matrix([float(v) for v in child_rpy[:3]])
+        parent_inv = _matrix_transpose(parent_rot)
+        delta = [child_xyz[i] - parent_xyz[i] for i in range(3)]
+        local_xyz = _matrix_vec_multiply(parent_inv, delta)
+        local_rot = _matrix_multiply(parent_inv, child_rot)
+        local_rpy = _rpy_from_xyz_matrix(local_rot)
+    except Exception:  # noqa: BLE001 - diagnostics should not break export
+        return None
+    return {"xyz": [float(v) for v in local_xyz], "rpy": [float(v) for v in local_rpy]}
+
+
+def _annotate_parent_to_child_poses(generated: Dict[str, List[Json]]) -> None:
+    """Store explicit parent-to-child local poses for browser hierarchy rendering.
+
+    The browser attaches each child link under its parent Object3D, so the local
+    transform must be parent_world^-1 * child_world (parent-to-child), not the
+    ambiguous legacy parent_from_child naming and not a stale raw joint origin.
+    """
+    items = [
+        item
+        for section in GENERATED_OUTPUT_SECTIONS
+        for item in generated.get(section, [])
+        if isinstance(item, dict)
+    ]
+    by_link: Dict[str, Json] = {}
+    for item in items:
+        link = str(item.get("link_name") or item.get("link") or item.get("frame") or item.get("object_name") or "")
+        if link and (link not in by_link or item.get("meshless_frame") or item.get("role") == "transform_anchor"):
+            by_link[link] = item
+    for item in items:
+        link = str(item.get("link_name") or item.get("link") or item.get("frame") or item.get("object_name") or "")
+        parent = str(item.get("parent_link") or item.get("joint_parent_link") or item.get("immediate_parent_link") or "")
+        if not link or not parent or parent not in by_link:
+            continue
+        parent_pose = by_link[parent].get("frame_world_pose") or by_link[parent].get("link_world_pose")
+        child_pose = item.get("frame_world_pose") or item.get("link_world_pose")
+        pose = _parent_to_child_pose(parent_pose, child_pose)
+        if pose is None:
+            continue
+        item["parent_to_child_pose"] = pose
+        item["parent_from_child"] = pose
+        item["joint_origin"] = pose
+        item["parent_joint_origin"] = pose
+        item["parent_to_child_pose_source"] = "web_export_parent_world_inverse_times_child_world"
+        item.setdefault("provenance", {}).update({
+            "parent_to_child_pose": "web_export_parent_world_inverse_times_child_world",
+            "parent_from_child": "web_export_parent_world_inverse_times_child_world",
+            "joint_origin": "web_export_parent_world_inverse_times_child_world",
+            "parent_joint_origin": "web_export_parent_world_inverse_times_child_world",
+        })
+
 def _authored_item(raw: Mapping[str, Any], source: str, index: int, scene_dir: Path) -> Json:
     fields = (
         "id", "type", "role", "category", "display_name", "frame", "pose", "pose_xyz", "pose_rpy", "dimensions",
@@ -1661,6 +1765,7 @@ def build_web_scene(scene_dir: Path, *, stage_assets: bool = False, output_path:
     _supplement_missing_tool_meshes(data, generated)
     _annotate_urdf_assembly_metadata(generated, scene_name)
     _apply_web_scene_transform_parity_fallbacks(data, generated, warnings)
+    _annotate_parent_to_child_poses(generated)
     _suppress_unresolved_placeholder_robot_visuals(generated, warnings)
     authored = _authored_sections(data, scene_dir, warnings)
     top_robots, top_tools, top_sensors = _top_level_entities(data, warnings)

--- a/tests/test_export_workcell_studio_web_scene.py
+++ b/tests/test_export_workcell_studio_web_scene.py
@@ -644,3 +644,24 @@ def test_ur5_2f_web_scene_preserves_tool0_transform_anchor_metadata(tmp_path):
     assert anchor["pose"] == anchor["link_world_pose"]
     assert anchor["source_layer"]
     assert anchor["active_visual_source"]
+
+    items_by_link = {
+        item.get("link") or item.get("link_name") or item.get("frame"): item
+        for section in ("robots", "tools", "frames")
+        for item in payload.get(section, [])
+    }
+    wrist = items_by_link["wrist_3_link"]
+    gripper = items_by_link["gripper_base_link"]
+    assert anchor["parent_link"] == "wrist_3_link"
+    assert anchor["meshless_frame"] is True
+    assert anchor["assembly_group"] == wrist["assembly_group"] == gripper["assembly_group"]
+    assert anchor["robot_instance_id"] == wrist["robot_instance_id"] == gripper["robot_instance_id"]
+    assert gripper["parent_link"] == "tool0"
+    assert gripper["mesh_uri"]
+    assert gripper["parent_to_child_pose"]["xyz"] == [0.0, 0.0, 0.0]
+    assert gripper["parent_to_child_pose_source"] == "web_export_parent_world_inverse_times_child_world"
+    for link, item in items_by_link.items():
+        if str(link).startswith("gripper_"):
+            assert item["assembly_group"] == wrist["assembly_group"]
+            assert item["robot_instance_id"] == wrist["robot_instance_id"]
+            assert item.get("parent_to_child_pose"), f"{link} must carry explicit parent-to-child local pose"

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -2017,8 +2017,8 @@ function renderScene(items) {
 
 function linkNameOfItem(item) { return String(item?.link_name || item?.link || item?.frame || item?.object_name || item?.id || '').trim(); }
 function parentLinkOfItem(item) { return String(item?.parent_link || item?.joint_parent_link || item?.immediate_parent_link || '').trim(); }
-function jointOriginOfItem(item) { return item?.parent_from_child || item?.joint_origin || item?.parent_joint_origin || { xyz: [0, 0, 0], rpy: [0, 0, 0] }; }
-function derivedParentFromChildPose(item, parentItem) {
+function jointOriginOfItem(item) { return item?.parent_to_child_pose || item?.parent_from_child || item?.joint_origin || item?.parent_joint_origin || { xyz: [0, 0, 0], rpy: [0, 0, 0] }; }
+function derivedParentToChildPose(item, parentItem) {
   if (!THREE?.Matrix4 || !item || !parentItem) return null;
   const childPose = item?.link_world_pose || item?.frame_world_pose;
   const parentPose = parentItem?.link_world_pose || parentItem?.frame_world_pose;
@@ -2028,14 +2028,16 @@ function derivedParentFromChildPose(item, parentItem) {
   return poseBlockFromMatrix(parentWorld.clone().invert().multiply(childWorld));
 }
 function jointOriginForChildItem(item, parentItem) {
-  const explicit = item?.parent_from_child || item?.joint_origin || item?.parent_joint_origin;
+  const explicit = item?.parent_to_child_pose || item?.parent_from_child || item?.joint_origin || item?.parent_joint_origin;
   if (hasFinitePoseBlock(explicit)) return explicit;
-  const derived = derivedParentFromChildPose(item, parentItem);
+  const derived = derivedParentToChildPose(item, parentItem);
   if (derived) {
     const pose = { xyz: finiteXyzArrayFromVector(derived.xyz) || [0, 0, 0], rpy: finiteXyzArrayFromVector(derived.rpy) || [0, 0, 0] };
+    item.parent_to_child_pose = pose;
     item.parent_from_child = pose;
     item.joint_origin = pose;
     item.parent_joint_origin = pose;
+    item.parent_to_child_pose_source = 'viewer_derived_parent_world_inverse_times_child_world';
     item.parent_from_child_source = 'viewer_derived_parent_world_inverse_times_child_world';
     return pose;
   }


### PR DESCRIPTION
### Motivation
- The Robotiq gripper cluster was visually detached from the UR5 wrist because parent-relative transforms for the `wrist_3_link -> tool0 -> gripper_base_link` chain were ambiguous or derived in the wrong direction for the browser hierarchy model. 
- The goal is to ensure the browser receives explicit parent-to-child local poses so the assembled UR5+Robotiq hierarchy mounts correctly with `tool0` meshless and the gripper attached at the wrist.

### Description
- Added explicit parent-to-child pose derivation in the exporter by computing parent_world^-1 * child_world and storing the result as `parent_to_child_pose`, and propagated that into `parent_from_child`, `joint_origin`, and provenance fields in `scripts/export_workcell_studio_web_scene.py`.
- Implemented small matrix/RPY helpers (`_rpy_xyz_matrix`, `_matrix_transpose`, `_matrix_multiply`, `_matrix_vec_multiply`, `_rpy_from_xyz_matrix`, `_parent_to_child_pose`) and a new exporter step `_annotate_parent_to_child_poses` which is invoked after transform parity fallbacks.
- Updated the Web3D viewer (`workcell_studio_web/viewer/viewer.js`) to prefer `parent_to_child_pose` when building the assembled Object3D hierarchy and to record viewer-derived `parent_to_child_pose` as a fallback using the same parent_world^-1 * child_world math.
- Strengthened the export contract and tests to assert `tool0` is a meshless transform anchor with `parent_link: wrist_3_link`, `gripper_base_link` has `parent_link: tool0`, and all Robotiq links carry `parent_to_child_pose` and matching `assembly_group` / `robot_instance_id`.
- Changes are limited to static web scene export/viewer metadata and tests; no runtime robot execution, MoveIt, controllers, or hardware defaults were modified.

### Testing
- Ran `python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py tests/test_workcell_studio_web_scene_contract.py tests/test_workcell_web3d_visual_acceptance.py tests/test_export_workcell_studio_web_scene.py` and all tests passed (`94 passed`).
- Regenerated canonical web scene with `python3 scripts/ensure_workcell_studio_web_scene_fresh.py --scene scenes/ur5_2f_test --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json --stage-assets --force` and the export completed successfully.
- Ran a focused smoke run `python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py tests/test_export_workcell_studio_web_scene.py` after viewer rename tweaks and those tests passed (`47 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fbcb915c88331b3ae33f1517b9326)