### PR TITLE
Fix direct web export UR5 tool0 anchor contract

### DIFF
--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -64,6 +64,8 @@ ROBOTIQ_85_FALLBACK_LINK_TRANSFORMS = {
     "gripper_finger1_finger_tip_link": {"parent_link": "gripper_finger1_inner_knuckle_link", "joint_origin": {"xyz": [0.04303959807, -0.03759940821, 0.0], "rpy": [0.0, 0.0, 0.0]}},
     "gripper_finger2_finger_tip_link": {"parent_link": "gripper_finger2_inner_knuckle_link", "joint_origin": {"xyz": [0.04303959807, -0.03759940821, 0.0], "rpy": [0.0, 0.0, 0.0]}},
 }
+UR_VISUAL_MESH_TOKEN = "package://ur_description/meshes/"
+ROBOTIQ_VISUAL_MESH_TOKEN = "package://robotiq_85_description/meshes/visual/"
 
 HELPER_TOKENS = (
     "overlay",
@@ -398,6 +400,74 @@ def _is_transform_anchor(item: Mapping[str, Any]) -> bool:
     return str(item.get("type", "")).lower() == "transform_anchor" or str(item.get("role", "")).lower() == "transform_anchor"
 
 
+def _mesh_uri_values(item: Mapping[str, Any]) -> List[str]:
+    return [str(item.get(field)) for field in MESH_URI_FIELDS if isinstance(item.get(field), str) and str(item.get(field))]
+
+
+def _has_ur_visual_mesh_reference(item: Mapping[str, Any]) -> bool:
+    return any(UR_VISUAL_MESH_TOKEN in value and "/visual/" in value for value in _mesh_uri_values(item))
+
+
+def _has_robotiq_visual_mesh_reference(item: Mapping[str, Any]) -> bool:
+    return any(ROBOTIQ_VISUAL_MESH_TOKEN in value for value in _mesh_uri_values(item))
+
+
+def _normalize_generated_urdf_mesh_preview_item(item: Json) -> None:
+    """Classify generated URDF mesh rows before direct web export bucketing.
+
+    ``ensure_workcell_studio_web_scene_fresh.py`` also normalizes the generated
+    visual mesh index on disk, but callers of this exporter must not depend on
+    that refresh wrapper.  Normalize the copied row in memory so direct
+    ``export_workcell_studio_web_scene.py --no-stage-assets`` exports preserve
+    UR robot links, Robotiq tool links, and the meshless ``tool0`` anchor
+    contract even when the extractor emitted plain mesh rows with no role or
+    category.
+    """
+    link = str(item.get("link") or item.get("link_name") or item.get("object_name") or item.get("frame") or "")
+    if link:
+        item.setdefault("link", link)
+        item.setdefault("link_name", link)
+
+    if _is_transform_anchor(item) and link == "tool0":
+        item["id"] = "urdf_frame_anchor_tool0"
+        item["type"] = "transform_anchor"
+        item["role"] = "transform_anchor"
+        item["category"] = "frame"
+        item["render_expected"] = False
+        item["mesh_available"] = False
+        item["mesh_load_required"] = False
+        item["meshless_frame"] = True
+        item["active_visual_source"] = "frame_anchor"
+        for field in MESH_URI_FIELDS:
+            item.pop(field, None)
+        return
+
+    if _has_ur_visual_mesh_reference(item):
+        item["role"] = "robot"
+        item["category"] = "robot_static_mesh_visual"
+        item["source_layer"] = "locked_generated_urdf_visual"
+        item["active_visual_source"] = "mesh_preview"
+        item["primitive_geometry_type"] = "mesh"
+        item["geometry_type"] = "mesh"
+        item["mesh_available"] = True
+        item["render_expected"] = True
+        item["primitive_fallback"] = False
+        item["fallback_reason"] = ""
+        return
+
+    if _has_robotiq_visual_mesh_reference(item):
+        item["role"] = "gripper"
+        item["category"] = "tool"
+        item["source_layer"] = "locked_generated_urdf_visual"
+        item["active_visual_source"] = "mesh_preview"
+        item["primitive_geometry_type"] = "mesh"
+        item["geometry_type"] = "mesh"
+        item["mesh_available"] = True
+        item["render_expected"] = True
+        item["primitive_fallback"] = False
+        item["fallback_reason"] = ""
+
+
 def _section_from_item(item: Mapping[str, Any]) -> str:
     if _is_transform_anchor(item):
         return "frames"
@@ -557,6 +627,7 @@ def _generated_preview_items(index: Mapping[str, Any], scene_dir: Path, warnings
         item["editable"] = False
         item["source_kind"] = "generated_preview"
         item["provenance"].update({"locked": INPUTS["visual_mesh_index"], "editable": INPUTS["visual_mesh_index"], "source_kind": INPUTS["visual_mesh_index"]})
+        _normalize_generated_urdf_mesh_preview_item(item)
         if _is_transform_anchor(raw):
             item["render_expected"] = False
             item["mesh_available"] = False
@@ -585,7 +656,7 @@ def _generated_preview_items(index: Mapping[str, Any], scene_dir: Path, warnings
                     item["provenance"]["original_frame_world_pose"] = INPUTS["visual_mesh_index"]
         if any(token in _identity_text(raw) for token in ("camera", "realsense", "d435")):
             _annotate_mesh_unit_evidence(item, scene_dir)
-        sections[_section_from_item(raw)].append(item)
+        sections[_section_from_item(item)].append(item)
     return sections
 
 

--- a/tests/test_export_workcell_studio_web_scene.py
+++ b/tests/test_export_workcell_studio_web_scene.py
@@ -665,3 +665,119 @@ def test_ur5_2f_web_scene_preserves_tool0_transform_anchor_metadata(tmp_path):
             assert item["assembly_group"] == wrist["assembly_group"]
             assert item["robot_instance_id"] == wrist["robot_instance_id"]
             assert item.get("parent_to_child_pose"), f"{link} must carry explicit parent-to-child local pose"
+
+
+def test_direct_web_export_normalizes_ur5_tool0_and_robotiq_generated_rows(tmp_path):
+    scene = tmp_path / "scene"
+    (scene / "layout").mkdir(parents=True)
+    (scene / "generated").mkdir()
+    (scene / "scene_manifest.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "scene": {"name": "ur5_2f_direct_contract"},
+                "robot": {"model": "ur5"},
+                "end_effector": {"id": "robotiq_85", "model": "robotiq_85"},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    (scene / "cell_definition.yaml").write_text(
+        yaml.safe_dump({"cell": {"id": "ur5_2f_direct_contract"}, "robot": {"model": "ur5"}}, sort_keys=False),
+        encoding="utf-8",
+    )
+    (scene / "environment.yaml").write_text(yaml.safe_dump({"scene": {"name": "ur5_2f_direct_contract"}}, sort_keys=False), encoding="utf-8")
+    (scene / "layout/workcell_studio_layout.yaml").write_text(yaml.safe_dump({"items": []}), encoding="utf-8")
+    wrist_pose = {"xyz": [0.4, 0.1, 0.5], "rpy": [0.0, 0.0, 0.0]}
+    (scene / "generated/scene_visual_mesh_index.json").write_text(
+        json.dumps(
+            {
+                "visual_items": [
+                    {
+                        "id": "urdf_static_mesh_ur5_static_wrist_3",
+                        "link": "wrist_3_link",
+                        "object_name": "wrist_3_link",
+                        "parent_link": "wrist_2_link",
+                        "joint_parent_link": "wrist_2_link",
+                        "joint_name": "wrist_3_joint",
+                        "link_world_pose": wrist_pose,
+                        "frame_world_pose": wrist_pose,
+                        "mesh_uri": "package://ur_description/meshes/ur5/visual/wrist3.dae",
+                        "package_uri": "package://ur_description/meshes/ur5/visual/wrist3.dae",
+                        "source_path": "package://ur_description/meshes/ur5/visual/wrist3.dae",
+                    },
+                    {
+                        "id": "urdf_frame_anchor_tool0",
+                        "type": "transform_anchor",
+                        "role": "transform_anchor",
+                        "category": "frame",
+                        "link": "tool0",
+                        "object_name": "tool0",
+                        "parent_link": "flange",
+                        "joint_parent_link": "flange",
+                        "joint_name": "flange-tool0",
+                        "render_expected": False,
+                        "mesh_available": False,
+                        "link_world_pose": wrist_pose,
+                        "frame_world_pose": wrist_pose,
+                    },
+                    {
+                        "id": "urdf_visual_7_gripper_base_link",
+                        "link": "gripper_base_link",
+                        "object_name": "gripper_base_link",
+                        "parent_link": "tool0",
+                        "joint_parent_link": "tool0",
+                        "joint_name": "gripper_base_joint",
+                        "link_world_pose": wrist_pose,
+                        "frame_world_pose": wrist_pose,
+                        "mesh_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+                        "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+                        "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    out = tmp_path / "direct.web_scene.json"
+    subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / SCRIPT),
+            "--scene",
+            str(scene),
+            "--output",
+            str(out),
+            "--no-stage-assets",
+        ],
+        cwd=ROOT,
+        check=True,
+    )
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    items_by_link = {
+        item.get("link") or item.get("link_name") or item.get("frame"): item
+        for section in ("robots", "tools", "frames")
+        for item in payload.get(section, [])
+    }
+    wrist = items_by_link["wrist_3_link"]
+    tool0 = items_by_link["tool0"]
+    gripper = items_by_link["gripper_base_link"]
+
+    assert wrist["role"] == "robot"
+    assert wrist["category"] == "robot_static_mesh_visual"
+    assert wrist["active_visual_source"] == "mesh_preview"
+    assert tool0["id"] == "urdf_frame_anchor_tool0"
+    assert tool0["role"] == "transform_anchor"
+    assert tool0["parent_link"] == "wrist_3_link"
+    assert tool0["joint_parent_link"] == "wrist_3_link"
+    assert tool0["render_expected"] is False
+    assert tool0["mesh_available"] is False
+    assert tool0["mesh_load_required"] is False
+    assert "mesh_uri" not in tool0
+    assert gripper["parent_link"] == "tool0"
+    assert wrist["assembly_group"] == tool0["assembly_group"] == gripper["assembly_group"]
+    assert wrist["robot_instance_id"] == tool0["robot_instance_id"] == gripper["robot_instance_id"]
+    assert tool0["parent_to_child_pose"]
+    assert gripper["parent_to_child_pose"]


### PR DESCRIPTION
### Motivation
- Direct `export_workcell_studio_web_scene.py --no-stage-assets` could omit or mis-bucket generated UR/Robotiq preview rows causing `wrist_3_link` to be missing and breaking the `tool0` anchor contract expected by the Product View and tests.
- Normalization of generated URDF mesh-preview rows previously lived only in the freshness wrapper `ensure_workcell_studio_web_scene_fresh.py`, so direct export callers could not rely on the on-disk normalization.
- The change preserves the meshless `tool0` transform-anchor contract and ensures parent/child transforms are available for browser hierarchy rendering without enabling any runtime/hardware behavior changes.

### Description
- Added in-export normalization helpers: `_mesh_uri_values`, `_has_ur_visual_mesh_reference`, `_has_robotiq_visual_mesh_reference`, and `_normalize_generated_urdf_mesh_preview_item` inside `scripts/export_workcell_studio_web_scene.py` to classify generated preview rows in memory before bucketing.
- Ensure generated preview rows are normalized during `_generated_preview_items(...)` by calling `_normalize_generated_urdf_mesh_preview_item(item)` and use normalized metadata when assigning sections via `sections[_section_from_item(item)].append(item)`.
- Normalization covers: UR5 generated mesh rows (`role="robot"`, `category="robot_static_mesh_visual"`, `active_visual_source="mesh_preview"`), Robotiq generated rows (`role="gripper"` / `category="tool"`), and the meshless `tool0` transform-anchor contract (`id="urdf_frame_anchor_tool0"`, `mesh_available=false`, `meshless_frame=true`, removed mesh fields).
- Added regression test `test_direct_web_export_normalizes_ur5_tool0_and_robotiq_generated_rows` in `tests/test_export_workcell_studio_web_scene.py` that calls the exporter directly with `--no-stage-assets` and asserts presence and relationships of `wrist_3_link`, `tool0`, and `gripper_base_link` including `parent_to_child_pose` and shared `assembly_group`/`robot_instance_id`.

### Testing
- Ran `python3 -m pytest -q tests/test_export_workcell_studio_web_scene.py` and observed the new test and existing tests in that file pass (`12 passed`).
- Ran the broader validation `python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py tests/test_workcell_studio_web_scene_contract.py tests/test_workcell_web3d_visual_acceptance.py tests/test_export_workcell_studio_web_scene.py` and observed all tests pass (`95 passed`).
- Ran the freshness/staging acceptance command `python3 scripts/ensure_workcell_studio_web_scene_fresh.py --scene scenes/ur5_2f_test --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json --stage-assets --force` and it completed successfully, confirming no regression to the freshness wrapper behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fc1dc400c8331b9442324e5081ee6)