### PR TITLE
Normalize Workcell Builder preview contexts

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -10852,6 +10852,8 @@ void MainWindow::populate_scene_hierarchy()
     ScenePreviewWidget::PreviewContext preview_context;
     preview_context.scene_id = selected_scene_state_.name;
     preview_context.absolute_scene_dir = selected_scene_state_.path;
+    preview_context.absolute_repo_root = resolve_scene3d_extractor_script_path(
+      fs::path(selected_scene_state_.path.toStdString()));
     scene_preview_widget_->set_preview_context(preview_context);
     apply_scene3d_product_view_layer_defaults_and_commit();
 

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -89,6 +89,35 @@ QString normalized_preview_token(const QString & value)
   return value.trimmed().toLower().replace('-', '_').replace(' ', '_');
 }
 
+QString normalized_absolute_preview_path(const QString & path)
+{
+  const QString trimmed_path = path.trimmed();
+  if (trimmed_path.isEmpty()) return {};
+
+  const QFileInfo info(trimmed_path);
+  const QString canonical_path = info.canonicalFilePath();
+  return QDir::cleanPath(canonical_path.isEmpty() ? info.absoluteFilePath() : canonical_path);
+}
+
+ScenePreviewWidget::PreviewContext normalized_preview_context(
+  const ScenePreviewWidget::PreviewContext & context)
+{
+  ScenePreviewWidget::PreviewContext normalized = context;
+  normalized.scene_id = normalized.scene_id.trimmed();
+  normalized.absolute_scene_dir = normalized_absolute_preview_path(normalized.absolute_scene_dir);
+  normalized.absolute_repo_root = normalized_absolute_preview_path(normalized.absolute_repo_root);
+  return normalized;
+}
+
+bool preview_contexts_equal(
+  const ScenePreviewWidget::PreviewContext & left,
+  const ScenePreviewWidget::PreviewContext & right)
+{
+  return left.scene_id == right.scene_id &&
+         left.absolute_scene_dir == right.absolute_scene_dir &&
+         left.absolute_repo_root == right.absolute_repo_root;
+}
+
 bool is_safe_embedded_web_scene_id(const QString & scene_id)
 {
   static const QRegularExpression kSafeSceneId(QStringLiteral("^[A-Za-z0-9][A-Za-z0-9_-]*$"));
@@ -1344,20 +1373,19 @@ void ScenePreviewWidget::show_embedded_web_product_view()
 
 void ScenePreviewWidget::set_preview_context(const PreviewContext & context)
 {
-  PreviewContext normalized = context;
-  normalized.scene_id = normalized.scene_id.trimmed();
-  normalized.absolute_scene_dir = normalized.absolute_scene_dir.trimmed();
-  normalized.absolute_repo_root = normalized.absolute_repo_root.trimmed();
-  const bool context_changed = preview_context_.scene_id != normalized.scene_id ||
-      preview_context_.absolute_scene_dir != normalized.absolute_scene_dir ||
-      preview_context_.absolute_repo_root != normalized.absolute_repo_root;
+  const PreviewContext normalized = normalized_preview_context(context);
+  const bool context_changed = !preview_contexts_equal(preview_context_, normalized);
+  if (!context_changed) return;
+
+  const QString effective_scene_name = normalized.scene_id.isEmpty() ?
+    QStringLiteral("No scene") : normalized.scene_id;
+  const bool scene_name_changed = preview_scene_name_ != effective_scene_name;
   if (context_changed) cancel_embedded_web_lifecycle(false);
   preview_context_ = normalized;
-  if (context_changed) {
-    root_resolution_summary_keys_.clear();
-  }
+  root_resolution_summary_keys_.clear();
   if (!normalized.scene_id.isEmpty()) {
     set_preview_scene_name(normalized.scene_id);
+    if (!scene_name_changed) refresh_embedded_web_product_view();
   } else {
     refresh_embedded_web_product_view();
   }
@@ -1539,19 +1567,17 @@ quint64 ScenePreviewWidget::embedded_web_preparation_request_count() const { ret
 void ScenePreviewWidget::set_preview_scene_name(const QString & scene_name)
 {
   const QString normalized_scene_name = scene_name.trimmed().isEmpty() ? QStringLiteral("No scene") : scene_name.trimmed();
-  if (preview_scene_name_ != normalized_scene_name) {
-    cancel_embedded_web_lifecycle(false);
-    preview_scene_name_ = normalized_scene_name;
-    preview_payload_revision_ = 0;
-    last_visual_quality_revision_logged_ = -1;
-    emitted_scene_diagnostic_keys_.clear();
-    emit_scene_diagnostic_once(
-      QStringLiteral("scene_load"),
-      0,
-      QStringLiteral("Scene loaded: %1").arg(preview_scene_name_));
-  } else {
-    preview_scene_name_ = normalized_scene_name;
-  }
+  if (preview_scene_name_ == normalized_scene_name) return;
+
+  cancel_embedded_web_lifecycle(false);
+  preview_scene_name_ = normalized_scene_name;
+  preview_payload_revision_ = 0;
+  last_visual_quality_revision_logged_ = -1;
+  emitted_scene_diagnostic_keys_.clear();
+  emit_scene_diagnostic_once(
+    QStringLiteral("scene_load"),
+    0,
+    QStringLiteral("Scene loaded: %1").arg(preview_scene_name_));
   auto * v = active_native_viewport();
   if (v) { v->scene_name = preview_scene_name_; v->update(); }
   refresh_embedded_web_product_view();

--- a/workcell_builder/workcell_builder/test/scene_preview_widget_ui_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene_preview_widget_ui_test.cpp
@@ -2,6 +2,8 @@
 
 #include <QApplication>
 #include <QComboBox>
+#include <QDir>
+#include <QTemporaryDir>
 
 #include "scene_preview_widget.h"
 
@@ -149,4 +151,35 @@ TEST(ScenePreviewWidgetUi, EquivalentPreviewPayloadsDoNotPrepareProductViewAgain
   EXPECT_EQ(widget.preview_payload_generation(), generation + 1);
   EXPECT_EQ(widget.embedded_web_preparation_request_count(), preparations + 1);
   EXPECT_EQ(widget.selected_preview_item_id(), robot.id);
+}
+
+TEST(ScenePreviewWidgetUi, EquivalentPreviewContextsPrepareProductViewOnlyOnce)
+{
+  ASSERT_NE(ensure_app(), nullptr);
+
+  QTemporaryDir temporary_root;
+  ASSERT_TRUE(temporary_root.isValid());
+  const QString repo_root = temporary_root.path();
+  const QString scene_dir = QDir(repo_root).filePath("scenes/ur5_2f_test");
+  ASSERT_TRUE(QDir().mkpath(scene_dir));
+
+  ScenePreviewWidget::PreviewContext first_context;
+  first_context.scene_id = "  ur5_2f_test  ";
+  first_context.absolute_scene_dir = QDir(repo_root).filePath("scenes/./ur5_2f_test");
+  first_context.absolute_repo_root = repo_root + "/.";
+
+  ScenePreviewWidget::PreviewContext equivalent_context;
+  equivalent_context.scene_id = "ur5_2f_test";
+  equivalent_context.absolute_scene_dir = scene_dir;
+  equivalent_context.absolute_repo_root = repo_root;
+
+  ScenePreviewWidget widget;
+  const quint64 preparations = widget.embedded_web_preparation_request_count();
+  widget.set_preview_context(first_context);
+  EXPECT_EQ(widget.embedded_web_preparation_request_count(), preparations + 1);
+
+  widget.set_preview_context(equivalent_context);
+  widget.set_preview_context(first_context);
+  widget.set_preview_scene_name(" ur5_2f_test ");
+  EXPECT_EQ(widget.embedded_web_preparation_request_count(), preparations + 1);
 }


### PR DESCRIPTION
### Motivation
- Reduce redundant embedded Web3D preparation churn by ensuring preview context comparisons use normalized, canonical-like values for scene and repository paths and trimmed scene IDs.

### Description
- Added `normalized_absolute_preview_path()`, `normalized_preview_context()` and `preview_contexts_equal()` helpers to normalize scene IDs and absolute paths preferring canonical paths when available. (workcell_builder/gui/scene_preview_widget.cpp)
- Updated `ScenePreviewWidget::set_preview_context()` to compare using normalized contexts and return early when the effective context is unchanged, avoiding unnecessary lifecycle cancellation, root-resolution resets, and extra preparation requests. (workcell_builder/gui/scene_preview_widget.cpp)
- Updated `ScenePreviewWidget::set_preview_scene_name()` to return early when the effective scene name is unchanged to avoid redundant refreshes. (workcell_builder/gui/scene_preview_widget.cpp)
- Populated `PreviewContext::absolute_repo_root` from the selected scene repository root using the extractor-based resolver when available. (workcell_builder/gui/mainwindow.cpp)
- Added a regression test `EquivalentPreviewContextsPrepareProductViewOnlyOnce` that exercises repeated `set_preview_context()` calls with equivalent-but-differently-formed paths and verifies only one automatic preparation request is issued. (workcell_builder/test/scene_preview_widget_ui_test.cpp)

### Testing
- Ran `python3 -m pytest tests/test_scene_preview_widget_lifecycle_cancellation.py tests/test_workcell_builder_embedded_web3d_readiness_policy.py tests/test_workcell_builder_product_view_defaults.py` and all selected tests passed.
- Ran `git diff --check` to validate no whitespace errors.
- Did not run a ROS/colcon C++ build in this environment because `/opt/ros/humble/setup.bash` is unavailable; recommend running `colcon build --symlink-install --packages-select workcell_builder` in a ROS Humble environment as a pre-merge validation step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a7f7be90c8331a11380e773535cbf)