### PR TITLE
Discard stale Product View preparation results

### DIFF
--- a/tests/test_workcell_builder_runtime_preview_status_flow.py
+++ b/tests/test_workcell_builder_runtime_preview_status_flow.py
@@ -68,3 +68,28 @@ def test_root_resolution_failure_summary_deduplicated():
     assert 'root_resolution_summary_keys_' in H
     assert 'root_resolution_failed' in CPP
     assert '!root_resolution_summary_keys_.contains(summary_key)' in CPP
+
+
+def test_stale_embedded_prepare_result_is_discarded_without_changing_current_preview_state():
+    start = CPP.index('void ScenePreviewWidget::on_embedded_web_prepare_finished')
+    body = CPP[start:CPP.index('void ScenePreviewWidget::load_prepared_embedded_web_scene', start)]
+    stale_start = body.index('if (!still_current)')
+    stale_body = body[stale_start:body.index('const QString absolute_output_path', stale_start)]
+
+    assert 'Discarded embedded Product View preparation result for completed scene %1 revision %2' in stale_body
+    assert '.arg(scene)' in stale_body
+    assert '.arg(revision)' in stale_body
+    assert 'process->deleteLater();' in body[:stale_start]
+    assert 'embedded_web_prepare_process_ = nullptr;' in body[:stale_start]
+    assert 'maybe_start_next_embedded_web_prepare();' in stale_body
+    assert 'activate_native_compatibility_preview' not in stale_body
+    assert 'set_embedded_product_view_state' not in stale_body
+    assert 'simple_3d_view_' not in stale_body
+    assert 'embedded_web_last_error_' not in stale_body
+
+
+def test_current_embedded_prepare_failures_still_use_compatibility_preview():
+    start = CPP.index('void ScenePreviewWidget::on_embedded_web_prepare_finished')
+    body = CPP[start:CPP.index('void ScenePreviewWidget::load_prepared_embedded_web_scene', start)]
+    current_failure = body[body.index('auto reject_prepare'):]
+    assert 'activate_native_compatibility_preview(reason);' in current_failure

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -852,6 +852,16 @@ void ScenePreviewWidget::on_embedded_web_prepare_finished(int exit_code, QProces
   embedded_web_prepare_process_ = nullptr;
 
   const bool still_current = (preview_scene_name_.trimmed() == scene && revision == embedded_web_request_revision_);
+  if (!still_current) {
+    emit studio_log_requested(QStringLiteral("Discarded embedded Product View preparation result for completed scene %1 revision %2; current scene is %3 revision %4.")
+      .arg(scene)
+      .arg(revision)
+      .arg(preview_scene_name_.trimmed())
+      .arg(embedded_web_request_revision_));
+    maybe_start_next_embedded_web_prepare();
+    return;
+  }
+
   const QString absolute_output_path = QDir(embedded_web_repo_root_).filePath(output_path);
   const bool output_is_fresh = QFileInfo::exists(QDir(embedded_web_repo_root_).filePath(output_path));  // Contract validation supersedes mtime freshness.
   Q_UNUSED(output_is_fresh);
@@ -861,10 +871,6 @@ void ScenePreviewWidget::on_embedded_web_prepare_finished(int exit_code, QProces
     maybe_start_next_embedded_web_prepare();
   };
 
-  if (!still_current) {
-    reject_prepare(QStringLiteral("discarded stale preparation for %1; current scene is %2").arg(scene, preview_scene_name_));
-    return;
-  }
   if (exit_status != QProcess::NormalExit || exit_code != 0) {
     reject_prepare(QStringLiteral("prepare command failed with exit code %1; old output is rejected even if present").arg(exit_code));
     return;


### PR DESCRIPTION
### Motivation
- Prevent stale embedded Web3D preparation completions from being treated as failures for the currently requested scene/revision and accidentally switching the UI into native-compatibility fallback or mutating current error/preview state.

### Description
- In `ScenePreviewWidget::on_embedded_web_prepare_finished()` add an early `still_current` check that logs the discarded result with the completed scene and revision, clears the finished process, calls `maybe_start_next_embedded_web_prepare()`, and returns without changing the active preview state.
- Ensure only failures belonging to the active request call `activate_native_compatibility_preview()` and update error state variables like `embedded_web_last_error_`.
- Add regression/static tests in `tests/test_workcell_builder_runtime_preview_status_flow.py` to assert that stale prepare results are discarded without altering `embedded_product_view_state_`, `simple_3d_view_`, or `embedded_web_last_error_`, and that current-request failures still trigger the compatibility fallback.
- Affected files: `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp` and `tests/test_workcell_builder_runtime_preview_status_flow.py`.

### Testing
- Ran `python3 -m pytest tests/test_workcell_builder_runtime_preview_status_flow.py tests/test_workcell_builder_embedded_web3d_policy.py` and all tests passed (`25 passed`).
- Ran `git diff --check` and there were no whitespace/patch issues.
- Did not run ROS/Qt build or GUI smoke tests in this container, as those require the ROS workspace and display environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a08df9b148331b90f6b0834f1635a)