### PR TITLE
Pin a compatible TrajOpt and OSQP dependency set

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,6 +779,9 @@ Repository scripts now resolve manifests in this order: canonical first, then le
 ### OSQP / TrajOpt consistency (read this first)
 
 - Do **not** manually build `src/osqp` or `src/osqp-eigen` as normal colcon packages in the standard install flow. The helper script owns OSQP compatibility handling for this repository.
+- `trajopt_sco` 0.33.0 requires the OSQP v1 API (`OSQPSolver`, `OSQPInt`, `OSQPCscMatrix`, `osqp_update_data_vec`, `osqp_update_data_mat`, `OSQPSettings::warm_starting`, `OSQP_NO_ERROR`, `OSQP_ALGEBRA_LOAD_ERROR`). The upstream `trajopt_sco` package declares `depend>osqp</depend>` and `find_package(osqp QUIET)`; this repository pins `osqp` to `v1.0.0` and `osqp-eigen` to `v0.11.0` in both dependency manifests.
+- Do not allow Jammy `libosqp-dev` to satisfy `osqp` or `osqp_vendor`; it exposes the older `OSQPWorkspace`/`warm_start` API. `scripts/rosdep_overrides.yaml` intentionally maps those keys to no apt package, and the build helpers skip the OSQP rosdep keys so the pinned source provider is used.
+- Run `scripts/preflight_trajopt_osqp_compatibility.sh <workspace>` after installing the pinned OSQP provider if `trajopt_sco` fails to configure or compile. It reports wrong TrajOpt commits, stale/flattened `trajopt_sco` checkouts, duplicate packages, incompatible OSQP headers, and `/usr` OSQP provider leakage.
 - `trajopt_sco` can fail when OSQP v0.6 and OSQP v1 headers/libraries are mixed.
 - Typical symptoms include compile errors mentioning missing `OSQPSolver`, `OSQPInt`, `OSQPFloat`, or `OSQPCscMatrix`.
 - Fix strategy: keep one consistent OSQP strategy through the helper script and dependency overlay. Do **not** randomly skip TrajOpt packages (`trajopt_sco`, `trajopt_sqp`, `trajopt_ifopt`) in full-profile EPD builds.

--- a/fix_and_build_humble.sh
+++ b/fix_and_build_humble.sh
@@ -548,6 +548,7 @@ build_phase() {
   run_cmd "eval \"\$(./src/easy_manipulation_deployment/scripts/ensure_taskflow_cmake_package.sh --export)\""
 
   prepare_osqp_stack
+  run_cmd "./src/easy_manipulation_deployment/scripts/preflight_trajopt_osqp_compatibility.sh \"$WORKSPACE\""
   capture_epd_state
 
   run_cmd "./src/easy_manipulation_deployment/scripts/verify_workspace_discovery.sh"

--- a/scripts/lib/dependencies.sh
+++ b/scripts/lib/dependencies.sh
@@ -194,6 +194,10 @@ install_rosdeps() {
     local skip_keys=(
         tesseract_visualization
         qt_advanced_docking
+        osqp
+        osqp_vendor
+        osqp-eigen
+        osqp_eigen
     )
 
     local preflight_helper="$REPO_ROOT/scripts/preflight_tesseract_apt.sh"

--- a/scripts/preflight_trajopt_osqp_compatibility.sh
+++ b/scripts/preflight_trajopt_osqp_compatibility.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WORKSPACE=${1:-${WORKSPACE:-$(pwd)}}
+SRC_DIR="$WORKSPACE/src"
+REPO_ROOT="${REPO_ROOT:-$SRC_DIR/easy_manipulation_deployment}"
+EXPECTED_TRAJOPT_REF="884e6177c4a220fc20a0c43100a0473c180a3bec"
+EXPECTED_OSQP_REF="v1.0.0"
+REQUIRE_PINNED_OSQP_PROVIDER=${REQUIRE_PINNED_OSQP_PROVIDER:-1}
+
+fail() { echo "TrajOpt/OSQP preflight: FAILED: $*" >&2; exit 1; }
+info() { echo "TrajOpt/OSQP preflight: $*"; }
+
+[[ -d "$SRC_DIR" ]] || fail "workspace source directory not found: $SRC_DIR"
+
+mapfile -t sco_pkgs < <(find "$SRC_DIR" -path '*/trajopt_sco/package.xml' -print | sort)
+[[ ${#sco_pkgs[@]} -gt 0 ]] || fail "trajopt_sco package not found under $SRC_DIR. Corrective command: vcs import --recursive --skip-existing src < src/easy_manipulation_deployment/dependencies/emd_epd_ws.repos"
+[[ ${#sco_pkgs[@]} -eq 1 ]] || fail "multiple trajopt_sco packages found: ${sco_pkgs[*]}. Remove stale/flattened duplicate checkouts, then rerun scripts/fix_workspace_layout.sh."
+
+sco_dir=$(dirname "${sco_pkgs[0]}")
+trajopt_root="$sco_dir"
+while [[ "$trajopt_root" != "$SRC_DIR" && ! -d "$trajopt_root/.git" ]]; do
+  trajopt_root=$(dirname "$trajopt_root")
+done
+[[ -d "$trajopt_root/.git" ]] || fail "trajopt_sco at $sco_dir is not inside a git checkout; likely stale/flattened source. Corrective command: remove that tree and re-import dependencies/emd_epd_ws.repos."
+actual_ref=$(git -C "$trajopt_root" rev-parse HEAD 2>/dev/null || true)
+[[ -n "$actual_ref" ]] || fail "cannot read TrajOpt git commit at $trajopt_root"
+[[ "$actual_ref" == "$EXPECTED_TRAJOPT_REF" ]] || fail "wrong TrajOpt commit at $trajopt_root: expected $EXPECTED_TRAJOPT_REF (trajopt 0.33.0), found $actual_ref. Corrective command: git -C '$trajopt_root' fetch --tags && git -C '$trajopt_root' checkout '$EXPECTED_TRAJOPT_REF'"
+info "TrajOpt checkout OK: $trajopt_root @ $actual_ref"
+
+osqp_src="$SRC_DIR/osqp"
+[[ -d "$osqp_src/.git" ]] || fail "pinned OSQP source checkout is required at $osqp_src; generic Jammy libosqp-dev is API-incompatible. Corrective command: vcs import --recursive --skip-existing src < src/easy_manipulation_deployment/dependencies/emd_epd_ws.repos"
+osqp_ref=$(git -C "$osqp_src" describe --tags --exact-match 2>/dev/null || git -C "$osqp_src" rev-parse HEAD 2>/dev/null || true)
+[[ "$osqp_ref" == "$EXPECTED_OSQP_REF" ]] || fail "wrong OSQP source at $osqp_src: expected $EXPECTED_OSQP_REF, found $osqp_ref. Corrective command: git -C '$osqp_src' fetch --tags && git -C '$osqp_src' checkout '$EXPECTED_OSQP_REF'"
+
+check_header_dir() {
+  local dir="$1"
+  [[ -f "$dir/osqp_api_types.h" ]] || return 1
+  grep -R -q "OSQPSolver" "$dir" || return 1
+  grep -R -q "OSQPInt" "$dir" || return 1
+  grep -R -q "OSQPCscMatrix" "$dir" || return 1
+  grep -R -q "osqp_update_data_vec" "$dir" || return 1
+  grep -R -q "warm_starting" "$dir" || return 1
+}
+
+providers=()
+for dir in /usr/local/include/osqp /usr/include/osqp; do
+  [[ -d "$dir" ]] && providers+=("$dir")
+done
+[[ ${#providers[@]} -gt 0 ]] || fail "no installed OSQP headers found. Build/install pinned OSQP $EXPECTED_OSQP_REF from $osqp_src before building trajopt_sco."
+
+for dir in "${providers[@]}"; do
+  if check_header_dir "$dir"; then
+    if [[ "$REQUIRE_PINNED_OSQP_PROVIDER" == "1" && "$dir" == /usr/include/osqp ]]; then
+      fail "OSQP v1-compatible headers were found from /usr ($dir), but this workspace requires the pinned source provider from /usr/local. Corrective command: build/install src/osqp $EXPECTED_OSQP_REF to /usr/local and ensure CMAKE_PREFIX_PATH prefers /usr/local."
+    fi
+    info "OSQP headers OK: $dir"
+    exit 0
+  fi
+done
+
+fail "incompatible OSQP headers found (${providers[*]}): trajopt 0.33.0 requires the OSQP v1 API symbols OSQPSolver, OSQPCscMatrix, OSQPInt, osqp_update_data_vec/osqp_update_data_mat, OSQPSettings::warm_starting, OSQP_NO_ERROR and OSQP_ALGEBRA_LOAD_ERROR. Jammy libosqp-dev exposes the older OSQPWorkspace/warm_start API."

--- a/scripts/rosdep_overrides.yaml
+++ b/scripts/rosdep_overrides.yaml
@@ -59,7 +59,9 @@ openmp:
   ubuntu: [libomp-dev]
 
 osqp:
-  ubuntu: [libosqp-dev]
+  # Do not resolve to Jammy libosqp-dev: trajopt 0.33.0 requires OSQP v1 API.
+  # Import/build the pinned source provider from dependencies/emd_epd_ws.repos instead.
+  ubuntu: []
 
 osqp-eigen:
   ubuntu:
@@ -67,7 +69,9 @@ osqp-eigen:
     noble: [libosqp-eigen-dev]
 
 osqp_vendor:
-  ubuntu: [libosqp-dev]
+  # Do not resolve to Jammy libosqp-dev: it exposes the older OSQPWorkspace API.
+  # Use the pinned source OSQP provider from dependencies/emd_epd_ws.repos.
+  ubuntu: []
 
 ignition-math6:
   ubuntu:

--- a/tesseract.repos
+++ b/tesseract.repos
@@ -62,3 +62,14 @@ repositories:
     type: git
     url: https://github.com/Levi-Armstrong/ruckig.git
     version: cpack-v0.9.2
+
+  # TrajOpt 0.33.0 uses the OSQP v1 API (OSQPSolver/OSQPInt/OSQPCscMatrix).
+  # Jammy libosqp-dev is the older API and must not satisfy this dependency.
+  osqp:
+    type: git
+    url: https://github.com/osqp/osqp.git
+    version: v1.0.0
+  osqp-eigen:
+    type: git
+    url: https://github.com/robotology/osqp-eigen.git
+    version: v0.11.0

--- a/tests/test_trajopt_osqp_dependency_compatibility.py
+++ b/tests/test_trajopt_osqp_dependency_compatibility.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+CANONICAL = REPO / "dependencies" / "emd_epd_ws.repos"
+LEGACY = REPO / "tesseract.repos"
+ROSDEP = REPO / "scripts" / "rosdep_overrides.yaml"
+PREFLIGHT = REPO / "scripts" / "preflight_trajopt_osqp_compatibility.sh"
+
+
+def _text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_canonical_manifests_pin_trajopt_033_with_osqp_v1_stack():
+    for path in (CANONICAL, LEGACY):
+        text = _text(path)
+        assert "https://github.com/tesseract-robotics/trajopt.git" in text
+        assert "version: 884e6177c4a220fc20a0c43100a0473c180a3bec" in text or "version: 0.33.0" in text
+        assert "https://github.com/osqp/osqp.git" in text
+        assert "version: v1.0.0" in text
+        assert "https://github.com/robotology/osqp-eigen.git" in text
+        assert "version: v0.11.0" in text
+
+
+def test_rosdep_overrides_do_not_select_generic_jammy_libosqp():
+    text = _text(ROSDEP)
+    assert "osqp:\n  ubuntu: [libosqp-dev]" not in text
+    assert "osqp_vendor:\n  ubuntu: [libosqp-dev]" not in text
+    assert "trajopt 0.33.0 requires OSQP v1 API" in text
+    assert "ubuntu: []" in text
+
+
+def test_preflight_detects_osqp_api_major_mismatch_symbols():
+    text = _text(PREFLIGHT)
+    for new_symbol in [
+        "OSQPSolver",
+        "OSQPCscMatrix",
+        "OSQPInt",
+        "osqp_update_data_vec",
+        "osqp_update_data_mat",
+        "warm_starting",
+        "OSQP_NO_ERROR",
+        "OSQP_ALGEBRA_LOAD_ERROR",
+    ]:
+        assert new_symbol in text
+    for old_symbol in ["OSQPWorkspace", "warm_start"]:
+        assert old_symbol in text
+
+
+def test_preflight_reports_stale_duplicate_and_wrong_provider_cases():
+    text = _text(PREFLIGHT)
+    assert "multiple trajopt_sco packages found" in text
+    assert "not inside a git checkout" in text
+    assert "wrong TrajOpt commit" in text
+    assert "wrong OSQP source" in text
+    assert "OSQP v1-compatible headers were found from /usr" in text
+    assert "Corrective command" in text
+
+
+def test_helper_scripts_skip_rosdep_osqp_and_run_preflight():
+    fix = _text(REPO / "fix_and_build_humble.sh")
+    deps = _text(REPO / "scripts" / "lib" / "dependencies.sh")
+    assert "preflight_trajopt_osqp_compatibility.sh" in fix
+    for key in ["osqp", "osqp_vendor", "osqp-eigen", "osqp_eigen"]:
+        assert key in fix
+        assert key in deps


### PR DESCRIPTION
Summary:
- Pins the legacy `tesseract.repos` manifest to include the same OSQP v1.0.0 / OsqpEigen v0.11.0 source provider used by the canonical dependency manifest.
- Prevents rosdep from silently satisfying `osqp` or `osqp_vendor` with Jammy `libosqp-dev`, which exposes the older OSQPWorkspace/warm_start API incompatible with TrajOpt 0.33.0.
- Adds `scripts/preflight_trajopt_osqp_compatibility.sh` and wires it into the Humble build helper to fail early on wrong TrajOpt commits, stale/flattened checkouts, duplicate `trajopt_sco` packages, incompatible OSQP headers, and `/usr` OSQP provider leakage.
- Adds regression tests covering dependency manifest agreement, rosdep behavior, OSQP API mismatch detection, and preflight diagnostics.

Validation:
- `python3 -m pytest tests/test_trajopt_osqp_dependency_compatibility.py tests/test_humble_build_regressions.py` — passed, 29 tests.
- `bash -n scripts/preflight_trajopt_osqp_compatibility.sh fix_and_build_humble.sh scripts/lib/dependencies.sh` — passed.
- `python3 -m pytest tests/test_trajopt_osqp_dependency_compatibility.py` — passed, 5 tests after commit staging.
- `source /opt/ros/humble/setup.bash && colcon build --build-base build_trajopt_check --install-base install_trajopt_check --symlink-install --packages-select trajopt_sco --cmake-clean-cache --event-handlers console_direct+` — not run in this container because `/opt/ros/humble/setup.bash` is absent.

Safety:
- No launch files, controllers, runtime services, robot transforms, Workcell Builder UI, Web3D, or hardware parameters were changed.
- Fake-hardware defaults and real-hardware safety gates remain unchanged.

Risks / rollback:
- This enforces the source-pinned OSQP v1 stack for the TrajOpt 0.33.0 overlay; workspaces relying on distro `libosqp-dev` for this build path will now fail early with corrective commands instead of compiling against incompatible headers.
- Roll back by reverting commit `ed57245` if a future TrajOpt release is intentionally selected that supports Jammy's distro OSQP API.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54adf283e48331b3fc0c3c7b90ffdc)