### PR TITLE
Add machine-readable web-scene freshener JSON contract and GUI validation

### DIFF
--- a/scripts/ensure_workcell_studio_web_scene_fresh.py
+++ b/scripts/ensure_workcell_studio_web_scene_fresh.py
@@ -22,9 +22,11 @@ import json
 import os
 import shutil
 import subprocess
+import tempfile
+import hashlib
 import sys
 from pathlib import Path
-from typing import Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Iterable, List, Optional, Sequence, Tuple
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCENES_ROOT = REPO_ROOT / "scenes"
@@ -339,7 +341,8 @@ def normalize_ur5_mesh_preview_rows(mesh_index: Path) -> bool:
         mesh_index.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         print(
             "[workcell_web_scene_fresh] normalized mesh preview rows: "
-            + ",".join(sorted(normalized_links | visible_pose_links))
+            + ",".join(sorted(normalized_links | visible_pose_links)),
+            file=sys.stderr,
         )
     return changed
 
@@ -355,7 +358,7 @@ def run_checked(command: Sequence[str]) -> None:
         print(result.stderr or "", file=sys.stderr, end="" if result.stderr.endswith("\n") else "\n")
         raise SystemExit(result.returncode)
     if result.stdout:
-        print(result.stdout, end="")
+        print(result.stdout, end="", file=sys.stderr)
     if result.stderr:
         print(result.stderr, end="", file=sys.stderr)
 
@@ -366,6 +369,89 @@ def repo_relative(path: Path) -> str:
         return str(resolved.relative_to(REPO_ROOT))
     return str(resolved)
 
+
+
+FRESHENER_RESULT_SCHEMA_VERSION = "workcell_studio_web_scene_freshener/v1"
+SUPPORTED_WEB_SCENE_SCHEMA_VERSIONS = {"workcell_studio_web_scene/v1"}
+
+
+def file_fingerprint(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def _collect_strings(value: Any) -> Iterable[str]:
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for child in value.values():
+            yield from _collect_strings(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _collect_strings(child)
+
+
+def staged_asset_diagnostics(payload: dict[str, Any], asset_dir: Path, stage_assets: bool) -> dict[str, Any]:
+    refs = sorted({s for s in _collect_strings(payload) if isinstance(s, str) and (s.startswith("assets/") or "/assets/" in s)})
+    missing: list[str] = []
+    for ref in refs:
+        candidate_text = ref.split("?", 1)[0].split("#", 1)[0]
+        if candidate_text.startswith("assets/"):
+            candidate = WEB_BUILD_ROOT / candidate_text
+        else:
+            candidate = WEB_BUILD_ROOT / candidate_text[candidate_text.find("assets/"):]
+        if not candidate.exists():
+            missing.append(ref)
+    files = [p for p in asset_dir.rglob("*") if p.is_file()] if asset_dir.exists() else []
+    return {
+        "stage_assets_requested": bool(stage_assets),
+        "asset_dir": repo_relative(asset_dir),
+        "asset_dir_exists": asset_dir.is_dir(),
+        "staged_file_count": len(files),
+        "referenced_asset_count": len(refs),
+        "missing_referenced_assets": missing,
+        "ok": (not stage_assets or asset_dir.is_dir()) and not missing,
+    }
+
+
+def validate_web_scene_output(output: Path, scene_id: str, asset_dir: Path, stage_assets: bool, status: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    if status not in {"current", "rebuilt"}:
+        raise RuntimeError(f"freshener status must be current or rebuilt, got {status!r}")
+    if not output.exists():
+        raise RuntimeError(f"web scene output does not exist: {output}")
+    try:
+        payload = json.loads(output.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise RuntimeError(f"web scene output is not valid JSON: {output}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"web scene output must be a JSON object: {output}")
+    schema_version = str(payload.get("schema_version") or "")
+    if schema_version not in SUPPORTED_WEB_SCENE_SCHEMA_VERSIONS:
+        raise RuntimeError(f"unsupported web scene schema_version {schema_version!r} in {output}")
+    actual_scene = str(payload.get("scene_id") or payload.get("scene_name") or "")
+    if actual_scene != scene_id:
+        raise RuntimeError(f"web scene scene_id mismatch: expected {scene_id!r}, got {actual_scene!r} in {output}")
+    diagnostics = staged_asset_diagnostics(payload, asset_dir, stage_assets)
+    if diagnostics["missing_referenced_assets"]:
+        raise RuntimeError(f"web scene references missing staged assets: {diagnostics['missing_referenced_assets']}")
+    return payload, diagnostics
+
+
+def atomic_export_web_scene(command: Sequence[str], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(prefix=output_path.name + ".", suffix=".tmp", dir=output_path.parent, delete=False) as handle:
+        tmp_path = Path(handle.name)
+    try:
+        tmp_command = list(command)
+        out_index = tmp_command.index("--output") + 1
+        tmp_command[out_index] = repo_relative(tmp_path)
+        run_checked(tmp_command)
+        os.replace(tmp_path, output_path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser(description="Refresh stale Workcell Studio web-scene outputs.")
@@ -404,7 +490,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     if args.force or mesh_stale:
         reason = "forced" if args.force else mesh_reason
-        print(f"Refreshing mesh index for {scene_id}: {reason}")
+        print(f"Refreshing mesh index for {scene_id}: {reason}", file=sys.stderr)
         command = [sys.executable, repo_relative(extractor_script), "--scene", repo_relative(scene_dir), "--prefer-xacro"]
         if real_xacro_is_discoverable():
             command.append("--require-xacro")
@@ -428,13 +514,30 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             reasons.append(web_reason)
         if assets_stale:
             reasons.append(assets_reason)
-        print(f"Refreshing web scene for {scene_id}: {'; '.join(reasons)}")
+        print(f"Refreshing web scene for {scene_id}: {'; '.join(reasons)}", file=sys.stderr)
         command = [sys.executable, repo_relative(exporter_script), "--scene", repo_relative(scene_dir), "--output", repo_relative(output_path)]
         if args.stage_assets:
             command.append("--stage-assets")
-        run_checked(command)
+        atomic_export_web_scene(command, output_path)
+        status = "rebuilt"
     else:
-        print(f"Workcell Studio web scene is fresh for {scene_id}: {repo_relative(output_path)}")
+        print(f"Workcell Studio web scene is fresh for {scene_id}: {repo_relative(output_path)}", file=sys.stderr)
+        status = "current"
+    try:
+        payload, asset_diagnostics = validate_web_scene_output(output_path, scene_id, asset_dir, args.stage_assets, status)
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 3
+    result = {
+        "schema_version": FRESHENER_RESULT_SCHEMA_VERSION,
+        "status": status,
+        "scene_id": scene_id,
+        "output": repo_relative(output_path),
+        "fingerprint": file_fingerprint(output_path),
+        "web_scene_schema_version": payload.get("schema_version"),
+        "staged_asset_diagnostics": asset_diagnostics,
+    }
+    print(json.dumps(result, sort_keys=True))
     return 0
 
 

--- a/tests/test_ensure_workcell_studio_web_scene_fresh.py
+++ b/tests/test_ensure_workcell_studio_web_scene_fresh.py
@@ -54,6 +54,13 @@ def _minimal_repo(tmp_path, monkeypatch):
     return repo, scene, source, extractor, exporter, build
 
 
+def _write_export_for_command(command, scene_id="demo_scene"):
+    out = Path(command[command.index("--output") + 1])
+    if not out.is_absolute():
+        out = ensure.REPO_ROOT / out
+    _write(out, json.dumps({"schema_version": "workcell_studio_web_scene/v1", "scene_id": scene_id}))
+
+
 def test_missing_mesh_index_runs_extractor_then_exporter(tmp_path, monkeypatch):
     _repo, scene, _source, _extractor, _exporter, build = _minimal_repo(tmp_path, monkeypatch)
     output = build / "demo_scene.web_scene.json"
@@ -68,7 +75,7 @@ def test_missing_mesh_index_runs_extractor_then_exporter(tmp_path, monkeypatch):
                 json.dumps({"extractor_version": "expected-v1", "visual_items": []}),
             )
         elif script.endswith("export_workcell_studio_web_scene.py"):
-            _write(output, json.dumps({"schema_version": "workcell_studio_web_scene/v1"}))
+            _write_export_for_command(command)
 
     monkeypatch.setattr(ensure, "run_checked", fake_run)
 
@@ -85,7 +92,7 @@ def test_older_mesh_index_than_source_or_generator_input_triggers_regeneration(t
         scene / "generated" / "scene_visual_mesh_index.json",
         json.dumps({"extractor_version": "expected-v1", "visual_items": []}),
     )
-    output = _write(build / "demo_scene.web_scene.json", "{}")
+    output = _write(build / "demo_scene.web_scene.json", json.dumps({"schema_version": "workcell_studio_web_scene/v1", "scene_id": "demo_scene"}))
     _touch(mesh_index, 100)
     _touch(source, 200)
     _touch(output, 300)
@@ -95,6 +102,8 @@ def test_older_mesh_index_than_source_or_generator_input_triggers_regeneration(t
         calls.append(Path(command[1]).name)
         if command[1].endswith("extract_scene_urdf_visual_mesh_index.py"):
             _write(mesh_index, json.dumps({"extractor_version": "expected-v1", "visual_items": []}))
+        elif command[1].endswith("export_workcell_studio_web_scene.py"):
+            _write_export_for_command(command)
 
     monkeypatch.setattr(ensure, "run_checked", fake_run)
 
@@ -111,7 +120,7 @@ def test_older_web_scene_than_mesh_index_or_source_input_triggers_export_only(tm
         scene / "generated" / "scene_visual_mesh_index.json",
         json.dumps({"extractor_version": "expected-v1", "visual_items": []}),
     )
-    output = _write(build / "demo_scene.web_scene.json", "{}")
+    output = _write(build / "demo_scene.web_scene.json", json.dumps({"schema_version": "workcell_studio_web_scene/v1", "scene_id": "demo_scene"}))
     _touch(output, 100)
     _touch(mesh_index, 300)
     _touch(source, 250)
@@ -121,11 +130,12 @@ def test_older_web_scene_than_mesh_index_or_source_input_triggers_export_only(tm
     ):
         _touch(generator_input, 200)
     calls = []
-    monkeypatch.setattr(
-        ensure,
-        "run_checked",
-        lambda command: calls.append(Path(command[1]).name),
-    )
+    def fake_run(command):
+        calls.append(Path(command[1]).name)
+        if command[1].endswith("export_workcell_studio_web_scene.py"):
+            _write_export_for_command(command)
+
+    monkeypatch.setattr(ensure, "run_checked", fake_run)
 
     assert ensure.main(["--scene", "demo_scene", "--output", str(output)]) == 0
     assert calls == ["export_workcell_studio_web_scene.py"]
@@ -137,7 +147,7 @@ def test_fresh_mesh_web_scene_and_staged_assets_do_not_rerun(tmp_path, monkeypat
         scene / "generated" / "scene_visual_mesh_index.json",
         json.dumps({"extractor_version": "expected-v1", "visual_items": []}),
     )
-    output = _write(build / "demo_scene.web_scene.json", "{}")
+    output = _write(build / "demo_scene.web_scene.json", json.dumps({"schema_version": "workcell_studio_web_scene/v1", "scene_id": "demo_scene"}))
     asset_dir = build / "assets" / "demo_scene"
     asset_file = _write(asset_dir / "mesh.stl", "solid mesh\nendsolid mesh\n")
     for path in (source, extractor, exporter):
@@ -145,7 +155,10 @@ def test_fresh_mesh_web_scene_and_staged_assets_do_not_rerun(tmp_path, monkeypat
     for path in (mesh_index, output, asset_dir, asset_file):
         _touch(path, 300)
     calls = []
-    monkeypatch.setattr(ensure, "run_checked", lambda command: calls.append(command))
+    def fake_run_noop(command):
+        calls.append(command)
+
+    monkeypatch.setattr(ensure, "run_checked", fake_run_noop)
 
     assert ensure.main(["--scene", "demo_scene", "--output", str(output), "--stage-assets"]) == 0
     assert calls == []
@@ -157,7 +170,7 @@ def test_mismatched_extractor_version_marks_mesh_index_stale(tmp_path, monkeypat
         scene / "generated" / "scene_visual_mesh_index.json",
         json.dumps({"extractor_version": "old-v0", "visual_items": []}),
     )
-    output = _write(build / "demo_scene.web_scene.json", "{}")
+    output = _write(build / "demo_scene.web_scene.json", json.dumps({"schema_version": "workcell_studio_web_scene/v1", "scene_id": "demo_scene"}))
     for path in (mesh_index, output):
         _touch(path, 300)
     calls = []
@@ -166,6 +179,8 @@ def test_mismatched_extractor_version_marks_mesh_index_stale(tmp_path, monkeypat
         calls.append(Path(command[1]).name)
         if command[1].endswith("extract_scene_urdf_visual_mesh_index.py"):
             _write(mesh_index, json.dumps({"extractor_version": "expected-v1", "visual_items": []}))
+        elif command[1].endswith("export_workcell_studio_web_scene.py"):
+            _write_export_for_command(command)
 
     monkeypatch.setattr(ensure, "run_checked", fake_run)
 
@@ -196,7 +211,7 @@ def test_sourced_real_xacro_requires_real_expansion_status(tmp_path, monkeypatch
                 }),
             )
         elif command[1].endswith("export_workcell_studio_web_scene.py"):
-            _write(output, "{}")
+            _write_export_for_command(command)
 
     monkeypatch.setattr(ensure, "run_checked", fake_run)
 
@@ -298,7 +313,7 @@ def test_real_script_reports_fresh_for_temporary_minimal_scene(tmp_path):
         scene / "generated" / "scene_visual_mesh_index.json",
         json.dumps({"extractor_version": extractor_version, "visual_items": []}),
     )
-    output = _write(tmp_path / "build" / "minimal_scene.web_scene.json", "{}")
+    output = _write(tmp_path / "build" / "minimal_scene.web_scene.json", json.dumps({"schema_version": "workcell_studio_web_scene/v1", "scene_id": "minimal_scene"}))
     future = int(time.time()) + 60
     _touch(mesh_index, future)
     _touch(output, future)
@@ -311,8 +326,11 @@ def test_real_script_reports_fresh_for_temporary_minimal_scene(tmp_path):
     )
 
     assert result.returncode == 0, result.stderr
-    assert "is fresh" in result.stdout
-    assert "Refreshing" not in result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "current"
+    assert payload["scene_id"] == "minimal_scene"
+    assert "is fresh" in result.stderr
+    assert "Refreshing" not in result.stderr
 
 
 def test_real_ur5_2f_freshness_helper_recreates_missing_mesh_index(tmp_path):
@@ -352,3 +370,88 @@ def test_real_ur5_2f_freshness_helper_recreates_missing_mesh_index(tmp_path):
             mesh_index.write_bytes(backup.read_bytes())
         else:
             mesh_index.unlink(missing_ok=True)
+
+
+
+def test_freshener_json_contract_reports_rebuilt(tmp_path, monkeypatch, capsys):
+    _repo, scene, _source, _extractor, _exporter, build = _minimal_repo(tmp_path, monkeypatch)
+    output = build / "demo_scene.web_scene.json"
+
+    def fake_run(command):
+        if command[1].endswith("extract_scene_urdf_visual_mesh_index.py"):
+            _write(scene / "generated" / "scene_visual_mesh_index.json", json.dumps({"extractor_version": "expected-v1", "visual_items": []}))
+        elif command[1].endswith("export_workcell_studio_web_scene.py"):
+            _write_export_for_command(command)
+
+    monkeypatch.setattr(ensure, "run_checked", fake_run)
+
+    assert ensure.main(["--scene", "demo_scene", "--output", str(output)]) == 0
+    result = json.loads(capsys.readouterr().out)
+    assert result["schema_version"] == "workcell_studio_web_scene_freshener/v1"
+    assert result["status"] == "rebuilt"
+    assert result["scene_id"] == "demo_scene"
+    assert result["output"].endswith("demo_scene.web_scene.json")
+    assert result["fingerprint"].startswith("sha256:")
+    assert result["staged_asset_diagnostics"]["missing_referenced_assets"] == []
+
+
+def test_freshener_json_contract_reports_current_noop(tmp_path, monkeypatch, capsys):
+    _repo, scene, source, extractor, exporter, build = _minimal_repo(tmp_path, monkeypatch)
+    mesh_index = _write(scene / "generated" / "scene_visual_mesh_index.json", json.dumps({"extractor_version": "expected-v1", "visual_items": []}))
+    output = _write(build / "demo_scene.web_scene.json", json.dumps({"schema_version": "workcell_studio_web_scene/v1", "scene_id": "demo_scene"}))
+    for path in (source, extractor, exporter):
+        _touch(path, 100)
+    for path in (mesh_index, output):
+        _touch(path, 300)
+    monkeypatch.setattr(ensure, "run_checked", lambda command: (_ for _ in ()).throw(AssertionError(command)))
+
+    assert ensure.main(["--scene", "demo_scene", "--output", str(output)]) == 0
+    assert json.loads(capsys.readouterr().out)["status"] == "current"
+
+
+def test_semantic_validation_rejects_missing_output(tmp_path, monkeypatch):
+    _repo, _scene, _source, _extractor, _exporter, build = _minimal_repo(tmp_path, monkeypatch)
+    missing = build / "missing.web_scene.json"
+    try:
+        ensure.validate_web_scene_output(missing, "demo_scene", build / "assets" / "demo_scene", False, "current")
+    except RuntimeError as exc:
+        assert "does not exist" in str(exc)
+    else:
+        raise AssertionError("missing output should be rejected")
+
+
+def test_semantic_validation_rejects_malformed_output(tmp_path, monkeypatch):
+    _repo, scene, source, extractor, exporter, build = _minimal_repo(tmp_path, monkeypatch)
+    mesh_index = _write(scene / "generated" / "scene_visual_mesh_index.json", json.dumps({"extractor_version": "expected-v1", "visual_items": []}))
+    output = _write(build / "demo_scene.web_scene.json", "not json")
+    for path in (source, extractor, exporter): _touch(path, 100)
+    for path in (mesh_index, output): _touch(path, 300)
+    assert ensure.main(["--scene", "demo_scene", "--output", str(output)]) == 3
+
+
+def test_semantic_validation_rejects_wrong_scene_id(tmp_path, monkeypatch):
+    _repo, scene, source, extractor, exporter, build = _minimal_repo(tmp_path, monkeypatch)
+    mesh_index = _write(scene / "generated" / "scene_visual_mesh_index.json", json.dumps({"extractor_version": "expected-v1", "visual_items": []}))
+    output = _write(build / "demo_scene.web_scene.json", json.dumps({"schema_version": "workcell_studio_web_scene/v1", "scene_id": "other_scene"}))
+    for path in (source, extractor, exporter): _touch(path, 100)
+    for path in (mesh_index, output): _touch(path, 300)
+    assert ensure.main(["--scene", "demo_scene", "--output", str(output)]) == 3
+
+
+def test_failed_command_with_old_output_present_does_not_replace_or_validate_as_current(tmp_path, monkeypatch):
+    _repo, scene, _source, _extractor, _exporter, build = _minimal_repo(tmp_path, monkeypatch)
+    output = _write(build / "demo_scene.web_scene.json", json.dumps({"schema_version": "workcell_studio_web_scene/v1", "scene_id": "demo_scene", "old": True}))
+    before = output.read_text(encoding="utf-8")
+
+    def fake_run(command):
+        if command[1].endswith("extract_scene_urdf_visual_mesh_index.py"):
+            _write(scene / "generated" / "scene_visual_mesh_index.json", json.dumps({"extractor_version": "expected-v1", "visual_items": []}))
+        elif command[1].endswith("export_workcell_studio_web_scene.py"):
+            raise SystemExit(7)
+
+    monkeypatch.setattr(ensure, "run_checked", fake_run)
+    try:
+        ensure.main(["--scene", "demo_scene", "--output", str(output), "--force"])
+    except SystemExit as exc:
+        assert exc.code == 7
+    assert output.read_text(encoding="utf-8") == before

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -4,6 +4,11 @@
 #include <QRectF>
 #include <QtGlobal>
 #include <QVariantMap>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+#include <QFile>
+#include <QIODevice>
 
 namespace {
 constexpr double kOverlayFitDominanceRatio = 4.0;
@@ -544,20 +549,66 @@ void ScenePreviewWidget::on_embedded_web_prepare_finished(int exit_code, QProces
   embedded_web_prepare_process_ = nullptr;
 
   const bool still_current = (preview_scene_name_.trimmed() == scene && revision == embedded_web_request_revision_);
-  const QFileInfo prepared_output_info(QDir(embedded_web_repo_root_).filePath(output_path));
-  const bool output_exists = prepared_output_info.exists();
-  const bool output_is_fresh = output_exists && prepared_output_info.lastModified().toUTC() >= embedded_web_prepare_started_at_.addSecs(-1);
-  if (exit_status != QProcess::NormalExit || exit_code != 0 || !output_exists || !output_is_fresh || !still_current) {
-    QString reason;
-    if (!still_current) reason = QStringLiteral("discarded stale preparation for %1; current scene is %2").arg(scene, preview_scene_name_);
-    else if (!output_exists) reason = QStringLiteral("expected output missing: %1").arg(output_path);
-    else if (!output_is_fresh) reason = QStringLiteral("prepared output was stale and will not be loaded: %1").arg(output_path);
-    else reason = QStringLiteral("prepare command failed with exit code %1").arg(exit_code);
+  const QString absolute_output_path = QDir(embedded_web_repo_root_).filePath(output_path);
+  const bool output_is_fresh = QFileInfo::exists(QDir(embedded_web_repo_root_).filePath(output_path));  // Contract validation supersedes mtime freshness.
+  Q_UNUSED(output_is_fresh);
+  auto reject_prepare = [&](const QString & reason) {
     set_embedded_product_view_state(EmbeddedProductViewState::Failed, reason);
     emit studio_log_requested(QStringLiteral("Embedded Product View preparation failed; stale output will not be loaded.\nCommand: %1\nExit code: %2\nExpected output: %3\nStdout excerpt: %4\nStderr excerpt: %5").arg(command).arg(exit_code).arg(output_path, stdout_text.left(600), stderr_text.left(600)));
     maybe_start_next_embedded_web_prepare();
+  };
+
+  if (!still_current) {
+    reject_prepare(QStringLiteral("discarded stale preparation for %1; current scene is %2").arg(scene, preview_scene_name_));
     return;
   }
+  if (exit_status != QProcess::NormalExit || exit_code != 0) {
+    reject_prepare(QStringLiteral("prepare command failed with exit code %1; old output is rejected even if present").arg(exit_code));
+    return;
+  }
+
+  QJsonParseError result_parse_error;
+  const QJsonDocument result_doc = QJsonDocument::fromJson(stdout_text.toUtf8(), &result_parse_error);
+  if (result_parse_error.error != QJsonParseError::NoError || !result_doc.isObject()) {
+    reject_prepare(QStringLiteral("freshener did not return a valid JSON object on stdout: %1").arg(result_parse_error.errorString()));
+    return;
+  }
+  const QJsonObject result = result_doc.object();
+  const QString freshener_schema = result.value(QStringLiteral("schema_version")).toString();
+  const QString freshener_status = result.value(QStringLiteral("status")).toString();
+  const QString freshener_scene = result.value(QStringLiteral("scene_id")).toString();
+  const QString freshener_output = result.value(QStringLiteral("output")).toString();
+  if (freshener_schema != QStringLiteral("workcell_studio_web_scene_freshener/v1") ||
+      (freshener_status != QStringLiteral("current") && freshener_status != QStringLiteral("rebuilt")) ||
+      freshener_scene != scene || freshener_output != output_path) {
+    reject_prepare(QStringLiteral("freshener JSON contract validation failed for scene %1").arg(scene));
+    return;
+  }
+  const QJsonObject asset_diagnostics = result.value(QStringLiteral("staged_asset_diagnostics")).toObject();
+  if (asset_diagnostics.contains(QStringLiteral("ok")) && !asset_diagnostics.value(QStringLiteral("ok")).toBool()) {
+    reject_prepare(QStringLiteral("freshener reported missing staged assets for %1").arg(scene));
+    return;
+  }
+
+  QFile output_file(absolute_output_path);
+  if (!output_file.open(QIODevice::ReadOnly)) {
+    reject_prepare(QStringLiteral("expected output missing or unreadable: %1").arg(output_path));
+    return;
+  }
+  QJsonParseError output_parse_error;
+  const QJsonDocument output_doc = QJsonDocument::fromJson(output_file.readAll(), &output_parse_error);
+  if (output_parse_error.error != QJsonParseError::NoError || !output_doc.isObject()) {
+    reject_prepare(QStringLiteral("prepared output JSON validation failed: %1").arg(output_parse_error.errorString()));
+    return;
+  }
+  const QJsonObject output = output_doc.object();
+  const QString web_schema = output.value(QStringLiteral("schema_version")).toString();
+  const QString output_scene = output.value(QStringLiteral("scene_id")).toString(output.value(QStringLiteral("scene_name")).toString());
+  if (web_schema != QStringLiteral("workcell_studio_web_scene/v1") || output_scene != scene) {
+    reject_prepare(QStringLiteral("prepared output semantic validation failed for scene %1").arg(scene));
+    return;
+  }
+
   ensure_embedded_web_server_started(embedded_web_repo_root_);
   maybe_start_next_embedded_web_prepare();
 #endif


### PR DESCRIPTION
### Motivation
- Make the web-scene freshness helper emit a stable, machine-readable JSON result so the GUI can safely decide whether to load or reject prepared web-scene outputs. 
- Ensure rebuilt exports are written atomically to avoid partial/corrupt outputs being loaded by the Product View. 
- Add semantic validation (schema, scene id, staged assets) to avoid silent mismatches between requested scene and on-disk output. 

### Description
- `scripts/ensure_workcell_studio_web_scene_fresh.py` now emits a JSON result on stdout with fields including `schema_version` (freshener), `status` (`current` | `rebuilt`), `scene_id`, `output`, `fingerprint`, `web_scene_schema_version`, and `staged_asset_diagnostics`, and moves human logs to stderr. 
- The freshener performs semantic validation on both current and rebuilt paths, validating output existence, JSON parsing, supported web-scene `schema_version`, `scene_id` parity, and staged asset references, and returns nonzero on validation failure. 
- Regeneration uses an atomic write: the exporter writes to a temporary file in the output directory and the script atomically replaces the final output only after successful export. 
- `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp` now parses the freshener JSON result (stdout) after the process finishes, validates the freshener contract, and only loads the prepared output when the contract and prepared output semantics validate; it explicitly rejects old output when the prepare process exits nonzero. 
- Tests were added/updated in `tests/test_ensure_workcell_studio_web_scene_fresh.py` to cover rebuilt vs current/no-op, missing output, malformed output, wrong scene id, and failed command with old output present. 

### Testing
- Ran `python3 -m py_compile scripts/ensure_workcell_studio_web_scene_fresh.py` which succeeded. 
- Ran the freshener unit tests: `python3 -m pytest tests/test_ensure_workcell_studio_web_scene_fresh.py -q -k 'not ur5_mesh_index_regeneration and not real_ur5_2f'` which passed (14 passed / 2 deselected). 
- Ran GUI preparation tests: `python3 -m pytest tests/test_workcell_builder_web_viewer_action.py tests/test_workcell_builder_embedded_web3d_policy.py -q` which passed (17 passed). 
- Ran full freshener test suite: `python3 -m pytest tests/test_ensure_workcell_studio_web_scene_fresh.py -q` which produced 14 passed and 2 failing tests that exercise the real `ur5_2f_test` exporter path; these two failures are environment/repo-artifact related because `scenes/ur5_2f_test/generated/expanded_scene_preview.urdf` (real xacro-expanded URDF) is not present in this checkout and the exporter correctly blocks exporting, so the failures are expected in this trimmed environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54e9e9e5fc83318b90a42ecd844c81)