### PR TITLE
Coalesce embedded Product View refresh lifecycle using normalized context + payload fingerprint

### DIFF
--- a/tests/test_scene_preview_widget_refresh_lifecycle.py
+++ b/tests/test_scene_preview_widget_refresh_lifecycle.py
@@ -1,0 +1,104 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CPP = (ROOT / "workcell_builder/workcell_builder/gui/scene_preview_widget.cpp").read_text(encoding="utf-8")
+
+
+@dataclass(frozen=True)
+class RequestKey:
+    scene: str
+    directory: str
+    fingerprint: bytes
+    revision: int
+
+
+class RefreshLifecycle:
+    """Small behavioral model for the Product View request lifecycle contract."""
+
+    def __init__(self):
+        self.generation = 0
+        self.active = None
+        self.pending = None
+        self.started = []
+        self.retired = []
+
+    def request(self, key, force=False):
+        if not force and ((self.active and key == self.active[0]) or (self.pending and key == self.pending[0])):
+            return
+        if force:
+            self.active = None
+            self.pending = None
+        self.generation += 1
+        request = (key, self.generation)
+        self.active = request
+        self.pending = request
+
+    def start_pending(self):
+        if self.pending is not None:
+            self.started.append(self.pending)
+            self.pending = None
+
+    def finish(self, request):
+        if request != self.active:
+            self.retired.append(request)
+            self.start_pending()
+            return
+        self.start_pending()
+
+
+def test_repeated_automatic_notifications_keep_one_generation_and_active_request():
+    lifecycle = RefreshLifecycle()
+    key = RequestKey("ur5_2f_test", "/cells/ur5_2f_test", b"same", 7)
+    lifecycle.request(key)
+    active = lifecycle.active
+    lifecycle.request(key)
+    lifecycle.request(key)
+
+    assert lifecycle.generation == 1
+    assert lifecycle.active == active
+    assert lifecycle.pending == active
+
+
+def test_scene_or_payload_change_retires_old_completion_and_starts_replacement():
+    lifecycle = RefreshLifecycle()
+    old = RequestKey("ur5_2f_test", "/cells/ur5_2f_test", b"old", 7)
+    changed_scene = RequestKey("ur5_3f_test", "/cells/ur5_3f_test", b"new", 8)
+    lifecycle.request(old)
+    lifecycle.start_pending()
+    lifecycle.request(changed_scene)
+    lifecycle.finish((old, 1))
+
+    assert lifecycle.retired == [(old, 1)]
+    assert lifecycle.started == [(old, 1), (changed_scene, 2)]
+    assert lifecycle.active == (changed_scene, 2)
+
+
+def test_one_manual_refresh_invalidates_once_and_creates_one_retry():
+    lifecycle = RefreshLifecycle()
+    key = RequestKey("ur5_2f_test", "/cells/ur5_2f_test", b"same", 7)
+    lifecycle.request(key)
+    lifecycle.start_pending()
+    lifecycle.request(key, force=True)
+
+    assert lifecycle.generation == 2
+    assert lifecycle.active == (key, 2)
+    assert lifecycle.pending == (key, 2)
+
+
+def test_cpp_coalesces_before_generation_and_retires_stale_process_before_ui_work():
+    refresh_start = CPP.index("void ScenePreviewWidget::request_embedded_web_product_view_refresh")
+    identity_start = CPP.index("ScenePreviewWidget::EmbeddedWebRequestIdentity", refresh_start)
+    refresh = CPP[refresh_start:identity_start]
+    assert refresh.index("matches_context(request_key)") < refresh.index("++embedded_web_request_generation_")
+    assert "const PreviewContext normalized_context = normalized_preview_context(preview_context_);" in CPP
+    assert "identity.payload_fingerprint = preview_payload_fingerprint_;" in CPP
+
+    prepare_start = CPP.index("void ScenePreviewWidget::on_embedded_web_prepare_finished")
+    readiness_start = CPP.index("void ScenePreviewWidget::start_embedded_web_readiness_polling", prepare_start)
+    prepare = CPP[prepare_start:readiness_start]
+    stale = prepare.index("if (!embedded_web_identity_is_current(identity))")
+    assert prepare.index("embedded_web_prepare_process_ = nullptr;", stale) > stale
+    assert prepare.index("maybe_start_next_embedded_web_prepare();", stale) > stale
+    assert stale < prepare.index("const QString scene = identity.scene_id;")

--- a/tests/test_workcell_builder_embedded_web3d_readiness_policy.py
+++ b/tests/test_workcell_builder_embedded_web3d_readiness_policy.py
@@ -92,12 +92,12 @@ def test_native_backend_is_suppressed_unless_explicitly_requested_or_webengine_u
 
 def test_embedded_refresh_identity_coalesces_duplicate_context_and_payload_requests():
     assert "struct EmbeddedWebRequestIdentity" in HDR
-    for field in ["scene_id", "absolute_scene_dir", "payload_revision", "generation"]:
+    for field in ["scene_id", "absolute_scene_dir", "payload_fingerprint", "payload_revision", "generation"]:
         assert field in HDR
     assert "matches_context" in HDR
     refresh = _between(CPP, "void ScenePreviewWidget::request_embedded_web_product_view_refresh", "ScenePreviewWidget::EmbeddedWebRequestIdentity")
-    assert "embedded_web_active_identity_.matches_context(identity)" in refresh
-    assert "pending_embedded_web_identity_.matches_context(identity)" in refresh
+    assert "embedded_web_active_identity_.matches_context(request_key)" in refresh
+    assert "pending_embedded_web_identity_.matches_context(request_key)" in refresh
     assert "pending_embedded_web_request_ = true" in refresh
     labels_handler = _between(CPP, "connect(labels_selector_", "connect(snap_mode_selector_")
     assert "refresh_embedded_web_product_view" not in labels_handler

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -934,20 +934,26 @@ void ScenePreviewWidget::request_embedded_web_product_view_refresh(bool force)
   return;
 #else
   if (!embedded_web_view_) return;
-  if (force) cancel_embedded_web_lifecycle(false);
-  const quint64 generation = ++embedded_web_request_generation_;
-  const EmbeddedWebRequestIdentity identity = embedded_web_request_identity(generation);
-  if (identity.scene_id.isEmpty() || identity.scene_id == QStringLiteral("No scene")) {
+  // Form the effective key before allocating a generation.  Automatic callers
+  // can be noisy (payload delivery and UI state often arrive separately), so a
+  // duplicate must leave both in-flight work and its callback identity intact.
+  const EmbeddedWebRequestIdentity request_key = embedded_web_request_identity(0);
+  if (request_key.scene_id.isEmpty() || request_key.scene_id == QStringLiteral("No scene")) {
     set_embedded_product_view_state(EmbeddedProductViewState::Idle);
     return;
   }
 
-  // Automatic payload/context notifications are coalesced.  In particular, UI-only
-  // controls (such as Labels) must not start a fresh scene-preparation process.
-  if (!force && ((embedded_web_has_active_identity_ && embedded_web_active_identity_.matches_context(identity)) ||
-                 (pending_embedded_web_request_ && pending_embedded_web_identity_.matches_context(identity)))) {
+  // Automatic payload/context notifications are coalesced before they can
+  // consume a generation or replace the active callback identity.
+  if (!force && ((embedded_web_has_active_identity_ && embedded_web_active_identity_.matches_context(request_key)) ||
+                 (pending_embedded_web_request_ && pending_embedded_web_identity_.matches_context(request_key)))) {
     return;
   }
+
+  // Refresh Preview is deliberately the sole forced path.  It retires the
+  // previous lifecycle, then creates one fresh generation and one retry.
+  if (force) cancel_embedded_web_lifecycle(false);
+  const EmbeddedWebRequestIdentity identity = embedded_web_request_identity(++embedded_web_request_generation_);
 
   embedded_web_active_identity_ = identity;
   embedded_web_has_active_identity_ = true;
@@ -961,13 +967,15 @@ void ScenePreviewWidget::request_embedded_web_product_view_refresh(bool force)
 ScenePreviewWidget::EmbeddedWebRequestIdentity ScenePreviewWidget::embedded_web_request_identity(quint64 generation) const
 {
   EmbeddedWebRequestIdentity identity;
-  identity.scene_id = preview_context_.scene_id.trimmed().isEmpty() ? preview_scene_name_.trimmed() : preview_context_.scene_id.trimmed();
-  const QString scene_dir = preview_context_.absolute_scene_dir.trimmed();
+  const PreviewContext normalized_context = normalized_preview_context(preview_context_);
+  identity.scene_id = normalized_context.scene_id.isEmpty() ? preview_scene_name_.trimmed() : normalized_context.scene_id;
+  const QString scene_dir = normalized_context.absolute_scene_dir;
   if (!scene_dir.isEmpty()) {
     const QFileInfo info(scene_dir);
     identity.absolute_scene_dir = QDir::cleanPath(info.exists() ?
       (info.canonicalFilePath().isEmpty() ? info.absoluteFilePath() : info.canonicalFilePath()) : info.absoluteFilePath());
   }
+  identity.payload_fingerprint = preview_payload_fingerprint_;
   identity.payload_revision = static_cast<quint64>(preview_payload_revision_);
   identity.generation = generation;
   return identity;
@@ -995,6 +1003,12 @@ void ScenePreviewWidget::maybe_start_next_embedded_web_prepare()
   const bool force = pending_embedded_web_force_;
   pending_embedded_web_request_ = false;
   pending_embedded_web_force_ = false;
+  // A newer forced request can retire the pending identity while the previous
+  // process is finishing.  Do not revive that stale work.
+  if (!embedded_web_identity_is_current(identity)) {
+    maybe_start_next_embedded_web_prepare();
+    return;
+  }
   start_embedded_web_prepare(identity, force);
 #endif
 }
@@ -1051,8 +1065,6 @@ void ScenePreviewWidget::start_embedded_web_prepare(const EmbeddedWebRequestIden
   embedded_web_repo_root_ = repo_root;
   embedded_web_prepare_scene_ = scene_id;
   embedded_web_prepare_scene_dir_ = selected_scene_dir;
-  embedded_web_active_identity_ = identity;
-  embedded_web_has_active_identity_ = true;
   embedded_web_prepare_output_path_ = QStringLiteral("build/workcell_studio_web_scene/%1.web_scene.json").arg(scene_id);
   if (embedded_web_prepare_process_) embedded_web_prepare_process_->deleteLater();
   embedded_web_prepare_process_ = new QProcess(this);
@@ -1078,7 +1090,17 @@ void ScenePreviewWidget::on_embedded_web_prepare_finished(const EmbeddedWebReque
 #ifndef WORKCELL_BUILDER_HAS_WEBENGINE
   Q_UNUSED(identity); Q_UNUSED(process); Q_UNUSED(exit_code); Q_UNUSED(exit_status);
 #else
-  if (!process || process != embedded_web_prepare_process_ || !embedded_web_identity_is_current(identity)) return;
+  if (!process || process != embedded_web_prepare_process_) return;
+
+  // A real automatic replacement updates the active identity without killing
+  // the old process.  Retire that completion before reading output, changing
+  // UI state, or loading its scene, then start the valid pending replacement.
+  if (!embedded_web_identity_is_current(identity)) {
+    process->deleteLater();
+    embedded_web_prepare_process_ = nullptr;
+    maybe_start_next_embedded_web_prepare();
+    return;
+  }
   const QString scene = identity.scene_id;
   const QString output_path = embedded_web_prepare_output_path_;
   const QString stdout_text = QString::fromUtf8(process->readAllStandardOutput()).trimmed();

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -321,13 +321,14 @@ private:
   {
     QString scene_id;
     QString absolute_scene_dir;
+    QByteArray payload_fingerprint;
     quint64 payload_revision{ 0 };
     quint64 generation{ 0 };
 
     bool matches_context(const EmbeddedWebRequestIdentity & other) const
     {
       return scene_id == other.scene_id && absolute_scene_dir == other.absolute_scene_dir &&
-        payload_revision == other.payload_revision;
+        payload_fingerprint == other.payload_fingerprint && payload_revision == other.payload_revision;
     }
     bool operator==(const EmbeddedWebRequestIdentity & other) const
     {


### PR DESCRIPTION
### Motivation
- Prevent noisy automatic Product View notifications from cancelling or replacing in-flight scene preparation work by coalescing duplicate non-forced refreshes on an effective request key built from normalized scene context and the stable payload fingerprint/revision. 
- Preserve `Refresh Preview` as the only forced path that invalidates the prior lifecycle and produces exactly one new generation/retry. 
- Ensure stale prepare completions are retired safely without touching the current UI/state and that a valid pending replacement is started when appropriate. 

### Description
- Build an effective request key before allocating a generation by calling `embedded_web_request_identity(0)` and using the normalized preview context so automatic notifications can be coalesced without consuming a generation. 
- Extend `EmbeddedWebRequestIdentity` with a `payload_fingerprint` field and include it in `matches_context()` so matching considers normalized scene + stable payload fingerprint + payload revision. 
- Change `request_embedded_web_product_view_refresh()` to coalesce against `embedded_web_active_identity_` and `pending_embedded_web_identity_` using the prebuilt `request_key`, and only then increment the generation and install the real `identity`; keep `force` as the single path that calls `cancel_embedded_web_lifecycle()` and creates a new generation. 
- Prevent reviving stale pending work in `maybe_start_next_embedded_web_prepare()` by checking `embedded_web_identity_is_current()` before starting a pending prepare. 
- Update `on_embedded_web_prepare_finished()` to retire stale process completions early (delete the process and call `maybe_start_next_embedded_web_prepare()`), and only read output / update UI when the completion matches the active identity. 
- Normalize preview context in `embedded_web_request_identity()` (via `normalized_preview_context`) and attach `preview_payload_fingerprint_` into each identity. 
- Add `tests/test_scene_preview_widget_refresh_lifecycle.py` with behavioral lifecycle coverage for repeated automatic notifications, scene/payload replacement, and one manual forced refresh, and update `tests/test_workcell_builder_embedded_web3d_readiness_policy.py` assertions to include the new fingerprint field. 
- Affected files: `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp`, `workcell_builder/workcell_builder/gui/scene_preview_widget.h`, `tests/test_workcell_builder_embedded_web3d_readiness_policy.py`, and `tests/test_scene_preview_widget_refresh_lifecycle.py`. 

### Testing
- Ran unit/static tests with `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py tests/test_scene_preview_widget_lifecycle_cancellation.py tests/test_workcell_builder_embedded_web3d_readiness_policy.py tests/test_scene_preview_widget_refresh_lifecycle.py` and all tests passed. 
- Ran `git diff --check` as part of validation and no whitespace/patch errors were reported. 
- GUI/Qt and ROS end-to-end smoke were not executed in this checkout because no display/ROS workspace build artifacts were available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a80afc43c83318f25bfa6679806f4)