### PR TITLE
Fix web URDF preview mode wiring

### DIFF
--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -506,6 +506,7 @@ def _stage_expanded_robot_urdf(payload: Json, scene_dir: Path, output_path: Path
     if synthesized_text is not None:
         text = synthesized_text
         preview_mode = "legacy_flattened_rows_robot_preview"
+        source_mode = "legacy_flattened_rows_robot_preview"
         rviz_parity = False
     else:
         try:
@@ -519,9 +520,11 @@ def _stage_expanded_robot_urdf(payload: Json, scene_dir: Path, output_path: Path
                 return
             text = synthesized_text
             preview_mode = "legacy_flattened_rows_robot_preview"
+            source_mode = "legacy_flattened_rows_robot_preview"
             rviz_parity = False
         else:
-            preview_mode = "expanded_urdf_robot_subtree"
+            preview_mode = "expanded_urdf_loader"
+            source_mode = "expanded_urdf_robot_subtree"
             rviz_parity = True
     asset_root = (repo_root / "build" / "workcell_studio_web_scene" / "assets" / scene_id).resolve()
     asset_root.mkdir(parents=True, exist_ok=True)
@@ -544,6 +547,7 @@ def _stage_expanded_robot_urdf(payload: Json, scene_dir: Path, output_path: Path
     dest.write_text(text, encoding="utf-8")
     payload["robot_preview"] = {
         "mode": preview_mode,
+        "source_mode": source_mode,
         "urdf_url": os.path.relpath(dest, repo_root).replace(os.sep, "/"),
         "robot_root_link": "base_link",
         "rviz_parity": rviz_parity,

--- a/tests/test_export_workcell_studio_web_scene.py
+++ b/tests/test_export_workcell_studio_web_scene.py
@@ -825,3 +825,46 @@ def test_direct_web_export_normalizes_ur5_tool0_and_robotiq_generated_rows(tmp_p
     assert wrist["robot_instance_id"] == tool0["robot_instance_id"] == gripper["robot_instance_id"]
     assert tool0["parent_to_child_pose"]
     assert gripper["parent_to_child_pose"]
+
+
+def test_stage_expanded_robot_preview_uses_loader_mode_and_source_mode(tmp_path):
+    scene = tmp_path / "scene"
+    scene.mkdir()
+    source = tmp_path / "expanded.urdf"
+    source.write_text(
+        """<?xml version="1.0"?>
+<robot name="demo_scene">
+  <link name="world"/>
+  <link name="base_link"/>
+  <link name="tool0"/>
+  <link name="gripper_base_link"/>
+  <joint name="world_to_robot" type="fixed"><parent link="world"/><child link="base_link"/></joint>
+  <joint name="base_to_tool0" type="fixed"><parent link="base_link"/><child link="tool0"/></joint>
+  <joint name="tool0_to_gripper" type="fixed"><parent link="tool0"/><child link="gripper_base_link"/></joint>
+</robot>
+""",
+        encoding="utf-8",
+    )
+    payload = {"scene": {"id": "preview_contract"}, "_visual_mesh_index_source": {"source_expanded_urdf_path": str(source)}}
+
+    exporter._stage_expanded_robot_urdf(payload, scene, tmp_path / "out.json", [])
+
+    assert payload["robot_preview"]["mode"] == "expanded_urdf_loader"
+    assert payload["robot_preview"]["source_mode"] == "expanded_urdf_robot_subtree"
+    assert payload["robot_preview"]["rviz_parity"] is True
+
+
+def test_stage_legacy_synthesized_robot_preview_keeps_provenance_and_no_rviz_parity(tmp_path):
+    scene = tmp_path / "scene"
+    scene.mkdir()
+    payload = {
+        "scene": {"id": "legacy_preview_contract"},
+        "robots": [{"id": "ur5", "link": "base_link", "mesh_uri": "meshes/base.dae"}],
+        "tools": [{"id": "gripper", "link": "gripper_base_link", "parent_link": "base_link", "mesh_uri": "meshes/gripper.dae"}],
+    }
+
+    exporter._stage_expanded_robot_urdf(payload, scene, tmp_path / "out.json", [])
+
+    assert payload["robot_preview"]["mode"] == "legacy_flattened_rows_robot_preview"
+    assert payload["robot_preview"]["source_mode"] == "legacy_flattened_rows_robot_preview"
+    assert payload["robot_preview"]["rviz_parity"] is False

--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -901,8 +901,8 @@ def test_viewer_has_expanded_urdf_loader_robot_preview_path():
     index = (VIEWER / "index.html").read_text(encoding="utf-8")
     assert "expanded_urdf_loader" in js
     assert "function loadExpandedUrdfRobotPreview" in js
-    assert "const urdfPreviewActive = state.sceneJson?.robot_preview?.mode === 'expanded_urdf_loader';" in js
-    assert "new Set(items.filter(isGeneratedUrdfMeshVisualItem))" in js
+    assert "const urdfPreviewActive = isExpandedUrdfRobotPreview(state.sceneJson?.robot_preview);" in js
+    assert "new Set(robotToolGeneratedUrdfItems)" in js
     assert "robot_preview_loaded" in js
     assert "robot_loaded_link_count" in js
     assert "robot_loaded_visual_count" in js
@@ -910,3 +910,34 @@ def test_viewer_has_expanded_urdf_loader_robot_preview_path():
     assert "skipped_legacy_generated_urdf_visual_count" in js
     assert "Robot preview: expanded URDF loader" in js
     assert 'data-summary-field="robot-preview-mode"' in index
+
+
+def test_viewer_expanded_urdf_preview_helper_accepts_canonical_and_legacy_modes():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    helper = js.split("function isExpandedUrdfRobotPreview(preview)", 1)[1].split("function robotPreviewSummaryMode", 1)[0]
+    assert "expanded_urdf_loader" in helper
+    assert "expanded_urdf_robot_subtree" in helper
+    render_body = js.split("function renderScene(items)", 1)[1].split("function loadExpandedUrdfRobotPreview", 1)[0]
+    assert "isExpandedUrdfRobotPreview(state.sceneJson?.robot_preview)" in render_body
+    assert "state.sceneJson?.robot_preview?.mode === 'expanded_urdf_loader'" not in render_body
+
+
+def test_viewer_urdf_preview_suppression_is_limited_to_robot_tool_generated_rows():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    helper = js.split("function isRobotToolGeneratedUrdfMeshVisualItem(item)", 1)[1].split("function itemAssemblyGroup", 1)[0]
+    assert "isGeneratedUrdfMeshVisualItem(item)" in helper
+    assert "isGeneratedRobotItem(item) || isGeneratedToolOrGripperItem(item)" in helper
+    render_body = js.split("function renderScene(items)", 1)[1].split("function loadExpandedUrdfRobotPreview", 1)[0]
+    assert "items.filter(isRobotToolGeneratedUrdfMeshVisualItem)" in render_body
+    assert "items.filter(isGeneratedUrdfMeshVisualItem)" not in render_body
+    assert "new Set(robotToolGeneratedUrdfItems)" in render_body
+
+
+def test_viewer_summary_reports_expanded_urdf_loader_for_aliases():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    summary = js.split("function robotPreviewSummaryMode(preview)", 1)[1].split("function isGeneratedUrdfMeshVisualItem", 1)[0]
+    assert "Robot preview: expanded URDF loader" in summary
+    assert "isExpandedUrdfRobotPreview(preview)" in summary
+    summary_fields = js.split("const fields = {", 1)[1].split("};", 1)[0]
+    assert "'robot-preview-mode': summary.robotPreviewMode" in summary_fields
+    assert "summary.robotPreviewMode === 'expanded_urdf_loader'" not in summary_fields

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -87,7 +87,7 @@ function computeSceneSummary() {
     meshFailedCount: statusRendered.filter(obj => isMissingOrFailedMeshStatus(obj.item?.mesh_status)).length,
     generatedLockedCount: rendered.filter(obj => isGeneratedOrLockedItem(obj.item)).length,
     editableCount: rendered.filter(obj => canEditItem(obj.item)).length,
-    robotPreviewMode: state.sceneJson?.robot_preview?.mode || '',
+    robotPreviewMode: robotPreviewSummaryMode(state.sceneJson?.robot_preview),
   };
 }
 function isExpectedMeshlessTool0Frame(item) {
@@ -394,7 +394,7 @@ function renderSceneSummary() {
     'mesh-failed-count': summary.meshFailedCount,
     'generated-locked-count': summary.generatedLockedCount,
     'editable-count': summary.editableCount,
-    'robot-preview-mode': summary.robotPreviewMode === 'expanded_urdf_loader' ? 'Robot preview: expanded URDF loader' : (summary.robotPreviewMode || 'mesh rows'),
+    'robot-preview-mode': summary.robotPreviewMode,
   };
   for (const [name, value] of Object.entries(fields)) {
     const node = el.summary.querySelector(`[data-summary-field="${name}"]`);
@@ -441,6 +441,13 @@ function bakedVisibleWorldPoseSource(item) {
 function hasMeshBackedVisualContract(item) {
   return Boolean(displayMeshUri(item) || item?.mesh_loaded || item?.meshLoaded || item?.mesh_status === 'loaded' || item?.renderInfo?.render_status === 'mesh_loaded');
 }
+function isExpandedUrdfRobotPreview(preview) {
+  const mode = String(preview?.mode || '').trim();
+  return mode === 'expanded_urdf_loader' || mode === 'expanded_urdf_robot_subtree';
+}
+function robotPreviewSummaryMode(preview) {
+  return isExpandedUrdfRobotPreview(preview) ? 'Robot preview: expanded URDF loader' : (preview?.mode || 'mesh rows');
+}
 function isGeneratedUrdfMeshVisualItem(item) {
   if (!isGeneratedUrdfItem(item)) return false;
   if (!hasMeshBackedVisualContract(item)) return false;
@@ -452,6 +459,9 @@ function isGeneratedUrdfMeshVisualItem(item) {
     item?.mesh_uri || item?.package_uri || item?.mesh_path || item?.source_path ||
     /\b(mesh|visual|link|robot|tool|gripper|camera|table|workbench)\b/.test(identity)
   );
+}
+function isRobotToolGeneratedUrdfMeshVisualItem(item) {
+  return Boolean(isGeneratedUrdfMeshVisualItem(item) && (isGeneratedRobotItem(item) || isGeneratedToolOrGripperItem(item)));
 }
 function itemAssemblyGroup(item) { return String(item?.assembly_group || item?.robot_instance_id || '').trim(); }
 function isAssemblyCandidateItem(item) {
@@ -1987,8 +1997,9 @@ function renderScene(items) {
   updateDirtyState();
   const scene = state.three.scene;
   state.robotUrdfPreviewDiagnostics = {};
-  const urdfPreviewActive = state.sceneJson?.robot_preview?.mode === 'expanded_urdf_loader';
-  const assemblyBuild = urdfPreviewActive ? { handled: new Set(items.filter(isGeneratedUrdfMeshVisualItem)), assemblies: [], renderDiagnostics: { skipped_flattened_urdf_visual_count: 0, assembled_hierarchy_rendered_mesh_count: 0, rendered_fk_visual_count: 0, skipped_legacy_generated_urdf_count: items.filter(isGeneratedUrdfMeshVisualItem).length, skipped_legacy_generated_urdf_visual_count: items.filter(isGeneratedUrdfMeshVisualItem).length, visible_duplicate_generated_urdf_count: 0, visible_tool0_fallback_count: 0, detached_robot_mesh_clusters: 0 } } : buildRobotAssemblies(items);
+  const urdfPreviewActive = isExpandedUrdfRobotPreview(state.sceneJson?.robot_preview);
+  const robotToolGeneratedUrdfItems = items.filter(isRobotToolGeneratedUrdfMeshVisualItem);
+  const assemblyBuild = urdfPreviewActive ? { handled: new Set(robotToolGeneratedUrdfItems), assemblies: [], renderDiagnostics: { skipped_flattened_urdf_visual_count: 0, assembled_hierarchy_rendered_mesh_count: 0, rendered_fk_visual_count: 0, skipped_legacy_generated_urdf_count: robotToolGeneratedUrdfItems.length, skipped_legacy_generated_urdf_visual_count: robotToolGeneratedUrdfItems.length, visible_duplicate_generated_urdf_count: 0, visible_tool0_fallback_count: 0, detached_robot_mesh_clusters: 0 } } : buildRobotAssemblies(items);
   state.robotAssemblyDiagnostics = assemblyBuild.assemblies;
   state.robotAssemblyRenderDiagnostics = assemblyBuild.renderDiagnostics || {};
   if (urdfPreviewActive) loadExpandedUrdfRobotPreview(state.sceneJson.robot_preview);


### PR DESCRIPTION
Summary:
- Split robot preview renderer selection from provenance: extracted expanded URDF previews now export `mode: expanded_urdf_loader` with `source_mode: expanded_urdf_robot_subtree`, while legacy synthesized previews retain legacy provenance and `rviz_parity: false`.
- Added a viewer helper that accepts both canonical and legacy expanded-URDF mode aliases and reports the summary as `Robot preview: expanded URDF loader`.
- Limited URDF-preview suppression to generated robot/tool rows so table, camera, zones, and authored layout/environment items continue rendering normally.
- Affected files/packages: `scripts/export_workcell_studio_web_scene.py`, `workcell_studio_web/viewer/viewer.js`, focused export/viewer tests.

Validation:
- `python3 -m py_compile scripts/export_workcell_studio_web_scene.py scripts/run_workcell_web3d_visual_acceptance.py` passed.
- `node --check workcell_studio_web/viewer/viewer.js` passed.
- `node --check workcell_studio_web/viewer/urdf_robot_renderer.js` passed.
- `python3 -m pytest -q tests/test_export_workcell_studio_web_scene.py tests/test_workcell_studio_web_viewer_static.py` passed: 55 passed.
- `python3 -m pytest -q tests/test_export_workcell_studio_web_scene.py tests/test_workcell_studio_web_viewer_static.py tests/test_workcell_studio_web_scene_contract.py tests/test_workcell_web3d_visual_acceptance.py` was attempted; 100 tests passed and 3 scene-contract tests failed because this container could not produce the real `scenes/ur5_2f_test/generated/expanded_scene_preview.urdf`, so the canonical-scene exporter correctly refused the legacy flattened-row fallback.
- `source /opt/ros/humble/setup.bash; source /home/user/workcell_ws/install/setup.bash 2>/dev/null || true; python3 scripts/ensure_workcell_studio_web_scene_fresh.py --scene scenes/ur5_2f_test --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json --stage-assets --force` was attempted and failed for the same missing real expanded URDF blocker.
- Browser acceptance was not run because the fresh web scene export was blocked before browser launch.

Safety:
- No MoveIt, controller, launch, fake-hardware default, or real-hardware behavior was changed.
- No real robot motion path was enabled.

Risks / rollback:
- Browser visual assembly is covered by static/focused tests here, but needs the real ROS Humble/xacro workspace browser acceptance run to prove the screenshot-level hierarchy is assembled.
- Roll back by reverting commit `ddd02d6` if the mode-contract change needs to be backed out.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a522cb682c88331a9c9fc568414a9ff)