### PR TITLE
Fix optional generated-directory installation for scene packages

### DIFF
--- a/scenes/suction_test/CMakeLists.txt
+++ b/scenes/suction_test/CMakeLists.txt
@@ -30,14 +30,8 @@ install(DIRECTORY urdf
 )
 
 install_scene_directory_if_present(config)
-
-install(DIRECTORY generated
-  DESTINATION share/${PROJECT_NAME}
-)
-
-install(DIRECTORY layout
-  DESTINATION share/${PROJECT_NAME}
-)
+install_scene_directory_if_present(generated)
+install_scene_directory_if_present(layout)
 
 install(FILES
   cell_definition.yaml

--- a/scenes/ur10_2f_test/CMakeLists.txt
+++ b/scenes/ur10_2f_test/CMakeLists.txt
@@ -30,14 +30,8 @@ install(DIRECTORY urdf
 )
 
 install_scene_directory_if_present(config)
-
-install(DIRECTORY generated
-  DESTINATION share/${PROJECT_NAME}
-)
-
-install(DIRECTORY layout
-  DESTINATION share/${PROJECT_NAME}
-)
+install_scene_directory_if_present(generated)
+install_scene_directory_if_present(layout)
 
 install(FILES
   cell_definition.yaml

--- a/scenes/ur3_suction_test/CMakeLists.txt
+++ b/scenes/ur3_suction_test/CMakeLists.txt
@@ -30,14 +30,8 @@ install(DIRECTORY urdf
 )
 
 install_scene_directory_if_present(config)
-
-install(DIRECTORY generated
-  DESTINATION share/${PROJECT_NAME}
-)
-
-install(DIRECTORY layout
-  DESTINATION share/${PROJECT_NAME}
-)
+install_scene_directory_if_present(generated)
+install_scene_directory_if_present(layout)
 
 install(FILES
   cell_definition.yaml

--- a/scenes/ur5_2f_builder_pick_place_demo/CMakeLists.txt
+++ b/scenes/ur5_2f_builder_pick_place_demo/CMakeLists.txt
@@ -30,14 +30,8 @@ install(DIRECTORY urdf
 )
 
 install_scene_directory_if_present(config)
-
-install(DIRECTORY generated
-  DESTINATION share/${PROJECT_NAME}
-)
-
-install(DIRECTORY layout
-  DESTINATION share/${PROJECT_NAME}
-)
+install_scene_directory_if_present(generated)
+install_scene_directory_if_present(layout)
 
 install(FILES
   cell_definition.yaml

--- a/scenes/ur5_2f_sorting_test/CMakeLists.txt
+++ b/scenes/ur5_2f_sorting_test/CMakeLists.txt
@@ -31,14 +31,8 @@ install(DIRECTORY urdf
 )
 
 install_scene_directory_if_present(config)
-
-install(DIRECTORY generated
-  DESTINATION share/${PROJECT_NAME}
-)
-
-install(DIRECTORY layout
-  DESTINATION share/${PROJECT_NAME}
-)
+install_scene_directory_if_present(generated)
+install_scene_directory_if_present(layout)
 
 install(FILES
   cell_definition.yaml

--- a/scenes/ur5_2f_test/CMakeLists.txt
+++ b/scenes/ur5_2f_test/CMakeLists.txt
@@ -13,6 +13,14 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 
+function(install_scene_directory_if_present directory_name)
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${directory_name}")
+    install(DIRECTORY ${directory_name}
+      DESTINATION share/${PROJECT_NAME}
+    )
+  endif()
+endfunction()
+
 install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}
 )
@@ -21,9 +29,9 @@ install(DIRECTORY urdf
   DESTINATION share/${PROJECT_NAME}
 )
 
-install(DIRECTORY config generated layout
-  DESTINATION share/${PROJECT_NAME}
-)
+install_scene_directory_if_present(config)
+install_scene_directory_if_present(generated)
+install_scene_directory_if_present(layout)
 
 install(FILES
   cell_definition.yaml

--- a/scenes/ur5_3f_test/CMakeLists.txt
+++ b/scenes/ur5_3f_test/CMakeLists.txt
@@ -30,14 +30,8 @@ install(DIRECTORY urdf
 )
 
 install_scene_directory_if_present(config)
-
-install(DIRECTORY generated
-  DESTINATION share/${PROJECT_NAME}
-)
-
-install(DIRECTORY layout
-  DESTINATION share/${PROJECT_NAME}
-)
+install_scene_directory_if_present(generated)
+install_scene_directory_if_present(layout)
 
 install(FILES
   cell_definition.yaml

--- a/scenes/ur5_airpick4_test/CMakeLists.txt
+++ b/scenes/ur5_airpick4_test/CMakeLists.txt
@@ -30,14 +30,8 @@ install(DIRECTORY urdf
 )
 
 install_scene_directory_if_present(config)
-
-install(DIRECTORY generated
-  DESTINATION share/${PROJECT_NAME}
-)
-
-install(DIRECTORY layout
-  DESTINATION share/${PROJECT_NAME}
-)
+install_scene_directory_if_present(generated)
+install_scene_directory_if_present(layout)
 
 install(FILES
   cell_definition.yaml

--- a/tests/test_humble_build_regressions.py
+++ b/tests/test_humble_build_regressions.py
@@ -225,3 +225,28 @@ def test_discovered_package_names_are_unique():
         packages_by_name.setdefault(name, []).append(str(package_xml.parent))
     duplicates = {name: paths for name, paths in packages_by_name.items() if len(paths) > 1}
     assert duplicates == {}
+
+
+def test_scene_generated_directories_are_installed_conditionally():
+    """Scene generated/ output is optional in a clean checkout."""
+    import re
+
+    def exists_guarded_generated_installs(cmake_text: str) -> bool:
+        lines = cmake_text.splitlines()
+        for index, line in enumerate(lines):
+            if not re.search(r"if\s*\([^)]*EXISTS[^)]*generated[^)]*\)", line):
+                continue
+            guarded_block = "\n".join(lines[index : index + 8])
+            if re.search(r"install\s*\(\s*DIRECTORY\s+generated\b", guarded_block):
+                return True
+        return False
+
+    offenders = []
+    for cmake_path in sorted(Path("scenes").glob("*/CMakeLists.txt")):
+        text = cmake_path.read_text()
+        has_helper = re.search(r"install_scene_directory_if_present\s*\(\s*generated\s*\)", text)
+        has_exists_guard = exists_guarded_generated_installs(text)
+        if not (has_helper or has_exists_guard):
+            offenders.append(str(cmake_path))
+
+    assert offenders == []


### PR DESCRIPTION
Summary:
- Replaced unconditional `install(DIRECTORY generated ...)` calls in scene packages with `install_scene_directory_if_present(generated)`.
- Also made optional `layout` installs use the existing conditional helper alongside already-conditional `config` installs.
- Added the missing conditional install helper to `scenes/ur5_2f_test/CMakeLists.txt` so it matches the other scene packages.
- Added a focused Humble build regression test that scans scene `CMakeLists.txt` files and requires `generated/` to be installed through the conditional helper or an equivalent `EXISTS` guard.

Affected files/packages:
- `scenes/suction_test/CMakeLists.txt`
- `scenes/ur5_2f_builder_pick_place_demo/CMakeLists.txt`
- `scenes/ur5_2f_sorting_test/CMakeLists.txt`
- `scenes/ur5_2f_test/CMakeLists.txt`
- `scenes/ur5_3f_test/CMakeLists.txt`
- `scenes/ur5_airpick4_test/CMakeLists.txt`
- `scenes/ur3_suction_test/CMakeLists.txt`
- `scenes/ur10_2f_test/CMakeLists.txt`
- `tests/test_humble_build_regressions.py`

Validation:
- `python3 -m pytest -q tests/test_humble_build_regressions.py` passed: 24 passed.
- Audited scene CMake install directives for optional `generated`, `config`, `layout`, `fixtures`, and `docs` directory installs; no unconditional optional-directory install matches remained.
- Full ROS 2 Humble build could not be run in this container because `/opt/ros/humble/setup.bash` is not present and `/home/ubuntu/workcell_ws` is not available. Final build totals are therefore not available from this environment.

Safety:
- Only CMake install logic and a static regression test were changed.
- Fake-hardware defaults and real-hardware guards were not touched.
- No generated artifacts or empty `generated/` directories were added.

Risks / rollback:
- Risk is limited to scene package install layout. If rollback is needed, revert commit `ac9c1d3` to restore the previous unconditional install behavior, though that will reintroduce clean-checkout failures when `generated/` is absent.
- Next remaining blocker: rerun the requested clean full workspace build in a ROS 2 Humble workspace and report the next first real root cause if another package fails.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54aa54b980833194f7ea7be3862005)