### PR TITLE
Require embedded Web3D (Qt WebEngine) and default embedded Product View

### DIFF
--- a/scripts/install_system_deps.sh
+++ b/scripts/install_system_deps.sh
@@ -18,6 +18,7 @@ REQUIRED_PACKAGES=(
   libboost-program-options-dev
   libboost-serialization-dev
   libcereal-dev
+  qtwebengine5-dev
 )
 
 OSQP_NATIVE_PACKAGE=libosqp-dev

--- a/tests/test_workcell_builder_embedded_web3d_policy.py
+++ b/tests/test_workcell_builder_embedded_web3d_policy.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CMAKE = (ROOT / "workcell_builder/workcell_builder/CMakeLists.txt").read_text()
+PKG = (ROOT / "workcell_builder/workcell_builder/package.xml").read_text()
+CPP = (ROOT / "workcell_builder/workcell_builder/gui/scene_preview_widget.cpp").read_text()
+HDR = (ROOT / "workcell_builder/workcell_builder/gui/scene_preview_widget.h").read_text()
+INSTALL = (ROOT / "scripts/install_system_deps.sh").read_text()
+
+
+def test_default_cmake_requires_webengine_with_actionable_fallback_message():
+    assert 'option(WORKCELL_BUILDER_ALLOW_NATIVE_3D_FALLBACK' in CMAKE
+    assert 'OFF)' in CMAKE
+    assert 'find_package(Qt5 COMPONENTS Widgets Concurrent Svg OpenGL Network REQUIRED)' in CMAKE
+    assert 'find_package(Qt5 COMPONENTS WebEngineWidgets QUIET)' in CMAKE
+    assert 'if(NOT Qt5WebEngineWidgets_FOUND AND NOT WORKCELL_BUILDER_ALLOW_NATIVE_3D_FALLBACK)' in CMAKE
+    assert 'message(FATAL_ERROR' in CMAKE
+    for token in [
+        'embedded Web3D Product View is required',
+        'Qt5 WebEngineWidgets',
+        'sudo apt install qtwebengine5-dev',
+        '-DWORKCELL_BUILDER_ALLOW_NATIVE_3D_FALLBACK=ON',
+    ]:
+        assert token in CMAKE
+
+
+def test_webengine_compile_link_contract_and_native_opt_in():
+    assert 'target_compile_definitions(workcell_builder PRIVATE WORKCELL_BUILDER_HAS_WEBENGINE=1)' in CMAKE
+    assert 'target_link_libraries(workcell_builder Qt5::WebEngineWidgets)' in CMAKE
+    assert 'elseif(WORKCELL_BUILDER_ALLOW_NATIVE_3D_FALLBACK)' in CMAKE
+    assert 'WORKCELL_BUILDER_NATIVE_3D_FALLBACK=1' in CMAKE
+
+
+def test_ros_executable_install_path_uses_package_libexec():
+    install_block = CMAKE.split('install(TARGETS workcell_builder', 1)[1].split(')', 1)[0]
+    assert 'DESTINATION lib/${PROJECT_NAME}' in install_block
+    assert 'RUNTIME DESTINATION bin' not in install_block
+
+
+def test_package_and_system_deps_declare_qtwebengine_dev():
+    assert '<build_depend>qtwebengine5-dev</build_depend>' in PKG
+    assert '<exec_depend>qtwebengine5-dev</exec_depend>' in PKG
+    assert 'qtwebengine5-dev' in INSTALL
+
+
+def test_web3d_is_default_widget_and_native_ingest_is_skipped_when_active():
+    assert 'embedded_web_view_ = new QWebEngineView(view3d_container_)' in CPP
+    assert 'embedded_web_view_->setObjectName("embeddedWeb3dProductView")' in CPP
+    assert 'simple_3d_view_ = embedded_web_view_' in CPP
+    assert 'simple_3d_view_ = new Scene3DViewportWidget(view3d_container_)' in CPP
+    assert 'auto * viewport = qobject_cast<Scene3DViewportWidget *>(simple_3d_view_);\n  if (viewport) viewport->ingest_preview_items(preview_items_);' in CPP
+
+
+def test_backend_diagnostics_are_deterministic_and_concise():
+    assert 'emit_backend_startup_diagnostic_once' in HDR
+    assert 'backend_startup_diagnostic_emitted_' in HDR
+    assert 'Workcell Product View backend=embedded_web3d webengine_compiled=true' in CPP
+    assert 'Workcell Product View backend=native_compatibility reason=explicit_build_option' in CPP
+
+
+def test_product_view_lifecycle_prepares_before_loading_and_rejects_stale_output():
+    prepare_idx = CPP.index('set_embedded_product_view_state(EmbeddedProductViewState::Preparing, scene)')
+    server_idx = CPP.index('ensure_embedded_web_server_started(embedded_web_repo_root_)')
+    load_idx = CPP.index('set_embedded_product_view_state(EmbeddedProductViewState::Loading)', server_idx)
+    assert prepare_idx < server_idx < load_idx
+    assert 'scripts/ensure_workcell_studio_web_scene_fresh.py' in CPP
+    assert '"--scene", QStringLiteral("scenes/%1").arg(scene), "--output", embedded_web_prepare_output_path_, "--stage-assets"' in CPP
+    assert 'build/workcell_studio_web_scene/%1.web_scene.json' in CPP
+    assert 'output_is_fresh' in CPP
+    assert 'stale output will not be loaded' in CPP
+
+
+def test_server_is_loopback_only():
+    assert 'socket.connectToHost(QStringLiteral("127.0.0.1"), embedded_web_server_port_)' in CPP
+    assert '"--bind", "127.0.0.1"' in CPP
+    assert 'http://127.0.0.1:%1/workcell_studio_web/viewer/index.html?scene=%2&builderRevision=%3' in CPP
+
+
+def test_ready_state_only_from_successful_browser_load():
+    load_finished = CPP.index('&QWebEngineView::loadFinished')
+    ready = CPP.index('if (ok) set_embedded_product_view_state(EmbeddedProductViewState::Ready', load_finished)
+    failed = CPP.index('else set_embedded_product_view_state(EmbeddedProductViewState::Failed', load_finished)
+    assert load_finished < ready < failed
+    assert 'set_embedded_product_view_state(EmbeddedProductViewState::Ready' not in CPP[:load_finished]

--- a/tests/test_workcell_studio_local_build_contract.py
+++ b/tests/test_workcell_studio_local_build_contract.py
@@ -14,6 +14,6 @@ def test_workcell_studio_sources_in_cmake_once():
 
 
 def test_qt_svg_wiring_present_for_svg_usage():
-    assert 'find_package(Qt5 COMPONENTS Widgets Concurrent Svg REQUIRED)' in CMAKE
+    assert 'find_package(Qt5 COMPONENTS Widgets Concurrent Svg OpenGL Network REQUIRED)' in CMAKE
     assert 'Qt5::Svg' in CMAKE
     assert 'libqt5svg5-dev' in PKG

--- a/tests/test_workcell_studio_qt_shell_hardening.py
+++ b/tests/test_workcell_studio_qt_shell_hardening.py
@@ -18,7 +18,7 @@ REQUIRED_LABELS = [
 
 
 def test_cmake_keeps_qt5_widgets_wiring():
-    assert 'find_package(Qt5 COMPONENTS Widgets Concurrent Svg REQUIRED)' in CMAKE
+    assert 'find_package(Qt5 COMPONENTS Widgets Concurrent Svg OpenGL Network REQUIRED)' in CMAKE
     assert 'Qt5::Widgets' in CMAKE
     assert 'Qt5::Concurrent' in CMAKE
 

--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -41,8 +41,17 @@ find_package(pluginlib REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system filesystem)
+option(WORKCELL_BUILDER_ALLOW_NATIVE_3D_FALLBACK "Allow the legacy native Scene3DViewportWidget Product View when Qt WebEngine is unavailable" OFF)
+
 find_package(Qt5 COMPONENTS Widgets Concurrent Svg OpenGL Network REQUIRED)
 find_package(Qt5 COMPONENTS WebEngineWidgets QUIET)
+if(NOT Qt5WebEngineWidgets_FOUND AND NOT WORKCELL_BUILDER_ALLOW_NATIVE_3D_FALLBACK)
+  message(FATAL_ERROR
+    "embedded Web3D Product View is required by default for workcell_builder.\n"
+    "Missing Qt component: Qt5 WebEngineWidgets.\n"
+    "Ubuntu 22.04 / ROS 2 Humble install guidance: sudo apt install qtwebengine5-dev\n"
+    "If you intentionally need the legacy compatibility path, configure with -DWORKCELL_BUILDER_ALLOW_NATIVE_3D_FALLBACK=ON.")
+endif()
 find_package(OpenGL REQUIRED)
 find_package(assimp QUIET)
 
@@ -223,6 +232,8 @@ target_link_libraries(workcell_builder
 if(Qt5WebEngineWidgets_FOUND)
   target_compile_definitions(workcell_builder PRIVATE WORKCELL_BUILDER_HAS_WEBENGINE=1)
   target_link_libraries(workcell_builder Qt5::WebEngineWidgets)
+elseif(WORKCELL_BUILDER_ALLOW_NATIVE_3D_FALLBACK)
+  target_compile_definitions(workcell_builder PRIVATE WORKCELL_BUILDER_NATIVE_3D_FALLBACK=1)
 endif()
 
 if(assimp_FOUND)
@@ -695,7 +706,6 @@ endif()
 install(TARGETS workcell_builder
   EXPORT export_${PROJECT_NAME}
   DESTINATION lib/${PROJECT_NAME}
-  RUNTIME DESTINATION bin
 )
 
 install(DIRECTORY templates

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -91,6 +91,7 @@ void maybe_warn_overlay_fit_dominance(ScenePreviewWidget * self, const QRectF & 
 #include <QProcessEnvironment>
 #include <QTcpSocket>
 #include <QUrl>
+#include <QTimer>
 #ifdef WORKCELL_BUILDER_HAS_WEBENGINE
 #include <QWebEngineView>
 #endif
@@ -351,6 +352,7 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
   }
   refresh_info_chip();
   refresh_mode_and_state();
+  QTimer::singleShot(0, this, [this]() { emit_backend_startup_diagnostic_once(); });
 }
 
 QString ScenePreviewWidget::resolve_embedded_web_repo_root() const
@@ -473,6 +475,17 @@ void ScenePreviewWidget::maybe_start_next_embedded_web_prepare()
 #endif
 }
 
+void ScenePreviewWidget::emit_backend_startup_diagnostic_once()
+{
+  if (backend_startup_diagnostic_emitted_) return;
+  backend_startup_diagnostic_emitted_ = true;
+#ifdef WORKCELL_BUILDER_HAS_WEBENGINE
+  emit studio_log_requested(QStringLiteral("Workcell Product View backend=embedded_web3d webengine_compiled=true"));
+#else
+  emit studio_log_requested(QStringLiteral("Workcell Product View backend=native_compatibility reason=explicit_build_option"));
+#endif
+}
+
 void ScenePreviewWidget::start_embedded_web_prepare(const QString & scene, quint64 revision, bool force)
 {
 #ifndef WORKCELL_BUILDER_HAS_WEBENGINE
@@ -497,6 +510,7 @@ void ScenePreviewWidget::start_embedded_web_prepare(const QString & scene, quint
   embedded_web_prepare_process_->setWorkingDirectory(repo_root);
   embedded_web_prepare_process_->setProcessEnvironment(QProcessEnvironment::systemEnvironment());
   embedded_web_prepare_process_->setProcessChannelMode(QProcess::SeparateChannels);
+  embedded_web_prepare_started_at_ = QDateTime::currentDateTimeUtc();
   connect(embedded_web_prepare_process_, qOverload<int, QProcess::ExitStatus>(&QProcess::finished), this, &ScenePreviewWidget::on_embedded_web_prepare_finished);
   set_embedded_product_view_state(EmbeddedProductViewState::Preparing, scene);
   emit studio_log_requested(QStringLiteral("Preparing embedded Product View from repo root %1: %2").arg(repo_root, embedded_web_prepare_command_for_log(scene, embedded_web_prepare_output_path_, force)));
@@ -521,11 +535,14 @@ void ScenePreviewWidget::on_embedded_web_prepare_finished(int exit_code, QProces
   embedded_web_prepare_process_ = nullptr;
 
   const bool still_current = (preview_scene_name_.trimmed() == scene && revision == embedded_web_request_revision_);
-  const bool output_exists = QFileInfo::exists(QDir(embedded_web_repo_root_).filePath(output_path));
-  if (exit_status != QProcess::NormalExit || exit_code != 0 || !output_exists || !still_current) {
+  const QFileInfo prepared_output_info(QDir(embedded_web_repo_root_).filePath(output_path));
+  const bool output_exists = prepared_output_info.exists();
+  const bool output_is_fresh = output_exists && prepared_output_info.lastModified().toUTC() >= embedded_web_prepare_started_at_.addSecs(-1);
+  if (exit_status != QProcess::NormalExit || exit_code != 0 || !output_exists || !output_is_fresh || !still_current) {
     QString reason;
     if (!still_current) reason = QStringLiteral("discarded stale preparation for %1; current scene is %2").arg(scene, preview_scene_name_);
     else if (!output_exists) reason = QStringLiteral("expected output missing: %1").arg(output_path);
+    else if (!output_is_fresh) reason = QStringLiteral("prepared output was stale and will not be loaded: %1").arg(output_path);
     else reason = QStringLiteral("prepare command failed with exit code %1").arg(exit_code);
     set_embedded_product_view_state(EmbeddedProductViewState::Failed, reason);
     emit studio_log_requested(QStringLiteral("Embedded Product View preparation failed; stale output will not be loaded.\nCommand: %1\nExit code: %2\nExpected output: %3\nStdout excerpt: %4\nStderr excerpt: %5").arg(command).arg(exit_code).arg(output_path, stdout_text.left(600), stderr_text.left(600)));

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -6,6 +6,7 @@
 #include <QSet>
 #include <QMatrix4x4>
 #include <QProcess>
+#include <QDateTime>
 
 class QComboBox;
 class QLabel;
@@ -302,6 +303,7 @@ private:
   void set_embedded_product_view_state(EmbeddedProductViewState state, const QString & detail = QString());
   QString embedded_web_prepare_command_for_log(const QString & scene, const QString & output_path, bool force = false) const;
   QString resolve_embedded_web_repo_root() const;
+  void emit_backend_startup_diagnostic_once();
   bool diagnostic_debug_logging_enabled() const;
   bool emit_scene_diagnostic_once(const QString & event, int payload_count, const QString & message);
   void emit_visual_quality_assessment_once();
@@ -344,6 +346,8 @@ private:
   quint64 embedded_web_active_revision_{ 0 };
   quint64 pending_embedded_web_revision_{ 0 };
   bool pending_embedded_web_force_{ false };
+  bool backend_startup_diagnostic_emitted_{ false };
+  QDateTime embedded_web_prepare_started_at_;
   int embedded_web_server_port_{ 8765 };
   QGraphicsView * fallback_2d_view_{ nullptr };
   QLabel * info_chip_label_{ nullptr };

--- a/workcell_builder/workcell_builder/package.xml
+++ b/workcell_builder/workcell_builder/package.xml
@@ -31,10 +31,12 @@
   <build_depend>libqt5svg5-dev</build_depend>
   <build_depend>libqt5opengl5-dev</build_depend>
   <build_depend>qt5-qmake</build_depend>
+  <build_depend>qtwebengine5-dev</build_depend>
   <exec_depend>qtbase5-dev</exec_depend>
   <exec_depend>libqt5svg5-dev</exec_depend>
   <exec_depend>libqt5opengl5-dev</exec_depend>
   <exec_depend>qt5-qmake</exec_depend>
+  <exec_depend>qtwebengine5-dev</exec_depend>
   <!--test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend-->
   <test_depend>controller_manager_msgs</test_depend>


### PR DESCRIPTION
### Motivation

- Make the embedded Web3D Product View the default safe and testable 3D backend and fail configuration clearly when Qt WebEngine is missing so builders on Ubuntu 22.04 / ROS 2 Humble get actionable guidance.  
- Provide an explicit, opt-in compatibility flag for legacy/native Scene3D builds so older workflows remain possible but are not silently selected.  

### Description

- Add `option(WORKCELL_BUILDER_ALLOW_NATIVE_3D_FALLBACK OFF)` and require `Qt5::WebEngineWidgets` by default in `workcell_builder/CMakeLists.txt`, emitting a `message(FATAL_ERROR ...)` that names the missing component and suggests `sudo apt install qtwebengine5-dev` and the `-DWORKCELL_BUILDER_ALLOW_NATIVE_3D_FALLBACK=ON` opt-in.  
- Ensure normal builds define `WORKCELL_BUILDER_HAS_WEBENGINE` and link `Qt5::WebEngineWidgets`, and set `WORKCELL_BUILDER_NATIVE_3D_FALLBACK` only when the explicit fallback option is provided.  
- Change `install(TARGETS workcell_builder ...)` so the executable installs under `lib/${PROJECT_NAME}` (remove `RUNTIME DESTINATION bin`) so `ros2 run workcell_builder workcell_builder` works.  
- Declare `qtwebengine5-dev` in `workcell_builder/package.xml` and add it to `scripts/install_system_deps.sh` so repository preflight/install helpers advertise and install the verified Ubuntu 22.04 / Humble system package.  
- Make `embeddedWeb3dProductView` (a `QWebEngineView`) the default 3D surface when WebEngine is compiled in and avoid constructing/using the native `Scene3DViewportWidget` pipeline while embedded Web3D is active.  
- Add lifecycle ordering so the embedded Web3D path prepares the web scene with `scripts/ensure_workcell_studio_web_scene_fresh.py --scene scenes/ur5_2f_test --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json --stage-assets` before starting/reusing the local HTTP server and loading the browser, and reject missing or stale prepared output.  
- Ensure the local static server is only bound to `127.0.0.1:8765` and keep the viewer URL using that loopback address.  
- Add a single deterministic startup/backend diagnostic emitted once: `Workcell Product View backend=embedded_web3d webengine_compiled=true` (or, for explicit fallback builds, `Workcell Product View backend=native_compatibility reason=explicit_build_option`).  
- Add focused regression tests `tests/test_workcell_builder_embedded_web3d_policy.py` and update a few existing static tests to reflect the expanded Qt5 component set and new wiring expectations.  

### Testing

- Ran the focused regression suite: `python3 -m pytest tests/test_workcell_builder_embedded_web3d_policy.py tests/test_humble_build_regressions.py tests/test_workcell_studio_local_build_contract.py tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py`, and all tests passed.  
- Ran the broader static test set used during development (42 tests referenced in the rollout) and observed `42 passed`.  
- Verified `git diff --check` returned clean output.  
- Did not run `colcon build --packages-select workcell_builder`, `ros2 pkg executables workcell_builder`, or `ros2 run workcell_builder workcell_builder` inside this container because a sourced Ubuntu 22.04 / ROS 2 Humble workspace and a Qt WebEngine runtime session were not available in the CI/development environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54d86d2e38833192f28ad7b18f2fa7)