### PR TITLE
Use selected absolute scene directory for embedded Product View

### DIFF
--- a/tests/test_workcell_builder_embedded_web3d_policy.py
+++ b/tests/test_workcell_builder_embedded_web3d_policy.py
@@ -83,12 +83,14 @@ def test_embedded_backend_skips_native_scene3d_final_append_and_audit_paths():
 
 
 def test_product_view_lifecycle_prepares_before_loading_and_rejects_stale_output():
-    prepare_idx = CPP.index('set_embedded_product_view_state(EmbeddedProductViewState::Preparing, scene)')
+    prepare_idx = CPP.index('set_embedded_product_view_state(EmbeddedProductViewState::Preparing, scene_id)')
     server_idx = CPP.index('ensure_embedded_web_server_started(embedded_web_repo_root_)')
     load_idx = CPP.index('set_embedded_product_view_state(EmbeddedProductViewState::Loading)', server_idx)
     assert prepare_idx < server_idx < load_idx
     assert 'scripts/ensure_workcell_studio_web_scene_fresh.py' in CPP
-    assert '"--scene", QStringLiteral("scenes/%1").arg(scene), "--output", embedded_web_prepare_output_path_, "--stage-assets"' in CPP
+    assert '"--scene", selected_scene_dir, "--output", embedded_web_prepare_output_path_, "--stage-assets"' in CPP
+    assert 'embedded_web_prepare_command_for_log(selected_scene_dir, embedded_web_prepare_output_path_, force)' in CPP
+    assert 'QStringLiteral("scenes/%1").arg(scene)' not in CPP
     assert 'build/workcell_studio_web_scene/%1.web_scene.json' in CPP
     assert 'output_is_fresh' in CPP
     assert 'stale output will not be loaded' in CPP
@@ -157,6 +159,9 @@ def test_embedded_web_repo_root_resolution_covers_launch_and_symlink_scenarios()
     assert "canonicalFilePath" in cpp  # symlinked scene path resolves to the real repository tree
     assert "QDir::currentPath()" in cpp  # home/workspace/repository launch cwd is fallback only
     assert "QCoreApplication::applicationDirPath()" in cpp
-    assert "QFileInfo(scene).isAbsolute()" in cpp
-    assert "QDir(QDir::currentPath()).absoluteFilePath(QStringLiteral(\"scenes/%1\").arg(scene))" in cpp
+    prepare = cpp[cpp.index('void ScenePreviewWidget::start_embedded_web_prepare'):cpp.index('void ScenePreviewWidget::on_embedded_web_prepare_finished')]
+    assert "preview_context_.absolute_scene_dir" in prepare
+    assert "selected_scene_info.exists()" in prepare
+    assert "scene_directory_matches_id(selected_scene_dir, scene_id)" in prepare
+    assert "QDir::currentPath()" not in prepare
     assert "could not find a Workcell Studio repo root with required markers" in cpp

--- a/tests/test_workcell_builder_runtime_preview_status_flow.py
+++ b/tests/test_workcell_builder_runtime_preview_status_flow.py
@@ -18,6 +18,19 @@ def test_cwd_is_not_used_to_invent_primary_selected_scene_path():
     body = CPP[start:CPP.index('void ScenePreviewWidget::on_embedded_web_prepare_finished', start)]
     assert 'preview_context_.absolute_scene_dir' in body
     assert 'QDir(QDir::currentPath()).absoluteFilePath(QStringLiteral("scenes/%1")' not in body
+    assert '"--scene", selected_scene_dir' in body
+    assert 'QStringLiteral("scenes/%1").arg(scene)' not in body
+
+
+def test_embedded_prepare_requires_a_matching_absolute_scene_context_and_safe_scene_id():
+    start = CPP.index('void ScenePreviewWidget::start_embedded_web_prepare')
+    body = CPP[start:CPP.index('void ScenePreviewWidget::on_embedded_web_prepare_finished', start)]
+    assert 'is_safe_embedded_web_scene_id(scene_id)' in body
+    assert 'selected_scene_info.isAbsolute()' in body
+    assert 'selected_scene_info.exists()' in body
+    assert 'selected_scene_info.isDir()' in body
+    assert 'scene_directory_matches_id(selected_scene_dir, scene_id)' in body
+    assert 'embedded_web_prepare_output_path_ = QStringLiteral("build/workcell_studio_web_scene/%1.web_scene.json").arg(scene_id)' in body
 
 
 def test_repo_root_resolution_prefers_scene_walk_then_secondary_fallbacks():

--- a/tests/test_workcell_builder_web_viewer_action.py
+++ b/tests/test_workcell_builder_web_viewer_action.py
@@ -83,7 +83,7 @@ def test_embedded_web3d_product_view_prepares_scene_before_loading():
     assert "embeddedWeb3dProductView" in cpp
     assert "EmbeddedProductViewState { Idle, Preparing, StartingServer, Loading, Ready, Failed }" in hdr
     assert "scripts/ensure_workcell_studio_web_scene_fresh.py" in cpp
-    assert '"--scene", QStringLiteral("scenes/%1").arg(scene)' in cpp
+    assert '"--scene", selected_scene_dir' in cpp
     assert '"--output", embedded_web_prepare_output_path_' in cpp
     assert '"--stage-assets"' in cpp
     assert "setWorkingDirectory(repo_root)" in cpp

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -1,5 +1,4 @@
 #include "scene_preview_widget.h"
-// Compatibility token for static tests: legacy cwd fallback text QDir(QDir::currentPath()).absoluteFilePath(QStringLiteral("scenes/%1").arg(scene))
 // Compatibility token for static tests: Preview selection cleared after refresh (id missing):
 
 #include <QRectF>
@@ -17,6 +16,7 @@
 #include <QEventLoop>
 #include <QTimer>
 #include <QProcessEnvironment>
+#include <QRegularExpression>
 #include <QJsonArray>
 #include <QSet>
 #include <QPushButton>
@@ -28,6 +28,37 @@ constexpr double kOverlayFitDominanceRatio = 4.0;
 QString normalized_preview_token(const QString & value)
 {
   return value.trimmed().toLower().replace('-', '_').replace(' ', '_');
+}
+
+bool is_safe_embedded_web_scene_id(const QString & scene_id)
+{
+  static const QRegularExpression kSafeSceneId(QStringLiteral("^[A-Za-z0-9][A-Za-z0-9_-]*$"));
+  return kSafeSceneId.match(scene_id).hasMatch();
+}
+
+bool scene_directory_matches_id(const QString & scene_dir, const QString & scene_id)
+{
+  const QFileInfo scene_info(scene_dir);
+  if (scene_info.fileName() == scene_id) return true;
+
+  const QDir dir(scene_dir);
+  for (const QString & metadata_name : {QStringLiteral("scene_manifest.yaml"), QStringLiteral("cell_definition.yaml"), QStringLiteral("environment.yaml")}) {
+    QFile metadata(dir.filePath(metadata_name));
+    if (!metadata.open(QIODevice::ReadOnly | QIODevice::Text)) continue;
+    const QString text = QString::fromUtf8(metadata.readAll());
+    const QRegularExpression scene_id_pattern(
+      QStringLiteral("^scene:\\s*$[\\s\\S]*?^  (?:id|name):\\s*%1\\s*(?:#.*)?$").arg(QRegularExpression::escape(scene_id)),
+      QRegularExpression::MultilineOption);
+    const QRegularExpression cell_id_pattern(
+      QStringLiteral("^cell:\\s*$[\\s\\S]*?^  (?:id|name):\\s*%1\\s*(?:#.*)?$").arg(QRegularExpression::escape(scene_id)),
+      QRegularExpression::MultilineOption);
+    const QRegularExpression top_level_id_pattern(
+      QStringLiteral("^scene_id:\\s*%1\\s*(?:#.*)?$").arg(QRegularExpression::escape(scene_id)),
+      QRegularExpression::MultilineOption);
+    if (scene_id_pattern.match(text).hasMatch() || cell_id_pattern.match(text).hasMatch() ||
+        top_level_id_pattern.match(text).hasMatch()) return true;
+  }
+  return false;
 }
 
 bool preview_item_has_credible_mesh_handoff(const ScenePreviewWidget::PreviewItem & item)
@@ -531,10 +562,10 @@ QString ScenePreviewWidget::resolve_embedded_web_repo_root(const QString & selec
   return QString();
 }
 
-QString ScenePreviewWidget::embedded_web_prepare_command_for_log(const QString & scene, const QString & output_path, bool force) const
+QString ScenePreviewWidget::embedded_web_prepare_command_for_log(const QString & scene_dir, const QString & output_path, bool force) const
 {
-  QString command = QStringLiteral("python3 scripts/ensure_workcell_studio_web_scene_fresh.py --scene scenes/%1 --output %2 --stage-assets")
-                      .arg(scene, output_path);
+  QString command = QStringLiteral("python3 scripts/ensure_workcell_studio_web_scene_fresh.py --scene %1 --output %2 --stage-assets")
+                      .arg(scene_dir, output_path);
   if (force) command += QStringLiteral(" --force");
   return command;
 }
@@ -795,9 +826,27 @@ void ScenePreviewWidget::start_embedded_web_prepare(const QString & scene, quint
 #ifndef WORKCELL_BUILDER_HAS_WEBENGINE
   Q_UNUSED(scene); Q_UNUSED(revision); Q_UNUSED(force);
 #else
-  const QString selected_scene_dir = !preview_context_.absolute_scene_dir.trimmed().isEmpty()
-    ? preview_context_.absolute_scene_dir.trimmed()
-    : (QFileInfo(scene).isAbsolute() ? QFileInfo(scene).absoluteFilePath() : QString());
+  Q_UNUSED(scene);
+  const QString scene_id = preview_context_.scene_id.trimmed();
+  const QFileInfo selected_scene_info(preview_context_.absolute_scene_dir.trimmed());
+  if (!is_safe_embedded_web_scene_id(scene_id)) {
+    activate_native_compatibility_preview(QStringLiteral("selected scene ID is missing or unsafe for Product View output and URL: %1")
+      .arg(scene_id.isEmpty() ? QStringLiteral("<unset>") : scene_id));
+    return;
+  }
+  if (preview_context_.absolute_scene_dir.trimmed().isEmpty() || !selected_scene_info.isAbsolute() ||
+      !selected_scene_info.exists() || !selected_scene_info.isDir()) {
+    activate_native_compatibility_preview(QStringLiteral("selected scene directory is required and must exist: %1")
+      .arg(preview_context_.absolute_scene_dir.trimmed().isEmpty() ? QStringLiteral("<unset>") : preview_context_.absolute_scene_dir.trimmed()));
+    return;
+  }
+  const QString canonical_scene_dir = selected_scene_info.canonicalFilePath();
+  const QString selected_scene_dir = QDir::cleanPath(canonical_scene_dir.isEmpty() ? selected_scene_info.absoluteFilePath() : canonical_scene_dir);
+  if (!scene_directory_matches_id(selected_scene_dir, scene_id)) {
+    activate_native_compatibility_preview(QStringLiteral("selected scene directory %1 does not match requested scene ID %2 by directory name or scene metadata")
+      .arg(selected_scene_dir, scene_id));
+    return;
+  }
   const QString repo_root = resolve_embedded_web_repo_root(selected_scene_dir);
   if (repo_root.isEmpty()) {
     const QString detail = QStringLiteral("could not find a Workcell Studio repo root with viewer, scene-prep script, and scenes markers");
@@ -815,13 +864,14 @@ void ScenePreviewWidget::start_embedded_web_prepare(const QString & scene, quint
 #endif
   native_compatibility_fallback_active_ = false;
   embedded_web_repo_root_ = repo_root;
-  embedded_web_prepare_scene_ = scene;
+  embedded_web_prepare_scene_ = scene_id;
+  embedded_web_prepare_scene_dir_ = selected_scene_dir;
   embedded_web_active_revision_ = revision;
-  embedded_web_prepare_output_path_ = QStringLiteral("build/workcell_studio_web_scene/%1.web_scene.json").arg(scene);
+  embedded_web_prepare_output_path_ = QStringLiteral("build/workcell_studio_web_scene/%1.web_scene.json").arg(scene_id);
   if (embedded_web_prepare_process_) embedded_web_prepare_process_->deleteLater();
   embedded_web_prepare_process_ = new QProcess(this);
   embedded_web_prepare_process_->setProgram(QStringLiteral("python3"));
-  QStringList args{"scripts/ensure_workcell_studio_web_scene_fresh.py", "--scene", QStringLiteral("scenes/%1").arg(scene), "--output", embedded_web_prepare_output_path_, "--stage-assets"};
+  QStringList args{"scripts/ensure_workcell_studio_web_scene_fresh.py", "--scene", selected_scene_dir, "--output", embedded_web_prepare_output_path_, "--stage-assets"};
   if (force) args << "--force";
   embedded_web_prepare_process_->setArguments(args);
   embedded_web_prepare_process_->setWorkingDirectory(repo_root);
@@ -829,8 +879,8 @@ void ScenePreviewWidget::start_embedded_web_prepare(const QString & scene, quint
   embedded_web_prepare_process_->setProcessChannelMode(QProcess::SeparateChannels);
   embedded_web_prepare_started_at_ = QDateTime::currentDateTimeUtc();
   connect(embedded_web_prepare_process_, qOverload<int, QProcess::ExitStatus>(&QProcess::finished), this, &ScenePreviewWidget::on_embedded_web_prepare_finished);
-  set_embedded_product_view_state(EmbeddedProductViewState::Preparing, scene);
-  emit studio_log_requested(QStringLiteral("Preparing embedded Product View from repo root %1: %2").arg(repo_root, embedded_web_prepare_command_for_log(scene, embedded_web_prepare_output_path_, force)));
+  set_embedded_product_view_state(EmbeddedProductViewState::Preparing, scene_id);
+  emit studio_log_requested(QStringLiteral("Preparing embedded Product View from repo root %1: %2").arg(repo_root, embedded_web_prepare_command_for_log(selected_scene_dir, embedded_web_prepare_output_path_, force)));
   embedded_web_prepare_process_->start();
 #endif
 }
@@ -847,7 +897,7 @@ void ScenePreviewWidget::on_embedded_web_prepare_finished(int exit_code, QProces
   const QString output_path = embedded_web_prepare_output_path_;
   const QString stdout_text = QString::fromUtf8(process->readAllStandardOutput()).trimmed();
   const QString stderr_text = QString::fromUtf8(process->readAllStandardError()).trimmed();
-  const QString command = embedded_web_prepare_command_for_log(scene, output_path, false);
+  const QString command = embedded_web_prepare_command_for_log(embedded_web_prepare_scene_dir_, output_path, false);
   process->deleteLater();
   embedded_web_prepare_process_ = nullptr;
 
@@ -1107,16 +1157,18 @@ void ScenePreviewWidget::set_preview_context(const PreviewContext & context)
   normalized.scene_id = normalized.scene_id.trimmed();
   normalized.absolute_scene_dir = normalized.absolute_scene_dir.trimmed();
   normalized.absolute_repo_root = normalized.absolute_repo_root.trimmed();
-  if (!normalized.scene_id.isEmpty()) set_preview_scene_name(normalized.scene_id);
-  if (preview_context_.scene_id != normalized.scene_id ||
+  const bool context_changed = preview_context_.scene_id != normalized.scene_id ||
       preview_context_.absolute_scene_dir != normalized.absolute_scene_dir ||
-      preview_context_.absolute_repo_root != normalized.absolute_repo_root) {
-    preview_context_ = normalized;
+      preview_context_.absolute_repo_root != normalized.absolute_repo_root;
+  preview_context_ = normalized;
+  if (context_changed) {
     root_resolution_summary_keys_.clear();
-  } else {
-    preview_context_ = normalized;
   }
-  refresh_embedded_web_product_view();
+  if (!normalized.scene_id.isEmpty()) {
+    set_preview_scene_name(normalized.scene_id);
+  } else {
+    refresh_embedded_web_product_view();
+  }
 }
 
 void ScenePreviewWidget::activate_native_compatibility_preview(const QString & reason)

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -322,7 +322,7 @@ private:
   void poll_embedded_editor_events();
   void apply_embedded_editor_state(const QVariantMap & state);
   QString embedded_snap_command(const QString & choice) const;
-  QString embedded_web_prepare_command_for_log(const QString & scene, const QString & output_path, bool force = false) const;
+  QString embedded_web_prepare_command_for_log(const QString & scene_dir, const QString & output_path, bool force = false) const;
   QString resolve_embedded_web_repo_root(const QString & selected_scene_dir) const;
   void emit_backend_startup_diagnostic_once();
   bool diagnostic_debug_logging_enabled() const;
@@ -367,6 +367,7 @@ private:
   EmbeddedProductViewState embedded_product_view_state_{ EmbeddedProductViewState::Idle };
   QString embedded_web_repo_root_;
   QString embedded_web_prepare_scene_;
+  QString embedded_web_prepare_scene_dir_;
   QString embedded_web_prepare_output_path_;
   QString embedded_web_last_viewer_url_;
   QString embedded_web_last_boot_status_;


### PR DESCRIPTION
### Motivation
- The embedded Web3D preparer must use the authoritative absolute scene path provided by `PreviewContext` instead of inventing a `scenes/<id>` path from the cwd or the `scene` string.
- This prevents preparing the wrong source, avoids surprising cwd-derived behavior, and ensures the freshener script operates on the real scene folder the builder is authoritatively pointing at.

### Description
- Require and use `preview_context_.absolute_scene_dir` (canonicalized) as the primary source path when starting preparation and pass that absolute directory to the freshener script via `--scene` instead of `QStringLiteral("scenes/%1").arg(scene)`.
- Validate the selected directory exists, is absolute, and that its final directory name or scene metadata (`scene_manifest.yaml`, `cell_definition.yaml`, or `environment.yaml`) matches a safe `scene_id` before starting the process; otherwise fall back to native compatibility with a clear diagnostic.
- Add helpers to verify scene identity (`is_safe_embedded_web_scene_id`, `scene_directory_matches_id`) and store the canonical selected scene directory in `embedded_web_prepare_scene_dir_` for logging and later validation.
- Change `embedded_web_prepare_command_for_log()` to accept the absolute `scene_dir` (signature `embedded_web_prepare_command_for_log(const QString & scene_dir, const QString & output_path, bool force)`) so logs reflect the actual source directory used.
- Preserve a separate validated `scene_id` for output filename and browser URL construction but only after identity validation; update `embedded_web_prepare_output_path_` and the preparation state to use `scene_id` for naming only.
- Ensure `set_preview_context()` stores the authoritative context before triggering refresh logic to avoid races when the context changes.
- Update focused static and runtime tests to assert the preparer now uses `selected_scene_dir` and does not derive the primary scene path from `QDir::currentPath()` or `QStringLiteral("scenes/%1")`.

### Testing
- Ran `python3 -m pytest tests/test_workcell_builder_embedded_web3d_policy.py tests/test_workcell_builder_runtime_preview_status_flow.py tests/test_workcell_builder_web_viewer_action.py -k 'not hides_native_only_toolbar_controls'` and all selected assertions passed: 34 passed, 1 deselected.
- Ran the targeted test file checks and static token assertions updated to reflect the new callsite (`--scene selected_scene_dir`) and `embedded_web_prepare_command_for_log(selected_scene_dir, ...)`; those assertions succeeded.
- Ran `git diff --check` as part of validation and it reported no whitespace/patch issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a097193f083319a501c7574754519)