### PR TITLE
Fix missing Qt includes in ScenePreviewWidget

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -8,6 +8,8 @@
 #include <QJsonObject>
 #include <QJsonParseError>
 #include <QFile>
+#include <QFileInfo>
+#include <QDir>
 #include <QIODevice>
 #include <QStringList>
 #include <QNetworkAccessManager>
@@ -133,8 +135,6 @@ void maybe_warn_overlay_fit_dominance(ScenePreviewWidget * self, const QRectF & 
 #include <QLabel>
 #include <QMouseEvent>
 #include <QCoreApplication>
-#include <QDir>
-#include <QFileInfo>
 #include <QProcess>
 #include <QProcessEnvironment>
 #include <QUrl>


### PR DESCRIPTION
## Summary
Describe the change and the motivation.

## Checklist
- [ ] I have run the CI-equivalent commands from the README (or explained why not).
- [ ] I have added/updated tests where applicable.
- [ ] I have updated documentation where applicable.

## Testing
List the commands you ran and their results:

```bash
rosdep install --from-paths src --ignore-src -yr --rosdistro humble
colcon build --symlink-install
colcon test
colcon test-result --verbose
```

## Additional Notes
Anything else reviewers should know.
