### PR TITLE
Restore clean full-workspace ROS 2 Humble builds

### DIFF
--- a/assets/robots/universal_robot/ur_description/CMakeLists.txt
+++ b/assets/robots/universal_robot/ur_description/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.5)
+project(ur_description)
+
+find_package(ament_cmake REQUIRED)
+
+set(UR_DESCRIPTION_RESOURCE_DIRS
+  meshes
+  urdf
+  config
+  launch
+  rviz
+  calibration
+)
+
+foreach(resource_dir IN LISTS UR_DESCRIPTION_RESOURCE_DIRS)
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${resource_dir}")
+    install(
+      DIRECTORY "${resource_dir}"
+      DESTINATION "share/${PROJECT_NAME}"
+    )
+  endif()
+endforeach()
+
+install(FILES package.xml DESTINATION "share/${PROJECT_NAME}")
+
+ament_package()

--- a/tests/test_humble_build_regressions.py
+++ b/tests/test_humble_build_regressions.py
@@ -136,3 +136,92 @@ def test_humble_prereqs_check_moveit_ros_perception_for_octomap():
     assert "ros2 pkg prefix moveit_ros_perception" in text
     assert "Missing MoveIt perception package required for octomap pointcloud updates: ros-humble-moveit-ros-perception" in text
     assert "missing_tools+=(ros-humble-moveit-ros-perception)" in text
+
+
+def _ament_build_type(package_xml: Path) -> str:
+    import xml.etree.ElementTree as ET
+
+    root = ET.parse(package_xml).getroot()
+    export = root.find("export")
+    if export is not None:
+        build_type = export.find("build_type")
+        if build_type is not None and build_type.text:
+            return build_type.text.strip()
+    return "ament_cmake"
+
+
+def _is_colcon_ignored(path: Path) -> bool:
+    return any((parent / "COLCON_IGNORE").exists() for parent in [path, *path.parents])
+
+
+def test_every_discovered_ament_cmake_package_has_cmakelists():
+    missing = []
+    for package_xml in Path(".").rglob("package.xml"):
+        if any(part.startswith(".") for part in package_xml.parts):
+            continue
+        if _is_colcon_ignored(package_xml.parent):
+            continue
+        if _ament_build_type(package_xml) == "ament_cmake" and not (package_xml.parent / "CMakeLists.txt").is_file():
+            missing.append(str(package_xml.parent))
+    assert missing == []
+
+
+def test_ur_description_is_installable_ament_cmake_description_package():
+    package_dir = Path("assets/robots/universal_robot/ur_description")
+    cmake = (package_dir / "CMakeLists.txt").read_text()
+    package_xml = (package_dir / "package.xml").read_text()
+
+    assert "<name>ur_description</name>" in package_xml
+    assert "project(ur_description)" in cmake
+    assert "find_package(ament_cmake REQUIRED)" in cmake
+    assert "ament_package()" in cmake
+    assert "install(FILES package.xml" in cmake
+
+    for resource_dir in ["meshes", "urdf", "config", "launch", "rviz"]:
+        assert (package_dir / resource_dir).is_dir(), resource_dir
+        assert resource_dir in cmake
+    assert (package_dir / "urdf" / "ur.urdf.xacro").is_file()
+    assert any((package_dir / "meshes" / "ur5").rglob("*"))
+
+
+def test_ur_description_is_not_hidden_from_colcon():
+    package_dir = Path("assets/robots/universal_robot/ur_description")
+    assert not (package_dir / "COLCON_IGNORE").exists()
+    assert not (package_dir / "AMENT_IGNORE").exists()
+
+
+def test_scene_preview_widget_targets_link_qt_network():
+    cmake = Path("workcell_builder/workcell_builder/CMakeLists.txt").read_text()
+    assert "gui/scene_preview_widget.cpp" in cmake
+    assert "find_package(Qt5 COMPONENTS Widgets Concurrent Svg OpenGL Network REQUIRED)" in cmake
+    assert "target_link_libraries(workcell_builder" in cmake and "Qt5::Network" in cmake
+    assert "ament_add_gtest(workcell_scene_preview_widget_ui_test" in cmake
+    assert "target_link_libraries(workcell_scene_preview_widget_ui_test Qt5::Widgets Qt5::OpenGL Qt5::Network OpenGL::GL)" in cmake
+
+
+def test_scene_preview_widget_still_uses_qtcp_socket_for_server_probe():
+    source = Path("workcell_builder/workcell_builder/gui/scene_preview_widget.cpp").read_text()
+    assert "#include <QTcpSocket>" in source
+    assert "QTcpSocket socket" in source
+
+
+def test_embedded_workcell_builder_asset_copies_are_not_colcon_packages():
+    # These files are installed as workcell_builder runtime assets. The canonical
+    # buildable description packages live under the repository-level assets/ tree.
+    assert Path("workcell_builder/workcell_builder/assets/COLCON_IGNORE").is_file()
+    assert not Path("assets/COLCON_IGNORE").exists()
+
+
+def test_discovered_package_names_are_unique():
+    import xml.etree.ElementTree as ET
+
+    packages_by_name = {}
+    for package_xml in Path(".").rglob("package.xml"):
+        if any(part.startswith(".") for part in package_xml.parts):
+            continue
+        if _is_colcon_ignored(package_xml.parent):
+            continue
+        name = ET.parse(package_xml).getroot().findtext("name")
+        packages_by_name.setdefault(name, []).append(str(package_xml.parent))
+    duplicates = {name: paths for name, paths in packages_by_name.items() if len(paths) > 1}
+    assert duplicates == {}

--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -399,7 +399,7 @@ if(BUILD_TESTING)
   ament_add_gtest(workcell_mainwindow_rviz_preview_compile_test
     test/mainwindow_rviz_preview_compile_test.cpp)
   if(TARGET workcell_scene_preview_widget_ui_test)
-    target_link_libraries(workcell_scene_preview_widget_ui_test Qt5::Widgets Qt5::OpenGL OpenGL::GL)
+    target_link_libraries(workcell_scene_preview_widget_ui_test Qt5::Widgets Qt5::OpenGL Qt5::Network OpenGL::GL)
   endif()
 
   if(TARGET workcell_workspace_validation_test)


### PR DESCRIPTION
Summary:
- Added a genuine ament_cmake CMakeLists.txt for assets/robots/universal_robot/ur_description so the source package installs package.xml and existing runtime resources (meshes, urdf, config, launch, rviz, and calibration when present).
- Linked Qt5::Network into workcell_scene_preview_widget_ui_test, the test target that directly compiles gui/scene_preview_widget.cpp and therefore needs QTcpSocket headers/libraries.
- Added COLCON_IGNORE only to the embedded workcell_builder runtime asset copy tree so canonical repository-level description packages remain discoverable while duplicate package-name discovery is avoided.
- Added focused Humble build regression tests for ament_cmake package shape, ur_description packaging, ur_description visibility, duplicate discovered package names, and the scene preview Qt Network dependency/QTcpSocket probe.

Build blockers found:
- ur_description declared ament_cmake but had no CMakeLists.txt; fixed by adding an installable description-package CMakeLists.txt.
- workcell_scene_preview_widget_ui_test compiled scene_preview_widget.cpp without Qt5::Network; fixed by linking Qt5::Network.
- Static package audit found duplicate package names from workcell_builder/workcell_builder/assets embedded runtime copies; fixed by marking only that embedded asset subtree ignored by colcon, preserving canonical assets/ packages.

Validation:
- Full-build command attempted: source /opt/ros/humble/setup.bash && cd /home/ubuntu/workcell_ws && rm -rf build_full install_full log_full && colcon --log-base log_full build --build-base build_full --install-base install_full --symlink-install --event-handlers console_direct+
- Environment blocked full build: /opt/ros/humble/setup.bash is missing in this container, and colcon is not installed.
- Focused tests passed: python3 -m pytest tests/test_humble_build_regressions.py -q (23 passed).
- Static package audit after fixes: 45 discovered package names, no duplicate package names, no malformed discovered package problems.
- Final ROS package totals could not be produced in this container because ROS 2 Humble/colcon are unavailable.

Safety:
- No launch files, controllers, runtime execution nodes, or hardware defaults were changed.
- Fake-hardware defaults and guarded real-hardware behavior are unchanged.
- Web3D robot rendering code was not modified; QTcpSocket server verification remains in place.

Risks / rollback:
- The embedded workcell_builder asset subtree is now ignored by colcon discovery; rollback by removing workcell_builder/workcell_builder/assets/COLCON_IGNORE if those embedded copies are intentionally promoted to independent source packages, but then duplicate package names must be resolved another way.
- To revert safely, revert commit 9e251f5 and rerun the full Humble build loop on a ROS 2 Humble workstation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54a59ab8448331a9381ca3b1e61c01)