### PR TITLE
Expose browser Object3D matrices for URDF links and verify against ROS FK

### DIFF
--- a/scripts/compare_web_scene_fk_to_ros_tf.py
+++ b/scripts/compare_web_scene_fk_to_ros_tf.py
@@ -24,6 +24,7 @@ sys.path.insert(0, str(ROOT / "scripts"))
 import extract_scene_urdf_visual_mesh_index as fk  # noqa: E402
 
 IMPORTANT_LINKS = [
+    "base_link",
     "base_link_inertia", "shoulder_link", "upper_arm_link", "forearm_link",
     "wrist_1_link", "wrist_2_link", "wrist_3_link", "tool0", "gripper_base_link",
     "gripper_finger1_knuckle_link", "gripper_finger2_knuckle_link",
@@ -101,6 +102,67 @@ def _web_rows(payload: Mapping[str, Any]) -> list[dict[str, Any]]:
     return rows
 
 
+
+def _matrix_from_pose(pose: Mapping[str, Any] | None) -> list[float] | None:
+    if pose is None:
+        return None
+    xyz, rpy = _pose_tuple(pose)
+    cr, sr = math.cos(rpy[0]), math.sin(rpy[0])
+    cp, sp = math.cos(rpy[1]), math.sin(rpy[1])
+    cy, sy = math.cos(rpy[2]), math.sin(rpy[2])
+    # Rz * Ry * Rx, returned as THREE/ROS column-major Matrix4 elements.
+    r00 = cy * cp; r01 = cy * sp * sr - sy * cr; r02 = cy * sp * cr + sy * sr
+    r10 = sy * cp; r11 = sy * sp * sr + cy * cr; r12 = sy * sp * cr - cy * sr
+    r20 = -sp;     r21 = cp * sr;                  r22 = cp * cr
+    return [r00, r10, r20, 0.0, r01, r11, r21, 0.0, r02, r12, r22, 0.0, xyz[0], xyz[1], xyz[2], 1.0]
+
+
+def _matrix_translation(m: Sequence[float] | None) -> list[float]:
+    return [float(m[12]), float(m[13]), float(m[14])] if m and len(m) >= 15 else [0.0, 0.0, 0.0]
+
+
+def _matrix_rotation_angle(a: Sequence[float] | None, b: Sequence[float] | None) -> float:
+    if not a or not b or len(a) < 11 or len(b) < 11:
+        return math.inf
+    # Column-major rotation matrices; compute trace(Ra^T Rb).
+    trace = 0.0
+    for row in range(3):
+        for col in range(3):
+            trace += float(a[col * 4 + row]) * float(b[col * 4 + row])
+    value = max(-1.0, min(1.0, (trace - 1.0) / 2.0))
+    return abs(math.acos(value))
+
+
+def _matrix_delta(a: Sequence[float] | None, b: Sequence[float] | None) -> dict[str, Any]:
+    at = _matrix_translation(a); bt = _matrix_translation(b)
+    dxyz = [at[i] - bt[i] for i in range(3)]
+    return {"xyz": dxyz, "xyz_norm": math.sqrt(sum(v * v for v in dxyz)), "angle": _matrix_rotation_angle(a, b)}
+
+
+def _browser_status(path_value: str | None) -> Mapping[str, Any] | None:
+    if not path_value:
+        return None
+    path = Path(path_value)
+    if not path.is_absolute():
+        path = ROOT / path
+    data = _load_json(path)
+    status = data.get("browser", {}).get("status") if isinstance(data.get("browser"), Mapping) else data.get("status")
+    return status if isinstance(status, Mapping) else data
+
+
+def _browser_link_matrices(status: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    if not status:
+        return {}
+    value = status.get("robot_link_world_matrices") or status.get("robotLinkWorldMatrices") or {}
+    return value if isinstance(value, Mapping) else {}
+
+
+def _browser_visual_matrices(status: Mapping[str, Any] | None) -> list[Mapping[str, Any]]:
+    if not status:
+        return []
+    value = status.get("robot_visual_wrapper_world_matrices") or status.get("robotVisualWrapperWorldMatrices") or []
+    return [v for v in value if isinstance(v, Mapping)] if isinstance(value, list) else []
+
 def main(argv: Sequence[str] | None = None) -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--scene", required=True)
@@ -108,6 +170,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     ap.add_argument("--output", required=True)
     ap.add_argument("--tolerance", type=float, default=DEFAULT_TOLERANCE)
     ap.add_argument("--workspace-root", default=os.environ.get("WORKSPACE_ROOT", ""))
+    ap.add_argument("--browser-status", help="Visual acceptance report/status JSON containing actual browser Object3D matrixWorld diagnostics.")
     args = ap.parse_args(argv)
 
     scene_dir = _scene_path(args.scene)
@@ -116,6 +179,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     out_path = Path(args.output)
     if not out_path.is_absolute(): out_path = ROOT / out_path
     web = _load_json(web_path)
+    browser_status = _browser_status(args.browser_status)
+    browser_links = _browser_link_matrices(browser_status)
+    browser_visuals = _browser_visual_matrices(browser_status)
     xml_text, source = _resolve_urdf(scene_dir, args.workspace_root)
     computed = _computed_items(scene_dir, xml_text, args.workspace_root)
 
@@ -135,27 +201,44 @@ def main(argv: Sequence[str] | None = None) -> int:
     for link in IMPORTANT_LINKS:
         ros_item = computed_by_link.get(link)
         web_item = web_by_link.get(link)
-        ros_link = (ros_item.get("urdf_fk_link_world_pose") or ros_item.get("link_world_pose") or ros_item.get("frame_world_pose") or ros_item.get("final_transform")) if ros_item else None
-        ros_visual = (ros_item.get("urdf_fk_visual_world_pose") or ros_item.get("baked_world_visual_pose") or ros_item.get("expected_visual_pose") or ros_item.get("final_transform")) if ros_item else None
+        if link == "base_link" and not ros_item:
+            ros_link = {"xyz": [0.0, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]}
+            ros_visual = ros_link
+        else:
+            ros_link = (ros_item.get("urdf_fk_link_world_pose") or ros_item.get("link_world_pose") or ros_item.get("frame_world_pose") or ros_item.get("final_transform")) if ros_item else None
+            ros_visual = (ros_item.get("urdf_fk_visual_world_pose") or ros_item.get("baked_world_visual_pose") or ros_item.get("expected_visual_pose") or ros_item.get("final_transform")) if ros_item else None
         web_link = (web_item or {}).get("urdf_fk_link_world_pose") or (web_item or {}).get("link_world_pose") or (web_item or {}).get("frame_world_pose") or (web_item or {}).get("final_transform")
         web_visual = (web_item or {}).get("urdf_fk_visual_world_pose") or (web_item or {}).get("baked_world_visual_pose") or (web_item or {}).get("expected_visual_pose") or (web_item or {}).get("final_transform")
-        d_link = _delta(ros_link, web_link)
-        d_visual = _delta(ros_visual, web_visual)
-        passed = bool(ros_item and web_item and d_link["xyz_norm"] <= args.tolerance and d_link["rpy_max"] <= args.tolerance and d_visual["xyz_norm"] <= args.tolerance and d_visual["rpy_max"] <= args.tolerance)
+        actual_browser_link = browser_links.get(link) if isinstance(browser_links.get(link), Mapping) else None
+        browser_link_matrix = actual_browser_link.get("matrix_world") if actual_browser_link else None
+        expected_link_matrix = _matrix_from_pose(ros_link)
+        d_link = _matrix_delta(expected_link_matrix, browser_link_matrix) if browser_status else _delta(ros_link, web_link)
+        visual_candidates = [v for v in browser_visuals if str(v.get("link_name") or v.get("linkName") or "") == link]
+        browser_visual_matrix = visual_candidates[0].get("matrix_world") if visual_candidates else None
+        expected_visual_matrix = _matrix_from_pose(ros_visual)
+        d_visual = _matrix_delta(expected_visual_matrix, browser_visual_matrix) if browser_status and browser_visual_matrix else _delta(ros_visual, web_visual)
+        link_ok = d_link["xyz_norm"] <= args.tolerance and (d_link.get("angle", d_link.get("rpy_max", math.inf)) <= args.tolerance)
+        visual_ok = d_visual["xyz_norm"] <= args.tolerance and (d_visual.get("angle", d_visual.get("rpy_max", math.inf)) <= args.tolerance)
+        present_ok = bool((ros_item or link == "base_link") and ((actual_browser_link if browser_status else web_item)))
+        passed = bool(present_ok and link_ok and visual_ok)
         ok = ok and passed
         rows.append({
             "link_name": link,
             "ros_tf_xyz_rpy": ros_link,
             "ros_tf_visual_xyz_rpy": ros_visual,
             "exported_web_fk_xyz_rpy": web_link,
+            "browser_object3d_matrix_world": browser_link_matrix,
             "exported_web_fk_visual_xyz_rpy": web_visual,
+            "browser_visual_wrapper_matrix_world": browser_visual_matrix,
             "delta_link": d_link,
             "delta_visual": d_visual,
             "pass": passed,
         })
-        print(f"{link}: xyz_delta={d_link['xyz_norm']:.6g} rpy_delta={d_link['rpy_max']:.6g} visual_xyz_delta={d_visual['xyz_norm']:.6g} visual_rpy_delta={d_visual['rpy_max']:.6g} {'PASS' if passed else 'FAIL'}")
+        link_angle = d_link.get('angle', d_link.get('rpy_max', math.inf))
+        visual_angle = d_visual.get('angle', d_visual.get('rpy_max', math.inf))
+        print(f"{link}: xyz_delta={d_link['xyz_norm']:.6g} angle_delta={link_angle:.6g} visual_xyz_delta={d_visual['xyz_norm']:.6g} visual_angle_delta={visual_angle:.6g} {'PASS' if passed else 'FAIL'}")
 
-    report = {"scene": scene_dir.name, "source": source, "tolerance": args.tolerance, "passed": ok, "links": rows}
+    report = {"scene": scene_dir.name, "source": source, "tolerance": args.tolerance, "compared_browser_object3d_matrices": bool(browser_status), "passed": ok, "links": rows}
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 

--- a/scripts/run_workcell_web3d_visual_acceptance.py
+++ b/scripts/run_workcell_web3d_visual_acceptance.py
@@ -46,6 +46,15 @@ REQUIRED_RENDERED_MESH_ADJACENT_PAIRS = {
     "wrist_1_link -> wrist_2_link": 0.75,
     "wrist_2_link -> wrist_3_link": 0.75,
 }
+REQUIRED_BROWSER_MATRIX_LINKS = (
+    "base_link", "base_link_inertia", "shoulder_link", "upper_arm_link", "forearm_link",
+    "wrist_1_link", "wrist_2_link", "wrist_3_link", "tool0", "gripper_base_link",
+    "gripper_finger1_knuckle_link", "gripper_finger2_knuckle_link",
+    "gripper_finger1_finger_link", "gripper_finger2_finger_link",
+    "gripper_finger1_inner_knuckle_link", "gripper_finger2_inner_knuckle_link",
+    "gripper_finger1_finger_tip_link", "gripper_finger2_finger_tip_link",
+)
+
 REQUIRED_PRODUCT_FALLBACK_TOKENS = (
     "required_mesh_failed_debug_fallback",
     "primitive_fallback",
@@ -697,6 +706,34 @@ def _tool0_frame_contract_errors(status: Mapping[str, Any]) -> list[str]:
     return errors
 
 
+
+def _browser_matrix_contract_errors(status: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    matrices = status.get("robot_link_world_matrices") or status.get("robotLinkWorldMatrices") or {}
+    if not isinstance(matrices, Mapping):
+        return ["browser viewer must expose robot_link_world_matrices from actual Object3D matrixWorld values"]
+    absent = [link for link in REQUIRED_BROWSER_MATRIX_LINKS if link not in matrices]
+    # flange is optional, but if loaded it must have a matrix.
+    hierarchy = status.get("robot_hierarchy_links") or status.get("robotHierarchyLinks") or []
+    if isinstance(hierarchy, list) and "flange" in hierarchy and "flange" not in matrices:
+        absent.append("flange")
+    if absent:
+        errors.append(f"browser viewer actual Object3D matrix diagnostics missing required links: {', '.join(absent)}")
+    for link, diagnostic in matrices.items():
+        matrix = diagnostic.get("matrix_world") if isinstance(diagnostic, Mapping) else None
+        if not (isinstance(matrix, list) and len(matrix) == 16 and all(isinstance(v, (int, float)) and math.isfinite(float(v)) for v in matrix)):
+            errors.append(f"browser viewer Object3D matrixWorld for {link} must be a finite 16-number matrix")
+    visual_matrices = status.get("robot_visual_wrapper_world_matrices") or status.get("robotVisualWrapperWorldMatrices") or []
+    if not isinstance(visual_matrices, list) or not visual_matrices:
+        errors.append("browser viewer must expose robot_visual_wrapper_world_matrices for T_world_link × T_link_visual wrappers")
+    else:
+        visual_links = {str(row.get("link_name") or row.get("linkName") or "") for row in visual_matrices if isinstance(row, Mapping)}
+        mesh_links = [link for link in REQUIRED_BROWSER_MATRIX_LINKS if link != "tool0"]
+        missing_visuals = [link for link in mesh_links if link not in visual_links]
+        if missing_visuals:
+            errors.append(f"browser viewer visual-wrapper matrix diagnostics missing required mesh links: {', '.join(missing_visuals)}")
+    return errors
+
 def validate_browser_status(status: Mapping[str, Any]) -> list[str]:
     errors: list[str] = []
     mesh_loaded_count = _status_int(status, "mesh_loaded_count", "meshLoadedCount")
@@ -716,6 +753,7 @@ def validate_browser_status(status: Mapping[str, Any]) -> list[str]:
         if not (0.0 <= distance <= max_distance_m):
             errors.append(f"browser viewer resolved distance {pair} expected <= {max_distance_m:.3f} m, got {raw!r}")
     errors.extend(_robot_lifecycle_errors(status))
+    errors.extend(_browser_matrix_contract_errors(status))
     errors.extend(_assembled_hierarchy_errors(status))
     errors.extend(_tool0_frame_contract_errors(status))
     errors.extend(_rendered_mesh_adjacency_errors(status))
@@ -900,6 +938,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     if not screenshot_path.exists():
         screenshot_path.write_bytes(PNG_1X1)
 
+    browser_status_path = BUILD_ROOT / f"{scene_id}.browser_status.json"
+    if isinstance(browser.get("status"), Mapping):
+        browser_status_path.write_text(json.dumps({"status": browser.get("status")}, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        compare_report_path = BUILD_ROOT / f"{scene_id}.browser_fk_vs_ros_tf.json"
+        steps.append(run_step([sys.executable, "scripts/compare_web_scene_fk_to_ros_tf.py", "--scene", repo_relative(scene_dir), "--web-scene", repo_relative(output_path), "--output", repo_relative(compare_report_path), "--browser-status", repo_relative(browser_status_path), "--tolerance", "0.0001"]))
+
     report = {
         "scene_id": scene_id,
         "scene_dir": repo_relative(scene_dir),
@@ -909,6 +953,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         "browser": browser,
         "robot_preview_lifecycle_diagnostics": robot_preview_lifecycle_diagnostics(browser.get("status")) if isinstance(browser.get("status"), Mapping) else {},
         "steps": steps,
+        "browser_status_json": repo_relative(browser_status_path) if browser_status_path.exists() else "",
         "report": repo_relative(report_path),
         "screenshot": repo_relative(screenshot_path),
     }

--- a/tests/test_workcell_web3d_visual_acceptance.py
+++ b/tests/test_workcell_web3d_visual_acceptance.py
@@ -361,16 +361,13 @@ def _valid_frame_diagnostics():
 
 
 def _valid_robot_hierarchy_fields():
-    links = [
-        "base_link_inertia",
-        "shoulder_link",
-        "upper_arm_link",
-        "forearm_link",
-        "wrist_1_link",
-        "wrist_2_link",
-        "wrist_3_link",
-        "tool0",
-        "gripper_base_link",
+    links = list(module.REQUIRED_BROWSER_MATRIX_LINKS)
+    identity = [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0]
+    link_matrices = {link: {"matrix_world": identity, "parent_link_name": links[index - 1] if index else ""} for index, link in enumerate(links)}
+    visual_matrices = [
+        {"link_name": link, "visual_index": 0, "matrix_world": identity}
+        for link in links
+        if link != "tool0"
     ]
     return {
         "robot_render_mode": "expanded_urdf_loader",
@@ -391,6 +388,8 @@ def _valid_robot_hierarchy_fields():
         "robot_hierarchy_missing_links": [],
         "robot_hierarchy_missing_parents": [],
         "robot_hierarchy_mesh_count": 18,
+        "robot_link_world_matrices": link_matrices,
+        "robot_visual_wrapper_world_matrices": visual_matrices,
     }
 
 def _valid_browser_status_with_rendered_diagnostics():

--- a/workcell_studio_web/viewer/urdf_robot_renderer.js
+++ b/workcell_studio_web/viewer/urdf_robot_renderer.js
@@ -71,6 +71,83 @@ function loadMesh(path, manager, material, done, context, diagnostics) {
   else onError(new Error(`unsupported mesh format .${ext || 'unknown'}`));
 }
 
+
+function matrix4ToDiagnostics(object) {
+  if (!object?.matrixWorld) return null;
+  object.updateMatrixWorld?.(true);
+  return Array.from(object.matrixWorld.elements).map(value => Number(value));
+}
+
+function vector3ToDiagnostics(value) {
+  return value ? { x: Number(value.x), y: Number(value.y), z: Number(value.z) } : null;
+}
+
+function collectLinkMatrixDiagnostics(robot, links) {
+  robot?.updateMatrixWorld?.(true);
+  const out = {};
+  for (const [name, link] of Object.entries(links || {})) {
+    if (!link?.matrixWorld) continue;
+    const position = new THREE.Vector3();
+    const quaternion = new THREE.Quaternion();
+    const scale = new THREE.Vector3();
+    link.updateMatrixWorld?.(true);
+    link.matrixWorld.decompose(position, quaternion, scale);
+    out[name] = {
+      link_name: name,
+      name: link.name || name,
+      parent_name: link.parent?.name || '',
+      parent_link_name: Object.entries(links || {}).find(([, candidate]) => candidate === link.parent)?.[0] || '',
+      matrix_world: matrix4ToDiagnostics(link),
+      world_position: vector3ToDiagnostics(position),
+      world_quaternion: { x: quaternion.x, y: quaternion.y, z: quaternion.z, w: quaternion.w },
+      world_scale: vector3ToDiagnostics(scale),
+    };
+  }
+  return out;
+}
+
+function isVisualWrapperCandidate(child, links) {
+  if (!child || Object.values(links || {}).includes(child)) return false;
+  const type = String(child.type || '').toLowerCase();
+  const name = String(child.name || '').toLowerCase();
+  return child.isMesh || type.includes('mesh') || type.includes('group') || name.includes('visual') || child.children?.some?.(desc => desc?.isMesh);
+}
+
+function collectVisualWrapperMatrixDiagnostics(links) {
+  const out = [];
+  for (const [linkName, link] of Object.entries(links || {})) {
+    let visualIndex = 0;
+    for (const child of link.children || []) {
+      if (!isVisualWrapperCandidate(child, links)) continue;
+      child.updateMatrixWorld?.(true);
+      const position = new THREE.Vector3();
+      const quaternion = new THREE.Quaternion();
+      const scale = new THREE.Vector3();
+      child.matrixWorld.decompose(position, quaternion, scale);
+      out.push({
+        link_name: linkName,
+        linkName,
+        visual_index: visualIndex,
+        visualIndex,
+        object_name: child.name || `visual_${visualIndex}`,
+        objectName: child.name || `visual_${visualIndex}`,
+        parent_name: child.parent?.name || '',
+        parentName: child.parent?.name || '',
+        matrix_world: matrix4ToDiagnostics(child),
+        matrixWorld: matrix4ToDiagnostics(child),
+        world_position: vector3ToDiagnostics(position),
+        worldPosition: vector3ToDiagnostics(position),
+        world_quaternion: { x: quaternion.x, y: quaternion.y, z: quaternion.z, w: quaternion.w },
+        worldQuaternion: { x: quaternion.x, y: quaternion.y, z: quaternion.z, w: quaternion.w },
+        world_scale: vector3ToDiagnostics(scale),
+        worldScale: vector3ToDiagnostics(scale),
+      });
+      visualIndex += 1;
+    }
+  }
+  return out;
+}
+
 function buildLookupMap(source) {
   return new Map(Object.entries(source || {}));
 }
@@ -172,6 +249,10 @@ export function loadRobotPreview(previewConfig, rendererContext = {}) {
     diagnostics.robot_loaded_joint_count = result.joints.size;
     diagnostics.robot_joint_type_counts = jointTypeCounts(robot.joints);
     diagnostics.robot_hierarchy_links = Array.from(result.links.keys());
+    diagnostics.robot_link_world_matrices = collectLinkMatrixDiagnostics(robot, robot.links);
+    diagnostics.robotLinkWorldMatrices = diagnostics.robot_link_world_matrices;
+    diagnostics.robot_visual_wrapper_world_matrices = collectVisualWrapperMatrixDiagnostics(robot.links);
+    diagnostics.robotVisualWrapperWorldMatrices = diagnostics.robot_visual_wrapper_world_matrices;
     const rootDiagnostics = linkRootDiagnostics(robot, robot.links);
     diagnostics.robot_root_links = rootDiagnostics.roots;
     diagnostics.robotRootLinks = rootDiagnostics.roots;
@@ -184,6 +265,10 @@ export function loadRobotPreview(previewConfig, rendererContext = {}) {
     diagnostics.robot_hierarchy_missing_links = Array.isArray(previewConfig?.expected_links)
       ? previewConfig.expected_links.filter(link => !result.links.has(link))
       : [];
+    diagnostics.robot_link_world_matrices = collectLinkMatrixDiagnostics(robot, robot.links);
+    diagnostics.robotLinkWorldMatrices = diagnostics.robot_link_world_matrices;
+    diagnostics.robot_visual_wrapper_world_matrices = collectVisualWrapperMatrixDiagnostics(robot.links);
+    diagnostics.robotVisualWrapperWorldMatrices = diagnostics.robot_visual_wrapper_world_matrices;
     diagnostics.robot_preview_loaded = diagnostics.robot_failed_visual_count === 0 && diagnostics.robot_hierarchy_missing_links.length === 0;
     setLifecycleState(diagnostics, diagnostics.robot_preview_loaded ? 'ready' : 'failed');
     rendererContext?.scene?.add?.(robot);


### PR DESCRIPTION
### Motivation

- Ensure the browser-rendered URDF preview exposes the actual Three.js `Object3D.matrixWorld` values for core UR and Robotiq links and their mesh-wrapper children so acceptance tests can validate what the browser actually rendered.  
- Use those real browser matrices to detect transform mismatches vs ROS/URDF FK (double-applied visual origins, missing mesh scales, wrong parent attachments, mimic/joint issues, detached grippers, duplicate roots, missing meshes, primitive fallbacks).  
- Make the Web 3D visual acceptance workflow stricter and able to run a matrix-based FK comparison after `window.__WORKCELL_ROBOT_PREVIEW_READY__` resolves to raise actionable diagnostics when browser rendering diverges from ROS FK.

### Description

- Expose per-link world matrices and diagnostics in the browser by adding `collectLinkMatrixDiagnostics` and `collectVisualWrapperMatrixDiagnostics` and attaching `robot_link_world_matrices` / `robot_visual_wrapper_world_matrices` to the robot preview diagnostics in `workcell_studio_web/viewer/urdf_robot_renderer.js`.  
- Extend the FK comparator `scripts/compare_web_scene_fk_to_ros_tf.py` to accept a `--browser-status` JSON, extract actual browser `matrix_world` entries and visual-wrapper matrices, convert ROS poses to 4x4 column-major matrices, and compute translation/angular deltas for each required link; include `base_link` in the important link set.  
- Update the visual acceptance driver `scripts/run_workcell_web3d_visual_acceptance.py` to require browser matrix diagnostics (a required link list including gripper fingers/knuckles/tips and optional `flange`), save `browser_status.json` and invoke the browser-matrix FK comparison step using tolerances of `0.0001` m/rad.  
- Update test fixtures to supply valid `robot_link_world_matrices` and `robot_visual_wrapper_world_matrices` for the acceptance unit tests and adapt printed diagnostics to include angle deltas and browser matrix fields.  
- Files changed: `workcell_studio_web/viewer/urdf_robot_renderer.js`, `scripts/compare_web_scene_fk_to_ros_tf.py`, `scripts/run_workcell_web3d_visual_acceptance.py`, and updated tests in `tests/test_workcell_web3d_visual_acceptance.py`.

### Testing

- `python3 -m py_compile scripts/run_workcell_web3d_visual_acceptance.py scripts/compare_web_scene_fk_to_ros_tf.py` passed.  
- `node --check workcell_studio_web/viewer/urdf_robot_renderer.js` passed.  
- `python3 -m pytest tests/test_workcell_web3d_visual_acceptance.py` passed after updating fixtures to include browser matrix diagnostics.  
- A larger test run (`python3 -m pytest tests/test_workcell_web3d_visual_acceptance.py tests/test_workcell_builder_web_viewer_action.py tests/test_workcell_studio_web_viewer_static.py`) surfaced two failing assertions in `tests/test_workcell_builder_web_viewer_action.py` related to an expected C++ viewer-action URL string; those failures are due to stale/strict string assertions in the test and not to the new browser-matrix logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a521f9fed988331881fce21838b3e3e)