### PR TITLE
Polish embedded Web3D Product View labeling

### DIFF
--- a/tests/test_workcell_builder_guided_scene_setup_v1.py
+++ b/tests/test_workcell_builder_guided_scene_setup_v1.py
@@ -43,7 +43,7 @@ def test_primary_actions_and_advanced_labels_present():
 
 
 def test_native_scene3d_and_2d_labels_demoted():
-    assert 'Native Scene3D Preview — experimental, not RViz-equivalent' in CPP
+    assert 'Native Scene3D compatibility preview: lightweight editable layout preview; not guaranteed RViz-equivalent.' in CPP
     assert '2D Layout Draft' in CPP
 
 

--- a/tests/test_workcell_builder_web_viewer_action.py
+++ b/tests/test_workcell_builder_web_viewer_action.py
@@ -115,3 +115,36 @@ def test_embedded_web3d_server_is_local_reused_and_controls_are_not_native_noops
     assert "hide native Scene3DViewportWidget-only controls" in cpp
     assert "set_visible(view_actions_label_, !embedded_web_active)" in cpp
     assert "Qt5::Network" in cmake
+
+
+def test_embedded_web3d_header_and_mode_do_not_show_native_banner_text():
+    main_cpp = (ROOT / "workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text(encoding="utf-8")
+    preview_cpp = SCENE_PREVIEW_CPP.read_text(encoding="utf-8")
+    product_view_block = main_cpp.split("#ifdef WORKCELL_BUILDER_HAS_WEBENGINE", 1)[1].split("top_bar->addWidget(product_view_help_label);", 1)[0]
+    webengine_block = product_view_block.split("#else", 1)[0]
+    native_fallback_block = product_view_block.split("#else", 1)[1].split("#endif", 1)[0]
+
+    assert "Native Scene3D: lightweight editable layout preview; not guaranteed RViz-equivalent." not in main_cpp
+    assert "Web3D Product View" in webengine_block
+    assert "Native Scene3D" not in webengine_block
+    assert "Native Scene3D compatibility preview" in native_fallback_block
+    assert 'mode_selector_->addItems({"Web3D Product View", "2D Layout"})' in preview_cpp
+
+
+def test_embedded_web3d_hides_native_only_toolbar_controls():
+    cpp = SCENE_PREVIEW_CPP.read_text(encoding="utf-8")
+    visibility_body = cpp.split("void ScenePreviewWidget::refresh_toolbar_visibility()", 1)[1].split("void ScenePreviewWidget::refresh_mode_and_state()", 1)[0]
+    assert "const bool embedded_web_active = (qobject_cast<Scene3DViewportWidget *>(simple_3d_view_) == nullptr);" in visibility_body
+    for token in [
+        "set_visible(mesh_preview_mode_label_, !embedded_web_active)",
+        "set_visible(mesh_preview_mode_selector_, !embedded_web_active)",
+        "set_visible(gizmo_mode_label_, !embedded_web_active)",
+        "set_visible(gizmo_mode_selector_, !embedded_web_active)",
+        "set_visible(labels_label_, !embedded_web_active)",
+        "set_visible(labels_selector_, !embedded_web_active)",
+        "set_visible(view_actions_label_, !embedded_web_active)",
+        "set_visible(view_actions_selector_, !embedded_web_active)",
+        "set_visible(interaction_mode_label_, !embedded_web_active)",
+        "set_visible(interaction_mode_selector_, !embedded_web_active)",
+    ]:
+        assert token in visibility_body

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -3132,12 +3132,20 @@ void MainWindow::build_studio_header_actions()
   run_next_menu->addAction(action_export_open_page_);
   run_next_button->setMenu(run_next_menu);
   top_bar->addWidget(run_next_button);
-  auto * native_scene3d_help_label = new QLabel(
-    "Native Scene3D: lightweight editable layout preview; not guaranteed RViz-equivalent.",
+#ifdef WORKCELL_BUILDER_HAS_WEBENGINE
+  auto * product_view_help_label = new QLabel(
+    "Web3D Product View",
     this);
-  native_scene3d_help_label->setWordWrap(true);
-  native_scene3d_help_label->setObjectName("studioNativeScene3DHelpLabel");
-  top_bar->addWidget(native_scene3d_help_label);
+  product_view_help_label->setToolTip("Embedded Web3D Product View is active; use the viewer surface for product framing and overlay controls.");
+#else
+  auto * product_view_help_label = new QLabel(
+    "Native Scene3D compatibility preview: lightweight editable layout preview; not guaranteed RViz-equivalent.",
+    this);
+  product_view_help_label->setToolTip("Native compatibility wording is shown only when WebEngine is unavailable and the native fallback is active.");
+#endif
+  product_view_help_label->setWordWrap(true);
+  product_view_help_label->setObjectName("studioProductViewHelpLabel");
+  top_bar->addWidget(product_view_help_label);
   auto * more_button = new QToolButton(this);
   more_button->setText("More");
   more_button->setPopupMode(QToolButton::InstantPopup);

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -142,7 +142,11 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
   view_mode_label_ = new QLabel("View mode", this);
   controls->addWidget(view_mode_label_);
   mode_selector_ = new QComboBox(this);
+#ifdef WORKCELL_BUILDER_HAS_WEBENGINE
+  mode_selector_->addItems({"Web3D Product View", "2D Layout"});
+#else
   mode_selector_->addItems({"3D Layout Preview", "2D Layout"});
+#endif
   controls->addWidget(mode_selector_);
   controls->addSpacing(8);
   mesh_preview_mode_label_ = new QLabel("Mesh Preview:", this);
@@ -1175,15 +1179,15 @@ void ScenePreviewWidget::refresh_toolbar_visibility()
   set_visible(gizmo_mode_selector_, !embedded_web_active);
   set_visible(snap_mode_label_, false);
   set_visible(snap_mode_selector_, false);
-  set_visible(interaction_mode_label_, true);
-  set_visible(interaction_mode_selector_, true);
+  set_visible(interaction_mode_label_, !embedded_web_active);
+  set_visible(interaction_mode_selector_, !embedded_web_active);
   set_visible(overlays_selector_, true);
 }
 
 void ScenePreviewWidget::refresh_mode_and_state()
 {
   const QString mode = mode_selector_->currentText();
-  const bool requested_3d = (mode == "3D Layout Preview");
+  const bool requested_3d = (mode == "3D Layout Preview" || mode == "Web3D Product View");
   const bool use3d = requested_3d && preview3d_available_;
   refresh_toolbar_visibility();
 
@@ -1338,7 +1342,7 @@ void ScenePreviewWidget::refresh_info_chip()
 {
   if (!info_chip_label_) return;
   const QString mode = mode_selector_ ? mode_selector_->currentText() : QStringLiteral("2D Layout");
-  const bool requested_3d = (mode == "3D Layout Preview");
+  const bool requested_3d = (mode == "3D Layout Preview" || mode == "Web3D Product View");
   const QString render_mode = requested_3d && preview3d_available_ ? mode : QStringLiteral("2D Layout (Fallback)");
   const QString summary = preview_status_summary_.isEmpty() ? QString("Items: %1").arg(preview_items_.size()) : preview_status_summary_;
 


### PR DESCRIPTION
### Motivation
- When Qt WebEngine is available the embedded Web3D surface is the canonical Product View and the UI should not show the old “Native Scene3D” compatibility banner or surface-specific native controls that would be no-ops in the embedded view.
- Make the header and mode selector explicitly identify the embedded surface as “Web3D Product View” while keeping native compatibility wording only in the non-WebEngine fallback.
- Ensure native-only toolbar controls are hidden when the embedded Web3D surface is active to avoid confusing or non-functional UI affordances.
- Add static tests to assert the native banner text is not present for the embedded Web3D path and that native-only controls remain gated.

### Description
- Replace the single static native help label in `mainwindow.cpp` with a conditional label that shows `"Web3D Product View"` when `WORKCELL_BUILDER_HAS_WEBENGINE` is defined and shows native-compatibility wording only in the `#else` fallback, and set the new widget object name to `studioProductViewHelpLabel`.
- Update `scene_preview_widget.cpp` to present `"Web3D Product View"` in the view-mode combo when WebEngine is compiled, keep `"3D Layout Preview"` in non-WebEngine builds, and treat both strings as valid 3D modes for state/status handling.
- Hide native-only toolbar controls when the embedded web surface is active by using the `embedded_web_active` check; specifically hide or gate mesh preview, gizmo controls, native label controls, view-action controls, and interaction controls when the web view is used.
- Adjust `refresh_info_chip()`/`refresh_mode_and_state()` logic to recognise `"Web3D Product View"` as a 3D mode and keep fallback behaviour unchanged when preview is unavailable.
- Add and update static tests in `tests/test_workcell_builder_web_viewer_action.py` to verify the header wording and visibility tokens, and update `tests/test_workcell_builder_guided_scene_setup_v1.py` to expect the new native-fallback compatibility wording.

### Testing
- Ran targeted Web3D tests: `python3 -m pytest tests/test_workcell_builder_web_viewer_action.py::test_embedded_web3d_header_and_mode_do_not_show_native_banner_text tests/test_workcell_builder_web_viewer_action.py::test_embedded_web3d_hides_native_only_toolbar_controls tests/test_workcell_builder_web_viewer_action.py::test_embedded_web3d_server_is_local_reused_and_controls_are_not_native_noops` — all passed.
- Ran product view related smoke/static tests: `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py` — passed.
- Verified `git diff --check` and static code checks — passed.
- Note: during iterative testing an unrelated pre-existing static expectation in a broader guided-setup test run surfaced; the guided-setup assertion was updated to match the intended native-fallback wording and the Web3D-specific tests were re-run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54efb00c4c83318a9bd3933a75a5ad)