### PR TITLE
Fix Humble Workcell Builder compile regressions

### DIFF
--- a/workcell_builder/workcell_builder/gui/object_placement_yaml_io.cpp
+++ b/workcell_builder/workcell_builder/gui/object_placement_yaml_io.cpp
@@ -80,11 +80,11 @@ std::vector<PlacedObject> load_placed_objects_from_environment_yaml(const std::s
       }
       auto pose_xyz_alias = n["pose_xyz"];
       if (pose_xyz_alias && pose_xyz_alias.IsSequence() && pose_xyz_alias.size() == 3) {
-        z.x = pose_xyz_alias[0].as<double>(0.0); z.y = pose_xyz_alias[1].as<double>(0.0); z.z = pose_xyz_alias[2].as<double>(0.0);
+        o.x = pose_xyz_alias[0].as<double>(0.0); o.y = pose_xyz_alias[1].as<double>(0.0); o.z = pose_xyz_alias[2].as<double>(0.0);
       }
       auto pose_rpy_alias = n["pose_rpy"];
       if (pose_rpy_alias && pose_rpy_alias.IsSequence() && pose_rpy_alias.size() == 3) {
-        z.roll = pose_rpy_alias[0].as<double>(0.0); z.pitch = pose_rpy_alias[1].as<double>(0.0); z.yaw = pose_rpy_alias[2].as<double>(0.0);
+        o.roll = pose_rpy_alias[0].as<double>(0.0); o.pitch = pose_rpy_alias[1].as<double>(0.0); o.yaw = pose_rpy_alias[2].as<double>(0.0);
       }
       auto pose = n["pose"];
       if (pose && pose.IsMap()) {

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -510,7 +510,7 @@ void ScenePreviewWidget::set_embedded_product_view_state(EmbeddedProductViewStat
   }
 }
 
-bool ScenePreviewWidget::embedded_web_server_is_usable(const QString & repo_root, const QString & scene) const
+bool ScenePreviewWidget::embedded_web_server_is_usable(const QString & repo_root, const QString & scene)
 {
   const QString trimmed_repo_root = repo_root.trimmed().isEmpty() ? embedded_web_repo_root_ : repo_root.trimmed();
   const QString trimmed_scene = scene.trimmed().isEmpty() ? embedded_web_prepare_scene_ : scene.trimmed();

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -301,7 +301,7 @@ private:
   void start_embedded_web_prepare(const QString & scene, quint64 revision, bool force);
   void on_embedded_web_prepare_finished(int exit_code, QProcess::ExitStatus exit_status);
   void ensure_embedded_web_server_started(const QString & repo_root);
-  bool embedded_web_server_is_usable(const QString & repo_root = QString(), const QString & scene = QString()) const;
+  bool embedded_web_server_is_usable(const QString & repo_root = QString(), const QString & scene = QString());
   void load_prepared_embedded_web_scene(const QString & scene, quint64 revision);
   void start_embedded_web_readiness_polling(const QString & scene, quint64 revision, const QString & expected_json_path, const QString & viewer_url);
   void poll_embedded_web_readiness(const QString & scene, quint64 revision, const QString & expected_json_path, const QString & viewer_url);

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -166,6 +166,8 @@ fs::path derive_ros_workspace_root(const fs::path & selected_workcell_path)
 }
 
 
+}  // namespace
+
 struct RobotHomeJoint
 {
   std::string name;
@@ -188,6 +190,8 @@ struct RobotHomeJointState
   std::vector<std::string> validation_errors;
   std::string status_note{"Suggested home"};
 };
+
+namespace {
 
 constexpr double kRobotHomePi = 3.14159265358979323846;
 


### PR DESCRIPTION
Fixes four compile blockers verified on a real Ubuntu 22.04 / ROS 2 Humble workstation:

- Makes RobotHomeJointState match the type owned by SceneSelect instead of defining a conflicting anonymous-namespace type.
- Removes the invalid const qualifier from embedded_web_server_is_usable(), which emits a Qt signal.
- Corrects placed-object pose_xyz and pose_rpy alias loading to populate PlacedObject o rather than undeclared z.
- Preserves the legitimate TaskZone z alias handling.

Validation:

colcon build --symlink-install --packages-select workcell_builder \
  --cmake-args -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release

Result:
1 package finished successfully.

No generated scenes, node_modules, temporary test outputs or binaries are included.