### PR TITLE
Use expanded URDF loader for web robot preview

### DIFF
--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -22,6 +22,7 @@ import json
 import os
 import shutil
 import sys
+import re
 import xml.etree.ElementTree as ET
 from pathlib import Path
 from urllib.parse import unquote, urlparse
@@ -66,6 +67,27 @@ ROBOTIQ_85_FALLBACK_LINK_TRANSFORMS = {
 }
 UR_VISUAL_MESH_TOKEN = "package://ur_description/meshes/"
 ROBOTIQ_VISUAL_MESH_TOKEN = "package://robotiq_85_description/meshes/visual/"
+
+DEFAULT_ROBOT_PREVIEW_JOINT_VALUES = {
+    "shoulder_pan_joint": 0.0,
+    "shoulder_lift_joint": -1.5708,
+    "elbow_joint": 1.5708,
+    "wrist_1_joint": -1.5708,
+    "wrist_2_joint": -1.5708,
+    "wrist_3_joint": 0.0,
+}
+EXPECTED_ROBOT_PREVIEW_LINKS = [
+    "base_link",
+    "base_link_inertia",
+    "shoulder_link",
+    "upper_arm_link",
+    "forearm_link",
+    "wrist_1_link",
+    "wrist_2_link",
+    "wrist_3_link",
+    "tool0",
+    "gripper_base_link",
+]
 
 HELPER_TOKENS = (
     "overlay",
@@ -298,6 +320,117 @@ def _staging_failure_status(warnings: Sequence[str]) -> str:
         return "unsupported_scheme"
     return "resolve_failed"
 
+
+
+
+def _xml_attr(value: Any) -> str:
+    return str(value if value is not None else "").replace("&", "&amp;").replace('"', "&quot;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _pose_xyz_rpy_text(pose: Mapping[str, Any]) -> Tuple[str, str]:
+    xyz = pose.get("xyz") if isinstance(pose, Mapping) else None
+    rpy = pose.get("rpy") if isinstance(pose, Mapping) else None
+    xyz_vals = xyz if isinstance(xyz, list) and len(xyz) >= 3 else [0, 0, 0]
+    rpy_vals = rpy if isinstance(rpy, list) and len(rpy) >= 3 else [0, 0, 0]
+    return " ".join(str(float(v)) for v in xyz_vals[:3]), " ".join(str(float(v)) for v in rpy_vals[:3])
+
+
+def _synthesize_robot_preview_urdf_from_rows(payload: Json) -> Optional[str]:
+    rows: List[Json] = []
+    for section in ("robots", "tools"):
+        rows.extend([item for item in payload.get(section, []) if isinstance(item, dict) and item.get("mesh_uri")])
+    if not rows:
+        return None
+    links = {"base_link"}
+    joints: Dict[str, Tuple[str, Json]] = {}
+    visuals: Dict[str, List[Json]] = {}
+    for item in rows:
+        link = str(item.get("link_name") or item.get("link") or item.get("object_name") or "").strip()
+        if not link:
+            continue
+        parent = str(item.get("parent_link") or item.get("joint_parent_link") or item.get("immediate_parent_link") or "").strip()
+        links.add(link)
+        if parent:
+            links.add(parent)
+            joints.setdefault(link, (parent, item))
+        visuals.setdefault(link, []).append(item)
+    out = ['<?xml version="1.0" ?>', '<robot name="workcell_studio_preview_robot">']
+    for link in sorted(links):
+        out.append(f'  <link name="{_xml_attr(link)}">')
+        for idx, item in enumerate(visuals.get(link, [])):
+            xyz, rpy = _pose_xyz_rpy_text(_as_map(item.get("visual_origin")))
+            mesh = _xml_attr(item.get("mesh_uri"))
+            out.extend([
+                f'    <visual name="visual_{idx}">',
+                f'      <origin xyz="{xyz}" rpy="{rpy}"/>',
+                '      <geometry>',
+                f'        <mesh filename="{mesh}"/>',
+                '      </geometry>',
+                '    </visual>',
+            ])
+        out.append('  </link>')
+    for child, (parent, item) in sorted(joints.items()):
+        joint = str(item.get("joint_name") or item.get("parent_joint_name") or f"{parent}_to_{child}")
+        jtype = str(item.get("joint_type") or item.get("parent_joint_type") or "fixed")
+        xyz, rpy = _pose_xyz_rpy_text(_as_map(item.get("joint_origin") or item.get("parent_joint_origin") or item.get("parent_to_child_pose")))
+        axis = item.get("joint_axis") if isinstance(item.get("joint_axis"), list) else [1, 0, 0]
+        axis_text = " ".join(str(float(v)) for v in axis[:3])
+        out.extend([
+            f'  <joint name="{_xml_attr(joint)}" type="{_xml_attr(jtype)}">',
+            f'    <parent link="{_xml_attr(parent)}"/>',
+            f'    <child link="{_xml_attr(child)}"/>',
+            f'    <origin xyz="{xyz}" rpy="{rpy}"/>',
+            f'    <axis xyz="{axis_text}"/>',
+            '  </joint>',
+        ])
+    out.append('</robot>')
+    return "\n".join(out) + "\n"
+
+
+def _stage_expanded_robot_urdf(payload: Json, scene_dir: Path, output_path: Path, warnings: List[Json]) -> None:
+    """Copy the xacro-expanded scene URDF beside the web scene and rewrite mesh URIs for browser loading."""
+    data = _as_map(payload.get("_visual_mesh_index_source"))
+    rel = str(data.get("source_expanded_urdf_path") or "generated/expanded_scene_preview.urdf")
+    source = (Path.cwd() / rel).resolve() if rel and not Path(rel).is_absolute() else Path(rel).resolve()
+    if not source.is_file():
+        source = scene_dir / "generated" / "expanded_scene_preview.urdf"
+    synthesized_text = None
+    if not source.is_file():
+        synthesized_text = _synthesize_robot_preview_urdf_from_rows(payload)
+        if not synthesized_text:
+            _warn(warnings, "expanded_robot_urdf_missing", "Expanded robot URDF was not available for browser robot preview; legacy rows remain as fallback metadata only.", rel)
+            return
+    scene_id = str(payload.get("scene", {}).get("id") or scene_dir.name)
+    repo_root = Path.cwd().resolve()
+    dest = (repo_root / "build" / "workcell_studio_web_scene" / f"{scene_id}.expanded.urdf").resolve()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    text = synthesized_text if synthesized_text is not None else source.read_text(encoding="utf-8")
+    asset_root = (repo_root / "build" / "workcell_studio_web_scene" / "assets" / scene_id).resolve()
+    asset_root.mkdir(parents=True, exist_ok=True)
+
+    def rewrite(match: re.Match[str]) -> str:
+        uri = match.group(0)
+        resolved, package, dest_rel, warning = _resolve_package_uri(uri, repo_root)
+        if resolved is None or dest_rel is None:
+            _warn(warnings, "expanded_robot_urdf_mesh_unresolved", warning or f"Could not resolve package mesh URI: {uri}", uri)
+            return uri
+        target = (asset_root / dest_rel).resolve()
+        if not _is_relative_to(target, asset_root):
+            _warn(warnings, "expanded_robot_urdf_mesh_unsafe", f"Staged URDF mesh destination escaped asset root: {target}", uri)
+            return uri
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(resolved, target)
+        return os.path.relpath(target, repo_root).replace(os.sep, "/")
+
+    text = re.sub(r"package://[^\s'\"<>]+", rewrite, text)
+    dest.write_text(text, encoding="utf-8")
+    payload["robot_preview"] = {
+        "mode": "expanded_urdf_loader",
+        "urdf_url": os.path.relpath(dest, repo_root).replace(os.sep, "/"),
+        "robot_root_link": "base_link",
+        "joint_values": dict(DEFAULT_ROBOT_PREVIEW_JOINT_VALUES),
+        "expected_links": list(EXPECTED_ROBOT_PREVIEW_LINKS),
+    }
 
 def _stage_visual_meshes(payload: Json, scene_dir: Path, output_path: Path) -> None:
     repo_root = Path.cwd().resolve()
@@ -1905,8 +2038,11 @@ def build_web_scene(scene_dir: Path, *, stage_assets: bool = False, output_path:
             },
         ],
     }
+    output["_visual_mesh_index_source"] = _as_map(data.get("visual_mesh_index"))
     if stage_assets:
         _stage_visual_meshes(output, scene_dir, output_path or Path("build/workcell_studio_web_scene/scene.web_scene.json"))
+        _stage_expanded_robot_urdf(output, scene_dir, output_path or Path("build/workcell_studio_web_scene/scene.web_scene.json"), warnings)
+    output.pop("_visual_mesh_index_source", None)
     _populate_visual_bounds_item_fields(output, data)
     output["metadata"] = {
         "mesh_contract": _populate_mesh_contract_fields(output, staged=stage_assets),

--- a/scripts/run_workcell_web3d_visual_acceptance.py
+++ b/scripts/run_workcell_web3d_visual_acceptance.py
@@ -437,12 +437,11 @@ def baked_pose_render_mode_summary(status: Mapping[str, Any]) -> dict[str, Any]:
 
 def _assembled_hierarchy_mode_active(status: Mapping[str, Any]) -> bool:
     mode = str(status.get("robot_render_mode") or status.get("robotRenderMode") or "").strip()
-    return mode in {"assembled_urdf_hierarchy", "verified_urdf_fk_visual_world_pose"}
+    return mode in {"assembled_urdf_hierarchy", "verified_urdf_fk_visual_world_pose", "expanded_urdf_loader"}
 
 def _expanded_urdf_fk_mode_active(status: Mapping[str, Any]) -> bool:
     mode = str(status.get("robot_render_mode") or status.get("robotRenderMode") or "").strip()
-    source = str(status.get("robot_transform_source") or status.get("robotTransformSource") or "").strip()
-    return mode == "verified_urdf_fk_visual_world_pose" and source == "ros_tf_verified_urdf_fk"
+    return mode == "expanded_urdf_loader"
 
 
 def _baked_pose_render_mode_errors(status: Mapping[str, Any]) -> list[str]:
@@ -460,11 +459,11 @@ def _baked_pose_render_mode_errors(status: Mapping[str, Any]) -> list[str]:
 def _assembled_hierarchy_errors(status: Mapping[str, Any]) -> list[str]:
     errors: list[str] = []
     if not _expanded_urdf_fk_mode_active(status):
-        errors.append("browser viewer ur5_2f_test must use robot_transform_source=ros_tf_verified_urdf_fk and robot_render_mode=verified_urdf_fk_visual_world_pose")
+        errors.append("browser viewer ur5_2f_test must use robot_render_mode=expanded_urdf_loader")
     links = status.get("robot_hierarchy_links") or status.get("robotHierarchyLinks") or []
     missing_links = status.get("robot_hierarchy_missing_links") or []
     missing_parents = status.get("robot_hierarchy_missing_parents") or []
-    mesh_count = _status_int(status, "robot_hierarchy_mesh_count", "robotHierarchyMeshCount")
+    mesh_count = _status_int_any(status, "robot_loaded_visual_count", "robotLoadedVisualCount", "robot_hierarchy_mesh_count", "robotHierarchyMeshCount")
     required = ["base_link_inertia", "shoulder_link", "upper_arm_link", "forearm_link", "wrist_1_link", "wrist_2_link", "wrist_3_link", "tool0", "gripper_base_link"]
     absent = [link for link in required if link not in links]
     if absent:
@@ -474,13 +473,14 @@ def _assembled_hierarchy_errors(status: Mapping[str, Any]) -> list[str]:
     if missing_parents:
         errors.append(f"browser viewer robot_hierarchy_missing_parents must be empty, got {missing_parents!r}")
     if mesh_count < 16:
-        errors.append(f"browser viewer robot_hierarchy_mesh_count expected >= 16, got {mesh_count}")
+        errors.append(f"browser viewer robot_loaded_visual_count expected >= 16, got {mesh_count}")
     duplicate_count = _status_int(status, "visible_duplicate_generated_urdf_count", "visibleDuplicateGeneratedUrdfCount")
     if duplicate_count > 0:
         errors.append(f"browser viewer visible_duplicate_generated_urdf_count must be 0, got {duplicate_count}")
-    rendered_count = _status_int(status, "assembled_hierarchy_rendered_mesh_count", "assembledHierarchyRenderedMeshCount")
-    if ("assembled_hierarchy_rendered_mesh_count" in status or "assembledHierarchyRenderedMeshCount" in status) and rendered_count < 16:
-        errors.append(f"browser viewer assembled_hierarchy_rendered_mesh_count expected >= 16, got {rendered_count}")
+    if status.get("robot_preview_loaded") is not True:
+        errors.append("browser viewer robot_preview_loaded must be true")
+    if status.get("robot_missing_meshes"):
+        errors.append(f"browser viewer robot_missing_meshes must be empty, got {status.get('robot_missing_meshes')!r}")
     tool0_fallback_count = _status_int(status, "visible_tool0_fallback_count", "visibleTool0FallbackCount")
     if tool0_fallback_count > 0:
         errors.append(f"browser viewer visible_tool0_fallback_count must be 0, got {tool0_fallback_count}")

--- a/tests/test_workcell_studio_web_scene_contract.py
+++ b/tests/test_workcell_studio_web_scene_contract.py
@@ -241,6 +241,16 @@ def test_ur5_2f_web_scene_stages_required_product_meshes_without_required_fallba
     assert required["robotiq"]
     assert required["table"]
     assert required["camera"]
+    preview = payload["robot_preview"]
+    assert preview["mode"] == "expanded_urdf_loader"
+    assert preview["urdf_url"] == "build/workcell_studio_web_scene/ur5_2f_test.expanded.urdf"
+    assert (REPO_ROOT / preview["urdf_url"]).is_file()
+    assert preview["robot_root_link"] == "base_link"
+    assert "gripper_base_link" in preview["expected_links"]
+    assert preview["joint_values"]["shoulder_lift_joint"] == -1.5708
+    expanded_text = (REPO_ROOT / preview["urdf_url"]).read_text(encoding="utf-8")
+    assert "package://" not in expanded_text
+    assert "build/workcell_studio_web_scene/assets/ur5_2f_test/" in expanded_text
 
     renderable_items = [
         item

--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -894,3 +894,19 @@ def test_viewer_reports_hierarchy_acceptance_diagnostics():
         "tool0','gripper_base_link",
     ]:
         assert token in js
+
+
+def test_viewer_has_expanded_urdf_loader_robot_preview_path():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    index = (VIEWER / "index.html").read_text(encoding="utf-8")
+    assert "expanded_urdf_loader" in js
+    assert "function loadExpandedUrdfRobotPreview" in js
+    assert "const urdfPreviewActive = state.sceneJson?.robot_preview?.mode === 'expanded_urdf_loader';" in js
+    assert "new Set(items.filter(isGeneratedUrdfMeshVisualItem))" in js
+    assert "robot_preview_loaded" in js
+    assert "robot_loaded_link_count" in js
+    assert "robot_loaded_visual_count" in js
+    assert "robot_missing_meshes" in js
+    assert "skipped_legacy_generated_urdf_visual_count" in js
+    assert "Robot preview: expanded URDF loader" in js
+    assert 'data-summary-field="robot-preview-mode"' in index

--- a/tests/test_workcell_web3d_visual_acceptance.py
+++ b/tests/test_workcell_web3d_visual_acceptance.py
@@ -349,8 +349,10 @@ def _valid_robot_hierarchy_fields():
         "gripper_base_link",
     ]
     return {
-        "robot_transform_source": "ros_tf_verified_urdf_fk",
-        "robot_render_mode": "verified_urdf_fk_visual_world_pose",
+        "robot_render_mode": "expanded_urdf_loader",
+        "robot_preview_loaded": True,
+        "robot_missing_meshes": [],
+        "robot_loaded_visual_count": 18,
         "robot_hierarchy_links": links,
         "robot_hierarchy_missing_links": [],
         "robot_hierarchy_missing_parents": [],

--- a/workcell_studio_web/viewer/index.html
+++ b/workcell_studio_web/viewer/index.html
@@ -66,6 +66,7 @@
           <span>Missing/failed meshes</span><strong data-summary-field="mesh-failed-count">0</strong>
           <span>Generated/locked</span><strong data-summary-field="generated-locked-count">0</strong>
           <span>Editable layout/env</span><strong data-summary-field="editable-count">0</strong>
+          <span>Robot preview</span><strong data-summary-field="robot-preview-mode">mesh rows</strong>
         </div>
       </section>
       <div id="empty-state" class="state empty">Choose an exported <code>web_scene.json</code> file to begin.</div>

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -12,7 +12,7 @@ const LOCKED_EDIT_REASON = 'Locked/generated preview item; edit source layout/en
 const MIN_FRAME_RADIUS = 1.2;
 const EMPTY_SCENE_MESSAGE = 'Scene contains no renderable robots, tools, assets, sensors, zones, items, or objects.';
 const FRAME_DISTANCE_MULTIPLIER = 2.7;
-const state = { sceneJson: null, sourceWebSceneFile: '', frameLookup: new Map(), resolvedFramePoses: new Map(), objects: [], assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, selected: null, three: {}, animationId: null, lastFrameBounds: null, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: new Map(), undoStack: [], redoStack: [], gizmoDragStart: null };
+const state = { sceneJson: null, sourceWebSceneFile: '', frameLookup: new Map(), resolvedFramePoses: new Map(), objects: [], assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, robotUrdfPreviewDiagnostics: {}, selected: null, three: {}, animationId: null, lastFrameBounds: null, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: new Map(), undoStack: [], redoStack: [], gizmoDragStart: null };
 const RESET_VIEW_TITLE = 'Fit Scene / Reset View: recomputes and reapplies the fitted workcell overview from renderable bounds.';
 const STAGED_MESH_ROOTS = [
   'build/workcell_studio_web_scene/assets/',
@@ -86,6 +86,7 @@ function computeSceneSummary() {
     meshFailedCount: statusRendered.filter(obj => isMissingOrFailedMeshStatus(obj.item?.mesh_status)).length,
     generatedLockedCount: rendered.filter(obj => isGeneratedOrLockedItem(obj.item)).length,
     editableCount: rendered.filter(obj => canEditItem(obj.item)).length,
+    robotPreviewMode: state.sceneJson?.robot_preview?.mode || '',
   };
 }
 function isExpectedMeshlessTool0Frame(item) {
@@ -365,13 +366,14 @@ function updateViewerStatus() {
     rendered_object_statuses: renderedObjectStatuses,
     robot_transform_source: state.robotAssemblyDiagnostics?.some(d => d.robot_transform_source === 'ros_tf_verified_urdf_fk') ? 'ros_tf_verified_urdf_fk' : (state.robotAssemblyDiagnostics?.some(d => d.robot_transform_source === 'expanded_urdf_joint_tree') ? 'expanded_urdf_joint_tree' : ''),
     robotTransformSource: state.robotAssemblyDiagnostics?.some(d => d.robot_transform_source === 'ros_tf_verified_urdf_fk') ? 'ros_tf_verified_urdf_fk' : (state.robotAssemblyDiagnostics?.some(d => d.robot_transform_source === 'expanded_urdf_joint_tree') ? 'expanded_urdf_joint_tree' : ''),
-    robot_render_mode: state.robotAssemblyDiagnostics?.some(d => d.robot_render_mode === 'verified_urdf_fk_visual_world_pose') ? 'verified_urdf_fk_visual_world_pose' : (state.robotAssemblyDiagnostics?.some(d => d.robot_render_mode === 'urdf_fk_visual_world_pose') ? 'urdf_fk_visual_world_pose' : (state.robotAssemblyDiagnostics?.length ? 'assembled_urdf_hierarchy' : '')),
-    robotRenderMode: state.robotAssemblyDiagnostics?.some(d => d.robot_render_mode === 'verified_urdf_fk_visual_world_pose') ? 'verified_urdf_fk_visual_world_pose' : (state.robotAssemblyDiagnostics?.some(d => d.robot_render_mode === 'urdf_fk_visual_world_pose') ? 'urdf_fk_visual_world_pose' : (state.robotAssemblyDiagnostics?.length ? 'assembled_urdf_hierarchy' : '')),
+    robot_render_mode: state.robotUrdfPreviewDiagnostics?.robot_render_mode || (state.robotAssemblyDiagnostics?.some(d => d.robot_render_mode === 'verified_urdf_fk_visual_world_pose') ? 'verified_urdf_fk_visual_world_pose' : (state.robotAssemblyDiagnostics?.some(d => d.robot_render_mode === 'urdf_fk_visual_world_pose') ? 'urdf_fk_visual_world_pose' : (state.robotAssemblyDiagnostics?.length ? 'assembled_urdf_hierarchy' : ''))),
+    robotRenderMode: state.robotUrdfPreviewDiagnostics?.robot_render_mode || (state.robotAssemblyDiagnostics?.some(d => d.robot_render_mode === 'verified_urdf_fk_visual_world_pose') ? 'verified_urdf_fk_visual_world_pose' : (state.robotAssemblyDiagnostics?.some(d => d.robot_render_mode === 'urdf_fk_visual_world_pose') ? 'urdf_fk_visual_world_pose' : (state.robotAssemblyDiagnostics?.length ? 'assembled_urdf_hierarchy' : ''))),
+    ...state.robotUrdfPreviewDiagnostics,
     robot_hierarchy_diagnostics: state.robotAssemblyDiagnostics || [],
     robotHierarchyDiagnostics: state.robotAssemblyDiagnostics || [],
-    robot_hierarchy_links: Array.from(new Set((state.robotAssemblyDiagnostics || []).flatMap(d => d.robot_hierarchy_links || []))),
-    robotHierarchyLinks: Array.from(new Set((state.robotAssemblyDiagnostics || []).flatMap(d => d.robot_hierarchy_links || []))),
-    robot_hierarchy_missing_links: Array.from(new Set((state.robotAssemblyDiagnostics || []).flatMap(d => d.robot_hierarchy_missing_links || []))),
+    robot_hierarchy_links: state.robotUrdfPreviewDiagnostics?.robot_hierarchy_links || Array.from(new Set((state.robotAssemblyDiagnostics || []).flatMap(d => d.robot_hierarchy_links || []))),
+    robotHierarchyLinks: state.robotUrdfPreviewDiagnostics?.robot_hierarchy_links || Array.from(new Set((state.robotAssemblyDiagnostics || []).flatMap(d => d.robot_hierarchy_links || []))),
+    robot_hierarchy_missing_links: state.robotUrdfPreviewDiagnostics?.robot_hierarchy_missing_links || Array.from(new Set((state.robotAssemblyDiagnostics || []).flatMap(d => d.robot_hierarchy_missing_links || []))),
     robot_hierarchy_missing_parents: Array.from(new Set((state.robotAssemblyDiagnostics || []).flatMap(d => d.robot_hierarchy_missing_parents || []))),
     robot_hierarchy_mesh_count: (state.robotAssemblyDiagnostics || []).reduce((total, d) => total + Number(d.robot_hierarchy_mesh_count || 0), 0),
     robotHierarchyMeshCount: (state.robotAssemblyDiagnostics || []).reduce((total, d) => total + Number(d.robot_hierarchy_mesh_count || 0), 0),
@@ -391,6 +393,7 @@ function renderSceneSummary() {
     'mesh-failed-count': summary.meshFailedCount,
     'generated-locked-count': summary.generatedLockedCount,
     'editable-count': summary.editableCount,
+    'robot-preview-mode': summary.robotPreviewMode === 'expanded_urdf_loader' ? 'Robot preview: expanded URDF loader' : (summary.robotPreviewMode || 'mesh rows'),
   };
   for (const [name, value] of Object.entries(fields)) {
     const node = el.summary.querySelector(`[data-summary-field="${name}"]`);
@@ -1982,9 +1985,12 @@ function renderScene(items) {
   detachTransformGizmo();
   updateDirtyState();
   const scene = state.three.scene;
-  const assemblyBuild = buildRobotAssemblies(items);
+  state.robotUrdfPreviewDiagnostics = {};
+  const urdfPreviewActive = state.sceneJson?.robot_preview?.mode === 'expanded_urdf_loader';
+  const assemblyBuild = urdfPreviewActive ? { handled: new Set(items.filter(isGeneratedUrdfMeshVisualItem)), assemblies: [], renderDiagnostics: { skipped_flattened_urdf_visual_count: 0, assembled_hierarchy_rendered_mesh_count: 0, rendered_fk_visual_count: 0, skipped_legacy_generated_urdf_count: items.filter(isGeneratedUrdfMeshVisualItem).length, skipped_legacy_generated_urdf_visual_count: items.filter(isGeneratedUrdfMeshVisualItem).length, visible_duplicate_generated_urdf_count: 0, visible_tool0_fallback_count: 0, detached_robot_mesh_clusters: 0 } } : buildRobotAssemblies(items);
   state.robotAssemblyDiagnostics = assemblyBuild.assemblies;
   state.robotAssemblyRenderDiagnostics = assemblyBuild.renderDiagnostics || {};
+  if (urdfPreviewActive) loadExpandedUrdfRobotPreview(state.sceneJson.robot_preview);
   for (const item of items) {
     if (assemblyBuild.handled.has(item)) continue;
     if (usesAssembledUrdfHierarchy(item)) {
@@ -2023,6 +2029,113 @@ function renderScene(items) {
   renderSceneSummary();
 }
 
+
+
+function parseNumberList(value, fallback = [0, 0, 0]) {
+  const parts = String(value || '').trim().split(/\s+/).filter(Boolean).map(Number);
+  return parts.length >= 3 && parts.slice(0, 3).every(Number.isFinite) ? parts.slice(0, 3) : fallback;
+}
+function applyUrdfOrigin(object, originEl) {
+  const xyz = parseNumberList(originEl?.getAttribute('xyz'), [0, 0, 0]);
+  const rpy = parseNumberList(originEl?.getAttribute('rpy'), [0, 0, 0]);
+  object.position.set(xyz[0], xyz[1], xyz[2]);
+  object.rotation.set(rpy[0], rpy[1], rpy[2], 'XYZ');
+}
+function rewriteUrdfMeshUrl(filename) {
+  const raw = String(filename || '').trim();
+  if (!raw || raw.startsWith('package://')) return '';
+  return meshUriDiagnostic({ mesh_uri: raw, mesh_staging_status: 'staged' }).uri || '';
+}
+function loadUrdfVisualMesh(meshUrl, linkName, visualIndex, parent, diagnostics) {
+  const uri = rewriteUrdfMeshUrl(meshUrl);
+  if (!uri) { diagnostics.robot_missing_meshes.push(meshUrl); return; }
+  const item = { id: `${linkName}_urdf_visual_${visualIndex}`, link_name: linkName, mesh_uri: uri, mesh_staging_status: 'staged', source_layer: 'expanded_urdf_loader', role: 'robot', category: 'robot' };
+  const loadUrl = repoRootRelativeUrl(uri);
+  const ext = meshExtensionFromUri(uri);
+  const onLoaded = loaded => {
+    const meshObject = materializeLoadedMesh(item, uri, loaded);
+    parent.add(meshObject);
+    diagnostics.robot_loaded_visual_count += 1;
+    renderSceneSummary();
+    const bounds = computeFitBounds();
+    if (bounds) frameScene(bounds);
+  };
+  const onError = err => {
+    diagnostics.robot_missing_meshes.push(`${uri}: ${err?.message || err || 'load failed'}`);
+    renderSceneSummary();
+  };
+  if (ext === 'stl') new STLLoader().load(loadUrl, geom => onLoaded(geom), undefined, onError);
+  else if (ext === 'dae') new ColladaLoader().load(loadUrl, dae => onLoaded(dae), undefined, onError);
+  else if (ext === 'obj') new OBJLoader().load(loadUrl, obj => onLoaded(obj), undefined, onError);
+  else diagnostics.robot_missing_meshes.push(`${uri}: unsupported mesh format`);
+}
+async function loadExpandedUrdfRobotPreview(preview) {
+  const diagnostics = state.robotUrdfPreviewDiagnostics = {
+    robot_render_mode: 'expanded_urdf_loader',
+    robot_preview_loaded: false,
+    robot_urdf_url: preview?.urdf_url || '',
+    robot_loaded_link_count: 0,
+    robot_loaded_visual_count: 0,
+    robot_missing_meshes: [],
+    robot_joint_values_applied: preview?.joint_values || {},
+    skipped_legacy_generated_urdf_visual_count: state.robotAssemblyRenderDiagnostics?.skipped_legacy_generated_urdf_visual_count || state.robotAssemblyRenderDiagnostics?.skipped_legacy_generated_urdf_count || 0,
+  };
+  try {
+    const url = repoRootRelativeUrl(preview.urdf_url);
+    const response = await fetch(url);
+    if (!response.ok) throw new Error(`HTTP ${response.status} while loading ${url}`);
+    const xml = new DOMParser().parseFromString(await response.text(), 'application/xml');
+    if (xml.querySelector('parsererror')) throw new Error('expanded URDF XML parse failed');
+    const root = new THREE.Group();
+    root.name = `${sceneDisplayName()}_expanded_urdf_loader_robot`;
+    root.userData.robot_render_mode = 'expanded_urdf_loader';
+    const links = new Map();
+    xml.querySelectorAll('link').forEach(linkEl => {
+      const name = linkEl.getAttribute('name') || '';
+      const node = new THREE.Group();
+      node.name = `${name}_urdf_loader_link`;
+      node.userData.link_name = name;
+      links.set(name, node);
+      let visualIndex = 0;
+      linkEl.querySelectorAll(':scope > visual').forEach(visualEl => {
+        const visual = new THREE.Group();
+        visual.name = `${name}_urdf_loader_visual_${visualIndex}`;
+        applyUrdfOrigin(visual, visualEl.querySelector(':scope > origin'));
+        node.add(visual);
+        const mesh = visualEl.querySelector(':scope > geometry > mesh');
+        if (mesh) loadUrdfVisualMesh(mesh.getAttribute('filename'), name, visualIndex, visual, diagnostics);
+        visualIndex += 1;
+      });
+    });
+    xml.querySelectorAll('joint').forEach(jointEl => {
+      const parentName = jointEl.querySelector(':scope > parent')?.getAttribute('link') || '';
+      const childName = jointEl.querySelector(':scope > child')?.getAttribute('link') || '';
+      const child = links.get(childName);
+      if (!child) return;
+      applyUrdfOrigin(child, jointEl.querySelector(':scope > origin'));
+      const type = jointEl.getAttribute('type') || 'fixed';
+      const value = Number(preview?.joint_values?.[jointEl.getAttribute('name') || ''] || 0);
+      if (Number.isFinite(value) && type !== 'fixed') {
+        const axis = parseNumberList(jointEl.querySelector(':scope > axis')?.getAttribute('xyz'), [1, 0, 0]);
+        child.rotateOnAxis(new THREE.Vector3(axis[0], axis[1], axis[2]).normalize(), value);
+      }
+      if (links.has(parentName)) links.get(parentName).add(child);
+    });
+    for (const [name, node] of links.entries()) if (!node.parent) root.add(node);
+    state.three.scene.add(root);
+    state.assemblyRoots.push(root);
+    diagnostics.robot_loaded_link_count = links.size;
+    diagnostics.robot_preview_loaded = true;
+    diagnostics.robot_hierarchy_links = Array.from(links.keys());
+    diagnostics.robot_hierarchy_missing_links = asArray(preview?.expected_links).filter(link => !links.has(link));
+    renderSceneSummary();
+  } catch (err) {
+    diagnostics.robot_preview_loaded = false;
+    diagnostics.robot_missing_meshes.push(err?.message || String(err));
+    appendRuntimeWarning({}, preview?.urdf_url || '', `expanded_urdf_loader failed: ${err?.message || err}`, 'expanded_urdf_loader_failed');
+    refreshWarnings();
+  }
+}
 
 function linkNameOfItem(item) { return String(item?.link_name || item?.link || item?.frame || item?.object_name || item?.id || '').trim(); }
 function parentLinkOfItem(item) { return String(item?.parent_link || item?.joint_parent_link || item?.immediate_parent_link || '').trim(); }


### PR DESCRIPTION
### Motivation
- The existing per-link/generated-mesh rendering produced visually disconnected robot arms in the browser because the renderer rebuilt RViz-like robot assembly from independent mesh rows instead of a URDF hierarchy.
- The exporter/verification path staged meshes successfully but the viewer still assembled visuals incorrectly, so render-mode and diagnostics needed a single-source URDF preview path.

### Description
- Exporter: stage an expanded URDF next to the web-scene output and rewrite `package://` mesh URIs to staged browser asset URLs, and synthesize a minimal URDF from generated rows if a real expanded URDF is unavailable, producing `build/workcell_studio_web_scene/<scene>.expanded.urdf` and `robot_preview` metadata (mode, `urdf_url`, `robot_root_link`, `joint_values`, `expected_links`). (`scripts/export_workcell_studio_web_scene.py`)
- Viewer: add an `expanded_urdf_loader` path in `workcell_studio_web/viewer/viewer.js` that parses the expanded URDF, builds a link/joint Object3D tree, applies joint values, loads staged mesh files with existing Three.js loaders, and skips legacy per-link generated URDF mesh rows when the URDF loader is active, while preserving environment/tool/table rendering. (`workcell_studio_web/viewer/viewer.js`, `workcell_studio_web/viewer/index.html`)
- Diagnostics/UI: surface `robot_render_mode = expanded_urdf_loader` and detailed robot preview diagnostics including `robot_preview_loaded`, `robot_urdf_url`, `robot_loaded_link_count`, `robot_loaded_visual_count`, `robot_missing_meshes`, `robot_joint_values_applied`, and `skipped_legacy_generated_urdf_visual_count`, plus a small summary label in the viewer UI. (`workcell_studio_web/viewer/viewer.js`, `workcell_studio_web/viewer/index.html`)
- Validation/tests: update visual acceptance validator and static viewer tests to expect `expanded_urdf_loader` diagnostics and assert the presence of the staged expanded URDF and rewritten mesh paths. (updated `scripts/run_workcell_web3d_visual_acceptance.py`, `tests/*_web*`)

### Testing
- Ran the web-viewer/scene contract and acceptance suite with `python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py tests/test_workcell_studio_web_scene_contract.py tests/test_workcell_web3d_visual_acceptance.py tests/test_export_workcell_studio_web_scene.py` which completed successfully with `96 passed`.
- Regenerated a fresh scene with `python3 scripts/ensure_workcell_studio_web_scene_fresh.py --scene scenes/ur5_2f_test --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json --stage-assets --force` which produced `build/workcell_studio_web_scene/ur5_2f_test.expanded.urdf` and set `robot_preview.mode = "expanded_urdf_loader"` in the exported web scene JSON.
- Note: browser screenshot/manual runtime screenshot was not captured here because browser automation/runtime (Playwright/Chromium) is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fcc1adf2483319a89af5414c29b3a)