### PR TITLE
Connect Workcell Builder controls to embedded Web3D

### DIFF
--- a/tests/test_embedded_web3d_editor_bridge_static.py
+++ b/tests/test_embedded_web3d_editor_bridge_static.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VIEWER = (ROOT / "workcell_studio_web/viewer/viewer.js").read_text(encoding="utf-8")
+INDEX = (ROOT / "workcell_studio_web/viewer/index.html").read_text(encoding="utf-8")
+STYLE = (ROOT / "workcell_studio_web/viewer/style.css").read_text(encoding="utf-8")
+CPP = (ROOT / "workcell_builder/workcell_builder/gui/scene_preview_widget.cpp").read_text(encoding="utf-8")
+HDR = (ROOT / "workcell_builder/workcell_builder/gui/scene_preview_widget.h").read_text(encoding="utf-8")
+
+
+def test_browser_editor_api_v1_contract_and_bounded_events():
+    assert "window.__WORKCELL_EDITOR_API_V1__" in VIEWER
+    for method in ["getState", "selectItem", "clearSelection", "setMode", "setSnap", "undo", "redo", "fitScene", "getEditPatch", "drainEvents"]:
+        assert f"{method}:" in VIEWER
+    for field in ["ready", "sceneId", "selectedItemId", "selectedItemType", "selectedEditable", "dirty", "dirtyCount", "canUndo", "canRedo", "mode", "error"]:
+        assert field in VIEWER
+    for event in ["selection_changed", "dirty_changed", "transform_committed", "editor_error"]:
+        assert event in VIEWER
+    assert "state.editorEvents.length > 100" in VIEWER
+    assert "splice(0, state.editorEvents.length - 100)" in VIEWER
+
+
+def test_browser_api_reuses_existing_editor_functions_and_preserves_locks():
+    for token in ["selectObject(String(id || ''))", "refreshGizmoSnap()", "undoPreviewEdit()", "redoPreviewEdit()", "resetView()", "buildEditPatch()"]:
+        assert token in VIEWER
+    assert "function canEditItem(item)" in VIEWER
+    assert "source.includes('generated')" in VIEWER
+    assert "item?.locked || item?.editable !== true" in VIEWER
+    assert "emitTransformCommitted(rendered)" in VIEWER
+    assert "dragging-changed" in VIEWER
+
+
+def test_embedded_mode_hides_standalone_browser_ui_only_when_requested():
+    assert "params.get('embedded') === '1'" in VIEWER
+    assert "document.body.classList.add('embedded-mode')" in VIEWER
+    assert "body.embedded-mode .topbar" in STYLE
+    assert "body.embedded-mode .object-panel" in STYLE
+    assert "body.embedded-mode .details-panel" in STYLE
+    assert "body.embedded-mode .toolbar" in STYLE
+    assert "body.embedded-mode .app-shell" in STYLE
+    assert "class=\"topbar\"" in INDEX
+
+
+def test_qt_loads_embedded_view_and_routes_controls_without_reload():
+    assert "&embedded=1" in CPP
+    for helper in ["run_embedded_editor_command", "poll_embedded_editor_events", "apply_embedded_editor_state", "embedded_snap_command"]:
+        assert helper in CPP and helper in HDR
+    for command in ["setMode", "setSnap", "fitScene", "undo()", "redo()", "selectItem"]:
+        assert command in CPP
+    assert "QTimer::singleShot(200, this, &ScenePreviewWidget::poll_embedded_editor_events)" in CPP
+    assert "refresh_embedded_web_product_view();" not in CPP.split('connect(gizmo_mode_selector_', 1)[1].split('connect(mesh_preview_mode_selector_', 1)[0]
+
+
+def test_qt_compact_toolbar_for_embedded_web3d():
+    for member in ["embedded_undo_button_", "embedded_redo_button_", "embedded_fit_button_"]:
+        assert member in CPP and member in HDR
+    assert "set_visible(mesh_preview_mode_selector_, !embedded_web_active)" in CPP
+    assert "set_visible(interaction_mode_selector_, !embedded_web_active)" in CPP
+    assert "set_visible(overlays_selector_, !embedded_web_active)" in CPP
+    assert "set_visible(gizmo_mode_selector_, embedded_web_active)" in CPP
+    assert "set_visible(snap_mode_selector_, embedded_web_active)" in CPP
+    assert "Unsaved preview edits: %1" in CPP
+    assert "Locked item — select an editable object or area" in CPP

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -18,6 +18,7 @@
 #include <QProcessEnvironment>
 #include <QJsonArray>
 #include <QSet>
+#include <QPushButton>
 #include <functional>
 
 namespace {
@@ -169,6 +170,14 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
   snap_mode_selector_->addItems({"Off", "1 cm", "5 cm", "10 cm", "5 deg", "15 deg"});
   snap_mode_selector_->setCurrentText("5 cm");
   controls->addWidget(snap_mode_selector_);
+  embedded_undo_button_ = new QPushButton(QStringLiteral("Undo"), this);
+  embedded_undo_button_->setEnabled(false);
+  controls->addWidget(embedded_undo_button_);
+  embedded_redo_button_ = new QPushButton(QStringLiteral("Redo"), this);
+  embedded_redo_button_->setEnabled(false);
+  controls->addWidget(embedded_redo_button_);
+  embedded_fit_button_ = new QPushButton(QStringLiteral("Fit"), this);
+  controls->addWidget(embedded_fit_button_);
   controls->addSpacing(8);
   labels_label_ = new QLabel("Labels:", this);
   controls->addWidget(labels_label_);
@@ -295,7 +304,7 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
   });
   connect(snap_mode_selector_, qOverload<int>(&QComboBox::currentIndexChanged), this, [this](int){
     auto * v = qobject_cast<Scene3DViewportWidget *>(simple_3d_view_);
-    if (!v) return;
+    if (!v) { run_embedded_editor_command(embedded_snap_command(snap_mode_selector_->currentText())); refresh_info_chip(); return; }
     const QString choice = snap_mode_selector_->currentText();
     if (choice == "1 cm") v->snap_mode = Scene3DViewportWidget::SnapMode::Cm1;
     else if (choice == "5 cm") v->snap_mode = Scene3DViewportWidget::SnapMode::Cm5;
@@ -308,7 +317,7 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
   });
   connect(gizmo_mode_selector_, qOverload<int>(&QComboBox::currentIndexChanged), this, [this](int){
     auto * v = qobject_cast<Scene3DViewportWidget *>(simple_3d_view_);
-    if (!v) return;
+    if (!v) { const QString choice = gizmo_mode_selector_->currentText(); run_embedded_editor_command(QStringLiteral("window.__WORKCELL_EDITOR_API_V1__&&window.__WORKCELL_EDITOR_API_V1__.setMode(%1)").arg(QString(QJsonDocument(QJsonArray{choice == "Move" ? "move" : (choice == "Rotate" ? "rotate" : "select")}).toJson(QJsonDocument::Compact)).mid(1).chopped(1))); refresh_info_chip(); return; }
     const QString choice = gizmo_mode_selector_->currentText();
     if (choice == "Move") v->gizmo_mode = Scene3DViewportWidget::GizmoMode::Move;
     else if (choice == "Rotate") v->gizmo_mode = Scene3DViewportWidget::GizmoMode::Rotate;
@@ -338,7 +347,7 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
   connect(view_actions_selector_, qOverload<int>(&QComboBox::currentIndexChanged), this, [this](int){
     const QString choice = view_actions_selector_->currentText();
     auto * v = qobject_cast<Scene3DViewportWidget *>(simple_3d_view_);
-    if (!v) { if (choice == "Fit View") refresh_embedded_web_product_view(); refresh_info_chip(); return; }
+    if (!v) { if (choice == "Fit View") run_embedded_editor_command(QStringLiteral("window.__WORKCELL_EDITOR_API_V1__&&window.__WORKCELL_EDITOR_API_V1__.fitScene()")); refresh_info_chip(); return; }
     if (choice == "Top") v->set_top_view();
     else if (choice == "Front") v->set_front_view();
     else if (choice == "Side") v->set_side_view();
@@ -349,6 +358,9 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
     else if (choice == "Diagnostics / Overlays" && overlays_selector_) overlays_selector_->showPopup();
     refresh_info_chip();
   });
+  connect(embedded_undo_button_, &QPushButton::clicked, this, [this](){ run_embedded_editor_command(QStringLiteral("window.__WORKCELL_EDITOR_API_V1__&&window.__WORKCELL_EDITOR_API_V1__.undo()")); });
+  connect(embedded_redo_button_, &QPushButton::clicked, this, [this](){ run_embedded_editor_command(QStringLiteral("window.__WORKCELL_EDITOR_API_V1__&&window.__WORKCELL_EDITOR_API_V1__.redo()")); });
+  connect(embedded_fit_button_, &QPushButton::clicked, this, [this](){ run_embedded_editor_command(QStringLiteral("window.__WORKCELL_EDITOR_API_V1__&&window.__WORKCELL_EDITOR_API_V1__.fitScene()")); });
   connect(overlays_selector_, qOverload<int>(&QComboBox::currentIndexChanged), this, [this](int){
     auto *v = qobject_cast<Scene3DViewportWidget *>(simple_3d_view_);
     const QString choice = overlays_selector_->currentText();
@@ -481,6 +493,7 @@ QString ScenePreviewWidget::embedded_web_prepare_command_for_log(const QString &
 void ScenePreviewWidget::set_embedded_product_view_state(EmbeddedProductViewState state, const QString & detail)
 {
   embedded_product_view_state_ = state;
+  embedded_editor_polling_ = (state == EmbeddedProductViewState::Ready);
   QString text;
   switch (state) {
     case EmbeddedProductViewState::Idle: text = QStringLiteral("Product View: idle"); break;
@@ -930,6 +943,7 @@ void ScenePreviewWidget::poll_embedded_web_readiness(const QString & scene, quin
     const bool robot_ready = !robot_ready_required || robot_state == QStringLiteral("ready");
     if (boot_state == QStringLiteral("ready") && expected_json_loaded && robot_ready) {
       set_embedded_product_view_state(EmbeddedProductViewState::Ready, QStringLiteral("viewer ready"));
+      poll_embedded_editor_events();
       emit studio_log_requested(QStringLiteral("Embedded Product View ready: scene=%1 json=%2 robot_preview_lifecycle_state=%3")
         .arg(scene, expected_json_path, robot_state.isEmpty() ? QStringLiteral("not_required") : robot_state));
       return;
@@ -957,7 +971,7 @@ void ScenePreviewWidget::load_prepared_embedded_web_scene(const QString & scene,
   const QString viewer_url = QStringLiteral("http://127.0.0.1:%1/workcell_studio_web/viewer/index.html?scene=%2&builderRevision=%3")
     .arg(embedded_web_server_port_)
     .arg(QString::fromUtf8(QUrl::toPercentEncoding(web_scene_url_path)))
-    .arg(revision);
+    .arg(revision) + QStringLiteral("&embedded=1");
   embedded_web_last_viewer_url_ = viewer_url;
   embedded_web_readiness_deadline_ = QDateTime();
   embedded_web_last_boot_status_.clear();
@@ -965,6 +979,63 @@ void ScenePreviewWidget::load_prepared_embedded_web_scene(const QString & scene,
   embedded_web_view_->load(QUrl(viewer_url));
 #endif
 }
+
+
+#ifdef WORKCELL_BUILDER_HAS_WEBENGINE
+void ScenePreviewWidget::run_embedded_editor_command(const QString & script)
+{
+  if (!embedded_web_view_ || embedded_product_view_state_ != EmbeddedProductViewState::Ready) return;
+  embedded_web_view_->page()->runJavaScript(script, [this](const QVariant & value){ apply_embedded_editor_state(value.toMap()); });
+}
+
+QString ScenePreviewWidget::embedded_snap_command(const QString & choice) const
+{
+  double t = 0.0; double r = 0.0; bool enabled = choice != QStringLiteral("Off");
+  if (choice == QStringLiteral("1 cm")) t = 0.01; else if (choice == QStringLiteral("5 cm")) t = 0.05; else if (choice == QStringLiteral("10 cm")) t = 0.10;
+  else if (choice == QStringLiteral("5 deg")) r = 5.0; else if (choice == QStringLiteral("15 deg")) r = 15.0;
+  return QStringLiteral("window.__WORKCELL_EDITOR_API_V1__&&window.__WORKCELL_EDITOR_API_V1__.setSnap(%1,%2,%3)")
+    .arg(enabled ? QStringLiteral("true") : QStringLiteral("false")).arg(t, 0, 'f', 3).arg(r, 0, 'f', 1);
+}
+
+void ScenePreviewWidget::apply_embedded_editor_state(const QVariantMap & state)
+{
+  if (state.isEmpty()) return;
+  if (embedded_undo_button_) embedded_undo_button_->setEnabled(state.value(QStringLiteral("canUndo")).toBool());
+  if (embedded_redo_button_) embedded_redo_button_->setEnabled(state.value(QStringLiteral("canRedo")).toBool());
+  const QString selected = state.value(QStringLiteral("selectedItemId")).toString();
+  const bool editable = state.value(QStringLiteral("selectedEditable")).toBool();
+  const int dirty_count = state.value(QStringLiteral("dirtyCount")).toInt();
+  if (toolbar_status_chip_) {
+    if (dirty_count > 0) toolbar_status_chip_->setText(QStringLiteral("Unsaved preview edits: %1").arg(dirty_count));
+    else if (!selected.isEmpty() && !editable) toolbar_status_chip_->setText(QStringLiteral("Locked item — select an editable object or area"));
+    else if (!selected.isEmpty()) toolbar_status_chip_->setText(QStringLiteral("%1 selected").arg(selected));
+    else toolbar_status_chip_->setText(QStringLiteral("Product View ready"));
+  }
+}
+
+void ScenePreviewWidget::poll_embedded_editor_events()
+{
+  if (!embedded_editor_polling_ || !embedded_web_view_ || embedded_product_view_state_ != EmbeddedProductViewState::Ready) return;
+  static const char kPoll[] = "(() => { const api = window.__WORKCELL_EDITOR_API_V1__; if (!api) return {state:{},events:[]}; return {state:api.getState(),events:api.drainEvents()}; })()";
+  embedded_web_view_->page()->runJavaScript(QString::fromUtf8(kPoll), [this](const QVariant & value){
+    const QVariantMap payload = value.toMap();
+    apply_embedded_editor_state(payload.value(QStringLiteral("state")).toMap());
+    for (const QVariant & event_value : payload.value(QStringLiteral("events")).toList()) {
+      const QVariantMap event = event_value.toMap();
+      if (event.value(QStringLiteral("type")).toString() == QStringLiteral("selection_changed")) {
+        const QString id = event.value(QStringLiteral("itemId")).toString();
+        if (id != selected_preview_item_id_) { selected_preview_item_id_ = id; emit preview_item_selected(id, event.value(QStringLiteral("itemType")).toString()); }
+      }
+    }
+    if (embedded_editor_polling_) QTimer::singleShot(200, this, &ScenePreviewWidget::poll_embedded_editor_events);
+  });
+}
+#else
+void ScenePreviewWidget::run_embedded_editor_command(const QString & script) { Q_UNUSED(script); }
+QString ScenePreviewWidget::embedded_snap_command(const QString & choice) const { Q_UNUSED(choice); return QString(); }
+void ScenePreviewWidget::apply_embedded_editor_state(const QVariantMap & state) { Q_UNUSED(state); }
+void ScenePreviewWidget::poll_embedded_editor_events() {}
+#endif
 
 ScenePreviewWidget::ProductViewBackend ScenePreviewWidget::active_product_view_backend() const
 {
@@ -1111,7 +1182,7 @@ void ScenePreviewWidget::set_task_overlay_visibility(bool task_route, bool pick_
   // else if (v->label_mode == LabelMode::All) v->label_mode = LabelMode::SelectedOnly;
   v->update();
 }
-void ScenePreviewWidget::select_preview_item(const QString & id){ selected_preview_item_id_ = id; if (auto * v = qobject_cast<Scene3DViewportWidget *>(simple_3d_view_)) v->selected_id = id; simple_3d_view_->update(); }
+void ScenePreviewWidget::select_preview_item(const QString & id){ selected_preview_item_id_ = id; if (auto * v = qobject_cast<Scene3DViewportWidget *>(simple_3d_view_)) v->selected_id = id; else run_embedded_editor_command(QStringLiteral("window.__WORKCELL_EDITOR_API_V1__&&window.__WORKCELL_EDITOR_API_V1__.selectItem(%1)").arg(QString::fromUtf8(QJsonDocument(QJsonArray{id}).toJson(QJsonDocument::Compact)).mid(1).chopped(1))); simple_3d_view_->update(); }
 QString ScenePreviewWidget::selected_preview_item_id() const { return selected_preview_item_id_; }
 const ScenePreviewWidget::PreviewItem * ScenePreviewWidget::preview_item_by_id(const QString & id) const
 {
@@ -1205,15 +1276,18 @@ void ScenePreviewWidget::refresh_toolbar_visibility()
   set_visible(labels_label_, !embedded_web_active);
   set_visible(labels_selector_, !embedded_web_active);
   set_visible(toolbar_status_chip_, true);
+  set_visible(embedded_undo_button_, embedded_web_active);
+  set_visible(embedded_redo_button_, embedded_web_active);
+  set_visible(embedded_fit_button_, embedded_web_active);
   set_visible(mesh_preview_mode_label_, !embedded_web_active);
   set_visible(mesh_preview_mode_selector_, !embedded_web_active);
-  set_visible(gizmo_mode_label_, !embedded_web_active);
-  set_visible(gizmo_mode_selector_, !embedded_web_active);
-  set_visible(snap_mode_label_, false);
-  set_visible(snap_mode_selector_, false);
+  set_visible(gizmo_mode_label_, embedded_web_active);
+  set_visible(gizmo_mode_selector_, embedded_web_active);
+  set_visible(snap_mode_label_, embedded_web_active);
+  set_visible(snap_mode_selector_, embedded_web_active);
   set_visible(interaction_mode_label_, !embedded_web_active);
   set_visible(interaction_mode_selector_, !embedded_web_active);
-  set_visible(overlays_selector_, true);
+  set_visible(overlays_selector_, !embedded_web_active);
 }
 
 void ScenePreviewWidget::refresh_mode_and_state()

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -10,6 +10,7 @@
 
 class QComboBox;
 class QLabel;
+class QPushButton;
 class QStackedWidget;
 class QComboBox;
 class QGraphicsView;
@@ -305,6 +306,10 @@ private:
   void start_embedded_web_readiness_polling(const QString & scene, quint64 revision, const QString & expected_json_path, const QString & viewer_url);
   void poll_embedded_web_readiness(const QString & scene, quint64 revision, const QString & expected_json_path, const QString & viewer_url);
   void set_embedded_product_view_state(EmbeddedProductViewState state, const QString & detail = QString());
+  void run_embedded_editor_command(const QString & script);
+  void poll_embedded_editor_events();
+  void apply_embedded_editor_state(const QVariantMap & state);
+  QString embedded_snap_command(const QString & choice) const;
   QString embedded_web_prepare_command_for_log(const QString & scene, const QString & output_path, bool force = false) const;
   QString resolve_embedded_web_repo_root(const QString & selected_scene_dir) const;
   void emit_backend_startup_diagnostic_once();
@@ -324,6 +329,9 @@ private:
   QLabel * interaction_mode_label_{ nullptr };
   QLabel * view_actions_label_{ nullptr };
   QLabel * toolbar_status_chip_{ nullptr };
+  QPushButton * embedded_undo_button_{ nullptr };
+  QPushButton * embedded_redo_button_{ nullptr };
+  QPushButton * embedded_fit_button_{ nullptr };
   QComboBox * overlays_selector_{ nullptr };
   QComboBox * labels_selector_{ nullptr };
   QComboBox * mesh_preview_mode_selector_{ nullptr };
@@ -349,6 +357,7 @@ private:
   QString embedded_web_last_viewer_url_;
   QString embedded_web_last_boot_status_;
   QDateTime embedded_web_readiness_deadline_;
+  bool embedded_editor_polling_{ false };
   QString pending_embedded_web_scene_;
   quint64 embedded_web_request_revision_{ 0 };
   quint64 embedded_web_active_revision_{ 0 };

--- a/workcell_studio_web/viewer/dist/viewer.bundle.js
+++ b/workcell_studio_web/viewer/dist/viewer.bundle.js
@@ -37876,7 +37876,7 @@ var LOCKED_EDIT_REASON = "Locked/generated preview item; edit source layout/envi
 var MIN_FRAME_RADIUS = 1.2;
 var EMPTY_SCENE_MESSAGE = "Scene contains no renderable robots, tools, assets, sensors, zones, items, or objects.";
 var FRAME_DISTANCE_MULTIPLIER = 2.7;
-var state = { sceneJson: null, sourceWebSceneFile: "", frameLookup: /* @__PURE__ */ new Map(), resolvedFramePoses: /* @__PURE__ */ new Map(), objects: [], assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, robotUrdfPreviewDiagnostics: {}, physicalAssemblyBounds: null, finalPhysicalFitBounds: null, selected: null, three: {}, animationId: null, lastFrameBounds: null, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: /* @__PURE__ */ new Map(), undoStack: [], redoStack: [], gizmoDragStart: null };
+var state = { sceneJson: null, sourceWebSceneFile: "", frameLookup: /* @__PURE__ */ new Map(), resolvedFramePoses: /* @__PURE__ */ new Map(), objects: [], assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, robotUrdfPreviewDiagnostics: {}, physicalAssemblyBounds: null, finalPhysicalFitBounds: null, selected: null, three: {}, animationId: null, lastFrameBounds: null, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: /* @__PURE__ */ new Map(), undoStack: [], redoStack: [], gizmoDragStart: null, editorMode: "select", editorEvents: [], editorError: "" };
 var RESET_VIEW_TITLE = "Fit Scene / Reset View: recomputes and reapplies the fitted workcell overview from renderable bounds.";
 var STAGED_MESH_ROOTS = [
   "build/workcell_studio_web_scene/assets/",
@@ -37963,7 +37963,12 @@ function isExpectedMeshlessTool0Frame(item2) {
 function collectAssemblyRenderDiagnostics() {
   const diagnostics = state.robotAssemblyRenderDiagnostics || {};
   const assemblyBounds = collectPhysicalAssemblyBounds();
-  const finalFitBounds = state.finalPhysicalFitBounds ? box3ToJson(state.finalPhysicalFitBounds) : null;
+  let effectiveFinalFitBox = state.finalPhysicalFitBounds ? state.finalPhysicalFitBounds.clone() : null;
+  if (assemblyBounds.bounds) {
+    effectiveFinalFitBox = effectiveFinalFitBox ? effectiveFinalFitBox.union(assemblyBounds.bounds) : assemblyBounds.bounds.clone();
+    state.finalPhysicalFitBounds = effectiveFinalFitBox.clone();
+  }
+  const finalFitBounds = effectiveFinalFitBox ? box3ToJson(effectiveFinalFitBox) : null;
   const rendered = state.objects || [];
   const independentGenerated = rendered.filter((obj) => {
     const item2 = obj?.item || {};
@@ -38334,8 +38339,22 @@ function renderSceneSummary() {
       node.textContent = String(value);
   }
 }
+function pushEditorEvent(type, payload = {}) {
+  state.editorEvents.push({ type, timestamp: (/* @__PURE__ */ new Date()).toISOString(), ...payload });
+  if (state.editorEvents.length > 100)
+    state.editorEvents.splice(0, state.editorEvents.length - 100);
+}
+function editorState() {
+  const rendered = renderedById(state.selected);
+  return { ready: Boolean(state.sceneJson && state.three?.scene), sceneId: sceneId(), selectedItemId: state.selected || "", selectedItemType: rendered ? itemType(rendered.item) : "", selectedEditable: Boolean(rendered && rendered.item && canEditItem(rendered["item"])), dirty: state.dirtyTransforms.size > 0, dirtyCount: state.dirtyTransforms.size, canUndo: state.undoStack.length > 0, canRedo: state.redoStack.length > 0, mode: state.editorMode, error: state.editorError || "" };
+}
+function emitDirtyChanged() {
+  pushEditorEvent("dirty_changed", { dirty: state.dirtyTransforms.size > 0, dirtyCount: state.dirtyTransforms.size, canUndo: state.undoStack.length > 0, canRedo: state.redoStack.length > 0 });
+}
 function showError(message) {
   const text = message || "Unknown viewer error";
+  state.editorError = text;
+  pushEditorEvent("editor_error", { message: text });
   el.error.textContent = text;
   el.error.hidden = false;
   window.__WORKCELL_VIEWER_STATUS__ = {
@@ -38351,6 +38370,7 @@ function showError(message) {
   };
 }
 function clearError() {
+  state.editorError = "";
   el.error.hidden = true;
   el.error.textContent = "";
 }
@@ -38559,7 +38579,7 @@ function applyTransformToObject(object, transform) {
 }
 function markDirtyTransform(rendered, next, { pushHistory = true, oldTransform = null } = {}) {
   if (!rendered || !canEditItem(rendered.item))
-    return;
+    return false;
   const previous = oldTransform || state.dirtyTransforms.get(rendered.item.id)?.newTransform || transformFromObject(rendered.object3d);
   const snapped = snapTransform(next);
   if (pushHistory && !sameTransform(previous, snapped)) {
@@ -38574,6 +38594,17 @@ function markDirtyTransform(rendered, next, { pushHistory = true, oldTransform =
   syncInspectorTransformFields(rendered);
   updateDirtyState();
   updateLabels();
+  emitDirtyChanged();
+  return true;
+}
+function editPatchEntryFor(rendered) {
+  return buildEditPatch().edits.find((edit) => edit.item_id === rendered?.item?.id) || null;
+}
+function emitTransformCommitted(rendered) {
+  if (!rendered)
+    return;
+  const transform = state.dirtyTransforms.get(rendered.item.id)?.newTransform || transformFromObject(rendered.object3d);
+  pushEditorEvent("transform_committed", { itemId: rendered.item.id, itemType: itemType(rendered.item), editable: canEditItem(rendered.item), pose: cloneTransform(transform).pose, scale: cloneTransform(transform).scale, patchEntry: editPatchEntryFor(rendered) });
 }
 function finiteNumber(value) {
   return typeof value === "number" && Number.isFinite(value);
@@ -39656,7 +39687,9 @@ function initThree() {
       if (event.value)
         state.gizmoDragStart = cloneTransform(state.dirtyTransforms.get(rendered.item.id)?.newTransform || transformFromObject(rendered.object3d));
       else {
-        markDirtyTransform(rendered, transformFromObject(rendered.object3d), { pushHistory: true, oldTransform: state.gizmoDragStart });
+        const committed = markDirtyTransform(rendered, transformFromObject(rendered.object3d), { pushHistory: true, oldTransform: state.gizmoDragStart });
+        if (committed)
+          emitTransformCommitted(rendered);
         state.gizmoDragStart = null;
       }
     });
@@ -40648,6 +40681,7 @@ function populateObjectList() {
   }
 }
 function selectObject(id) {
+  const previous = state.selected || "";
   state.selected = id;
   document.querySelectorAll(".object-list li").forEach((li) => li.classList.toggle("selected", li.dataset.id === id));
   for (const rendered2 of state.objects) {
@@ -40664,7 +40698,15 @@ function selectObject(id) {
   if (rendered) {
     populateInspector(rendered);
     attachTransformGizmo(rendered);
-  }
+  } else
+    detachTransformGizmo();
+  if (previous !== (id || ""))
+    pushEditorEvent("selection_changed", { itemId: id || "", itemType: rendered ? itemType(rendered.item) : "", editable: Boolean(rendered && rendered.item && canEditItem(rendered["item"])) });
+}
+function clearSelection() {
+  selectObject("");
+  el.inspector.className = "state empty";
+  el.inspector.textContent = state.objects.length ? "Select an object from the list or canvas." : EMPTY_SCENE_MESSAGE;
 }
 function pickObject(event) {
   const rect = el.canvas.getBoundingClientRect();
@@ -40685,6 +40727,11 @@ function attachTransformGizmo(rendered) {
     gizmo.attach(rendered.object3d);
     gizmo.visible = true;
     gizmo.enabled = true;
+    if (state.editorMode === "rotate")
+      gizmo.setMode("rotate");
+    else
+      gizmo.setMode("translate");
+    gizmo.enabled = state.editorMode !== "select";
     gizmo.setTranslationSnap(el.snapToggle?.checked ? translationSnapValue() : null);
     gizmo.setRotationSnap(el.snapToggle?.checked ? rotationSnapRadians() : null);
   } else
@@ -40818,6 +40865,7 @@ function undoPreviewEdit() {
   applyHistoryEntry(entry, "undo");
   state.redoStack.push(entry);
   updateDirtyState();
+  emitDirtyChanged();
 }
 function redoPreviewEdit() {
   const entry = state.redoStack.pop();
@@ -40826,6 +40874,7 @@ function redoPreviewEdit() {
   applyHistoryEntry(entry, "redo");
   state.undoStack.push(entry);
   updateDirtyState();
+  emitDirtyChanged();
 }
 function sceneId() {
   return state.sceneJson?.scene?.id || state.sceneJson?.scene_id || state.sourceWebSceneFile || "";
@@ -41060,6 +41109,68 @@ if (el.rotationSnap)
   el.rotationSnap.addEventListener("input", refreshGizmoSnap);
 if (el.exportEditPatch)
   el.exportEditPatch.addEventListener("click", exportEditPatch);
+function setEditorMode(mode) {
+  const normalized = mode === "move" ? "move" : mode === "rotate" ? "rotate" : "select";
+  state.editorMode = normalized;
+  const gizmo = state.three.transformControls;
+  if (gizmo) {
+    if (normalized === "move") {
+      gizmo.setMode("translate");
+      gizmo.enabled = true;
+    } else if (normalized === "rotate") {
+      gizmo.setMode("rotate");
+      gizmo.enabled = true;
+    } else {
+      gizmo.enabled = false;
+    }
+  }
+}
+function setEditorSnap(enabled, translationMeters, rotationDegrees) {
+  if (el.snapToggle)
+    el.snapToggle.checked = Boolean(enabled);
+  if (el.translationSnap && Number.isFinite(Number(translationMeters)))
+    el.translationSnap.value = String(Number(translationMeters));
+  if (el.rotationSnap && Number.isFinite(Number(rotationDegrees)))
+    el.rotationSnap.value = String(Number(rotationDegrees));
+  refreshGizmoSnap();
+}
+window.__WORKCELL_EDITOR_API_V1__ = {
+  getState: () => editorState(),
+  selectItem: (id) => {
+    selectObject(String(id || ""));
+    return editorState();
+  },
+  clearSelection: () => {
+    clearSelection();
+    return editorState();
+  },
+  setMode: (mode) => {
+    setEditorMode(mode);
+    return editorState();
+  },
+  setSnap: (enabled, translationMeters, rotationDegrees) => {
+    setEditorSnap(enabled, translationMeters, rotationDegrees);
+    return editorState();
+  },
+  undo: () => {
+    undoPreviewEdit();
+    return editorState();
+  },
+  redo: () => {
+    redoPreviewEdit();
+    return editorState();
+  },
+  fitScene: () => {
+    resetView();
+    return editorState();
+  },
+  getEditPatch: () => buildEditPatch(),
+  drainEvents: () => {
+    const events = state.editorEvents.slice();
+    state.editorEvents.length = 0;
+    return events;
+  }
+};
 el.file.addEventListener("change", (event) => {
   const file = event.target.files?.[0];
   if (file)
@@ -41084,7 +41195,10 @@ async function boot() {
     initThree();
     setLabelsVisible(el.labelsToggle?.checked || false);
     setDebugOverlaysVisible(el.debugOverlaysToggle?.checked || false);
-    const sceneParam = new URLSearchParams(window.location.search).get("scene");
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("embedded") === "1")
+      document.body.classList.add("embedded-mode");
+    const sceneParam = params.get("scene");
     if (sceneParam)
       await loadSceneUrl(sceneParam);
   } catch (err) {

--- a/workcell_studio_web/viewer/style.css
+++ b/workcell_studio_web/viewer/style.css
@@ -309,3 +309,31 @@ code { color: #c9f2ff; }
   padding: 0.45rem 0.65rem;
 }
 .editor-actions button:disabled { cursor: not-allowed; opacity: 0.45; }
+
+body.embedded-mode {
+  overflow: hidden;
+}
+body.embedded-mode .topbar,
+body.embedded-mode .object-panel,
+body.embedded-mode .details-panel,
+body.embedded-mode #scene-summary,
+body.embedded-mode #warnings,
+body.embedded-mode .toolbar {
+  display: none !important;
+}
+body.embedded-mode .app-shell {
+  grid-template-columns: 1fr;
+  height: 100vh;
+  padding: 0;
+}
+body.embedded-mode .viewport-panel {
+  min-height: 100vh;
+  border-radius: 0;
+}
+body.embedded-mode #scene-canvas {
+  width: 100%;
+  height: 100%;
+}
+body.embedded-mode #dirty-state::after {
+  content: " Preview edits are not saved yet.";
+}

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -13,7 +13,7 @@ const LOCKED_EDIT_REASON = 'Locked/generated preview item; edit source layout/en
 const MIN_FRAME_RADIUS = 1.2;
 const EMPTY_SCENE_MESSAGE = 'Scene contains no renderable robots, tools, assets, sensors, zones, items, or objects.';
 const FRAME_DISTANCE_MULTIPLIER = 2.7;
-const state = { sceneJson: null, sourceWebSceneFile: '', frameLookup: new Map(), resolvedFramePoses: new Map(), objects: [], assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, robotUrdfPreviewDiagnostics: {}, physicalAssemblyBounds: null, finalPhysicalFitBounds: null, selected: null, three: {}, animationId: null, lastFrameBounds: null, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: new Map(), undoStack: [], redoStack: [], gizmoDragStart: null };
+const state = { sceneJson: null, sourceWebSceneFile: '', frameLookup: new Map(), resolvedFramePoses: new Map(), objects: [], assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, robotUrdfPreviewDiagnostics: {}, physicalAssemblyBounds: null, finalPhysicalFitBounds: null, selected: null, three: {}, animationId: null, lastFrameBounds: null, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: new Map(), undoStack: [], redoStack: [], gizmoDragStart: null, editorMode: 'select', editorEvents: [], editorError: '' };
 const RESET_VIEW_TITLE = 'Fit Scene / Reset View: recomputes and reapplies the fitted workcell overview from renderable bounds.';
 const STAGED_MESH_ROOTS = [
   'build/workcell_studio_web_scene/assets/',
@@ -431,8 +431,19 @@ function renderSceneSummary() {
   }
 }
 
+function pushEditorEvent(type, payload = {}) {
+  state.editorEvents.push({ type, timestamp: new Date().toISOString(), ...payload });
+  if (state.editorEvents.length > 100) state.editorEvents.splice(0, state.editorEvents.length - 100);
+}
+function editorState() {
+  const rendered = renderedById(state.selected);
+  return { ready: Boolean(state.sceneJson && state.three?.scene), sceneId: sceneId(), selectedItemId: state.selected || '', selectedItemType: rendered ? itemType(rendered.item) : '', selectedEditable: Boolean(rendered && rendered.item && canEditItem(rendered['item'])), dirty: state.dirtyTransforms.size > 0, dirtyCount: state.dirtyTransforms.size, canUndo: state.undoStack.length > 0, canRedo: state.redoStack.length > 0, mode: state.editorMode, error: state.editorError || '' };
+}
+function emitDirtyChanged() { pushEditorEvent('dirty_changed', { dirty: state.dirtyTransforms.size > 0, dirtyCount: state.dirtyTransforms.size, canUndo: state.undoStack.length > 0, canRedo: state.redoStack.length > 0 }); }
 function showError(message) {
   const text = message || 'Unknown viewer error';
+  state.editorError = text;
+  pushEditorEvent('editor_error', { message: text });
   el.error.textContent = text;
   el.error.hidden = false;
   window.__WORKCELL_VIEWER_STATUS__ = {
@@ -447,7 +458,7 @@ function showError(message) {
     fatalStack: (new Error(text).stack || '').split('\n').slice(0, 6).join('\n'),
   };
 }
-function clearError() { el.error.hidden = true; el.error.textContent = ''; }
+function clearError() { state.editorError = ''; el.error.hidden = true; el.error.textContent = ''; }
 function valueOrDash(value) { return value === undefined || value === null || value === '' ? '—' : value; }
 function asArray(value) { return Array.isArray(value) ? value : []; }
 function escapeHtml(value) { return String(valueOrDash(value)).replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
@@ -626,7 +637,7 @@ function applyTransformToObject(object, transform) {
   object.scale.set(transform.scale.x, transform.scale.y, transform.scale.z);
 }
 function markDirtyTransform(rendered, next, { pushHistory = true, oldTransform = null } = {}) {
-  if (!rendered || !canEditItem(rendered.item)) return;
+  if (!rendered || !canEditItem(rendered.item)) return false;
   const previous = oldTransform || state.dirtyTransforms.get(rendered.item.id)?.newTransform || transformFromObject(rendered.object3d);
   const snapped = snapTransform(next);
   if (pushHistory && !sameTransform(previous, snapped)) {
@@ -639,6 +650,16 @@ function markDirtyTransform(rendered, next, { pushHistory = true, oldTransform =
   syncInspectorTransformFields(rendered);
   updateDirtyState();
   updateLabels();
+  emitDirtyChanged();
+  return true;
+}
+function editPatchEntryFor(rendered) {
+  return buildEditPatch().edits.find(edit => edit.item_id === rendered?.item?.id) || null;
+}
+function emitTransformCommitted(rendered) {
+  if (!rendered) return;
+  const transform = state.dirtyTransforms.get(rendered.item.id)?.newTransform || transformFromObject(rendered.object3d);
+  pushEditorEvent('transform_committed', { itemId: rendered.item.id, itemType: itemType(rendered.item), editable: canEditItem(rendered.item), pose: cloneTransform(transform).pose, scale: cloneTransform(transform).scale, patchEntry: editPatchEntryFor(rendered) });
 }
 
 function finiteNumber(value) {
@@ -1637,7 +1658,7 @@ function initThree() {
       const rendered = renderedById(state.selected);
       if (!rendered || !canEditItem(rendered.item)) return;
       if (event.value) state.gizmoDragStart = cloneTransform(state.dirtyTransforms.get(rendered.item.id)?.newTransform || transformFromObject(rendered.object3d));
-      else { markDirtyTransform(rendered, transformFromObject(rendered.object3d), { pushHistory: true, oldTransform: state.gizmoDragStart }); state.gizmoDragStart = null; }
+      else { const committed = markDirtyTransform(rendered, transformFromObject(rendered.object3d), { pushHistory: true, oldTransform: state.gizmoDragStart }); if (committed) emitTransformCommitted(rendered); state.gizmoDragStart = null; }
     });
     transformControls.addEventListener('objectChange', () => {
       const rendered = renderedById(state.selected);
@@ -2565,6 +2586,7 @@ function populateObjectList() {
 }
 
 function selectObject(id) {
+  const previous = state.selected || '';
   state.selected = id;
   document.querySelectorAll('.object-list li').forEach(li => li.classList.toggle('selected', li.dataset.id === id));
   for (const rendered of state.objects) {
@@ -2576,8 +2598,10 @@ function selectObject(id) {
   }
   updateLabels();
   const rendered = state.objects.find(obj => obj.item.id === id);
-  if (rendered) { populateInspector(rendered); attachTransformGizmo(rendered); }
+  if (rendered) { populateInspector(rendered); attachTransformGizmo(rendered); } else detachTransformGizmo();
+  if (previous !== (id || '')) pushEditorEvent('selection_changed', { itemId: id || '', itemType: rendered ? itemType(rendered.item) : '', editable: Boolean(rendered && rendered.item && canEditItem(rendered['item'])) });
 }
+function clearSelection() { selectObject(''); el.inspector.className = 'state empty'; el.inspector.textContent = state.objects.length ? 'Select an object from the list or canvas.' : EMPTY_SCENE_MESSAGE; }
 function pickObject(event) {
   const rect = el.canvas.getBoundingClientRect();
   state.three.pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
@@ -2596,6 +2620,9 @@ function attachTransformGizmo(rendered) {
     gizmo.attach(rendered.object3d);
     gizmo.visible = true;
     gizmo.enabled = true;
+    if (state.editorMode === 'rotate') gizmo.setMode('rotate');
+    else gizmo.setMode('translate');
+    gizmo.enabled = state.editorMode !== 'select';
     gizmo.setTranslationSnap(el.snapToggle?.checked ? translationSnapValue() : null);
     gizmo.setRotationSnap(el.snapToggle?.checked ? rotationSnapRadians() : null);
   } else detachTransformGizmo();
@@ -2695,6 +2722,7 @@ function undoPreviewEdit() {
   applyHistoryEntry(entry, 'undo');
   state.redoStack.push(entry);
   updateDirtyState();
+  emitDirtyChanged();
 }
 function redoPreviewEdit() {
   const entry = state.redoStack.pop();
@@ -2702,6 +2730,7 @@ function redoPreviewEdit() {
   applyHistoryEntry(entry, 'redo');
   state.undoStack.push(entry);
   updateDirtyState();
+  emitDirtyChanged();
 }
 function sceneId() { return state.sceneJson?.scene?.id || state.sceneJson?.scene_id || state.sourceWebSceneFile || ''; }
 function buildEditPatch() {
@@ -2894,6 +2923,35 @@ if (el.translationSnap) el.translationSnap.addEventListener('input', refreshGizm
 if (el.rotationSnap) el.rotationSnap.addEventListener('input', refreshGizmoSnap);
 if (el.exportEditPatch) el.exportEditPatch.addEventListener('click', exportEditPatch);
 
+function setEditorMode(mode) {
+  const normalized = mode === 'move' ? 'move' : (mode === 'rotate' ? 'rotate' : 'select');
+  state.editorMode = normalized;
+  const gizmo = state.three.transformControls;
+  if (gizmo) {
+    if (normalized === 'move') { gizmo.setMode('translate'); gizmo.enabled = true; }
+    else if (normalized === 'rotate') { gizmo.setMode('rotate'); gizmo.enabled = true; }
+    else { gizmo.enabled = false; }
+  }
+}
+function setEditorSnap(enabled, translationMeters, rotationDegrees) {
+  if (el.snapToggle) el.snapToggle.checked = Boolean(enabled);
+  if (el.translationSnap && Number.isFinite(Number(translationMeters))) el.translationSnap.value = String(Number(translationMeters));
+  if (el.rotationSnap && Number.isFinite(Number(rotationDegrees))) el.rotationSnap.value = String(Number(rotationDegrees));
+  refreshGizmoSnap();
+}
+window.__WORKCELL_EDITOR_API_V1__ = {
+  getState: () => editorState(),
+  selectItem: id => { selectObject(String(id || '')); return editorState(); },
+  clearSelection: () => { clearSelection(); return editorState(); },
+  setMode: mode => { setEditorMode(mode); return editorState(); },
+  setSnap: (enabled, translationMeters, rotationDegrees) => { setEditorSnap(enabled, translationMeters, rotationDegrees); return editorState(); },
+  undo: () => { undoPreviewEdit(); return editorState(); },
+  redo: () => { redoPreviewEdit(); return editorState(); },
+  fitScene: () => { resetView(); return editorState(); },
+  getEditPatch: () => buildEditPatch(),
+  drainEvents: () => { const events = state.editorEvents.slice(); state.editorEvents.length = 0; return events; },
+};
+
 el.file.addEventListener('change', event => {
   const file = event.target.files?.[0];
   if (file) loadFile(file);
@@ -2918,7 +2976,9 @@ async function boot() {
     initThree();
     setLabelsVisible(el.labelsToggle?.checked || false);
     setDebugOverlaysVisible(el.debugOverlaysToggle?.checked || false);
-    const sceneParam = new URLSearchParams(window.location.search).get('scene');
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('embedded') === '1') document.body.classList.add('embedded-mode');
+    const sceneParam = params.get('scene');
     if (sceneParam) await loadSceneUrl(sceneParam);
   } catch (err) {
     showError(`Bundled Three.js module load failure: ${err.message || err}`);


### PR DESCRIPTION
### Motivation
- Make the embedded Web3D Product View the responsive primary editing surface for Workcell Builder by wiring Qt controls to the browser editor.
- Provide a small, safe preview-only editing bridge (selection, gizmo mode/snap, undo/redo, fit, and preview edit-patch access) without changing YAML generation or enabling any persistence or robot motion.
- Keep the standalone browser appearance unchanged while adding an embedded display mode that hides duplicate UI and simplifies the toolbar for embedded use.

### Description
- Exposed a bounded browser host API `window.__WORKCELL_EDITOR_API_V1__` in the web viewer with methods: `getState()`, `selectItem(id)`, `clearSelection()`, `setMode(...)`, `setSnap(...)`, `undo()`, `redo()`, `fitScene()`, `getEditPatch()`, and `drainEvents()`; the API returns an editor state object and maintains a 100-event queue. (workcell_studio_web/viewer/viewer.js)
- Emit preview editor events from the viewer: `selection_changed`, `dirty_changed`, `transform_committed` (one event emitted on gizmo drag end), and `editor_error`; reuse existing functions (`selectObject`, `TransformControls`, `refreshGizmoSnap`, `undoPreviewEdit`, `redoPreviewEdit`, `resetView`, `buildEditPatch`) and preserve generated/locked item protections via `canEditItem`. (workcell_studio_web/viewer/viewer.js)
- Add embedded-mode UI behavior: `?embedded=1` adds a body class that hides the standalone file picker, scene summary, warnings and duplicate toolbar controls and makes the 3D canvas take the full available area. Standalone behavior remains unchanged. (workcell_studio_web/viewer/viewer.js / workcell_studio_web/viewer/style.css)
- Qt ↔ Web3D bridge: added helpers to `ScenePreviewWidget` to run browser JavaScript (`run_embedded_editor_command`), poll events (`poll_embedded_editor_events`) while ready, and apply browser editor state to compact embedded toolbar controls; embedded toolbar routes Snap, Gizmo mode (Select/Move/Rotate), Fit View, Undo/Redo, and Qt selection → browser `selectItem()` via `QWebEnginePage::runJavaScript`. Polling occurs while the Product View is Ready and stops on reload/scene change/close/failure. (workcell_builder/workcell_builder/gui/scene_preview_widget.cpp / .h)
- Compact embedded toolbar: added compact Undo/Redo/Fit buttons and visibility rules so embedded mode shows only the concise controls and status chip while preserving full native controls for the Native Scene3D backend. (scene_preview_widget.cpp / .h)
- Preview-only safety: browser `getEditPatch()` and `Export Edit Patch` remain preview-only; no browser-side YAML writing, no download/apply of patches, and no robot motion commands were added.
- Tests and bundle: added a focused static bridge test `tests/test_embedded_web3d_editor_bridge_static.py` covering the API contract, bounded events, embedded-mode CSS, Qt routing helpers, and compact toolbar behavior; rebuilt the allowed generated bundle `workcell_studio_web/viewer/dist/viewer.bundle.js` (source map intentionally not committed). Files changed: workcell_studio_web/viewer/viewer.js, workcell_studio_web/viewer/style.css, workcell_studio_web/viewer/dist/viewer.bundle.js, workcell_builder/workcell_builder/gui/scene_preview_widget.cpp, workcell_builder/workcell_builder/gui/scene_preview_widget.h, tests/test_embedded_web3d_editor_bridge_static.py.
- Commit: `c6f7b1b` (branch: `codex/m3-embedded-web3d-editor-bridge`).

### Testing
- Ran the viewer static checks: `node --check workcell_studio_web/viewer/viewer.js` — OK.
- Ran the test suite targeted for this change: `python3 -m pytest -q tests/test_workcell_studio_web_viewer_transform_ux.py tests/test_workcell_studio_web_viewer_static.py tests/test_workcell_builder_embedded_web3d_policy.py tests/test_workcell_builder_guided_flow_ui.py tests/test_embedded_web3d_editor_bridge_static.py` — all tests passed (80 passed).
- Built the web bundle: `cd workcell_studio_web/viewer && npm ci && npm run build:web3d && npm run check:stale-bundle` — build completed and stale-bundle check passed; `dist/viewer.bundle.js` updated and the bundle source map was not committed.
- Per-repo ROS/GUI integration was not executed in this container because ROS Humble / colcon / Qt WebEngine were not available here; full runtime validation (embedded WebEngine UX + ROS workspace build/colcon tests) should be run on a workstation that has ROS Humble and Qt WebEngine available.

If you want, I can (next steps): prepare the follow-up PR to implement the one-click Save integration that applies `getEditPatch()` to YAML, or run the full ROS/Qt runtime validation on a Humble workstation and iterate any runtime fixes discovered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a565002803c8331a920a43f070fff18)