### PR TITLE
Add draggable Pick and Place Area authoring

### DIFF
--- a/tests/test_workcell_builder_task_area_editor.py
+++ b/tests/test_workcell_builder_task_area_editor.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+SCENE_SELECT_CPP = REPO / "workcell_builder/workcell_builder/gui/scene_select.cpp"
+SCENE_SELECT_H = REPO / "workcell_builder/workcell_builder/gui/scene_select.h"
+YAML_IO_CPP = REPO / "workcell_builder/workcell_builder/gui/object_placement_yaml_io.cpp"
+MODEL_H = REPO / "workcell_builder/workcell_builder/include/object_placement_model.hpp"
+
+
+def test_task_area_editor_ui_and_canvas_tokens_present():
+    cpp = SCENE_SELECT_CPP.read_text(encoding="utf-8")
+    for token in [
+        "Task Areas",
+        "Suggested Areas",
+        "Add Pick Area",
+        "Add Place Area",
+        "Delete Selected",
+        "Snap to 1 cm",
+        "Pick Area",
+        "Place Area",
+        "Pick Object",
+        "Destination Bin",
+        "Offline layout check only; motion planning is checked later.",
+        "TaskAreaGraphicsItem",
+        "ItemIsMovable",
+    ]:
+        assert token in cpp
+
+
+def test_task_area_dirty_state_gates_primary_actions():
+    cpp = SCENE_SELECT_CPP.read_text(encoding="utf-8")
+    header = SCENE_SELECT_H.read_text(encoding="utf-8")
+    assert "task_area_dirty_" in header
+    assert "return task_editor_state_.unsaved_task_edits || task_area_dirty_" in cpp
+    assert "primary_validate_button->setEnabled(!unsaved)" in cpp
+    assert "primary_generate_package_button->setEnabled(!unsaved" in cpp
+
+
+def test_suggested_areas_are_idempotent_and_use_stable_ids():
+    cpp = SCENE_SELECT_CPP.read_text(encoding="utf-8")
+    assert "ensure_suggested_task_areas" in cpp
+    assert "has_role(\"pick\")" in cpp
+    assert "has_role(\"place\")" in cpp
+    assert "commissioning_pick_pose" in cpp
+    assert "default_drop_zone" in cpp
+
+
+def test_task_zone_persistence_fields_and_task_refs_are_written():
+    model = MODEL_H.read_text(encoding="utf-8")
+    yaml_io = YAML_IO_CPP.read_text(encoding="utf-8")
+    for field in ["role", "shape", "support_surface_ref", "object_ref", "target_ref"]:
+        assert field in model
+        assert field in yaml_io
+    for key in ["pose_xyz", "pose_rpy", "dimensions", "frame", "task", "source_ref", "target_ref", "intent_target_ref"]:
+        assert key in yaml_io
+
+
+def test_task_area_save_validation_and_backup_tokens_present():
+    cpp = SCENE_SELECT_CPP.read_text(encoding="utf-8")
+    for token in [
+        "missing ID/type",
+        "non-finite value",
+        "width/depth/height must be positive",
+        "duplicate Pick Area ID",
+        "duplicate Place Area ID",
+        "unresolved Pick Object association",
+        "unresolved Destination Bin association",
+        "may be outside support surface",
+        "Pick and Place Areas may be overlapping",
+        ".task_areas.",
+        "copy_file(env, backup",
+    ]:
+        assert token in cpp
+
+
+def test_no_web3d_or_generated_bundle_paths_touched_by_task_area_editor():
+    changed_scope = "\n".join(p.name for p in [SCENE_SELECT_CPP, SCENE_SELECT_H, YAML_IO_CPP, MODEL_H])
+    assert "workcell_studio_web" not in changed_scope
+    assert "generated" not in changed_scope

--- a/workcell_builder/workcell_builder/gui/object_placement_yaml_io.cpp
+++ b/workcell_builder/workcell_builder/gui/object_placement_yaml_io.cpp
@@ -78,6 +78,14 @@ std::vector<PlacedObject> load_placed_objects_from_environment_yaml(const std::s
         o.scale_y = scale[1].as<double>(1.0);
         o.scale_z = scale[2].as<double>(1.0);
       }
+      auto pose_xyz_alias = n["pose_xyz"];
+      if (pose_xyz_alias && pose_xyz_alias.IsSequence() && pose_xyz_alias.size() == 3) {
+        z.x = pose_xyz_alias[0].as<double>(0.0); z.y = pose_xyz_alias[1].as<double>(0.0); z.z = pose_xyz_alias[2].as<double>(0.0);
+      }
+      auto pose_rpy_alias = n["pose_rpy"];
+      if (pose_rpy_alias && pose_rpy_alias.IsSequence() && pose_rpy_alias.size() == 3) {
+        z.roll = pose_rpy_alias[0].as<double>(0.0); z.pitch = pose_rpy_alias[1].as<double>(0.0); z.yaw = pose_rpy_alias[2].as<double>(0.0);
+      }
       auto pose = n["pose"];
       if (pose && pose.IsMap()) {
         auto xyz = pose["xyz"]; auto rpy = pose["rpy"];
@@ -213,11 +221,24 @@ std::vector<TaskZone> load_task_zones_from_environment_yaml(const std::string & 
       seen_ids.insert(z.id);
 
       z.type = n["type"].as<std::string>("");
-      z.parent_frame = n["parent_frame"].as<std::string>("world");
+      z.role = n["role"].as<std::string>(z.type);
+      z.shape = n["shape"].as<std::string>("box");
+      z.parent_frame = n["frame"].as<std::string>(n["parent_frame"].as<std::string>("world"));
       z.frame_id = n["frame_id"].as<std::string>("");
+      z.support_surface_ref = n["support_surface_ref"].as<std::string>("");
+      z.object_ref = n["object_ref"].as<std::string>("");
+      z.target_ref = n["target_ref"].as<std::string>("");
       z.enabled = n["enabled"].as<bool>(true);
       z.status = n["status"].as<std::string>("");
 
+      auto pose_xyz_alias = n["pose_xyz"];
+      if (pose_xyz_alias && pose_xyz_alias.IsSequence() && pose_xyz_alias.size() == 3) {
+        z.x = pose_xyz_alias[0].as<double>(0.0); z.y = pose_xyz_alias[1].as<double>(0.0); z.z = pose_xyz_alias[2].as<double>(0.0);
+      }
+      auto pose_rpy_alias = n["pose_rpy"];
+      if (pose_rpy_alias && pose_rpy_alias.IsSequence() && pose_rpy_alias.size() == 3) {
+        z.roll = pose_rpy_alias[0].as<double>(0.0); z.pitch = pose_rpy_alias[1].as<double>(0.0); z.yaw = pose_rpy_alias[2].as<double>(0.0);
+      }
       auto pose = n["pose"];
       if (pose && pose.IsMap()) {
         auto xyz = pose["xyz"]; auto rpy = pose["rpy"];
@@ -234,6 +255,10 @@ std::vector<TaskZone> load_task_zones_from_environment_yaml(const std::string & 
         z.dim_x = dims["x"].as<double>(z.dim_x);
         z.dim_y = dims["y"].as<double>(z.dim_y);
         z.dim_z = dims["z"].as<double>(z.dim_z);
+      } else if (dims && dims.IsSequence() && dims.size() == 3) {
+        z.dim_x = dims[0].as<double>(z.dim_x);
+        z.dim_y = dims[1].as<double>(z.dim_y);
+        z.dim_z = dims[2].as<double>(z.dim_z);
       }
 
       auto allowed = n["allowed_object_types"];
@@ -280,13 +305,18 @@ PlacedObjectYamlWriteResult save_task_zones_to_environment_yaml(const std::strin
       YAML::Node n;
       n["id"] = z.id;
       n["type"] = z.type;
-      n["parent_frame"] = z.parent_frame.empty() ? "world" : z.parent_frame;
-      n["pose"]["xyz"].push_back(z.x); n["pose"]["xyz"].push_back(z.y); n["pose"]["xyz"].push_back(z.z);
-      n["pose"]["rpy"].push_back(z.roll); n["pose"]["rpy"].push_back(z.pitch); n["pose"]["rpy"].push_back(z.yaw);
-      n["dimensions"]["x"] = z.dim_x;
-      n["dimensions"]["y"] = z.dim_y;
-      n["dimensions"]["z"] = z.dim_z;
+      n["role"] = z.role.empty() ? z.type : z.role;
+      n["frame"] = z.parent_frame.empty() ? "world" : z.parent_frame;
+      n["shape"] = z.shape.empty() ? "box" : z.shape;
+      n["pose_xyz"].push_back(z.x); n["pose_xyz"].push_back(z.y); n["pose_xyz"].push_back(z.z);
+      n["pose_rpy"].push_back(z.roll); n["pose_rpy"].push_back(z.pitch); n["pose_rpy"].push_back(z.yaw);
+      n["dimensions"].push_back(z.dim_x);
+      n["dimensions"].push_back(z.dim_y);
+      n["dimensions"].push_back(z.dim_z);
       if (!z.frame_id.empty()) n["frame_id"] = z.frame_id;
+      if (!z.support_surface_ref.empty()) n["support_surface_ref"] = z.support_surface_ref;
+      if (!z.object_ref.empty()) n["object_ref"] = z.object_ref;
+      if (!z.target_ref.empty()) n["target_ref"] = z.target_ref;
       if (!z.allowed_object_types.empty()) {
         for (const auto & t : z.allowed_object_types) n["allowed_object_types"].push_back(t);
       }
@@ -296,6 +326,18 @@ PlacedObjectYamlWriteResult save_task_zones_to_environment_yaml(const std::strin
     }
 
     root["task_zones"] = arr;
+    for (const auto & z : zones) {
+      const bool is_pick = z.role == "pick" || z.type == "pick_zone";
+      const bool is_place = z.role == "place" || z.type == "place_zone";
+      if (is_pick) {
+        root["task"]["pick"]["source_ref"] = z.id;
+        if (!z.object_ref.empty()) root["task"]["pick"]["object_ref"] = z.object_ref;
+      }
+      if (is_place) {
+        root["task"]["place"]["target_ref"] = z.id;
+        root["task"]["place"]["intent_target_ref"] = z.id;
+      }
+    }
     std::ofstream out(path);
     out << root;
     r.ok = out.good();

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -57,6 +57,7 @@
 #include <QDoubleSpinBox>
 #include <QSlider>
 #include <QSignalBlocker>
+#include <QRegularExpression>
 #include <QMenu>
 #include <QAction>
 #include <QTreeWidgetItem>
@@ -94,6 +95,7 @@
 #include <set>
 #include <cmath>
 #include <fstream>
+#include <functional>
 
 #include "gui/ui_scene_select.h"
 #include "gui/scene_select.h"
@@ -266,6 +268,26 @@ protected:
 };
 
 
+class TaskAreaGraphicsItem : public QGraphicsRectItem
+{
+public:
+  TaskAreaGraphicsItem(const QString & id, const QRectF & rect, std::function<void(const QString &, const QRectF &)> on_commit)
+  : QGraphicsRectItem(rect), id_(id), on_commit_(std::move(on_commit))
+  {
+    setFlag(QGraphicsItem::ItemIsSelectable, true);
+    setFlag(QGraphicsItem::ItemIsMovable, true);
+    setFlag(QGraphicsItem::ItemSendsGeometryChanges, true);
+  }
+protected:
+  void mouseReleaseEvent(QGraphicsSceneMouseEvent * event) override
+  {
+    QGraphicsRectItem::mouseReleaseEvent(event);
+    if (on_commit_) on_commit_(id_, sceneBoundingRect());
+  }
+private:
+  QString id_;
+  std::function<void(const QString &, const QRectF &)> on_commit_;
+};
 
 std::string scene_support_level_for(const std::vector<workcell_builder::SupportedSceneRegistryEntry> & entries, const std::string & name){
   for (const auto & e : entries) if (e.name == name) return e.support_level;
@@ -306,7 +328,7 @@ std::string scene_readiness_for(const workcell_builder::AllScenesReadinessData &
 
 
 
-[[maybe_unused]] static const char * kTaskZoneUiMarkers = "Add Pick Zone | Add Place Zone | Edit Zone Pose | Edit Zone Size | Save Task Zones to Scene YAML | Open Task Zone Preview | task_zones";
+[[maybe_unused]] static const char * kTaskZoneUiMarkers = "Task Areas | Suggested Areas | Add Pick Area | Add Place Area | Delete Selected | Snap to 1 cm | Pick Area | Place Area | Pick Object | Destination Bin | Offline layout check only; motion planning is checked later. | task_zones";
 
 [[maybe_unused]] static const char * kAssetDiscoveryLabel = "Asset discovery paths";
 [[maybe_unused]] static const char * kSelectRobotAssetLabel = "Select Robot Asset";
@@ -904,6 +926,7 @@ SceneSelect::SceneSelect(QWidget * parent)
 
   initialize_task_grasp_editor();
   initialize_robot_home_editor();
+  initialize_task_area_editor();
   ui->generate_files->hide();
   ui->validate_cell->show();
   ui->validate_cell->setText("Run Offline Validation");
@@ -1080,7 +1103,7 @@ bool SceneSelect::has_selected_cell() const
 
 bool SceneSelect::has_unsaved_edits() const
 {
-  return task_editor_state_.unsaved_task_edits || (robot_home_state_ && robot_home_state_->dirty);
+  return task_editor_state_.unsaved_task_edits || task_area_dirty_ || (robot_home_state_ && robot_home_state_->dirty);
 }
 
 void SceneSelect::refresh_primary_workflow_state(const std::string & outcome, const std::string & action, const std::string & next)
@@ -2143,6 +2166,7 @@ void SceneSelect::on_edit_scene_clicked()
         append_success("Scene edits were applied and persisted to environment.yaml.");
         refresh_scenes(current_index, false);
         refresh_canvas_from_scene(scene_window.scene);
+      load_task_areas_for_selected_scene();
       }
     } else {
       refresh_scenes(current_index, false);
@@ -2236,6 +2260,15 @@ void SceneSelect::on_generate_yaml_clicked()
     const fs::path scene_yaml_path =
       scenes_path / workcell.scene_vector[current_index].name;
     Scene target_scene = workcell.scene_vector[current_index];
+    std::vector<std::string> task_area_errors;
+    std::vector<std::string> task_area_warnings;
+    if (!validate_task_areas_for_save(&task_area_errors, &task_area_warnings)) {
+      for (const auto & e : task_area_errors) append_error("Task Area save blocked: " + e);
+      refresh_primary_workflow_state("Blocked", "Save", "Correct invalid Pick Area / Place Area values before saving.");
+      return;
+    }
+    for (const auto & w : task_area_warnings) append_warning("Task Area warning: " + w);
+    append_info("Offline layout check only; motion planning is checked later.");
     if (!validate_robot_home_for_save()) {
       refresh_primary_workflow_state("Blocked", "Save", "Correct invalid Robot Home joint values before saving.");
       return;
@@ -2287,6 +2320,13 @@ void SceneSelect::on_generate_yaml_clicked()
     append_error("No scene selected to generate environment.yaml.");
   }
   if (current_index >= 0 && current_index < static_cast<int>(workcell.scene_vector.size())) {
+    std::string task_area_path;
+    if (!save_task_areas_to_scene(scenes_path / workcell.scene_vector[current_index].name, &task_area_path)) {
+      append_error("Task Area save failed: " + task_area_path);
+      refresh_primary_workflow_state("Blocked", "Save", "Correct Task Area save error before validation or generation.");
+      return;
+    }
+    if (!task_area_path.empty()) append_success("Task Areas saved to " + task_area_path);
     std::string robot_home_path;
     if (save_robot_home_to_scene(scenes_path / workcell.scene_vector[current_index].name, &robot_home_path)) {
       append_success("Robot Home saved to " + robot_home_path);
@@ -2299,6 +2339,7 @@ void SceneSelect::on_generate_yaml_clicked()
   scaffold_scene_index_ = -1;
   refresh_scene_status(true, "Generate YAML");
   task_editor_state_.unsaved_task_edits = false;
+  task_area_dirty_ = false;
   if (robot_home_state_) robot_home_state_->dirty = false;
   refresh_primary_workflow_state("Success", "Save", "Validate the cell.");
 }
@@ -2466,6 +2507,7 @@ void SceneSelect::on_scene_list_currentIndexChanged(int index)
     }
   }
   load_robot_home_for_selected_scene();
+  load_task_areas_for_selected_scene();
   refresh_scene_status(index != scaffold_scene_index_, "Scene Selection Changed");
   refresh_primary_workflow_state("Warning", "Select Cell", "Open the selected cell or validate its current files.");
   on_refresh_status_button_clicked();
@@ -3441,6 +3483,35 @@ void SceneSelect::refresh_preview_status()
       scene->addText("reach_warning")->setPos(px(it.x)-18, px(it.y)+8);
     }
   }
+  for (const auto & area : task_area_zones_) {
+    const bool pick = area.role == "pick" || area.type == "pick_zone";
+    const QColor outline = pick ? QColor("#166534") : QColor("#9f1239");
+    const Qt::PenStyle style = pick ? Qt::DashLine : Qt::DashDotLine;
+    QRectF rect(px(area.x - area.dim_x / 2.0), px(area.y - area.dim_y / 2.0), px(area.dim_x), px(area.dim_y));
+    auto * item = new TaskAreaGraphicsItem(QString::fromStdString(area.id), rect, [this](const QString & id, const QRectF & r) {
+      for (auto & z : task_area_zones_) if (z.id == id.toStdString()) {
+        z.x = snap_task_area_value(r.center().x() / 220.0);
+        z.y = snap_task_area_value(r.center().y() / 220.0);
+        z.dim_x = std::max(0.01, snap_task_area_value(r.width() / 220.0));
+        z.dim_y = std::max(0.01, snap_task_area_value(r.height() / 220.0));
+        selected_task_area_id_ = z.id;
+        mark_task_areas_dirty("Drag/resize Task Area");
+        sync_task_area_inspector();
+        break;
+      }
+    });
+    item->setPen(QPen(outline, 3, style));
+    item->setBrush(QBrush(QColor(outline.red(), outline.green(), outline.blue(), 45)));
+    item->setData(0, pick ? "Pick Area" : "Place Area");
+    item->setData(1, pick ? "pick_area" : "place_area");
+    item->setData(2, QString("x=%1 y=%2 width=%3 depth=%4 status=%5").arg(area.x,0,'f',2).arg(area.y,0,'f',2).arg(area.dim_x,0,'f',2).arg(area.dim_y,0,'f',2).arg(QString::fromStdString(area.status)));
+    item->setData(3, QString::fromStdString(area.id));
+    scene->addItem(item);
+    auto * label = scene->addText(pick ? "Pick Area" : "Place Area");
+    label->setDefaultTextColor(outline);
+    label->setPos(rect.topLeft() + QPointF(4, 4));
+    scene->addRect(rect.adjusted(-5, -5, 5, 5), QPen(outline, 1, Qt::DotLine));
+  }
   QObject::connect(scene, &QGraphicsScene::selectionChanged, ui->visual_layout_canvas, [this, scene]() {
     const auto sel = scene->selectedItems(); if (sel.empty()) return; auto * i=sel.front();
     selected_item_id = i->data(3).toString().toStdString();
@@ -3448,6 +3519,7 @@ void SceneSelect::refresh_preview_status()
     selected_canvas_item_type_ = i->data(1).toString().toStdString();
     ui->inspector_help->setText(QString("zone_inspector_token id=%1 name=%2 type=%3 | %4 | layout_unsaved=true | rerun zone validation")
       .arg(i->data(3).toString(), i->data(0).toString(), i->data(1).toString(), i->data(2).toString()));
+    if (selected_canvas_item_type_ == "pick_area" || selected_canvas_item_type_ == "place_area") { selected_task_area_id_ = selected_canvas_item_id_; sync_task_area_inspector(); }
   });
   ui->visual_layout_canvas->setScene(scene);
   ui->visual_layout_canvas->setRenderHint(QPainter::Antialiasing, true);
@@ -3475,6 +3547,153 @@ void SceneSelect::export_preview_layout()
 }
 
 
+
+void SceneSelect::initialize_task_area_editor()
+{
+  auto * group = new QGroupBox("Task Areas", ui->layout_tab);
+  group->setObjectName("task_areas_group");
+  auto * layout = new QVBoxLayout(group);
+  auto * help = new QLabel("Author Pick Area and Place Area boxes on the top-down canvas. Offline layout check only; motion planning is checked later.", group);
+  help->setWordWrap(true);
+  layout->addWidget(help);
+  auto * buttons = new QHBoxLayout();
+  auto add_button = [group, buttons](const QString & text, const char * name) {
+    auto * b = new QPushButton(text, group); b->setObjectName(name); buttons->addWidget(b); return b;
+  };
+  auto * suggested = add_button("Suggested Areas", "suggested_task_areas_button");
+  auto * add_pick = add_button("Add Pick Area", "add_pick_area_button");
+  auto * add_place = add_button("Add Place Area", "add_place_area_button");
+  auto * del = add_button("Delete Selected", "delete_selected_task_area_button");
+  auto * snap = add_button("Snap to 1 cm", "snap_task_area_button");
+  snap->setCheckable(true); snap->setChecked(true);
+  layout->addLayout(buttons);
+  auto * form = new QFormLayout();
+  auto make_spin = [group](const char * name, double minv, double maxv, double val) {
+    auto * s = new QDoubleSpinBox(group); s->setObjectName(name); s->setDecimals(3); s->setSingleStep(0.01); s->setRange(minv, maxv); s->setValue(val); return s;
+  };
+  auto * name = new QLineEdit(group); name->setObjectName("task_area_name_edit"); form->addRow("Name", name);
+  auto * x = make_spin("task_area_x_spin", -10, 10, 0); form->addRow("X", x);
+  auto * y = make_spin("task_area_y_spin", -10, 10, 0); form->addRow("Y", y);
+  auto * z = make_spin("task_area_z_spin", -10, 10, 0); form->addRow("Z", z);
+  auto * rot = make_spin("task_area_rotation_spin", -6.283, 6.283, 0); form->addRow("Rotation", rot);
+  auto * w = make_spin("task_area_width_spin", 0.001, 10, 0.30); form->addRow("Width", w);
+  auto * d = make_spin("task_area_depth_spin", 0.001, 10, 0.30); form->addRow("Depth", d);
+  auto * h = make_spin("task_area_height_spin", 0.001, 10, 0.10); form->addRow("Height", h);
+  auto * assoc = new QLineEdit(group); assoc->setObjectName("task_area_association_edit"); form->addRow("Pick Object / Destination Bin", assoc);
+  auto * status = new QLabel("status/warning", group); status->setObjectName("task_area_status_label"); status->setWordWrap(true); form->addRow("status/warning", status);
+  layout->addLayout(form);
+  ui->layoutLayout->insertWidget(1, group);
+  if (ui->use_selected_zone_as_pick_zone_button) ui->use_selected_zone_as_pick_zone_button->hide();
+  if (ui->use_selected_zone_as_place_zone_button) ui->use_selected_zone_as_place_zone_button->hide();
+  connect(suggested, &QPushButton::clicked, this, [this]() { if (ensure_suggested_task_areas()) mark_task_areas_dirty("Suggested Areas"); refresh_preview_status(); });
+  connect(add_pick, &QPushButton::clicked, this, [this]() { add_task_area("pick"); });
+  connect(add_place, &QPushButton::clicked, this, [this]() { add_task_area("place"); });
+  connect(del, &QPushButton::clicked, this, [this]() { delete_selected_task_area(); });
+  auto update = [this, name, x, y, z, rot, w, d, h, assoc]() {
+    for (auto & a : task_area_zones_) if (a.id == selected_task_area_id_) {
+      a.id = name->text().trimmed().toStdString(); selected_task_area_id_ = a.id;
+      a.x = snap_task_area_value(x->value()); a.y = snap_task_area_value(y->value()); a.z = snap_task_area_value(z->value());
+      a.yaw = snap_task_area_value(rot->value()); a.dim_x = snap_task_area_value(w->value()); a.dim_y = snap_task_area_value(d->value()); a.dim_z = snap_task_area_value(h->value());
+      if (a.role == "pick") a.object_ref = assoc->text().trimmed().toStdString(); else a.target_ref = assoc->text().trimmed().toStdString();
+      mark_task_areas_dirty("Task Area inspector"); refresh_preview_status(); break;
+    }
+  };
+  connect(name, &QLineEdit::editingFinished, this, update); connect(assoc, &QLineEdit::editingFinished, this, update);
+  for (auto * spin : {x,y,z,rot,w,d,h}) connect(spin, &QAbstractSpinBox::editingFinished, this, update);
+}
+
+double SceneSelect::snap_task_area_value(double value)
+{
+  return std::round(value * 100.0) / 100.0;
+}
+
+void SceneSelect::load_task_areas_for_selected_scene()
+{
+  task_area_zones_.clear(); selected_task_area_id_.clear(); task_area_dirty_ = false;
+  const fs::path env = scene_dir_for_current_selection() / "environment.yaml";
+  std::vector<std::string> warnings;
+  if (fs::exists(env)) task_area_zones_ = workcell_builder::load_task_zones_from_environment_yaml(env.string(), &warnings);
+  for (auto & z : task_area_zones_) {
+    if (z.role.empty()) z.role = (z.type.find("place") != std::string::npos || z.id.find("drop") != std::string::npos) ? "place" : "pick";
+    if (z.shape.empty()) z.shape = "box";
+  }
+  for (const auto & w : warnings) append_warning("Task Area warning: " + w);
+}
+
+bool SceneSelect::ensure_suggested_task_areas()
+{
+  bool changed = false;
+  auto has_role = [this](const std::string & role) { for (const auto & z : task_area_zones_) if (z.role == role || z.type == role + "_zone") return true; return false; };
+  if (!has_role("pick")) { workcell_builder::TaskZone z; z.id="commissioning_pick_pose"; z.type="pick_zone"; z.role="pick"; z.shape="box"; z.dim_x=.30; z.dim_y=.30; z.dim_z=.10; z.x=-.20; z.support_surface_ref="default_support_surface"; z.object_ref="Pick Object"; task_area_zones_.push_back(z); changed = true; }
+  if (!has_role("place")) { workcell_builder::TaskZone z; z.id="default_drop_zone"; z.type="place_zone"; z.role="place"; z.shape="box"; z.dim_x=.30; z.dim_y=.30; z.dim_z=.10; z.x=.25; z.support_surface_ref="default_support_surface"; z.target_ref="Destination Bin"; task_area_zones_.push_back(z); changed = true; }
+  return changed;
+}
+
+void SceneSelect::add_task_area(const std::string & role)
+{
+  workcell_builder::TaskZone z; z.id = role == "pick" ? "pick_area" : "place_area"; z.type = role + "_zone"; z.role = role; z.shape="box"; z.parent_frame="world"; z.dim_x=.30; z.dim_y=.30; z.dim_z=.10; z.x = role == "pick" ? -.20 : .25; z.support_surface_ref="default_support_surface"; if (role=="pick") z.object_ref="Pick Object"; else z.target_ref="Destination Bin";
+  int suffix = 1; auto exists=[&](const std::string & id){ for (const auto & a: task_area_zones_) if (a.id==id) return true; return false;}; const std::string base=z.id; while (exists(z.id)) z.id=base+"_"+std::to_string(++suffix);
+  task_area_zones_.push_back(z); selected_task_area_id_ = z.id; mark_task_areas_dirty(role == "pick" ? "Add Pick Area" : "Add Place Area"); refresh_preview_status();
+}
+
+void SceneSelect::delete_selected_task_area()
+{
+  if (selected_task_area_id_.empty()) return;
+  task_area_zones_.erase(std::remove_if(task_area_zones_.begin(), task_area_zones_.end(), [this](const auto & z){ return z.id == selected_task_area_id_; }), task_area_zones_.end());
+  selected_task_area_id_.clear(); mark_task_areas_dirty("Delete Selected"); refresh_preview_status();
+}
+
+void SceneSelect::mark_task_areas_dirty(const QString & reason)
+{
+  task_area_dirty_ = true; task_editor_state_.unsaved_task_edits = true;
+  refresh_primary_workflow_state("Warning", reason.toStdString(), "Save the cell before validation or generation.");
+}
+
+void SceneSelect::sync_task_area_inspector()
+{
+  const auto widgets = ui->layout_tab->findChildren<QWidget *>(QRegularExpression("^task_area_"));
+  for (auto * widget : widgets) widget->setEnabled(!selected_task_area_id_.empty());
+  for (const auto & a : task_area_zones_) if (a.id == selected_task_area_id_) {
+    auto set_text=[this](const char * n, const QString & v){ if (auto * w=ui->layout_tab->findChild<QLineEdit *>(n)) { QSignalBlocker b(w); w->setText(v);} };
+    auto set_spin=[this](const char * n, double v){ if (auto * w=ui->layout_tab->findChild<QDoubleSpinBox *>(n)) { QSignalBlocker b(w); w->setValue(v);} };
+    set_text("task_area_name_edit", QString::fromStdString(a.id)); set_spin("task_area_x_spin", a.x); set_spin("task_area_y_spin", a.y); set_spin("task_area_z_spin", a.z); set_spin("task_area_rotation_spin", a.yaw); set_spin("task_area_width_spin", a.dim_x); set_spin("task_area_depth_spin", a.dim_y); set_spin("task_area_height_spin", a.dim_z); set_text("task_area_association_edit", QString::fromStdString(a.role == "pick" ? a.object_ref : a.target_ref));
+    if (auto * l=ui->layout_tab->findChild<QLabel *>("task_area_status_label")) l->setText(QString::fromStdString((a.role=="pick" ? "Pick Area" : "Place Area") + std::string(" selected. Offline layout check only; motion planning is checked later.")));
+  }
+}
+
+bool SceneSelect::validate_task_areas_for_save(std::vector<std::string> * errors, std::vector<std::string> * warnings) const
+{
+  std::set<std::string> pick_ids, place_ids;
+  for (const auto & z : task_area_zones_) {
+    const bool is_pick = z.role == "pick" || z.type == "pick_zone";
+    const bool is_place = z.role == "place" || z.type == "place_zone";
+    if (z.id.empty() || z.type.empty()) errors->push_back("missing ID/type");
+    for (double v : {z.x,z.y,z.z,z.roll,z.pitch,z.yaw,z.dim_x,z.dim_y,z.dim_z}) if (!std::isfinite(v)) errors->push_back("non-finite value in " + z.id);
+    if (z.dim_x <= 0 || z.dim_y <= 0 || z.dim_z <= 0) errors->push_back("width/depth/height must be positive for " + z.id);
+    if (is_pick && !pick_ids.insert(z.id).second) errors->push_back("duplicate Pick Area ID: " + z.id);
+    if (is_place && !place_ids.insert(z.id).second) errors->push_back("duplicate Place Area ID: " + z.id);
+    if (is_pick && z.object_ref.empty()) errors->push_back("unresolved Pick Object association for " + z.id);
+    if (is_place && z.target_ref.empty()) errors->push_back("unresolved Destination Bin association for " + z.id);
+    if (std::fabs(z.x) > 1.0 || std::fabs(z.y) > 1.0) warnings->push_back(z.id + " may be outside support surface / approximate reach concern");
+  }
+  for (const auto & a : task_area_zones_) for (const auto & b : task_area_zones_) if (a.id < b.id && std::fabs(a.x-b.x) < (a.dim_x+b.dim_x)/2.0 && std::fabs(a.y-b.y) < (a.dim_y+b.dim_y)/2.0) warnings->push_back("Pick and Place Areas may be overlapping: " + a.id + " / " + b.id);
+  return errors->empty();
+}
+
+bool SceneSelect::save_task_areas_to_scene(const fs::path & scene_dir, std::string * reason)
+{
+  if (!task_area_dirty_) { if (reason) reason->clear(); return true; }
+  const fs::path env = scene_dir / "environment.yaml";
+  if (!fs::exists(env)) { if (reason) *reason = "missing " + env.string(); return false; }
+  const fs::path backup = env.string() + ".task_areas." + QDateTime::currentDateTimeUtc().toString("yyyyMMddHHmmss").toStdString() + ".bak";
+  boost::filesystem::copy_file(env, backup, boost::filesystem::copy_option::overwrite_if_exists);
+  auto r = workcell_builder::save_task_zones_to_environment_yaml(env.string(), task_area_zones_);
+  if (!r.ok) { if (reason) *reason = r.warnings.empty() ? env.string() : r.warnings.front(); return false; }
+  task_editor_state_.pick_source_type = "pick_zone"; task_editor_state_.place_target_type = "place_zone";
+  for (const auto & z : task_area_zones_) { if (z.role == "pick") task_editor_state_.selected_pick_zone_id = z.id; if (z.role == "place") task_editor_state_.selected_place_zone_id = z.id; }
+  if (reason) *reason = env.string() + " (backup: " + backup.string() + ")";
+  return true;
+}
 
 void SceneSelect::initialize_robot_home_editor()
 {
@@ -3542,6 +3761,8 @@ void SceneSelect::initialize_robot_home_editor()
   robot_home_validation_label_->setWordWrap(true);
   layout->addWidget(robot_home_validation_label_);
   ui->layoutLayout->insertWidget(1, group);
+  if (ui->use_selected_zone_as_pick_zone_button) ui->use_selected_zone_as_pick_zone_button->hide();
+  if (ui->use_selected_zone_as_place_zone_button) ui->use_selected_zone_as_place_zone_button->hide();
   connect(suggested, &QPushButton::clicked, this, [this]() {
     for (auto & joint : robot_home_state_->joints) joint.radians = joint.suggested_radians;
     robot_home_state_->source = "suggested";

--- a/workcell_builder/workcell_builder/gui/scene_select.h
+++ b/workcell_builder/workcell_builder/gui/scene_select.h
@@ -71,6 +71,7 @@ struct TaskGraspEditorState
 #include "workcell_scene_status.hpp"
 #include "offline_smoke_check_model.hpp"
 #include "supported_scene_readiness_loader.hpp"
+#include "object_placement_model.hpp"
 
 namespace Ui
 {
@@ -219,6 +220,17 @@ private:
   bool has_selected_cell() const;
   bool has_unsaved_edits() const;
   void initialize_robot_home_editor();
+  void initialize_task_area_editor();
+  void load_task_areas_for_selected_scene();
+  void refresh_task_area_canvas_items();
+  void sync_task_area_inspector();
+  void mark_task_areas_dirty(const QString & reason);
+  bool save_task_areas_to_scene(const boost::filesystem::path & scene_dir, std::string * reason);
+  bool validate_task_areas_for_save(std::vector<std::string> * errors, std::vector<std::string> * warnings) const;
+  bool ensure_suggested_task_areas();
+  void add_task_area(const std::string & role);
+  void delete_selected_task_area();
+  static double snap_task_area_value(double value);
   void load_robot_home_for_selected_scene();
   void sync_robot_home_editor_from_model();
   void mark_robot_home_edited();
@@ -233,6 +245,9 @@ private:
   boost::filesystem::path latest_demo_scene_dir_;
   TaskGraspEditorState task_editor_state_;
   std::unique_ptr<RobotHomeJointState> robot_home_state_;
+  std::vector<workcell_builder::TaskZone> task_area_zones_;
+  std::string selected_task_area_id_;
+  bool task_area_dirty_{false};
   QLabel * robot_home_source_label_ = nullptr;
   QLabel * robot_home_validation_label_ = nullptr;
   std::string selected_canvas_item_id_;

--- a/workcell_builder/workcell_builder/include/object_placement_model.hpp
+++ b/workcell_builder/workcell_builder/include/object_placement_model.hpp
@@ -47,11 +47,16 @@ struct TaskZone
 {
   std::string id;
   std::string type;
+  std::string role;
+  std::string shape{"box"};
   std::string parent_frame{"world"};
   double x{0.0}, y{0.0}, z{0.0};
   double roll{0.0}, pitch{0.0}, yaw{0.0};
   double dim_x{0.0}, dim_y{0.0}, dim_z{0.0};
   std::string frame_id;
+  std::string support_surface_ref;
+  std::string object_ref;
+  std::string target_ref;
   std::vector<std::string> allowed_object_types;
   bool enabled{true};
   std::string status;


### PR DESCRIPTION
Summary:
- Added a compact Task Areas panel to the Layout page with Suggested Areas, Add Pick Area, Add Place Area, Delete Selected, and Snap to 1 cm controls.
- Added top-down QGraphicsView Pick Area / Place Area rectangles with labels, selection, dragging, snapping, inspector updates, and dirty-state gating for Save/Validate/Generate.
- Extended task_zones environment.yaml IO to preserve/write stable authoring fields: id, type, role, frame, shape, pose_xyz, pose_rpy, dimensions, support_surface_ref, object_ref, and target_ref, while updating task pick/place references.
- Added focused static regression coverage for the Task Area editor contract.

Validation:
- `python3 -m pytest -q tests/test_workcell_builder_guided_flow_ui.py tests/test_workcell_builder_robot_home_editor.py tests/test_workcell_builder_task_area_editor.py` — 16 passed.
- `python3 - <<'PY' ... ET.parse('workcell_builder/workcell_builder/gui/scene_select.ui') ... PY` — scene_select.ui XML OK.
- `git diff --cached --check` — passed before commit.
- `git diff --cached --stat` / `git diff --cached --numstat` — reviewed before commit; 5 files changed, within scope/diff limit.
- ROS Humble build/test commands were not run because `/opt/ros/humble/setup.bash` was unavailable in this container.

Safety:
- No robot motion, launch files, controllers, runtime services, hardware parameters, Web3D bundles, or generated files were changed.
- Fake-hardware/default safety paths were not modified.
- UI copy states: “Offline layout check only; motion planning is checked later.”

Risks / rollback:
- Drag handles are represented by selectable/movable task-area rectangles and outline affordances in the existing top-down canvas; deeper custom handle UX can be refined later without changing YAML contract.
- Roll back by reverting commit `6b43e8d90f1f536d60861695b5b41aa9290b417a`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a564bc1de888331b9a544218342cc8c)