### PR TITLE
Fix robot-preview staged mesh URL rebasing

### DIFF
--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -541,7 +541,11 @@ def _stage_expanded_robot_urdf(payload: Json, scene_dir: Path, output_path: Path
             return uri
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(resolved, target)
-        return os.path.relpath(target, repo_root).replace(os.sep, "/")
+        # Mesh filenames in the staged robot-preview URDF are resolved by
+        # urdf-loader relative to the URDF URL.  The preview URDF is written
+        # inside build/workcell_studio_web_scene/, so storing repo-root-relative
+        # filenames here would duplicate that directory in browser requests.
+        return os.path.relpath(target, dest.parent).replace(os.sep, "/")
 
     text = re.sub(r"package://[^\s'\"<>]+", rewrite, text)
     dest.write_text(text, encoding="utf-8")

--- a/tests/test_export_workcell_studio_web_scene.py
+++ b/tests/test_export_workcell_studio_web_scene.py
@@ -868,3 +868,56 @@ def test_stage_legacy_synthesized_robot_preview_keeps_provenance_and_no_rviz_par
     assert payload["robot_preview"]["mode"] == "legacy_flattened_rows_robot_preview"
     assert payload["robot_preview"]["source_mode"] == "legacy_flattened_rows_robot_preview"
     assert payload["robot_preview"]["rviz_parity"] is False
+
+
+def test_stage_expanded_robot_preview_rebases_package_meshes_relative_to_preview_urdf(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    for package, rel in [
+        ("ur_description", "meshes/ur5/visual/base.dae"),
+        ("robotiq_85_description", "meshes/visual/robotiq_85_base_link.dae"),
+    ]:
+        mesh = tmp_path / "assets" / package / rel
+        mesh.parent.mkdir(parents=True, exist_ok=True)
+        mesh.write_text(f"dummy {package}", encoding="utf-8")
+
+    scene = tmp_path / "scenes" / "ur5_2f_test"
+    scene.mkdir(parents=True)
+    source = tmp_path / "expanded.urdf"
+    source.write_text(
+        """<?xml version="1.0"?>
+<robot name="demo_scene">
+  <link name="world"/>
+  <link name="base_link"><visual><geometry><mesh filename="package://ur_description/meshes/ur5/visual/base.dae"/></geometry></visual></link>
+  <link name="tool0"/>
+  <link name="gripper_base_link"><visual><geometry><mesh filename="package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae"/></geometry></visual></link>
+  <joint name="world_to_robot" type="fixed"><parent link="world"/><child link="base_link"/></joint>
+  <joint name="base_to_tool0" type="fixed"><parent link="base_link"/><child link="tool0"/></joint>
+  <joint name="tool0_to_gripper" type="fixed"><parent link="tool0"/><child link="gripper_base_link"/></joint>
+</robot>
+""",
+        encoding="utf-8",
+    )
+    payload = {"scene": {"id": "ur5_2f_test"}, "_visual_mesh_index_source": {"source_expanded_urdf_path": str(source)}}
+
+    exporter._stage_expanded_robot_urdf(payload, scene, tmp_path / "build" / "workcell_studio_web_scene" / "ur5_2f_test.web_scene.json", [])
+
+    staged_urdf = tmp_path / payload["robot_preview"]["urdf_url"]
+    text = staged_urdf.read_text(encoding="utf-8")
+    assert 'filename="build/workcell_studio_web_scene/assets/' not in text
+    assert 'filename="assets/ur5_2f_test/ur_description/meshes/ur5/visual/base.dae"' in text
+    assert 'filename="assets/ur5_2f_test/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae"' in text
+    assert (tmp_path / "build/workcell_studio_web_scene/assets/ur5_2f_test/ur_description/meshes/ur5/visual/base.dae").is_file()
+    assert (tmp_path / "build/workcell_studio_web_scene/assets/ur5_2f_test/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae").is_file()
+
+
+def test_robot_preview_relative_mesh_urls_resolve_without_duplicate_build_directory():
+    from urllib.parse import urljoin, urlparse
+
+    preview_url = "/build/workcell_studio_web_scene/ur5_2f_test.robot_preview.urdf"
+    for mesh in [
+        "assets/ur5_2f_test/ur_description/meshes/ur5/visual/base.dae",
+        "assets/ur5_2f_test/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+    ]:
+        resolved = urlparse(urljoin(preview_url, mesh)).path
+        assert resolved == f"/build/workcell_studio_web_scene/{mesh}"
+        assert "build/workcell_studio_web_scene/build/workcell_studio_web_scene" not in resolved


### PR DESCRIPTION
Summary:
- Fixed `_stage_expanded_robot_urdf()` so staged package mesh filenames written into `<scene>.robot_preview.urdf` are relative to the preview URDF directory (`build/workcell_studio_web_scene/`) instead of the repository root.
- Before fix malformed browser request example: `/build/workcell_studio_web_scene/build/workcell_studio_web_scene/assets/ur5_2f_test/ur_description/meshes/ur5/visual/base.dae`.
- After fix corrected browser request example: `/build/workcell_studio_web_scene/assets/ur5_2f_test/ur_description/meshes/ur5/visual/base.dae`.
- Exporter/renderer contract: preview URDF URL remains repository-root relative; mesh filenames inside the preview URDF are relative to that URDF directory; URDFLoader resolves them once, and renderer URL handling must not add another `build/workcell_studio_web_scene/` prefix.
- Added regression coverage for UR5 and Robotiq package mesh staging and URL resolution without duplicated build directories.
- Affected files/packages: `scripts/export_workcell_studio_web_scene.py`, `tests/test_export_workcell_studio_web_scene.py`.

Validation:
- `python3 -m pytest -q tests/test_export_workcell_studio_web_scene.py tests/test_workcell_studio_web_viewer_static.py tests/test_workcell_web3d_visual_acceptance.py` — passed, 97 tests.
- `node --check workcell_studio_web/viewer/urdf_robot_renderer.js` — passed.
- `node --check workcell_studio_web/viewer/viewer.js` — passed.
- `python3 scripts/extract_scene_urdf_visual_mesh_index.py --scene ur5_2f_test --prefer-xacro-expanded` — completed in this container, but warned ROS setup was unavailable.
- `python3 scripts/ensure_workcell_studio_web_scene_fresh.py --scene scenes/ur5_2f_test --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json --stage-assets --force` — blocked in this container because `/opt/ros/humble/setup.bash` and the real expanded URDF `scenes/ur5_2f_test/generated/expanded_scene_preview.urdf` are unavailable; exporter refused the canonical scene fallback as designed.
- `grep -n 'mesh filename=' build/workcell_studio_web_scene/ur5_2f_test.robot_preview.urdf` — not available after the blocked export above.
- `python3 scripts/run_workcell_web3d_visual_acceptance.py --scene scenes/ur5_2f_test --require-browser --port 8765` — blocked before browser launch because the fresh scene export failed for the same missing real expanded URDF; report path printed as `build/workcell_studio_web_scene/ur5_2f_test.visual_acceptance.json` and screenshot path printed as `build/workcell_studio_web_scene/ur5_2f_test.rviz_parity.png`, but no real Product View screenshot was captured.

Safety:
- This change only rebases staged static mesh filenames in the browser preview URDF.
- No UR5 link transforms, Robotiq mounting origins, joint values, mimic joints, Collada transforms, scene xacro, launch files, controllers, or hardware parameters were changed.
- Fake hardware defaults remain untouched; no real-hardware path was enabled.

Risks / rollback:
- Real browser acceptance still needs to be rerun in a ROS Humble workspace that can generate `scenes/ur5_2f_test/generated/expanded_scene_preview.urdf` and has browser automation available.
- Roll back by reverting commit `b0f9d5d` if staged robot preview mesh loading regresses.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a549db609088331abb03daeb8380278)