### PR TITLE
Guard embedded Product View readiness

### DIFF
--- a/tests/test_workcell_builder_embedded_web3d_policy.py
+++ b/tests/test_workcell_builder_embedded_web3d_policy.py
@@ -76,9 +76,26 @@ def test_server_is_loopback_only():
     assert 'http://127.0.0.1:%1/workcell_studio_web/viewer/index.html?scene=%2&builderRevision=%3' in CPP
 
 
-def test_ready_state_only_from_successful_browser_load():
+def test_load_finished_true_only_starts_bounded_readiness_polling():
     load_finished = CPP.index('&QWebEngineView::loadFinished')
-    ready = CPP.index('if (ok) set_embedded_product_view_state(EmbeddedProductViewState::Ready', load_finished)
-    failed = CPP.index('else set_embedded_product_view_state(EmbeddedProductViewState::Failed', load_finished)
-    assert load_finished < ready < failed
-    assert 'set_embedded_product_view_state(EmbeddedProductViewState::Ready' not in CPP[:load_finished]
+    handler = CPP[load_finished:CPP.index('simple_3d_view_ = embedded_web_view_', load_finished)]
+    assert 'if (!ok)' in handler
+    assert 'set_embedded_product_view_state(EmbeddedProductViewState::Failed' in handler
+    assert 'set_embedded_product_view_state(EmbeddedProductViewState::Loading' in handler
+    assert 'start_embedded_web_readiness_polling' in handler
+    assert 'set_embedded_product_view_state(EmbeddedProductViewState::Ready' not in handler
+
+
+def test_product_view_ready_requires_viewer_status_not_load_finished_true():
+    assert 'window.__WORKCELL_VIEWER_STATUS__' in CPP
+    assert 'runJavaScript' in CPP
+    assert 'viewer_boot_state' in CPP
+    assert 'scene_json_loaded' in CPP
+    assert 'source_web_scene_file' in CPP
+    assert 'robot_preview_lifecycle_state' in CPP
+    assert 'scene == QStringLiteral("ur5_2f_test")' in CPP
+    assert 'boot_state == QStringLiteral("ready") && expected_json_loaded && robot_ready' in CPP
+    assert 'startup timed out after 45s' in CPP
+    assert 'failed_stage' in CPP
+    assert 'fatal_error' in CPP
+    assert 'fatal_stack' in CPP

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -3,6 +3,7 @@
 
 #include <QRectF>
 #include <QtGlobal>
+#include <QVariantMap>
 
 namespace {
 constexpr double kOverlayFitDominanceRatio = 4.0;
@@ -94,6 +95,7 @@ void maybe_warn_overlay_fit_dominance(ScenePreviewWidget * self, const QRectF & 
 #include <QTimer>
 #ifdef WORKCELL_BUILDER_HAS_WEBENGINE
 #include <QWebEngineView>
+#include <QWebEnginePage>
 #endif
 #include "scene3d_viewport_widget.h"
 #include <QPainter>
@@ -217,8 +219,15 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
   embedded_web_view_ = new QWebEngineView(view3d_container_);
   embedded_web_view_->setObjectName("embeddedWeb3dProductView");
   connect(embedded_web_view_, &QWebEngineView::loadFinished, this, [this](bool ok) {
-    if (ok) set_embedded_product_view_state(EmbeddedProductViewState::Ready, QStringLiteral("ready"));
-    else set_embedded_product_view_state(EmbeddedProductViewState::Failed, QStringLiteral("viewer load failed"));
+    if (!ok) {
+      const QString detail = QStringLiteral("browser failed to load Product View page for scene %1; viewer URL: %2; expected JSON: %3")
+        .arg(embedded_web_prepare_scene_, embedded_web_last_viewer_url_, embedded_web_prepare_output_path_);
+      set_embedded_product_view_state(EmbeddedProductViewState::Failed, detail);
+      emit studio_log_requested(QStringLiteral("Embedded Product View load failed. %1").arg(detail));
+      return;
+    }
+    set_embedded_product_view_state(EmbeddedProductViewState::Loading, QStringLiteral("browser loaded; waiting for viewer readiness"));
+    start_embedded_web_readiness_polling(embedded_web_prepare_scene_, embedded_web_active_revision_, embedded_web_prepare_output_path_, embedded_web_last_viewer_url_);
   });
   simple_3d_view_ = embedded_web_view_;
 #else
@@ -386,7 +395,7 @@ void ScenePreviewWidget::set_embedded_product_view_state(EmbeddedProductViewStat
     case EmbeddedProductViewState::Idle: text = QStringLiteral("Product View: idle"); break;
     case EmbeddedProductViewState::Preparing: text = QStringLiteral("Product View: preparing %1…").arg(detail); break;
     case EmbeddedProductViewState::StartingServer: text = QStringLiteral("Product View: starting local viewer server…"); break;
-    case EmbeddedProductViewState::Loading: text = QStringLiteral("Product View: loading…"); break;
+    case EmbeddedProductViewState::Loading: text = detail.trimmed().isEmpty() ? QStringLiteral("Product View: loading…") : QStringLiteral("Product View: %1…").arg(detail); break;
     case EmbeddedProductViewState::Ready: text = QStringLiteral("Product View: ready"); break;
     case EmbeddedProductViewState::Failed: text = QStringLiteral("Product View failed: %1").arg(detail); break;
   }
@@ -554,6 +563,97 @@ void ScenePreviewWidget::on_embedded_web_prepare_finished(int exit_code, QProces
 #endif
 }
 
+void ScenePreviewWidget::start_embedded_web_readiness_polling(const QString & scene, quint64 revision, const QString & expected_json_path, const QString & viewer_url)
+{
+#ifndef WORKCELL_BUILDER_HAS_WEBENGINE
+  Q_UNUSED(scene); Q_UNUSED(revision); Q_UNUSED(expected_json_path); Q_UNUSED(viewer_url);
+#else
+  embedded_web_readiness_deadline_ = QDateTime::currentDateTimeUtc().addSecs(45);
+  embedded_web_last_boot_status_ = QStringLiteral("browser_loaded");
+  poll_embedded_web_readiness(scene, revision, expected_json_path, viewer_url);
+#endif
+}
+
+void ScenePreviewWidget::poll_embedded_web_readiness(const QString & scene, quint64 revision, const QString & expected_json_path, const QString & viewer_url)
+{
+#ifndef WORKCELL_BUILDER_HAS_WEBENGINE
+  Q_UNUSED(scene); Q_UNUSED(revision); Q_UNUSED(expected_json_path); Q_UNUSED(viewer_url);
+#else
+  if (!embedded_web_view_) return;
+  if (preview_scene_name_.trimmed() != scene || revision != embedded_web_request_revision_) return;
+
+  if (QDateTime::currentDateTimeUtc() > embedded_web_readiness_deadline_) {
+    const QString detail = QStringLiteral(
+      "startup timed out after 45s for scene %1; viewer URL: %2; expected JSON: %3; last observed boot status: %4")
+      .arg(scene, viewer_url, expected_json_path, embedded_web_last_boot_status_.isEmpty() ? QStringLiteral("unavailable") : embedded_web_last_boot_status_);
+    set_embedded_product_view_state(EmbeddedProductViewState::Failed, detail);
+    emit studio_log_requested(QStringLiteral("Embedded Product View readiness timeout. %1").arg(detail));
+    return;
+  }
+
+  static const char kStatusScript[] = R"JS(
+(() => {
+  const s = window.__WORKCELL_VIEWER_STATUS__ || {};
+  return {
+    viewer_boot_state: s.viewer_boot_state || s.viewerBootState || 'booting',
+    scene_name: s.scene_name || s.sceneName || '',
+    source_web_scene_file: s.source_web_scene_file || s.sourceWebSceneFile || '',
+    scene_json_loaded: Boolean(s.scene_json_loaded || s.sceneJsonLoaded || s.source_web_scene_file || s.sourceWebSceneFile),
+    robot_preview_lifecycle_state: s.robot_preview_lifecycle_state || s.robotPreviewLifecycleState || '',
+    failed_stage: s.failed_stage || s.failedStage || '',
+    fatal_error: s.fatal_error || s.fatalError || '',
+    fatal_stack: String(s.fatal_stack || s.fatalStack || '').split('\n').slice(0, 6).join('\n')
+  };
+})()
+)JS";
+  embedded_web_view_->page()->runJavaScript(QString::fromUtf8(kStatusScript), [this, scene, revision, expected_json_path, viewer_url](const QVariant & value) {
+    if (preview_scene_name_.trimmed() != scene || revision != embedded_web_request_revision_) return;
+    const QVariantMap status = value.toMap();
+    const QString boot_state = status.value(QStringLiteral("viewer_boot_state")).toString();
+    const QString source_json = status.value(QStringLiteral("source_web_scene_file")).toString();
+    const bool scene_json_loaded = status.value(QStringLiteral("scene_json_loaded")).toBool();
+    const QString robot_state = status.value(QStringLiteral("robot_preview_lifecycle_state")).toString();
+    const QString failed_stage = status.value(QStringLiteral("failed_stage")).toString();
+    const QString fatal_error = status.value(QStringLiteral("fatal_error")).toString();
+    const QString fatal_stack = status.value(QStringLiteral("fatal_stack")).toString();
+    embedded_web_last_boot_status_ = QStringLiteral("boot=%1 json=%2 source=%3 robot=%4")
+      .arg(boot_state.isEmpty() ? QStringLiteral("unknown") : boot_state)
+      .arg(scene_json_loaded ? QStringLiteral("loaded") : QStringLiteral("not_loaded"))
+      .arg(source_json.isEmpty() ? QStringLiteral("unknown") : source_json)
+      .arg(robot_state.isEmpty() ? QStringLiteral("unknown") : robot_state);
+
+    if (boot_state == QStringLiteral("failed")) {
+      const QString detail = QStringLiteral("viewer JavaScript failed at %1: %2%3")
+        .arg(failed_stage.isEmpty() ? QStringLiteral("unknown_stage") : failed_stage,
+             fatal_error.isEmpty() ? QStringLiteral("unknown error") : fatal_error,
+             fatal_stack.isEmpty() ? QString() : QStringLiteral("; stack: %1").arg(fatal_stack.left(500)));
+      set_embedded_product_view_state(EmbeddedProductViewState::Failed, detail);
+      emit studio_log_requested(QStringLiteral("Embedded Product View JavaScript failure for scene %1.\nStage: %2\nFatal error: %3\nStack excerpt:\n%4")
+        .arg(scene,
+             failed_stage.isEmpty() ? QStringLiteral("unknown_stage") : failed_stage,
+             fatal_error.isEmpty() ? QStringLiteral("unknown error") : fatal_error,
+             fatal_stack.left(500)));
+      return;
+    }
+
+    const bool expected_json_loaded = scene_json_loaded && source_json == expected_json_path;
+    const bool robot_ready_required = scene == QStringLiteral("ur5_2f_test");
+    const bool robot_ready = !robot_ready_required || robot_state == QStringLiteral("ready");
+    if (boot_state == QStringLiteral("ready") && expected_json_loaded && robot_ready) {
+      set_embedded_product_view_state(EmbeddedProductViewState::Ready, QStringLiteral("viewer ready"));
+      emit studio_log_requested(QStringLiteral("Embedded Product View ready: scene=%1 json=%2 robot_preview_lifecycle_state=%3")
+        .arg(scene, expected_json_path, robot_state.isEmpty() ? QStringLiteral("not_required") : robot_state));
+      return;
+    }
+
+    set_embedded_product_view_state(EmbeddedProductViewState::Loading, QStringLiteral("waiting for viewer readiness (%1)").arg(embedded_web_last_boot_status_));
+    QTimer::singleShot(750, this, [this, scene, revision, expected_json_path, viewer_url]() {
+      poll_embedded_web_readiness(scene, revision, expected_json_path, viewer_url);
+    });
+  });
+#endif
+}
+
 void ScenePreviewWidget::load_prepared_embedded_web_scene(const QString & scene, quint64 revision)
 {
 #ifndef WORKCELL_BUILDER_HAS_WEBENGINE
@@ -569,6 +669,9 @@ void ScenePreviewWidget::load_prepared_embedded_web_scene(const QString & scene,
     .arg(embedded_web_server_port_)
     .arg(QString::fromUtf8(QUrl::toPercentEncoding(web_scene_url_path)))
     .arg(revision);
+  embedded_web_last_viewer_url_ = viewer_url;
+  embedded_web_readiness_deadline_ = QDateTime();
+  embedded_web_last_boot_status_.clear();
   set_embedded_product_view_state(EmbeddedProductViewState::Loading);
   embedded_web_view_->load(QUrl(viewer_url));
 #endif

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -300,6 +300,8 @@ private:
   void ensure_embedded_web_server_started(const QString & repo_root);
   bool embedded_web_server_is_usable() const;
   void load_prepared_embedded_web_scene(const QString & scene, quint64 revision);
+  void start_embedded_web_readiness_polling(const QString & scene, quint64 revision, const QString & expected_json_path, const QString & viewer_url);
+  void poll_embedded_web_readiness(const QString & scene, quint64 revision, const QString & expected_json_path, const QString & viewer_url);
   void set_embedded_product_view_state(EmbeddedProductViewState state, const QString & detail = QString());
   QString embedded_web_prepare_command_for_log(const QString & scene, const QString & output_path, bool force = false) const;
   QString resolve_embedded_web_repo_root() const;
@@ -341,6 +343,9 @@ private:
   QString embedded_web_repo_root_;
   QString embedded_web_prepare_scene_;
   QString embedded_web_prepare_output_path_;
+  QString embedded_web_last_viewer_url_;
+  QString embedded_web_last_boot_status_;
+  QDateTime embedded_web_readiness_deadline_;
   QString pending_embedded_web_scene_;
   quint64 embedded_web_request_revision_{ 0 };
   quint64 embedded_web_active_revision_{ 0 };

--- a/workcell_studio_web/viewer/dist/viewer.bundle.js
+++ b/workcell_studio_web/viewer/dist/viewer.bundle.js
@@ -38250,6 +38250,18 @@ function updateViewerStatus() {
   });
   const assemblyRenderDiagnostics = collectAssemblyRenderDiagnostics();
   window.__WORKCELL_VIEWER_STATUS__ = {
+    viewer_boot_state: 'ready',
+    viewerBootState: 'ready',
+    failed_stage: '',
+    failedStage: '',
+    fatal_error: '',
+    fatalError: '',
+    fatal_stack: '',
+    fatalStack: '',
+    source_web_scene_file: state.sourceWebSceneFile || '',
+    sourceWebSceneFile: state.sourceWebSceneFile || '',
+    scene_json_loaded: Boolean(state.sceneJson),
+    sceneJsonLoaded: Boolean(state.sceneJson),
     scene_name: summary.sceneName,
     sceneName: summary.sceneName,
     renderable_count: summary.renderableCount,
@@ -38311,8 +38323,20 @@ function renderSceneSummary() {
   }
 }
 function showError(message) {
-  el.error.textContent = message;
+  const text = message || 'Unknown viewer error';
+  el.error.textContent = text;
   el.error.hidden = false;
+  window.__WORKCELL_VIEWER_STATUS__ = {
+    ...(window.__WORKCELL_VIEWER_STATUS__ || {}),
+    viewer_boot_state: 'failed',
+    viewerBootState: 'failed',
+    failed_stage: 'viewer_runtime',
+    failedStage: 'viewer_runtime',
+    fatal_error: text,
+    fatalError: text,
+    fatal_stack: (new Error(text).stack || '').split('\n').slice(0, 6).join('\n'),
+    fatalStack: (new Error(text).stack || '').split('\n').slice(0, 6).join('\n'),
+  };
 }
 function clearError() {
   el.error.hidden = true;

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -343,6 +343,18 @@ function updateViewerStatus() {
   });
   const assemblyRenderDiagnostics = collectAssemblyRenderDiagnostics();
   window.__WORKCELL_VIEWER_STATUS__ = {
+    viewer_boot_state: 'ready',
+    viewerBootState: 'ready',
+    failed_stage: '',
+    failedStage: '',
+    fatal_error: '',
+    fatalError: '',
+    fatal_stack: '',
+    fatalStack: '',
+    source_web_scene_file: state.sourceWebSceneFile || '',
+    sourceWebSceneFile: state.sourceWebSceneFile || '',
+    scene_json_loaded: Boolean(state.sceneJson),
+    sceneJsonLoaded: Boolean(state.sceneJson),
     scene_name: summary.sceneName,
     sceneName: summary.sceneName,
     renderable_count: summary.renderableCount,
@@ -403,8 +415,20 @@ function renderSceneSummary() {
 }
 
 function showError(message) {
-  el.error.textContent = message;
+  const text = message || 'Unknown viewer error';
+  el.error.textContent = text;
   el.error.hidden = false;
+  window.__WORKCELL_VIEWER_STATUS__ = {
+    ...(window.__WORKCELL_VIEWER_STATUS__ || {}),
+    viewer_boot_state: 'failed',
+    viewerBootState: 'failed',
+    failed_stage: 'viewer_runtime',
+    failedStage: 'viewer_runtime',
+    fatal_error: text,
+    fatalError: text,
+    fatal_stack: (new Error(text).stack || '').split('\n').slice(0, 6).join('\n'),
+    fatalStack: (new Error(text).stack || '').split('\n').slice(0, 6).join('\n'),
+  };
 }
 function clearError() { el.error.hidden = true; el.error.textContent = ''; }
 function valueOrDash(value) { return value === undefined || value === null || value === '' ? '—' : value; }


### PR DESCRIPTION
### Motivation
- The embedded Web3D Product View previously marked the view `Ready` on `QWebEngineView::loadFinished(true)`, which could surface a falsely ready UI before the viewer had loaded scene JSON or completed internal boot steps.
- Improve truthfulness and debuggability by polling the viewer for runtime readiness and surfacing JavaScript-side failures and stack excerpts instead of an optimistic Ready state.

### Description
- Changed the `QWebEngineView::loadFinished` handler in `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp` to set `Failed` immediately when `ok == false` with a contextual message, and to set `Loading` and start bounded readiness polling when `ok == true` instead of marking `Ready` immediately.
- Added `start_embedded_web_readiness_polling` and `poll_embedded_web_readiness` helpers that use `QWebEnginePage::runJavaScript` to evaluate `window.__WORKCELL_VIEWER_STATUS__` and decide readiness based on `viewer_boot_state`, `scene_json_loaded` / `source_web_scene_file` matching the expected JSON path, and for `ur5_2f_test` an additional `robot_preview_lifecycle_state == "ready"` requirement, then set `EmbeddedProductViewState::Ready` only on a true terminal readiness.
- Implemented a bounded startup timeout (45 seconds) that reports scene name, viewer URL, expected JSON path, and the last observed boot status in the Product View status and studio log when expired.
- On JavaScript-detected failures the poller surfaces `failed_stage`, `fatal_error`, and a short `fatal_stack` excerpt in the Product View `Failed` message and emits the same details to the studio log.
- Added state fields and helper declarations in `scene_preview_widget.h` for `embedded_web_last_viewer_url_`, `embedded_web_last_boot_status_`, and `embedded_web_readiness_deadline_`, and updated the web viewer (`workcell_studio_web/viewer/viewer.js` and `dist/viewer.bundle.js`) to expose `viewer_boot_state`, `source_web_scene_file`, `scene_json_loaded`, and failure fields so the Qt poller can make reliable decisions.
- Added/updated static/unit assertions in `tests/test_workcell_builder_embedded_web3d_policy.py` to ensure `loadFinished(true)` alone does not set `EmbeddedProductViewState::Ready` and that the readiness contract relies on `window.__WORKCELL_VIEWER_STATUS__` and the timeout/failure fields.

### Testing
- Ran `python3 -m pytest tests/test_workcell_builder_embedded_web3d_policy.py` and `python3 -m pytest tests/test_workcell_web3d_visual_acceptance.py`, and the combined run completed successfully (tests passed).
- Ran `python3 -m pytest tests/test_workcell_web3d_visual_acceptance.py` which passed (38 tests) against the updated viewer status surface.
- A run of `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py` failed on an unrelated pre-existing static assertion expecting `src="viewer.js"` instead of the bundled `./dist/viewer.bundle.js`, which is not introduced by this change; other targeted tests and `git diff --check` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54e70e5a0c833184e3b66d91f8b967)