### PR TITLE
Guard embedded Web3D navigation completions

### DIFF
--- a/tests/test_workcell_builder_embedded_web3d_policy.py
+++ b/tests/test_workcell_builder_embedded_web3d_policy.py
@@ -112,6 +112,24 @@ def test_load_finished_true_only_starts_bounded_readiness_polling():
     assert 'set_embedded_product_view_state(EmbeddedProductViewState::Ready' not in handler
 
 
+def test_load_completion_and_readiness_are_scoped_to_the_current_navigation():
+    load_finished = CPP.index('&QWebEngineView::loadFinished')
+    handler = CPP[load_finished:CPP.index('simple_3d_view_ = embedded_web_view_', load_finished)]
+    load_scene = CPP[CPP.index('void ScenePreviewWidget::load_prepared_embedded_web_scene'):]
+    readiness = CPP[CPP.index('void ScenePreviewWidget::poll_embedded_web_readiness'):CPP.index('void ScenePreviewWidget::load_prepared_embedded_web_scene')]
+
+    assert 'embedded_web_loading_navigation_token_ = ++embedded_web_navigation_token_' in load_scene
+    assert 'embedded_web_expected_viewer_url_ = QUrl(viewer_url)' in load_scene
+    assert 'embedded_web_view_->load(embedded_web_expected_viewer_url_)' in load_scene
+    assert 'navigation_token != embedded_web_navigation_token_' in handler
+    assert 'embedded_web_view_->url() != expected_viewer_url' in handler
+    assert 'Ignored stale Embedded Product View load completion' in handler
+    assert 'embedded_web_view_->setVisible(false);' in handler
+    assert 'start_embedded_web_readiness_polling(identity, navigation_token' in handler
+    assert 'navigation_token != embedded_web_navigation_token_' in readiness
+    assert 'poll_embedded_web_readiness(identity, navigation_token' in readiness
+
+
 def test_product_view_ready_requires_viewer_status_not_load_finished_true():
     assert 'window.__WORKCELL_VIEWER_STATUS__' in CPP
     assert 'runJavaScript' in CPP

--- a/tests/test_workcell_builder_embedded_web3d_readiness_policy.py
+++ b/tests/test_workcell_builder_embedded_web3d_readiness_policy.py
@@ -113,4 +113,4 @@ def test_manual_refresh_creates_a_new_generation_and_invalidates_old_callbacks()
     finished = _between(CPP, "void ScenePreviewWidget::on_embedded_web_prepare_finished", "void ScenePreviewWidget::start_embedded_web_readiness_polling")
     assert "embedded_web_identity_is_current(identity)" in finished
     polling = _between(CPP, "void ScenePreviewWidget::poll_embedded_web_readiness", "void ScenePreviewWidget::load_prepared_embedded_web_scene")
-    assert "[this, identity, expected_json_path, viewer_url]" in polling
+    assert "[this, identity, navigation_token, expected_json_path, viewer_url]" in polling

--- a/tests/test_workcell_builder_web_viewer_action.py
+++ b/tests/test_workcell_builder_web_viewer_action.py
@@ -88,7 +88,8 @@ def test_embedded_web3d_product_view_prepares_scene_before_loading():
     assert '"--stage-assets"' in cpp
     assert "setWorkingDirectory(repo_root)" in cpp
     assert "setProcessEnvironment(QProcessEnvironment::systemEnvironment())" in cpp
-    assert "embedded_web_view_->load(QUrl(viewer_url))" in cpp
+    assert "embedded_web_expected_viewer_url_ = QUrl(viewer_url)" in cpp
+    assert "embedded_web_view_->load(embedded_web_expected_viewer_url_)" in cpp
     assert "QFileInfo::exists(QDir(embedded_web_repo_root_).filePath(output_path))" in cpp
     assert "stale output will not be loaded" in cpp
 

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -323,17 +323,30 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
     embedded_web_view_->setObjectName("embeddedWeb3dProductView");
     connect(embedded_web_view_, &QWebEngineView::loadFinished, this, [this](bool ok) {
       const EmbeddedWebRequestIdentity identity = embedded_web_loading_identity_;
-      if (!embedded_web_identity_is_current(identity)) return;
+      const quint64 navigation_token = embedded_web_loading_navigation_token_;
+      const QUrl expected_viewer_url = embedded_web_expected_viewer_url_;
+      if (!embedded_web_identity_is_current(identity) || navigation_token != embedded_web_navigation_token_) {
+        emit studio_log_requested(QStringLiteral("Ignored stale Embedded Product View load completion for scene %1 revision %2 navigation %3.")
+          .arg(identity.scene_id).arg(identity.generation).arg(navigation_token));
+        return;
+      }
+      if (embedded_web_view_->url() != expected_viewer_url) {
+        emit studio_log_requested(QStringLiteral("Ignored stale Embedded Product View load completion for scene %1 revision %2 navigation %3; expected viewer URL %4, active viewer URL %5.")
+          .arg(identity.scene_id).arg(identity.generation).arg(navigation_token)
+          .arg(expected_viewer_url.toString(), embedded_web_view_->url().toString()));
+        return;
+      }
       if (!ok) {
         const QString detail = QStringLiteral("browser failed to load Product View page for scene %1; viewer URL: %2; expected JSON: %3")
-          .arg(embedded_web_prepare_scene_, embedded_web_last_viewer_url_, embedded_web_prepare_output_path_);
+          .arg(identity.scene_id, expected_viewer_url.toString(), embedded_web_prepare_output_path_);
         // set_embedded_product_view_state(EmbeddedProductViewState::Failed, detail) is intentionally replaced by native compatibility fallback.
+        embedded_web_view_->setVisible(false);
         activate_native_compatibility_preview(detail);
         emit studio_log_requested(QStringLiteral("Embedded Product View load failed. %1").arg(detail));
         return;
       }
       set_embedded_product_view_state(EmbeddedProductViewState::Loading, QStringLiteral("browser loaded; waiting for viewer readiness"));
-      start_embedded_web_readiness_polling(embedded_web_loading_identity_, embedded_web_prepare_output_path_, embedded_web_last_viewer_url_);
+      start_embedded_web_readiness_polling(identity, navigation_token, embedded_web_prepare_output_path_, expected_viewer_url.toString());
     });
     simple_3d_view_ = embedded_web_view_;
   } else {
@@ -1015,24 +1028,30 @@ void ScenePreviewWidget::on_embedded_web_prepare_finished(const EmbeddedWebReque
 #endif
 }
 
-void ScenePreviewWidget::start_embedded_web_readiness_polling(const EmbeddedWebRequestIdentity & identity, const QString & expected_json_path, const QString & viewer_url)
+void ScenePreviewWidget::start_embedded_web_readiness_polling(const EmbeddedWebRequestIdentity & identity, quint64 navigation_token, const QString & expected_json_path, const QString & viewer_url)
 {
 #ifndef WORKCELL_BUILDER_HAS_WEBENGINE
-  Q_UNUSED(identity); Q_UNUSED(expected_json_path); Q_UNUSED(viewer_url);
+  Q_UNUSED(identity); Q_UNUSED(navigation_token); Q_UNUSED(expected_json_path); Q_UNUSED(viewer_url);
 #else
   embedded_web_readiness_deadline_ = QDateTime::currentDateTimeUtc().addSecs(45);
   embedded_web_last_boot_status_ = QStringLiteral("browser_loaded");
-  poll_embedded_web_readiness(identity, expected_json_path, viewer_url);
+  poll_embedded_web_readiness(identity, navigation_token, expected_json_path, viewer_url);
 #endif
 }
 
-void ScenePreviewWidget::poll_embedded_web_readiness(const EmbeddedWebRequestIdentity & identity, const QString & expected_json_path, const QString & viewer_url)
+void ScenePreviewWidget::poll_embedded_web_readiness(const EmbeddedWebRequestIdentity & identity, quint64 navigation_token, const QString & expected_json_path, const QString & viewer_url)
 {
 #ifndef WORKCELL_BUILDER_HAS_WEBENGINE
-  Q_UNUSED(identity); Q_UNUSED(expected_json_path); Q_UNUSED(viewer_url);
+  Q_UNUSED(identity); Q_UNUSED(navigation_token); Q_UNUSED(expected_json_path); Q_UNUSED(viewer_url);
 #else
   if (!embedded_web_view_) return;
-  if (!embedded_web_identity_is_current(identity)) return;
+  const QUrl expected_viewer_url(viewer_url);
+  if (!embedded_web_identity_is_current(identity) || navigation_token != embedded_web_navigation_token_ ||
+      embedded_web_view_->url() != expected_viewer_url) {
+    emit studio_log_requested(QStringLiteral("Ignored stale Embedded Product View readiness poll for scene %1 revision %2 navigation %3.")
+      .arg(identity.scene_id).arg(identity.generation).arg(navigation_token));
+    return;
+  }
 
   if (QDateTime::currentDateTimeUtc() > embedded_web_readiness_deadline_) {
     const QString detail = QStringLiteral(
@@ -1059,8 +1078,13 @@ void ScenePreviewWidget::poll_embedded_web_readiness(const EmbeddedWebRequestIde
   };
 })()
 )JS";
-  embedded_web_view_->page()->runJavaScript(QString::fromUtf8(kStatusScript), [this, identity, expected_json_path, viewer_url](const QVariant & value) {
-    if (!embedded_web_identity_is_current(identity)) return;
+  embedded_web_view_->page()->runJavaScript(QString::fromUtf8(kStatusScript), [this, identity, navigation_token, expected_json_path, viewer_url](const QVariant & value) {
+    if (!embedded_web_identity_is_current(identity) || navigation_token != embedded_web_navigation_token_ ||
+        embedded_web_view_->url() != QUrl(viewer_url)) {
+      emit studio_log_requested(QStringLiteral("Ignored stale Embedded Product View readiness result for scene %1 revision %2 navigation %3.")
+        .arg(identity.scene_id).arg(identity.generation).arg(navigation_token));
+      return;
+    }
     const QVariantMap status = value.toMap();
     const QString boot_state = status.value(QStringLiteral("viewer_boot_state")).toString();
     const QString source_json = status.value(QStringLiteral("source_web_scene_file")).toString();
@@ -1103,8 +1127,8 @@ void ScenePreviewWidget::poll_embedded_web_readiness(const EmbeddedWebRequestIde
     }
 
     set_embedded_product_view_state(EmbeddedProductViewState::Loading, QStringLiteral("waiting for viewer readiness (%1)").arg(embedded_web_last_boot_status_));
-    QTimer::singleShot(750, this, [this, identity, expected_json_path, viewer_url]() {
-      poll_embedded_web_readiness(identity, expected_json_path, viewer_url);
+    QTimer::singleShot(750, this, [this, identity, navigation_token, expected_json_path, viewer_url]() {
+      poll_embedded_web_readiness(identity, navigation_token, expected_json_path, viewer_url);
     });
   });
 #endif
@@ -1125,12 +1149,14 @@ void ScenePreviewWidget::load_prepared_embedded_web_scene(const EmbeddedWebReque
     .arg(embedded_web_server_port_)
     .arg(QString::fromUtf8(QUrl::toPercentEncoding(web_scene_url_path)))
     .arg(identity.generation) + QStringLiteral("&embedded=1");
-  embedded_web_loading_identity_ = identity;
-  embedded_web_last_viewer_url_ = viewer_url;
   embedded_web_readiness_deadline_ = QDateTime();
   embedded_web_last_boot_status_.clear();
   set_embedded_product_view_state(EmbeddedProductViewState::Loading);
-  embedded_web_view_->load(QUrl(viewer_url));
+  embedded_web_loading_identity_ = identity;
+  embedded_web_loading_navigation_token_ = ++embedded_web_navigation_token_;
+  embedded_web_expected_viewer_url_ = QUrl(viewer_url);
+  embedded_web_last_viewer_url_ = embedded_web_expected_viewer_url_.toString();
+  embedded_web_view_->load(embedded_web_expected_viewer_url_);
 #endif
 }
 

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -7,6 +7,7 @@
 #include <QMatrix4x4>
 #include <QProcess>
 #include <QDateTime>
+#include <QUrl>
 
 class QComboBox;
 class QLabel;
@@ -333,8 +334,8 @@ private:
   void ensure_embedded_web_server_started(const QString & repo_root, const EmbeddedWebRequestIdentity & identity);
   bool embedded_web_server_is_usable(const QString & repo_root = QString(), const QString & scene = QString());
   void load_prepared_embedded_web_scene(const EmbeddedWebRequestIdentity & identity);
-  void start_embedded_web_readiness_polling(const EmbeddedWebRequestIdentity & identity, const QString & expected_json_path, const QString & viewer_url);
-  void poll_embedded_web_readiness(const EmbeddedWebRequestIdentity & identity, const QString & expected_json_path, const QString & viewer_url);
+  void start_embedded_web_readiness_polling(const EmbeddedWebRequestIdentity & identity, quint64 navigation_token, const QString & expected_json_path, const QString & viewer_url);
+  void poll_embedded_web_readiness(const EmbeddedWebRequestIdentity & identity, quint64 navigation_token, const QString & expected_json_path, const QString & viewer_url);
   void set_embedded_product_view_state(EmbeddedProductViewState state, const QString & detail = QString());
   void activate_native_compatibility_preview(const QString & reason);
   void run_embedded_editor_command(const QString & script);
@@ -395,6 +396,9 @@ private:
   EmbeddedWebRequestIdentity embedded_web_active_identity_;
   EmbeddedWebRequestIdentity pending_embedded_web_identity_;
   EmbeddedWebRequestIdentity embedded_web_loading_identity_;
+  quint64 embedded_web_navigation_token_{ 0 };
+  quint64 embedded_web_loading_navigation_token_{ 0 };
+  QUrl embedded_web_expected_viewer_url_;
   bool embedded_web_has_active_identity_{ false };
   bool pending_embedded_web_request_{ false };
   quint64 embedded_web_request_generation_{ 0 };


### PR DESCRIPTION
### Motivation
- Prevent a previously-started embedded Web3D navigation from marking a newer scene load as ready after rapid refreshes or scene changes.
- Ensure readiness polling only applies to the exact navigation that initiated the load, and verify the WebEngine URL matches the expected viewer URL before proceeding.
- Failures during WebEngine load should not leave the broken browser view visible; the native compatibility preview must be activated and shown instead.

### Description
- Capture a monotonically-increasing `embedded_web_navigation_token_` and the `embedded_web_expected_viewer_url_` immediately before calling `QWebEngineView::load()` in `load_prepared_embedded_web_scene()` and store the token in `embedded_web_loading_navigation_token_`.
- In the `QWebEngineView::loadFinished` handler, verify the request identity, navigation token, and `embedded_web_view_->url()` match the expected values and log-and-ignore stale completions instead of changing state, and hide the failed WebEngine view before activating the native compatibility preview on load failure.
- Propagate the captured navigation token into `start_embedded_web_readiness_polling()` and `poll_embedded_web_readiness()` and check the token and expected URL at each readiness callback to ensure only the originating navigation can mark readiness.
- Add fields `embedded_web_navigation_token_`, `embedded_web_loading_navigation_token_`, and `embedded_web_expected_viewer_url_` to the widget state, and update related call sites and signatures accordingly in `ScenePreviewWidget`.
- Update and add focused static-policy/unit assertions in `tests/test_workcell_builder_embedded_web3d_policy.py`, `tests/test_workcell_builder_embedded_web3d_readiness_policy.py`, and `tests/test_workcell_builder_web_viewer_action.py` to cover navigation-scoped load and readiness handling.
- Key files changed: `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp`, `workcell_builder/workcell_builder/gui/scene_preview_widget.h`, and the three test files above.

### Testing
- Ran `python3 -m pytest tests/test_workcell_builder_embedded_web3d_policy.py tests/test_workcell_builder_embedded_web3d_readiness_policy.py tests/test_workcell_builder_web_viewer_action.py` and the updated suites passed (26 tests passed).
- Ran `git diff --check` which produced no whitespace or diff-check errors.
- Attempted `colcon build --packages-select workcell_builder` but it was skipped because `colcon` or `/opt/ros/humble/setup.bash` is unavailable in the container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a0e3a640c8331822db5e702028d23)