### PR TITLE
Add Web3D runtime dependency and embedded Product View readiness tests

### DIFF
--- a/tests/test_workcell_builder_embedded_web3d_readiness_policy.py
+++ b/tests/test_workcell_builder_embedded_web3d_readiness_policy.py
@@ -1,0 +1,90 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CPP_PATH = ROOT / "workcell_builder/workcell_builder/gui/scene_preview_widget.cpp"
+HDR_PATH = ROOT / "workcell_builder/workcell_builder/gui/scene_preview_widget.h"
+MAINWINDOW_PATH = ROOT / "workcell_builder/workcell_builder/gui/mainwindow.cpp"
+CPP = CPP_PATH.read_text(encoding="utf-8")
+HDR = HDR_PATH.read_text(encoding="utf-8")
+MAINWINDOW = MAINWINDOW_PATH.read_text(encoding="utf-8")
+
+
+def _between(text: str, start: str, end: str) -> str:
+    start_i = text.index(start)
+    return text[start_i:text.index(end, start_i)]
+
+
+def test_load_finished_true_does_not_mark_embedded_product_view_ready():
+    handler = _between(CPP, "&QWebEngineView::loadFinished", "simple_3d_view_ = embedded_web_view_")
+    assert "set_embedded_product_view_state(EmbeddedProductViewState::Loading" in handler
+    assert "start_embedded_web_readiness_polling" in handler
+    assert "set_embedded_product_view_state(EmbeddedProductViewState::Ready" not in handler
+
+
+def test_javascript_failed_status_sets_failed_with_stage_and_error_detail():
+    poll = _between(CPP, "void ScenePreviewWidget::poll_embedded_web_readiness", "void ScenePreviewWidget::load_prepared_embedded_web_scene")
+    assert "boot_state == QStringLiteral(\"failed\")" in poll
+    assert "set_embedded_product_view_state(EmbeddedProductViewState::Failed, detail)" in poll
+    assert "failed_stage" in poll
+    assert "fatal_error" in poll
+    assert "fatal_stack" in poll
+
+
+def test_scene_fetch_failure_is_reported_to_qt_as_failed_javascript_status():
+    viewer = (ROOT / "workcell_studio_web/viewer/viewer.js").read_text(encoding="utf-8")
+    bundle = (ROOT / "workcell_studio_web/viewer/dist/viewer.bundle.js").read_text(encoding="utf-8")
+    assert "Failed to load scene from" in viewer
+    assert "showError" in viewer
+    assert "viewer_boot_state: 'failed'" in viewer
+    assert "Failed to load scene from" in bundle
+    assert "viewer_boot_state: 'failed'" in bundle
+
+
+def test_readiness_timeout_sets_failed_and_logs_last_boot_status():
+    poll = _between(CPP, "void ScenePreviewWidget::poll_embedded_web_readiness", "static const char kStatusScript[]")
+    assert "startup timed out after 45s" in poll
+    assert "embedded_web_last_boot_status_" in poll
+    assert "set_embedded_product_view_state(EmbeddedProductViewState::Failed, detail)" in poll
+
+
+def test_ready_requires_scene_json_and_renderer_readiness():
+    poll = _between(CPP, "const bool expected_json_loaded", "set_embedded_product_view_state(EmbeddedProductViewState::Loading")
+    assert "scene_json_loaded && source_json == expected_json_path" in poll
+    assert "robot_ready_required" in poll
+    assert "robot_state == QStringLiteral(\"ready\")" in poll
+    assert "boot_state == QStringLiteral(\"ready\") && expected_json_loaded && robot_ready" in poll
+
+
+def test_preparation_accepts_only_rebuilt_or_current_and_rejects_malformed_wrong_scene_missing_and_failed_command():
+    prepare = _between(CPP, "void ScenePreviewWidget::on_embedded_web_prepare_finished", "void ScenePreviewWidget::start_embedded_web_readiness_polling")
+    assert "freshener_status != QStringLiteral(\"current\") && freshener_status != QStringLiteral(\"rebuilt\")" in prepare
+    assert "freshener did not return a valid JSON object" in prepare
+    assert "expected output missing or unreadable" in prepare
+    assert "prepared output JSON validation failed" in prepare
+    assert "prepared output semantic validation failed" in prepare
+    assert "prepare command failed with exit code" in prepare
+    assert "old output is rejected even if present" in prepare
+
+
+def test_repo_root_resolution_covers_home_workspace_repo_symlink_env_override_and_rejects_partial_roots():
+    resolver = _between(CPP, "QString ScenePreviewWidget::resolve_embedded_web_repo_root", "QString ScenePreviewWidget::embedded_web_prepare_command_for_log")
+    assert "canonicalFilePath" in resolver  # symlinked scene path is canonicalized before walking upward.
+    assert "selected scene directory upward walk" in resolver  # repository root from a selected scene path.
+    assert "WORKCELL_STUDIO_REPO_ROOT secondary override" in resolver  # valid explicit environment override.
+    assert "QDir::currentPath()" in resolver  # home/workspace/repo launch cwd fallback.
+    assert "QCoreApplication::applicationDirPath()" in resolver
+    for marker in ["workcell_studio_web/viewer/index.html", "scripts/ensure_workcell_studio_web_scene_fresh.py", "scenes"]:
+        assert marker in resolver
+    assert "candidate rejected" in resolver
+    assert "missing %3" in resolver
+
+
+def test_native_backend_is_suppressed_unless_explicitly_requested_or_webengine_unavailable():
+    assert "WORKCELL_BUILDER_PRODUCT_VIEW_BACKEND" in CPP
+    assert "native_scene3d_explicitly_requested" in CPP
+    assert "product_view_backend_ = ProductViewBackend::EmbeddedWeb3D" in CPP
+    assert "product_view_backend_ = ProductViewBackend::NativeScene3D" in CPP
+    assert "WORKCELL_BUILDER_ALLOW_NATIVE_3D_FALLBACK" in (ROOT / "workcell_builder/workcell_builder/CMakeLists.txt").read_text(encoding="utf-8")
+    assert "scene_preview_widget_->is_native_product_view_backend()" in MAINWINDOW
+    assert "auto * viewport = is_native_product_view_backend() ? qobject_cast<Scene3DViewportWidget *>(simple_3d_view_) : nullptr;" in CPP
+    assert "ProductViewBackend { EmbeddedWeb3D, NativeScene3D }" in HDR

--- a/tests/test_workcell_web3d_offline_bundle.py
+++ b/tests/test_workcell_web3d_offline_bundle.py
@@ -1,0 +1,84 @@
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+VIEWER = ROOT / "workcell_studio_web" / "viewer"
+RUNTIME_FILES = [
+    VIEWER / "index.html",
+    VIEWER / "style.css",
+    VIEWER / "dist" / "viewer.bundle.js",
+    VIEWER / "workcell_runtime_marker.json",
+]
+CDN_RE = re.compile(r"https?://[^\s\"']*(?:unpkg|jsdelivr|cdnjs|cdn)[^\s\"']*", re.I)
+BARE_THREE_URDF_IMPORT_RE = re.compile(
+    r"\bimport\s*(?:\([^)]*['\"](?:three(?:/[^'\"]*)?|urdf-loader)['\"]\)|[^;]*?from\s*['\"](?:three(?:/[^'\"]*)?|urdf-loader)['\"]|['\"](?:three(?:/[^'\"]*)?|urdf-loader)['\"])",
+    re.M,
+)
+
+
+def _text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_runtime_viewer_uses_committed_bundle_not_importmap():
+    html = _text(VIEWER / "index.html")
+    assert 'type="importmap"' not in html
+    assert "type='importmap'" not in html
+    assert (VIEWER / "dist" / "viewer.bundle.js").is_file()
+    assert 'src="./dist/viewer.bundle.js"' in html or 'src="dist/viewer.bundle.js"' in html or "src='./dist/viewer.bundle.js'" in html or "src='dist/viewer.bundle.js'" in html
+
+
+@pytest.mark.parametrize("path", RUNTIME_FILES, ids=lambda p: p.relative_to(ROOT).as_posix())
+def test_runtime_viewer_files_do_not_reference_cdn_urls(path):
+    assert path.is_file(), f"runtime viewer file is missing: {path.relative_to(ROOT)}"
+    text = _text(path)
+    assert "unpkg" not in text.lower()
+    assert "jsdelivr" not in text.lower()
+    assert not CDN_RE.search(text)
+
+
+@pytest.mark.parametrize("path", [VIEWER / "index.html", VIEWER / "dist" / "viewer.bundle.js"], ids=lambda p: p.relative_to(ROOT).as_posix())
+def test_delivered_runtime_files_have_no_unresolved_bare_three_or_urdf_imports(path):
+    assert not BARE_THREE_URDF_IMPORT_RE.search(_text(path))
+
+
+def test_dependency_lockfile_and_runtime_versions_are_pinned_exactly():
+    lockfile = VIEWER / "package-lock.json"
+    assert lockfile.is_file()
+    package = json.loads((VIEWER / "package.json").read_text(encoding="utf-8"))
+    lock = json.loads(lockfile.read_text(encoding="utf-8"))
+    deps = package["dependencies"]
+    assert deps["three"] == "0.160.0"
+    assert deps["urdf-loader"] == "0.13.0"
+    assert deps["esbuild"] == "0.20.2"
+    assert deps["@esbuild/linux-x64"] == "0.20.2"
+    assert lock["packages"][""]["dependencies"]["three"] == "0.160.0"
+    assert lock["packages"][""]["dependencies"]["urdf-loader"] == "0.13.0"
+    assert lock["packages"]["node_modules/three"]["version"] == "0.160.0"
+    assert lock["packages"]["node_modules/urdf-loader"]["version"] == "0.13.0"
+    assert lock["packages"]["node_modules/esbuild"]["version"] == "0.20.2"
+
+
+def test_stale_bundle_guard_runs_when_node_dependencies_are_available_or_is_wired():
+    package = json.loads((VIEWER / "package.json").read_text(encoding="utf-8"))
+    assert package["scripts"]["check:stale-bundle"] == "node scripts/check_stale_bundle.mjs"
+    assert (VIEWER / "scripts" / "check_stale_bundle.mjs").is_file()
+    if shutil.which("node") and (VIEWER / "node_modules" / "esbuild").exists():
+        result = subprocess.run(
+            ["npm", "run", "check:stale-bundle"],
+            cwd=VIEWER,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+    else:
+        workflow_text = "\n".join(path.read_text(encoding="utf-8") for path in (ROOT / ".github" / "workflows").glob("*.yml"))
+        readme = (VIEWER / "README.md").read_text(encoding="utf-8")
+        assert "check:stale-bundle" in workflow_text or "npm run check:stale-bundle" in readme


### PR DESCRIPTION
### Motivation
- Ensure the Web3D viewer is delivered as an offline committed bundle with no runtime CDN/importmap dependencies and that runtime imports are resolved by the bundle. 
- Enforce reproducible pinned dependency versions for the viewer toolchain (`three`, `urdf-loader`, `esbuild`) via manifest and lockfile checks. 
- Protect product UX by asserting embedded Product View readiness semantics (load vs readiness, JS failures, scene fetch/timeouts, preparation freshness) and repo-root discovery rules. 

### Description
- Added `tests/test_workcell_web3d_offline_bundle.py` which asserts no `type="importmap"` in `index.html`, no `unpkg`/`jsdelivr`/CDN URLs in runtime files, presence of `dist/viewer.bundle.js`, no unresolved bare `three`/`urdf-loader` imports, a committed `package-lock.json`, and exact pinned versions for `three`, `urdf-loader`, and `esbuild`, plus a stale-bundle guard check wired via the `check:stale-bundle` script. 
- Added `tests/test_workcell_builder_embedded_web3d_readiness_policy.py` which statically verifies `scene_preview_widget.cpp` and related viewer sources for correctness of embedded Product View lifecycle handling (rejecting `loadFinished(true)` as Ready, propagating JS `failed` state, scene-fetch failure handling, readiness timeout behavior, preparation freshness and rejection conditions, repo root resolution including symlink/env/workspace fallbacks, and explicit suppression of native backend unless requested). 
- Minor test assertion tweak to accept `./dist/viewer.bundle.js` URL forms in the `index.html` check to match the committed viewer HTML. 

### Testing
- Ran `python3 -m pytest tests/test_workcell_web3d_offline_bundle.py tests/test_workcell_builder_embedded_web3d_readiness_policy.py` and the two new test files passed: `17 passed`.
- Ran a broader suite that included `tests/test_ensure_workcell_studio_web_scene_fresh.py` and `tests/test_workcell_builder_embedded_web3d_policy.py`; that run surfaced unrelated environment limitations causing 3 failures in freshness/export tests because a real xacro-expanded URDF preview is not available in this container (these failures are environmental, not regressions in the added tests). 
- The stale-bundle guard test is conditional and will execute the actual `npm run check:stale-bundle` when Node and local `node_modules` are present; otherwise it validates that the stale-check command is wired into CI/docs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54fb585fc8833198842fb27c376693)