### PR TITLE
Include physical assembly roots in camera fit/diagnostics and adjust expanded URDF preview framing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+workcell_studio_web/viewer/dist/viewer.bundle.js linguist-generated=true

--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -16,7 +16,7 @@ def test_static_viewer_files_exist():
 def test_index_references_static_assets():
     index = (VIEWER / "index.html").read_text(encoding="utf-8")
     assert 'href="style.css"' in index
-    assert 'src="viewer.js"' in index
+    assert 'src="./dist/viewer.bundle.js"' in index or 'src="dist/viewer.bundle.js"' in index
     assert 'id="scene-file"' in index
     assert 'web_scene.json' in index
 
@@ -963,3 +963,55 @@ def test_viewer_summary_reports_expanded_urdf_loader_for_aliases():
     summary_fields = js.split("const fields = {", 1)[1].split("};", 1)[0]
     assert "'robot-preview-mode': summary.robotPreviewMode" in summary_fields
     assert "summary.robotPreviewMode === 'expanded_urdf_loader'" not in summary_fields
+
+
+def test_expanded_urdf_assembly_roots_are_first_class_physical_fit_bounds():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    fit_bounds_body = js.split("function computeFitBounds", 1)[1].split("function computeRenderedBounds", 1)[0]
+    collect_body = js.split("function collectPhysicalAssemblyBounds", 1)[1].split("function itemHiddenForFit", 1)[0]
+    status_body = js.split("function collectAssemblyRenderDiagnostics", 1)[1].split("function isUserFacingWarning", 1)[0]
+
+    assert "function collectPhysicalAssemblyBounds" in js
+    assert "for (const root of state.assemblyRoots || [])" in collect_body
+    assert "visibleRenderableBounds(root)" in collect_body
+    assert "if (!rootBounds) continue" in collect_body
+    assert "assemblyRootHiddenForFit(root)" in collect_body
+    assert "normalBounds.union(assemblyBounds.bounds)" in fit_bounds_body
+    assert "state.physicalAssemblyBounds = assemblyBounds.bounds.clone()" in fit_bounds_body
+    assert "state.finalPhysicalFitBounds = finiteNormal.clone()" in fit_bounds_body
+    for token in [
+        "physical_assembly_root_count",
+        "physical_assembly_bounds",
+        "physical_fit_included_robot_preview",
+        "final_physical_fit_bounds",
+        "physical_renderable_count",
+    ]:
+        assert token in status_body
+
+
+def test_expanded_urdf_robot_preview_fits_once_after_ready_not_per_mesh_callback():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    preview_body = js.split("function loadExpandedUrdfRobotPreview", 1)[1].split("function linkNameOfItem", 1)[0]
+    loaded_body = preview_body.split("onRobotLoaded: result =>", 1)[1].split("onRobotMeshLoaded", 1)[0]
+    mesh_loaded_body = preview_body.split("onRobotMeshLoaded: () =>", 1)[1].split("onRobotMeshLoadError", 1)[0]
+
+    assert "const bounds = computeFitBounds()" in loaded_body
+    assert "if (bounds) frameScene(bounds)" in loaded_body
+    assert "renderSceneSummary()" in mesh_loaded_body
+    assert "frameScene" not in mesh_loaded_body
+    assert "computeFitBounds" not in mesh_loaded_body
+
+
+def test_expanded_urdf_robot_assembly_stays_locked_single_root_and_legacy_rows_suppressed():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    render_body = js.split("function renderScene(items)", 1)[1].split("function loadExpandedUrdfRobotPreview", 1)[0]
+    assert "const urdfPreviewActive = isExpandedUrdfRobotPreview" in render_body
+    assert "handled: new Set(robotToolGeneratedUrdfItems)" in render_body
+    assert "skipped_legacy_generated_urdf_visual_count: robotToolGeneratedUrdfItems.length" in render_body
+    assert "if (assemblyBuild.handled.has(item)) continue" in render_body
+    assert "source.includes('generated')" in js
+    renderer = (VIEWER / "urdf_robot_renderer.js").read_text(encoding="utf-8")
+    ready_body = renderer.split("await meshCompletion.wait();", 1)[1].split("return result;", 1)[0]
+    assert ready_body.count("rendererContext?.scene?.add?.(robot)") == 1
+    assert ready_body.count("rendererContext?.assemblyRoots?.push?.(robot)") == 1
+    assert "world/root fixed chain -> URDF joint origin -> joint value -> link frame" in renderer

--- a/workcell_studio_web/viewer/dist/viewer.bundle.js
+++ b/workcell_studio_web/viewer/dist/viewer.bundle.js
@@ -37876,7 +37876,7 @@ var LOCKED_EDIT_REASON = "Locked/generated preview item; edit source layout/envi
 var MIN_FRAME_RADIUS = 1.2;
 var EMPTY_SCENE_MESSAGE = "Scene contains no renderable robots, tools, assets, sensors, zones, items, or objects.";
 var FRAME_DISTANCE_MULTIPLIER = 2.7;
-var state = { sceneJson: null, sourceWebSceneFile: "", frameLookup: /* @__PURE__ */ new Map(), resolvedFramePoses: /* @__PURE__ */ new Map(), objects: [], assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, robotUrdfPreviewDiagnostics: {}, selected: null, three: {}, animationId: null, lastFrameBounds: null, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: /* @__PURE__ */ new Map(), undoStack: [], redoStack: [], gizmoDragStart: null };
+var state = { sceneJson: null, sourceWebSceneFile: "", frameLookup: /* @__PURE__ */ new Map(), resolvedFramePoses: /* @__PURE__ */ new Map(), objects: [], assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, robotUrdfPreviewDiagnostics: {}, physicalAssemblyBounds: null, finalPhysicalFitBounds: null, selected: null, three: {}, animationId: null, lastFrameBounds: null, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: /* @__PURE__ */ new Map(), undoStack: [], redoStack: [], gizmoDragStart: null };
 var RESET_VIEW_TITLE = "Fit Scene / Reset View: recomputes and reapplies the fitted workcell overview from renderable bounds.";
 var STAGED_MESH_ROOTS = [
   "build/workcell_studio_web_scene/assets/",
@@ -37962,6 +37962,8 @@ function isExpectedMeshlessTool0Frame(item2) {
 }
 function collectAssemblyRenderDiagnostics() {
   const diagnostics = state.robotAssemblyRenderDiagnostics || {};
+  const assemblyBounds = collectPhysicalAssemblyBounds();
+  const finalFitBounds = state.finalPhysicalFitBounds ? box3ToJson(state.finalPhysicalFitBounds) : null;
   const rendered = state.objects || [];
   const independentGenerated = rendered.filter((obj) => {
     const item2 = obj?.item || {};
@@ -37984,6 +37986,16 @@ function collectAssemblyRenderDiagnostics() {
     renderedFkVisualCount: Number(diagnostics.rendered_fk_visual_count || 0),
     skipped_legacy_generated_urdf_count: Number(diagnostics.skipped_legacy_generated_urdf_count || 0),
     skippedLegacyGeneratedUrdfCount: Number(diagnostics.skipped_legacy_generated_urdf_count || 0),
+    physical_assembly_root_count: assemblyBounds.count,
+    physicalAssemblyRootCount: assemblyBounds.count,
+    physical_assembly_bounds: assemblyBounds.bounds_json,
+    physicalAssemblyBounds: assemblyBounds.bounds_json,
+    physical_fit_included_robot_preview: Boolean(assemblyBounds.count && assemblyBounds.bounds_json),
+    physicalFitIncludedRobotPreview: Boolean(assemblyBounds.count && assemblyBounds.bounds_json),
+    final_physical_fit_bounds: finalFitBounds,
+    finalPhysicalFitBounds: finalFitBounds,
+    physical_renderable_count: rendered.length + assemblyBounds.count,
+    physicalRenderableCount: rendered.length + assemblyBounds.count,
     visible_duplicate_generated_urdf_count: independentGenerated.length,
     visibleDuplicateGeneratedUrdfCount: independentGenerated.length,
     visible_tool0_fallback_count: visibleTool0Fallback.length,
@@ -38250,16 +38262,16 @@ function updateViewerStatus() {
   });
   const assemblyRenderDiagnostics = collectAssemblyRenderDiagnostics();
   window.__WORKCELL_VIEWER_STATUS__ = {
-    viewer_boot_state: 'ready',
-    viewerBootState: 'ready',
-    failed_stage: '',
-    failedStage: '',
-    fatal_error: '',
-    fatalError: '',
-    fatal_stack: '',
-    fatalStack: '',
-    source_web_scene_file: state.sourceWebSceneFile || '',
-    sourceWebSceneFile: state.sourceWebSceneFile || '',
+    viewer_boot_state: "ready",
+    viewerBootState: "ready",
+    failed_stage: "",
+    failedStage: "",
+    fatal_error: "",
+    fatalError: "",
+    fatal_stack: "",
+    fatalStack: "",
+    source_web_scene_file: state.sourceWebSceneFile || "",
+    sourceWebSceneFile: state.sourceWebSceneFile || "",
     scene_json_loaded: Boolean(state.sceneJson),
     sceneJsonLoaded: Boolean(state.sceneJson),
     scene_name: summary.sceneName,
@@ -38323,19 +38335,19 @@ function renderSceneSummary() {
   }
 }
 function showError(message) {
-  const text = message || 'Unknown viewer error';
+  const text = message || "Unknown viewer error";
   el.error.textContent = text;
   el.error.hidden = false;
   window.__WORKCELL_VIEWER_STATUS__ = {
-    ...(window.__WORKCELL_VIEWER_STATUS__ || {}),
-    viewer_boot_state: 'failed',
-    viewerBootState: 'failed',
-    failed_stage: 'viewer_runtime',
-    failedStage: 'viewer_runtime',
+    ...window.__WORKCELL_VIEWER_STATUS__ || {},
+    viewer_boot_state: "failed",
+    viewerBootState: "failed",
+    failed_stage: "viewer_runtime",
+    failedStage: "viewer_runtime",
     fatal_error: text,
     fatalError: text,
-    fatal_stack: (new Error(text).stack || '').split('\n').slice(0, 6).join('\n'),
-    fatalStack: (new Error(text).stack || '').split('\n').slice(0, 6).join('\n'),
+    fatal_stack: (new Error(text).stack || "").split("\n").slice(0, 6).join("\n"),
+    fatalStack: (new Error(text).stack || "").split("\n").slice(0, 6).join("\n")
   };
 }
 function clearError() {
@@ -39710,6 +39722,29 @@ function visibleRenderableBounds(object) {
 function objectHasVisibleRenderable(object) {
   return Boolean(visibleRenderableBounds(object));
 }
+function assemblyRootHiddenForFit(root) {
+  const data = root?.userData || {};
+  return root?.visible === false || data.exclude_from_fit_bounds === true || data.debug_only === true || data.diagnostic_only === true || data.helper_overlay === true;
+}
+function collectPhysicalAssemblyBounds() {
+  if (!(state.assemblyRoots || []).length || !THREE?.Box3)
+    return { count: 0, bounds: null, bounds_json: null, roots: [] };
+  const bounds = new THREE.Box3();
+  let count = 0;
+  const roots = [];
+  for (const root of state.assemblyRoots || []) {
+    if (!root || assemblyRootHiddenForFit(root))
+      continue;
+    const rootBounds = visibleRenderableBounds(root);
+    if (!rootBounds)
+      continue;
+    bounds.union(rootBounds);
+    count += 1;
+    roots.push({ name: root.name || "", robot_render_mode: root.userData?.robot_render_mode || "", bounds: box3ToJson(rootBounds) });
+  }
+  const finite = count ? finiteBox3(bounds) : null;
+  return { count: finite ? count : 0, bounds: finite, bounds_json: box3ToJson(finite), roots };
+}
 function itemHiddenForFit(item2) {
   return item2?.visible === false || item2?.hidden === true || item2?.rendered === false || item2?.enabled === false;
 }
@@ -39753,6 +39788,14 @@ function computeFitBounds({ includeDebugFallbacks = false } = {}) {
   let hasNormal = false;
   let hasFallback = false;
   const deferredWarnings = [];
+  const assemblyBounds = collectPhysicalAssemblyBounds();
+  if (assemblyBounds.bounds) {
+    normalBounds.union(assemblyBounds.bounds);
+    hasNormal = true;
+    state.physicalAssemblyBounds = assemblyBounds.bounds.clone();
+  } else {
+    state.physicalAssemblyBounds = null;
+  }
   for (const rendered of state.objects) {
     if (!rendered?.object3d)
       continue;
@@ -39791,6 +39834,7 @@ function computeFitBounds({ includeDebugFallbacks = false } = {}) {
     for (const warning of deferredWarnings)
       warnFitBlockerExcluded(...warning);
     maybeWarnSceneBoundsExceedWorkspace(finiteNormal);
+    state.finalPhysicalFitBounds = finiteNormal.clone();
     return finiteNormal;
   }
   const finiteFallback = includeDebugFallbacks || hasFallback ? finiteBox3(fallbackBounds) : null;
@@ -39806,8 +39850,10 @@ function computeFitBounds({ includeDebugFallbacks = false } = {}) {
       });
     }
     maybeWarnSceneBoundsExceedWorkspace(finiteFallback);
+    state.finalPhysicalFitBounds = finiteFallback.clone();
     return finiteFallback;
   }
+  state.finalPhysicalFitBounds = null;
   return null;
 }
 function box3ToJson(box) {
@@ -40066,6 +40112,8 @@ function clearSceneObjects() {
   state.assemblyRoots = [];
   state.robotAssemblyDiagnostics = [];
   state.robotAssemblyRenderDiagnostics = {};
+  state.physicalAssemblyBounds = null;
+  state.finalPhysicalFitBounds = null;
   state.resolvedFramePoses.clear();
   state.lastFrameBounds = null;
   state._sceneBoundsExceededWarned = false;
@@ -40186,9 +40234,6 @@ function loadExpandedUrdfRobotPreview(preview) {
     },
     onRobotMeshLoaded: () => {
       renderSceneSummary();
-      const bounds = computeFitBounds();
-      if (bounds)
-        frameScene(bounds);
     },
     onRobotMeshLoadError: () => renderSceneSummary(),
     onRobotError: (err) => {

--- a/workcell_studio_web/viewer/urdf_robot_renderer.js
+++ b/workcell_studio_web/viewer/urdf_robot_renderer.js
@@ -415,8 +415,11 @@ export function loadRobotPreview(previewConfig, rendererContext = {}) {
     await meshCompletion.wait();
 
     const jointValues = previewConfig?.joint_values || {};
-    // Delegate all supported fixed/revolute/continuous/prismatic and mimic propagation
-    // to urdf-loader's joint API; do not manually transform child link groups here.
+    // Transform chain for expanded previews is intentionally single-application:
+    // world/root fixed chain -> URDF joint origin -> joint value -> link frame
+    // -> URDF visual origin -> URDF mesh scale -> loader asset-coordinate conversion.
+    // Delegate fixed/revolute/continuous/prismatic and mimic propagation to
+    // urdf-loader's joint API; do not manually transform child link groups here.
     robot.setJointValues(jointValues);
     robot.updateMatrixWorld(true);
 

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -13,7 +13,7 @@ const LOCKED_EDIT_REASON = 'Locked/generated preview item; edit source layout/en
 const MIN_FRAME_RADIUS = 1.2;
 const EMPTY_SCENE_MESSAGE = 'Scene contains no renderable robots, tools, assets, sensors, zones, items, or objects.';
 const FRAME_DISTANCE_MULTIPLIER = 2.7;
-const state = { sceneJson: null, sourceWebSceneFile: '', frameLookup: new Map(), resolvedFramePoses: new Map(), objects: [], assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, robotUrdfPreviewDiagnostics: {}, selected: null, three: {}, animationId: null, lastFrameBounds: null, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: new Map(), undoStack: [], redoStack: [], gizmoDragStart: null };
+const state = { sceneJson: null, sourceWebSceneFile: '', frameLookup: new Map(), resolvedFramePoses: new Map(), objects: [], assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, robotUrdfPreviewDiagnostics: {}, physicalAssemblyBounds: null, finalPhysicalFitBounds: null, selected: null, three: {}, animationId: null, lastFrameBounds: null, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: new Map(), undoStack: [], redoStack: [], gizmoDragStart: null };
 const RESET_VIEW_TITLE = 'Fit Scene / Reset View: recomputes and reapplies the fitted workcell overview from renderable bounds.';
 const STAGED_MESH_ROOTS = [
   'build/workcell_studio_web_scene/assets/',
@@ -99,6 +99,8 @@ function isExpectedMeshlessTool0Frame(item) {
 }
 function collectAssemblyRenderDiagnostics() {
   const diagnostics = state.robotAssemblyRenderDiagnostics || {};
+  const assemblyBounds = collectPhysicalAssemblyBounds();
+  const finalFitBounds = state.finalPhysicalFitBounds ? box3ToJson(state.finalPhysicalFitBounds) : null;
   const rendered = state.objects || [];
   const independentGenerated = rendered.filter(obj => {
     const item = obj?.item || {};
@@ -123,6 +125,16 @@ function collectAssemblyRenderDiagnostics() {
     renderedFkVisualCount: Number(diagnostics.rendered_fk_visual_count || 0),
     skipped_legacy_generated_urdf_count: Number(diagnostics.skipped_legacy_generated_urdf_count || 0),
     skippedLegacyGeneratedUrdfCount: Number(diagnostics.skipped_legacy_generated_urdf_count || 0),
+    physical_assembly_root_count: assemblyBounds.count,
+    physicalAssemblyRootCount: assemblyBounds.count,
+    physical_assembly_bounds: assemblyBounds.bounds_json,
+    physicalAssemblyBounds: assemblyBounds.bounds_json,
+    physical_fit_included_robot_preview: Boolean(assemblyBounds.count && assemblyBounds.bounds_json),
+    physicalFitIncludedRobotPreview: Boolean(assemblyBounds.count && assemblyBounds.bounds_json),
+    final_physical_fit_bounds: finalFitBounds,
+    finalPhysicalFitBounds: finalFitBounds,
+    physical_renderable_count: rendered.length + assemblyBounds.count,
+    physicalRenderableCount: rendered.length + assemblyBounds.count,
     visible_duplicate_generated_urdf_count: independentGenerated.length,
     visibleDuplicateGeneratedUrdfCount: independentGenerated.length,
     visible_tool0_fallback_count: visibleTool0Fallback.length,
@@ -1679,6 +1691,30 @@ function visibleRenderableBounds(object) {
 function objectHasVisibleRenderable(object) {
   return Boolean(visibleRenderableBounds(object));
 }
+function assemblyRootHiddenForFit(root) {
+  const data = root?.userData || {};
+  return root?.visible === false
+    || data.exclude_from_fit_bounds === true
+    || data.debug_only === true
+    || data.diagnostic_only === true
+    || data.helper_overlay === true;
+}
+function collectPhysicalAssemblyBounds() {
+  if (!(state.assemblyRoots || []).length || !THREE?.Box3) return { count: 0, bounds: null, bounds_json: null, roots: [] };
+  const bounds = new THREE.Box3();
+  let count = 0;
+  const roots = [];
+  for (const root of state.assemblyRoots || []) {
+    if (!root || assemblyRootHiddenForFit(root)) continue;
+    const rootBounds = visibleRenderableBounds(root);
+    if (!rootBounds) continue;
+    bounds.union(rootBounds);
+    count += 1;
+    roots.push({ name: root.name || '', robot_render_mode: root.userData?.robot_render_mode || '', bounds: box3ToJson(rootBounds) });
+  }
+  const finite = count ? finiteBox3(bounds) : null;
+  return { count: finite ? count : 0, bounds: finite, bounds_json: box3ToJson(finite), roots };
+}
 function itemHiddenForFit(item) {
   return item?.visible === false || item?.hidden === true || item?.rendered === false || item?.enabled === false;
 }
@@ -1718,6 +1754,14 @@ function computeFitBounds({ includeDebugFallbacks = false } = {}) {
   let hasNormal = false;
   let hasFallback = false;
   const deferredWarnings = [];
+  const assemblyBounds = collectPhysicalAssemblyBounds();
+  if (assemblyBounds.bounds) {
+    normalBounds.union(assemblyBounds.bounds);
+    hasNormal = true;
+    state.physicalAssemblyBounds = assemblyBounds.bounds.clone();
+  } else {
+    state.physicalAssemblyBounds = null;
+  }
   for (const rendered of state.objects) {
     if (!rendered?.object3d) continue;
     if (rendered.item?.exclude_from_fit_bounds === true || rendered.object3d.userData?.exclude_from_fit_bounds === true) {
@@ -1755,6 +1799,7 @@ function computeFitBounds({ includeDebugFallbacks = false } = {}) {
   if (finiteNormal) {
     for (const warning of deferredWarnings) warnFitBlockerExcluded(...warning);
     maybeWarnSceneBoundsExceedWorkspace(finiteNormal);
+    state.finalPhysicalFitBounds = finiteNormal.clone();
     return finiteNormal;
   }
   const finiteFallback = (includeDebugFallbacks || hasFallback) ? finiteBox3(fallbackBounds) : null;
@@ -1769,8 +1814,10 @@ function computeFitBounds({ includeDebugFallbacks = false } = {}) {
       });
     }
     maybeWarnSceneBoundsExceedWorkspace(finiteFallback);
+    state.finalPhysicalFitBounds = finiteFallback.clone();
     return finiteFallback;
   }
+  state.finalPhysicalFitBounds = null;
   return null;
 }
 function computeRenderedBounds() {
@@ -2003,6 +2050,8 @@ function clearSceneObjects() {
   state.assemblyRoots = [];
   state.robotAssemblyDiagnostics = [];
   state.robotAssemblyRenderDiagnostics = {};
+  state.physicalAssemblyBounds = null;
+  state.finalPhysicalFitBounds = null;
   state.resolvedFramePoses.clear();
   state.lastFrameBounds = null;
   state._sceneBoundsExceededWarned = false;
@@ -2122,8 +2171,6 @@ function loadExpandedUrdfRobotPreview(preview) {
     },
     onRobotMeshLoaded: () => {
       renderSceneSummary();
-      const bounds = computeFitBounds();
-      if (bounds) frameScene(bounds);
     },
     onRobotMeshLoadError: () => renderSceneSummary(),
     onRobotError: err => {


### PR DESCRIPTION
### Motivation
- Ensure assembly roots produced by the expanded URDF loader are treated as first-class physical renderables for camera framing and viewer diagnostics.
- Avoid repeated per-mesh framing callbacks when loading expanded URDF previews and surface clearer diagnostic reporting for assembled robots.
- Mark the generated bundle as linguist-generated to avoid code-language noise in the repo.

### Description
- Added `physicalAssemblyBounds` and `finalPhysicalFitBounds` to the viewer `state` and cleared them when the scene is cleared via `clearSceneObjects`.
- Implemented `assemblyRootHiddenForFit` and `collectPhysicalAssemblyBounds` to compute a combined bounding box for `state.assemblyRoots` and return counts/roots, and integrated that into `computeFitBounds` so assembly bounds are included in normal fit calculations and stored on `state`.
- Updated `collectAssemblyRenderDiagnostics` to expose new diagnostic fields: `physical_assembly_root_count`, `physical_assembly_bounds`, `physical_fit_included_robot_preview`, `final_physical_fit_bounds`, and `physical_renderable_count` (with both snake_case and camelCase variants), populated from the collected assembly bounds.
- Changed expanded-URDF preview lifecycle so the viewer frames once after the robot is loaded (`onRobotLoaded`) but no longer attempts to re-frame in the per-mesh `onRobotMeshLoaded` callback, preventing repeated frames.
- Small clarification comment in `urdf_robot_renderer.js` describing the intended single-application transform chain for expanded previews.
- Added `.gitattributes` entry to mark `workcell_studio_web/viewer/dist/viewer.bundle.js` as `linguist-generated=true`.
- Updated `tests/test_workcell_studio_web_viewer_static.py` to expect the bundled `dist/viewer.bundle.js` reference in `index.html` and added tests exercising the new assembly/fit behavior and expanded URDF preview framing and assembly handling (`test_expanded_urdf_assembly_roots_are_first_class_physical_fit_bounds`, `test_expanded_urdf_robot_preview_fits_once_after_ready_not_per_mesh_callback`, and `test_expanded_urdf_robot_assembly_stays_locked_single_root_and_legacy_rows_suppressed`).

### Testing
- Ran the static viewer test module with `pytest tests/test_workcell_studio_web_viewer_static.py` and the test suite covering the added assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55fff1b26c83318aeab0832a7a1e62)