### PR TITLE
Show gizmo controls in Embedded Web3D toolbar

### DIFF
--- a/tests/test_embedded_web3d_editor_bridge_static.py
+++ b/tests/test_embedded_web3d_editor_bridge_static.py
@@ -54,9 +54,16 @@ def test_qt_loads_embedded_view_and_routes_controls_without_reload():
 def test_qt_compact_toolbar_for_embedded_web3d():
     for member in ["embedded_undo_button_", "embedded_redo_button_", "embedded_fit_button_"]:
         assert member in CPP and member in HDR
+    assert "set_visible(view_actions_label_, !embedded_web_active)" in CPP
+    assert "set_visible(view_actions_selector_, !embedded_web_active)" in CPP
+    assert "set_visible(labels_label_, !embedded_web_active)" in CPP
+    assert "set_visible(labels_selector_, !embedded_web_active)" in CPP
+    assert "set_visible(mesh_preview_mode_label_, !embedded_web_active)" in CPP
     assert "set_visible(mesh_preview_mode_selector_, !embedded_web_active)" in CPP
+    assert "set_visible(interaction_mode_label_, !embedded_web_active)" in CPP
     assert "set_visible(interaction_mode_selector_, !embedded_web_active)" in CPP
     assert "set_visible(overlays_selector_, !embedded_web_active)" in CPP
+    assert "set_visible(gizmo_mode_label_, embedded_web_active)" in CPP
     assert "set_visible(gizmo_mode_selector_, embedded_web_active)" in CPP
     assert "set_visible(snap_mode_selector_, embedded_web_active)" in CPP
     assert "Unsaved preview edits: %1" in CPP

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -1,6 +1,5 @@
 #include "scene_preview_widget.h"
 // Compatibility token for static tests: legacy cwd fallback text QDir(QDir::currentPath()).absoluteFilePath(QStringLiteral("scenes/%1").arg(scene))
-// Compatibility token for static tests: set_visible(gizmo_mode_selector_, embedded_web_active)
 // Compatibility token for static tests: Preview selection cleared after refresh (id missing):
 
 #include <QRectF>
@@ -1378,8 +1377,8 @@ void ScenePreviewWidget::refresh_toolbar_visibility()
   set_visible(embedded_fit_button_, embedded_web_active);
   set_visible(mesh_preview_mode_label_, !embedded_web_active);
   set_visible(mesh_preview_mode_selector_, !embedded_web_active);
-  set_visible(gizmo_mode_label_, !embedded_web_active);
-  set_visible(gizmo_mode_selector_, !embedded_web_active);
+  set_visible(gizmo_mode_label_, embedded_web_active);
+  set_visible(gizmo_mode_selector_, embedded_web_active);
   set_visible(snap_mode_label_, embedded_web_active);
   set_visible(snap_mode_selector_, embedded_web_active);
   set_visible(interaction_mode_label_, !embedded_web_active);


### PR DESCRIPTION
### Motivation
- Embedded Web3D Product View should expose the existing Select/Move/Rotate gizmo controls so the in-browser editor bridge remains usable without showing native-only no-op controls.

### Description
- Update `ScenePreviewWidget::refresh_toolbar_visibility()` to make `gizmo_mode_label_` and `gizmo_mode_selector_` visible when `embedded_web_active` is true while leaving native-only controls (mesh preview, interaction labels/selectors, overlays, and native view actions) hidden.
- Preserve the existing embedded bridge behavior where Select/Move/Rotate continue to route via `window.__WORKCELL_EDITOR_API_V1__.setMode(...)` without changing bridge logic.
- Add/adjust static tests in `tests/test_embedded_web3d_editor_bridge_static.py` to explicitly assert the full embedded/native toolbar visibility contract including the gizmo label and selector.

### Testing
- Ran `python3 -m pytest tests/test_embedded_web3d_editor_bridge_static.py tests/test_workcell_builder_product_view_defaults.py` and all tests passed (`9 passed`).
- Ran `git diff --check` to verify no whitespace/errors and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59fd4c8c988331a71431e53f25202f)