### PR TITLE
Restore clean ROS 2 Humble workspace build

### DIFF
--- a/.github/workflows/humble-ci.yml
+++ b/.github/workflows/humble-ci.yml
@@ -103,14 +103,32 @@ jobs:
           restore-keys: |
             colcon-humble-
 
+      - name: Import source dependencies
+        working-directory: ws
+        run: |
+          if ! command -v vcs >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y python3-vcstool
+          fi
+          vcs import --recursive --skip-existing src < src/easy_manipulation_deployment/dependencies/emd_epd_ws.repos
+
       - name: Install dependencies
         working-directory: ws
         run: |
+          set -o pipefail
           ./src/easy_manipulation_deployment/scripts/ensure_rosdep_overrides.sh
           ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh
           rosdep update
-          rosdep install --from-paths src --ignore-src -yr --rosdistro humble \
-            --skip-keys "qt_advanced_docking tesseract_visualization"
+          if ! rosdep install --from-paths src --ignore-src -yr --rosdistro humble \
+            --skip-keys "qt_advanced_docking tesseract_visualization"; then
+            ./src/easy_manipulation_deployment/scripts/diagnose_rosdep_workspace.py \
+              --src src \
+              --rosdistro humble \
+              --os-name ubuntu \
+              --os-codename jammy \
+              --skip-keys "qt_advanced_docking tesseract_visualization"
+            exit 1
+          fi
 
       - name: Reproducibility guard (workspace discovery)
         working-directory: ws

--- a/scripts/diagnose_rosdep_workspace.py
+++ b/scripts/diagnose_rosdep_workspace.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Print rosdep/package diagnostics for a workspace dependency failure."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+DEPENDENCY_TAGS = {
+    "build_depend",
+    "build_export_depend",
+    "buildtool_depend",
+    "depend",
+    "exec_depend",
+    "test_depend",
+}
+
+
+def package_name(package_xml: Path) -> str:
+    try:
+        return (ET.parse(package_xml).getroot().findtext("name") or "").strip()
+    except ET.ParseError:
+        return ""
+
+
+def collect_packages(src: Path) -> dict[str, Path]:
+    packages: dict[str, Path] = {}
+    for package_xml in sorted(src.rglob("package.xml")):
+        if any((parent / "COLCON_IGNORE").exists() or (parent / "AMENT_IGNORE").exists() for parent in package_xml.parents):
+            continue
+        name = package_name(package_xml)
+        if name:
+            packages[name] = package_xml.parent
+    return packages
+
+
+def collect_declared_dependencies(src: Path) -> dict[str, set[Path]]:
+    declared: dict[str, set[Path]] = {}
+    for package_xml in sorted(src.rglob("package.xml")):
+        if any((parent / "COLCON_IGNORE").exists() or (parent / "AMENT_IGNORE").exists() for parent in package_xml.parents):
+            continue
+        try:
+            root = ET.parse(package_xml).getroot()
+        except ET.ParseError:
+            continue
+        for element in root:
+            if element.tag not in DEPENDENCY_TAGS or not element.text:
+                continue
+            key = element.text.strip()
+            if key:
+                declared.setdefault(key, set()).add(package_xml)
+    return declared
+
+
+def rosdep_resolve(key: str, rosdistro: str, os_name: str, os_codename: str) -> tuple[int, str]:
+    cmd = [
+        "rosdep",
+        "resolve",
+        key,
+        "--rosdistro",
+        rosdistro,
+        "--os",
+        f"{os_name}:{os_codename}",
+    ]
+    proc = subprocess.run(cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False)
+    return proc.returncode, proc.stdout.strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--src", default="src", type=Path)
+    parser.add_argument("--rosdistro", required=True)
+    parser.add_argument("--os-name", default="ubuntu")
+    parser.add_argument("--os-codename", required=True)
+    parser.add_argument("--skip-keys", default="")
+    args = parser.parse_args()
+
+    skip_keys = {key for key in args.skip_keys.replace(",", " ").split() if key}
+    packages = collect_packages(args.src)
+    declared = collect_declared_dependencies(args.src)
+
+    print("rosdep failure diagnostics")
+    print(f"  ROS distribution: {args.rosdistro}")
+    print(f"  OS codename: {args.os_name}:{args.os_codename}")
+    print(f"  workspace source root: {args.src}")
+    print(f"  discovered source packages: {len(packages)}")
+    if skip_keys:
+        print(f"  skipped rosdep keys: {', '.join(sorted(skip_keys))}")
+
+    unresolved = []
+    for key in sorted(declared):
+        providers = sorted(str(path) for path in declared[key])
+        if key in packages:
+            print(f"SOURCE {key}: provided by {packages[key]}; declared by {', '.join(providers)}")
+            continue
+        if key in skip_keys:
+            print(f"SKIP {key}: declared by {', '.join(providers)}")
+            continue
+        rc, output = rosdep_resolve(key, args.rosdistro, args.os_name, args.os_codename)
+        first_line = output.splitlines()[0] if output else "<no rosdep output>"
+        if rc == 0:
+            print(f"ROSDEP {key}: {first_line}; declared by {', '.join(providers)}")
+        else:
+            unresolved.append((key, providers, output))
+            print(f"UNRESOLVED {key}: declared by {', '.join(providers)}")
+            print(output)
+
+    if unresolved:
+        print("Unresolved rosdep keys:", ", ".join(key for key, _, _ in unresolved), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_humble_build_regressions.py
+++ b/tests/test_humble_build_regressions.py
@@ -250,3 +250,76 @@ def test_scene_generated_directories_are_installed_conditionally():
             offenders.append(str(cmake_path))
 
     assert offenders == []
+
+
+def test_humble_ci_imports_source_dependencies_before_layout_fix():
+    text = Path(".github/workflows/humble-ci.yml").read_text()
+    import_idx = text.index("vcs import --recursive --skip-existing src < src/easy_manipulation_deployment/dependencies/emd_epd_ws.repos")
+    layout_idx = text.index("./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh")
+    rosdep_idx = text.index("rosdep install --from-paths src --ignore-src -yr --rosdistro humble")
+    assert import_idx < layout_idx < rosdep_idx
+
+
+def test_humble_ci_rosdep_failure_runs_workspace_diagnostics():
+    text = Path(".github/workflows/humble-ci.yml").read_text()
+    assert "diagnose_rosdep_workspace.py" in text
+    assert "--os-codename jammy" in text
+    assert "--rosdistro humble" in text
+    assert "--skip-keys \"qt_advanced_docking tesseract_visualization\"" in text
+
+
+def test_rosdep_diagnostics_reports_source_providers_and_declaring_packages(tmp_path, monkeypatch, capsys):
+    import importlib.util
+
+    script = Path("scripts/diagnose_rosdep_workspace.py")
+    spec = importlib.util.spec_from_file_location("diagnose_rosdep_workspace", script)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    src = tmp_path / "src"
+    provider = src / "provider"
+    consumer = src / "consumer"
+    provider.mkdir(parents=True)
+    consumer.mkdir(parents=True)
+    (provider / "package.xml").write_text("""
+<package format='3'>
+  <name>source_only_dep</name>
+  <version>0.0.0</version>
+  <description>provider</description>
+  <maintainer email='dev@example.com'>Dev</maintainer>
+  <license>Apache-2.0</license>
+</package>
+""")
+    (consumer / "package.xml").write_text("""
+<package format='3'>
+  <name>consumer</name>
+  <version>0.0.0</version>
+  <description>consumer</description>
+  <maintainer email='dev@example.com'>Dev</maintainer>
+  <license>Apache-2.0</license>
+  <depend>source_only_dep</depend>
+  <exec_depend>skipped_dep</exec_depend>
+</package>
+""")
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            str(script),
+            "--src",
+            str(src),
+            "--rosdistro",
+            "humble",
+            "--os-codename",
+            "jammy",
+            "--skip-keys",
+            "skipped_dep",
+        ],
+    )
+
+    assert module.main() == 0
+    output = capsys.readouterr().out
+    assert "SOURCE source_only_dep: provided by" in output
+    assert "declared by" in output and "consumer/package.xml" in output
+    assert "SKIP skipped_dep" in output


### PR DESCRIPTION
Summary:
- Import the pinned source dependency overlay before Humble workspace layout repair and rosdep installation.
- Add rosdep failure diagnostics that report ROS distro, Ubuntu codename, declaring package.xml files, source providers, skipped keys, and rosdep resolution output.
- Add regression coverage for Humble workflow ordering and the diagnostic source-provider reporting path.

Validation:
- python3 -m py_compile scripts/diagnose_rosdep_workspace.py: passed.
- bash -n scripts/ensure_rosdep_overrides.sh scripts/fix_workspace_layout.sh: passed.
- python3 -m pytest -q tests/test_humble_build_regressions.py::test_humble_ci_imports_source_dependencies_before_layout_fix tests/test_humble_build_regressions.py::test_humble_ci_rosdep_failure_runs_workspace_diagnostics tests/test_humble_build_regressions.py::test_rosdep_diagnostics_reports_source_providers_and_declaring_packages: passed.
- python3 -m pytest -q tests/test_humble_build_regressions.py tests/test_workspace_layout_assets_scenes_aliases.py tests/test_trajopt_osqp_dependency_compatibility.py: failed on pre-existing static assertion expecting #include <QTcpSocket> in scene_preview_widget.cpp.
- Full rosdep/colcon/GitHub Actions validation was not run in this container because ROS 2 Humble tooling is not installed and branch push failed without GitHub credentials.

Safety:
- Fake-hardware defaults and runtime launch behavior were not changed.
- workcell_builder package.xml and Qt WebEngine requirement were not changed.
- Web3D rendering, viewer bundles, robot/gripper geometry, and visual acceptance thresholds were not modified.

Risks / rollback:
- If the imported source overlay exposes a second independent Humble build issue, inspect the new CI log and fix that separate blocker in a follow-up commit.
- Roll back by reverting commit 031b8e05139e1c492dc3f536c843ac053bd3fbb8.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5638b52f788331ae97ab61c5e0d38f)