### PR TITLE
Extract web robot preview from expanded URDF

### DIFF
--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -23,6 +23,7 @@ import os
 import shutil
 import sys
 import re
+import copy
 import xml.etree.ElementTree as ET
 from pathlib import Path
 from urllib.parse import unquote, urlparse
@@ -116,6 +117,10 @@ GENERATED_OUTPUT_SECTIONS = ("robots", "tools", "assets", "sensors", "zones", "f
 RENDERABLE_OUTPUT_SECTIONS = ("robots", "tools", "assets", "sensors", "zones")
 
 Json = Dict[str, Any]
+
+
+class BlockingExportError(RuntimeError):
+    """Raised when a canonical scene cannot be exported honestly."""
 
 
 def _warn(warnings: List[Json], code: str, message: str, source: Optional[str] = None) -> None:
@@ -387,24 +392,137 @@ def _synthesize_robot_preview_urdf_from_rows(payload: Json) -> Optional[str]:
     return "\n".join(out) + "\n"
 
 
+def _child_text(element: ET.Element, tag: str, attr: str) -> str:
+    child = element.find(tag)
+    return child.get(attr, "") if child is not None else ""
+
+
+def _extract_robot_preview_urdf(expanded_urdf_text: str, source: Path) -> str:
+    """Extract the robot/tool branch from a full xacro-expanded scene URDF."""
+    try:
+        full_robot = ET.fromstring(expanded_urdf_text)
+    except ET.ParseError as exc:
+        raise BlockingExportError(f"failed to parse expanded scene URDF {source}: {exc}") from exc
+    if full_robot.tag != "robot":
+        raise BlockingExportError(f"expanded scene URDF {source} does not contain a <robot> root")
+
+    links = {link.get("name", ""): link for link in full_robot.findall("link") if link.get("name")}
+    joints = [joint for joint in full_robot.findall("joint") if joint.get("name")]
+    if "base_link" not in links:
+        raise BlockingExportError(f"expanded scene URDF {source} does not contain required robot base link 'base_link'")
+
+    child_to_joint: Dict[str, ET.Element] = {}
+    children_by_parent: Dict[str, List[ET.Element]] = {}
+    for joint in joints:
+        parent = _child_text(joint, "parent", "link")
+        child = _child_text(joint, "child", "link")
+        if not parent or not child:
+            continue
+        child_to_joint[child] = joint
+        children_by_parent.setdefault(parent, []).append(joint)
+
+    # Retain the exact fixed world/root-to-base chain, if the expanded scene has
+    # one, then recurse downward from base_link only. This naturally excludes
+    # table/camera/bin/zone sibling branches mounted under world.
+    selected_links = {"base_link"}
+    selected_joints: List[ET.Element] = []
+    cursor = "base_link"
+    seen = set()
+    while cursor in child_to_joint and cursor not in seen:
+        seen.add(cursor)
+        joint = child_to_joint[cursor]
+        parent = _child_text(joint, "parent", "link")
+        if not parent:
+            break
+        if joint.get("type", "fixed") != "fixed":
+            raise BlockingExportError(
+                f"expanded scene URDF {source} has non-fixed root-to-base joint "
+                f"{joint.get('name')} ({parent} -> {cursor}); robot preview requires an exact fixed world/root-to-base transform"
+            )
+        selected_links.add(parent)
+        selected_joints.insert(0, joint)
+        cursor = parent
+
+    stack = ["base_link"]
+    while stack:
+        parent = stack.pop()
+        for joint in sorted(children_by_parent.get(parent, []), key=lambda j: j.get("name", "")):
+            child = _child_text(joint, "child", "link")
+            if not child or child in selected_links:
+                continue
+            selected_joints.append(joint)
+            selected_links.add(child)
+            stack.append(child)
+
+    required = {"base_link", "tool0", "gripper_base_link"}
+    missing = sorted(link for link in required if link not in selected_links)
+    if missing:
+        raise BlockingExportError(
+            f"expanded scene URDF {source} robot-preview extraction is missing required robot/tool links: {', '.join(missing)}"
+        )
+
+    material_names = {
+        material.get("name", "")
+        for link_name in selected_links
+        for material in links[link_name].findall(".//material")
+        if material.get("name")
+    }
+    out = ET.Element("robot", {"name": f"{full_robot.get('name', 'workcell')}_robot_preview"})
+    for material in full_robot.findall("material"):
+        if material.get("name") in material_names:
+            out.append(copy.deepcopy(material))
+    for link_name in sorted(selected_links):
+        out.append(copy.deepcopy(links[link_name]))
+    for joint in selected_joints:
+        out.append(copy.deepcopy(joint))
+    ET.indent(out, space="  ")
+    return ET.tostring(out, encoding="unicode", xml_declaration=True) + "\n"
+
+
 def _stage_expanded_robot_urdf(payload: Json, scene_dir: Path, output_path: Path, warnings: List[Json]) -> None:
-    """Copy the xacro-expanded scene URDF beside the web scene and rewrite mesh URIs for browser loading."""
+    """Stage a browser robot-preview URDF extracted from the xacro-expanded scene URDF."""
     data = _as_map(payload.get("_visual_mesh_index_source"))
     rel = str(data.get("source_expanded_urdf_path") or "generated/expanded_scene_preview.urdf")
     source = (Path.cwd() / rel).resolve() if rel and not Path(rel).is_absolute() else Path(rel).resolve()
     if not source.is_file():
         source = scene_dir / "generated" / "expanded_scene_preview.urdf"
     synthesized_text = None
+    scene_id = str(payload.get("scene", {}).get("id") or scene_dir.name)
+    canonical_scene_requires_real_expanded_urdf = scene_id == "ur5_2f_test"
     if not source.is_file():
+        if canonical_scene_requires_real_expanded_urdf:
+            raise BlockingExportError(
+                f"blocking export error: {scene_id} requires real xacro-expanded scene URDF at "
+                f"{scene_dir / 'generated' / 'expanded_scene_preview.urdf'}; run the visual mesh index extractor with real xacro expansion first. "
+                "Refusing to synthesize robot preview from flattened mesh rows."
+            )
         synthesized_text = _synthesize_robot_preview_urdf_from_rows(payload)
         if not synthesized_text:
             _warn(warnings, "expanded_robot_urdf_missing", "Expanded robot URDF was not available for browser robot preview; legacy rows remain as fallback metadata only.", rel)
             return
-    scene_id = str(payload.get("scene", {}).get("id") or scene_dir.name)
     repo_root = Path.cwd().resolve()
-    dest = (repo_root / "build" / "workcell_studio_web_scene" / f"{scene_id}.expanded.urdf").resolve()
+    dest = (repo_root / "build" / "workcell_studio_web_scene" / f"{scene_id}.robot_preview.urdf").resolve()
     dest.parent.mkdir(parents=True, exist_ok=True)
-    text = synthesized_text if synthesized_text is not None else source.read_text(encoding="utf-8")
+    if synthesized_text is not None:
+        text = synthesized_text
+        preview_mode = "legacy_flattened_rows_robot_preview"
+        rviz_parity = False
+    else:
+        try:
+            text = _extract_robot_preview_urdf(source.read_text(encoding="utf-8"), source)
+        except BlockingExportError:
+            if canonical_scene_requires_real_expanded_urdf:
+                raise
+            _warn(warnings, "robot_preview_extraction_failed", "Could not extract robot subtree from expanded URDF; using temporary legacy flattened-row fallback without RViz parity.", str(source))
+            synthesized_text = _synthesize_robot_preview_urdf_from_rows(payload)
+            if not synthesized_text:
+                return
+            text = synthesized_text
+            preview_mode = "legacy_flattened_rows_robot_preview"
+            rviz_parity = False
+        else:
+            preview_mode = "expanded_urdf_robot_subtree"
+            rviz_parity = True
     asset_root = (repo_root / "build" / "workcell_studio_web_scene" / "assets" / scene_id).resolve()
     asset_root.mkdir(parents=True, exist_ok=True)
 
@@ -425,9 +543,10 @@ def _stage_expanded_robot_urdf(payload: Json, scene_dir: Path, output_path: Path
     text = re.sub(r"package://[^\s'\"<>]+", rewrite, text)
     dest.write_text(text, encoding="utf-8")
     payload["robot_preview"] = {
-        "mode": "expanded_urdf_loader",
+        "mode": preview_mode,
         "urdf_url": os.path.relpath(dest, repo_root).replace(os.sep, "/"),
         "robot_root_link": "base_link",
+        "rviz_parity": rviz_parity,
         "joint_values": dict(DEFAULT_ROBOT_PREVIEW_JOINT_VALUES),
         "expected_links": list(EXPECTED_ROBOT_PREVIEW_LINKS),
     }
@@ -2066,7 +2185,11 @@ def main(argv: Optional[List[str]] = None) -> int:
         print(f"error: --scene must be an existing directory: {scene_dir}", file=sys.stderr)
         return 2
 
-    payload = build_web_scene(scene_dir, stage_assets=args.stage_assets, output_path=output_path)
+    try:
+        payload = build_web_scene(scene_dir, stage_assets=args.stage_assets, output_path=output_path)
+    except BlockingExportError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 3
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return 0

--- a/tests/test_export_workcell_studio_web_scene.py
+++ b/tests/test_export_workcell_studio_web_scene.py
@@ -4,11 +4,55 @@ import sys
 from pathlib import Path
 
 import yaml
+import importlib.util
 
 
 SCRIPT = Path("scripts/export_workcell_studio_web_scene.py")
 ROOT = Path(__file__).resolve().parents[1]
 EXTRACT_INDEX_SCRIPT = ROOT / "scripts" / "extract_scene_urdf_visual_mesh_index.py"
+spec = importlib.util.spec_from_file_location("export_workcell_studio_web_scene", ROOT / SCRIPT)
+exporter = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(exporter)
+
+
+def test_robot_preview_extraction_keeps_robot_subtree_and_excludes_scene_siblings(tmp_path):
+    source = tmp_path / "expanded_scene_preview.urdf"
+    text = """<?xml version="1.0"?>
+<robot name="demo_scene">
+  <material name="robot_blue"><color rgba="0.1 0.2 0.3 1"/></material>
+  <material name="table_gray"><color rgba="0.5 0.5 0.5 1"/></material>
+  <link name="world"/>
+  <link name="base_link"><visual><geometry><mesh filename="package://ur_description/meshes/ur5/visual/base.dae" scale="1 1 1"/></geometry><material name="robot_blue"/></visual></link>
+  <link name="shoulder_link"/>
+  <link name="tool0"/>
+  <link name="gripper_base_link"/>
+  <link name="left_finger_link"/>
+  <link name="workbench"><visual><material name="table_gray"/></visual></link>
+  <link name="camera_link"/>
+  <joint name="world_to_robot" type="fixed"><parent link="world"/><child link="base_link"/><origin xyz="0.4 0.1 0.2" rpy="0 0 1.57"/></joint>
+  <joint name="shoulder_pan_joint" type="revolute"><parent link="base_link"/><child link="shoulder_link"/><origin xyz="0 0 0.089" rpy="0 0 0"/><axis xyz="0 0 1"/><limit lower="-6.28" upper="6.28" effort="150" velocity="3.15"/></joint>
+  <joint name="wrist_3_joint" type="revolute"><parent link="shoulder_link"/><child link="tool0"/><origin xyz="0 0 0.1" rpy="0 0 0"/><axis xyz="0 0 1"/><mimic joint="shoulder_pan_joint" multiplier="0" offset="0"/></joint>
+  <joint name="tool0_to_gripper" type="fixed"><parent link="tool0"/><child link="gripper_base_link"/><origin xyz="0 0 0" rpy="0 0 0"/></joint>
+  <joint name="finger_joint" type="revolute"><parent link="gripper_base_link"/><child link="left_finger_link"/><axis xyz="1 0 0"/><limit lower="0" upper="0.8" effort="20" velocity="1"/></joint>
+  <joint name="world_to_table" type="fixed"><parent link="world"/><child link="workbench"/><origin xyz="1 0 0" rpy="0 0 0"/></joint>
+  <joint name="world_to_camera" type="fixed"><parent link="world"/><child link="camera_link"/><origin xyz="0 1 1" rpy="0 0 0"/></joint>
+</robot>
+"""
+    extracted = exporter._extract_robot_preview_urdf(text, source)
+
+    assert 'link name="world"' in extracted
+    assert 'joint name="world_to_robot" type="fixed"' in extracted
+    assert 'link name="base_link"' in extracted
+    assert 'link name="tool0"' in extracted
+    assert 'link name="gripper_base_link"' in extracted
+    assert 'link name="left_finger_link"' in extracted
+    assert 'mesh filename="package://ur_description/meshes/ur5/visual/base.dae" scale="1 1 1"' in extracted
+    assert 'material name="robot_blue"' in extracted
+    assert 'limit lower="-6.28" upper="6.28" effort="150" velocity="3.15"' in extracted
+    assert 'mimic joint="shoulder_pan_joint" multiplier="0" offset="0"' in extracted
+    assert "workbench" not in extracted
+    assert "camera_link" not in extracted
+    assert "table_gray" not in extracted
 
 
 def test_export_web_scene_contract_and_determinism(tmp_path):


### PR DESCRIPTION
### Motivation
- Ensure the canonical `ur5_2f_test` scene uses the real xacro-expanded URDF for a faithful robot preview instead of a synthesized flattened-row fallback. 
- Provide a dedicated robot-preview URDF that contains only the physical robot subtree so the Product View and web preview show mesh-backed robot visuals and not scene siblings like table/camera/bins. 
- Fail loudly when the canonical scene cannot produce a truthful robot preview so callers must run the proper xacro expansion/visual-index pipeline rather than silently degrading RViz parity.

### Description
- Added `BlockingExportError` and changed the CLI to return a non-zero exit when a canonical scene export cannot be performed honestly via `_stage_expanded_robot_urdf`.
- Implemented `_extract_robot_preview_urdf` which parses an xacro-expanded URDF XML, finds the joint graph, preserves the fixed world/root-to-`base_link` chain, recursively follows only `base_link` descendants, and assembles a new URDF containing selected links, joints and referenced global `material` entries.
- Staged the extracted preview at `build/workcell_studio_web_scene/<scene>.robot_preview.urdf`, preserved link/joint names, joint types, origins, axes, limits, `mimic` tags, visuals (mesh filenames/scales) and material RGBA, and rewrote `package://` mesh URIs into build assets as before.
- Kept the existing flattened-row synthesizer as a legacy fallback for non-canonical scenes and added a `rviz_parity` flag to label whether the preview was produced from the expanded URDF (`true`) or a legacy flatten (`false`).
- Added a regression test `test_robot_preview_extraction_keeps_robot_subtree_and_excludes_scene_siblings` that verifies the extractor retains the robot/world-to-base chain, UR5/tool0/Robotiq branches, joint metadata, mesh filenames and materials while excluding table/camera sibling branches.

### Testing
- Ran `python3 -m pytest tests/test_export_workcell_studio_web_scene.py` and it passed (all exporter-focused tests succeeded). 
- Verified `python3 -m py_compile scripts/export_workcell_studio_web_scene.py` succeeded and running `python3 scripts/export_workcell_studio_web_scene.py --scene scenes/ur5_2f_test --output /tmp/ur5.web_scene.json --stage-assets` returned exit code `3` with the intended blocking error when the expanded URDF is not present. 
- Ran the broader pairing `python3 -m pytest tests/test_export_workcell_studio_web_scene.py tests/test_workcell_studio_web_mesh_staging.py` which produced partial failures: the exporter tests passed but three existing web-mesh-staging tests failed due to unrelated viewer JS string-drift assertions and because the `ur5_2f_test` freshener path is now correctly blocked without a real expanded URDF.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50deb381f08331b775874c09d09834)