### PR TITLE
Avoid redundant Product View payload commits

### DIFF
--- a/tests/test_scene3d_full_payload_handoff.py
+++ b/tests/test_scene3d_full_payload_handoff.py
@@ -89,14 +89,14 @@ def test_ur5_2f_final_viewport_audit_requires_renderable_ur5_links_table_and_cam
 
 
 def test_loader_filter_warning_is_suppressed_when_required_final_viewport_links_are_visible():
-    filter_start = MAIN_CPP.index('if (has_selected_scene() && selected_scene_name() == QStringLiteral("ur5_2f_test"))')
-    filter_end = MAIN_CPP.index('const Scene3DTransformParityReadiness transform_parity', filter_start)
-    filter_block = MAIN_CPP[filter_start:filter_end]
+    audit_start = MAIN_CPP.index('void MainWindow::refresh_scene3d_product_view_status_and_audit')
+    audit_end = MAIN_CPP.index('void MainWindow::populate_scene_hierarchy', audit_start)
+    audit_block = MAIN_CPP[audit_start:audit_end]
 
-    assert 'audit_ur5_2f_test_committed_viewport_items(viewport, &missing_required_visible_links)' in filter_block
-    assert 'if (!missing_required_visible_links.isEmpty())' in filter_block
-    assert 'retained visual rows missing after loader filtering' in filter_block
-    assert 'final viewport audit passed for ur5_2f_test required visible UR5 viewport/renderable links' in filter_block
+    assert 'audit_ur5_2f_test_committed_viewport_items(viewport, &missing_required_visible_links)' in audit_block
+    assert 'if (!missing_required_visible_links.isEmpty())' in audit_block
+    assert 'retained visual rows missing after loader filtering' in audit_block
+    assert 'final viewport audit passed for ur5_2f_test required visible UR5 viewport/renderable links' in audit_block
 
 
 def test_viewport_generated_urdf_renderer_rejects_environment_yaml_semantic_rows_before_mesh_path():

--- a/tests/test_scene_preview_widget_refresh_lifecycle.py
+++ b/tests/test_scene_preview_widget_refresh_lifecycle.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 CPP = (ROOT / "workcell_builder/workcell_builder/gui/scene_preview_widget.cpp").read_text(encoding="utf-8")
+MAINWINDOW_CPP = (ROOT / "workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text(encoding="utf-8")
 
 
 @dataclass(frozen=True)
@@ -102,3 +103,48 @@ def test_cpp_coalesces_before_generation_and_retires_stale_process_before_ui_wor
     assert prepare.index("embedded_web_prepare_process_ = nullptr;", stale) > stale
     assert prepare.index("maybe_start_next_embedded_web_prepare();", stale) > stale
     assert stale < prepare.index("const QString scene = identity.scene_id;")
+
+
+def test_selected_scene_status_refreshes_leave_the_committed_product_payload_identity_unchanged():
+    """Status/audit work must not create another Web3D payload preparation."""
+
+    class SelectedSceneStatusRefresh:
+        def __init__(self):
+            self.preparations = 0
+            self.payload_revision = 0
+            self.payload_generation = 0
+            self.committed_fingerprint = None
+
+        def apply_filtered_payload(self, fingerprint):
+            if fingerprint == self.committed_fingerprint:
+                return
+            self.committed_fingerprint = fingerprint
+            self.payload_revision += 1
+            self.payload_generation += 1
+            self.preparations += 1
+
+        def refresh_status_and_audit(self):
+            # The extracted status/audit helper intentionally has no payload commit.
+            return "camera-fit-and-audit-updated"
+
+    refresh = SelectedSceneStatusRefresh()
+    refresh.apply_filtered_payload(b"stable-filtered-payload")
+    before = (refresh.preparations, refresh.payload_revision, refresh.payload_generation)
+
+    assert refresh.refresh_status_and_audit() == "camera-fit-and-audit-updated"
+    assert refresh.refresh_status_and_audit() == "camera-fit-and-audit-updated"
+    assert (refresh.preparations, refresh.payload_revision, refresh.payload_generation) == before
+
+    filter_start = MAINWINDOW_CPP.index("void MainWindow::apply_scene3d_preview_layer_filters")
+    audit_start = MAINWINDOW_CPP.index("void MainWindow::refresh_scene3d_product_view_status_and_audit", filter_start)
+    filter_block = MAINWINDOW_CPP[filter_start:audit_start]
+    audit_end = MAINWINDOW_CPP.index("void MainWindow::populate_scene_hierarchy", audit_start)
+    audit_block = MAINWINDOW_CPP[audit_start:audit_end]
+
+    assert "preview_payload_matches(filtered_items)" in filter_block
+    assert "if (filtered_payload_changed)" in filter_block
+    assert "scene_preview_widget_->set_preview_items(filtered_items);" in filter_block
+    assert "viewport->ingest_preview_items(filtered_items);" not in filter_block
+    assert "set_preview_items" not in audit_block
+    assert "fit_product_view();" in audit_block
+    assert "set_preview_status_summary" in audit_block

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -7895,16 +7895,49 @@ void MainWindow::apply_scene3d_preview_layer_filters(bool log_change)
   if (filtered_items.isEmpty() && !all_scene_preview_items_.isEmpty()) {
     append_studio_log("Scene3D blocker: current layer filters hide all items. Re-enable editable layout, mesh preview, primitive fallback, or locked generated URDF visuals.");
   }
-  scene_preview_widget_->set_preview_items(filtered_items);
+  const bool filtered_payload_changed = !scene_preview_widget_->preview_payload_matches(filtered_items);
+  if (filtered_payload_changed) {
+    scene_preview_widget_->set_preview_items(filtered_items);
+  } else if (scene3d_debug_logging_enabled()) {
+    append_studio_log(QStringLiteral(
+      "Scene3D filtered payload unchanged; skipped Product View payload commit."));
+  }
+  refresh_scene3d_product_view_status_and_audit();
+  if (scene3d_debug_logging_enabled()) {
+    append_studio_log(
+      QString("Scene3D diagnostics {model_items_count=%1, filtered_visible_count=%2}")
+        .arg(all_scene_preview_items_.size())
+        .arg(filtered_items.size()));
+    append_studio_log(
+      QString("Scene3D diagnostics: visible item count after filters=%1/%2")
+        .arg(filtered_items.size())
+        .arg(all_scene_preview_items_.size()));
+  }
+  if (log_change) {
+    append_studio_log(
+      QString("Scene3D preview-only visibility updated: editable=%1 urdf_visuals=%2 mesh=%3 primitives=%4 overlays=%5 warnings=%6 (visible %7/%8). No files changed.")
+      .arg(preview_layer_editable_layout_box_ && preview_layer_editable_layout_box_->isChecked() ? "on" : "off")
+      .arg(preview_layer_generated_urdf_visual_box_ && preview_layer_generated_urdf_visual_box_->isChecked() ? "on" : "off")
+      .arg(preview_layer_mesh_preview_box_ && preview_layer_mesh_preview_box_->isChecked() ? "on" : "off")
+      .arg(preview_layer_primitive_fallback_box_ && preview_layer_primitive_fallback_box_->isChecked() ? "on" : "off")
+      .arg(preview_layer_overlays_helpers_box_ && preview_layer_overlays_helpers_box_->isChecked() ? "on" : "off")
+      .arg(preview_layer_warnings_missing_assets_box_ && preview_layer_warnings_missing_assets_box_->isChecked() ? "on" : "off")
+      .arg(filtered_items.size())
+      .arg(all_scene_preview_items_.size()));
+  }
+}
+
+
+void MainWindow::refresh_scene3d_product_view_status_and_audit()
+{
+  // This helper deliberately performs status, camera-fit, and audit work only.
+  // Payload delivery belongs to apply_scene3d_preview_layer_filters(), so a
+  // selected-scene status refresh cannot alter the Embedded Web3D request key.
+  if (!scene_preview_widget_) return;
+
   auto * viewport = scene_preview_widget_->is_native_product_view_backend()
     ? scene_preview_widget_->findChild<Scene3DViewportWidget *>()
     : nullptr;
-  if (scene_preview_widget_->is_native_product_view_backend() && viewport) {
-    // set_preview_items() normally commits the payload into the active viewport.
-    // Re-ingest here as an explicit guard so the camera fit below always uses
-    // the exact post-filter payload, including final UR5 mesh/fallback draw bounds.
-    viewport->ingest_preview_items(filtered_items);
-  }
   QStringList missing_required_visible_links;
   const QJsonObject viewport_audit =
     audit_ur5_2f_test_committed_viewport_items(viewport, &missing_required_visible_links);
@@ -7919,9 +7952,7 @@ void MainWindow::apply_scene3d_preview_layer_filters(bool log_change)
     scene3d_filter_diagnostics_[QStringLiteral("camera_fit_target")] = viewport->last_camera_fit_target();
     scene3d_filter_diagnostics_[QStringLiteral("camera_fit_includes_robot")] = viewport->last_initial_fit_included_robot_bounds();
   }
-  if (scene_preview_widget_->is_native_product_view_backend() &&
-      has_selected_scene() && selected_scene_name() == QStringLiteral("ur5_2f_test")) {
-    // audit_ur5_2f_test_committed_viewport_items(viewport, &missing_required_visible_links) is computed above after final ingest.
+  if (scene_preview_widget_->is_native_product_view_backend() && selected_ur5_2f_test) {
     scene3d_filter_diagnostics_[QStringLiteral("ur5_2f_test_final_viewport_audit")] = viewport_audit;
     append_studio_log(
       QStringLiteral("Scene3D final viewport audit for ur5_2f_test: %1")
@@ -7946,28 +7977,6 @@ void MainWindow::apply_scene3d_preview_layer_filters(bool log_change)
       scene_preview_widget_->total_warning_count(),
       transform_parity.warning,
       transform_parity.failed));
-  if (scene3d_debug_logging_enabled()) {
-    append_studio_log(
-      QString("Scene3D diagnostics {model_items_count=%1, filtered_visible_count=%2}")
-        .arg(all_scene_preview_items_.size())
-        .arg(filtered_items.size()));
-    append_studio_log(
-      QString("Scene3D diagnostics: visible item count after filters=%1/%2")
-        .arg(filtered_items.size())
-        .arg(all_scene_preview_items_.size()));
-  }
-  if (log_change) {
-    append_studio_log(
-      QString("Scene3D preview-only visibility updated: editable=%1 urdf_visuals=%2 mesh=%3 primitives=%4 overlays=%5 warnings=%6 (visible %7/%8). No files changed.")
-      .arg(preview_layer_editable_layout_box_ && preview_layer_editable_layout_box_->isChecked() ? "on" : "off")
-      .arg(preview_layer_generated_urdf_visual_box_ && preview_layer_generated_urdf_visual_box_->isChecked() ? "on" : "off")
-      .arg(preview_layer_mesh_preview_box_ && preview_layer_mesh_preview_box_->isChecked() ? "on" : "off")
-      .arg(preview_layer_primitive_fallback_box_ && preview_layer_primitive_fallback_box_->isChecked() ? "on" : "off")
-      .arg(preview_layer_overlays_helpers_box_ && preview_layer_overlays_helpers_box_->isChecked() ? "on" : "off")
-      .arg(preview_layer_warnings_missing_assets_box_ && preview_layer_warnings_missing_assets_box_->isChecked() ? "on" : "off")
-      .arg(filtered_items.size())
-      .arg(all_scene_preview_items_.size()));
-  }
 }
 
 void MainWindow::populate_scene_hierarchy()

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -362,6 +362,7 @@ private:
   void populate_scene_hierarchy();
   void apply_scene3d_product_view_layer_defaults_and_commit();
   void apply_scene3d_preview_layer_filters(bool log_change = false);
+  void refresh_scene3d_product_view_status_and_audit();
   void keyPressEvent(QKeyEvent * event) override;
   void populate_asset_catalog();
   void on_hierarchy_item_selected(QTreeWidgetItem * item);

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -1718,6 +1718,10 @@ void ScenePreviewWidget::set_preview_items(const QVector<PreviewItem> & items)
 int ScenePreviewWidget::preview_payload_revision() const { return preview_payload_revision_; }
 quint64 ScenePreviewWidget::preview_payload_generation() const { return preview_payload_generation_; }
 quint64 ScenePreviewWidget::embedded_web_preparation_request_count() const { return embedded_web_preparation_request_count_; }
+bool ScenePreviewWidget::preview_payload_matches(const QVector<PreviewItem> & items) const
+{
+  return preview_payload_fingerprint(items) == preview_payload_fingerprint_;
+}
 void ScenePreviewWidget::set_preview_scene_name(const QString & scene_name)
 {
   const QString normalized_scene_name = scene_name.trimmed().isEmpty() ? QStringLiteral("No scene") : scene_name.trimmed();

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -294,6 +294,7 @@ public:
   int preview_payload_revision() const;
   quint64 preview_payload_generation() const;
   quint64 embedded_web_preparation_request_count() const;
+  bool preview_payload_matches(const QVector<PreviewItem> & items) const;
 
 signals:
   void studio_log_requested(const QString & message);


### PR DESCRIPTION
### Motivation
- Reduce noisy/duplicate Product View preparatory work by preventing commits when the effective filtered payload is unchanged. 
- Keep `apply_scene3d_product_view_layer_defaults_and_commit()` focused on layer/default or filtered-payload changes and move status/audit-only work out of payload-commit paths. 
- Preserve existing explicit camera-fit and audit behaviour while ensuring no status-only refresh can change the Embedded Web3D request identity.

### Description
- Add `ScenePreviewWidget::preview_payload_matches(const QVector<PreviewItem>&)` to compare an incoming filtered payload fingerprint against the last committed fingerprint. 
- Change `MainWindow::apply_scene3d_preview_layer_filters()` to check the filtered payload with `preview_payload_matches()` and only call `scene_preview_widget_->set_preview_items(filtered_items)` when the payload actually changed, logging when a commit is skipped. 
- Extract camera-fit, status-summary, and UR5 audit logic into `MainWindow::refresh_scene3d_product_view_status_and_audit()` which does not call `set_preview_items()` or re-ingest payloads into the native viewport. 
- Remove the redundant `viewport->ingest_preview_items(filtered_items)` post-commit re-ingestion and ensure status/audit flows update diagnostics and camera fit without altering the Embedded Web3D request identity. 
- Update/add regression tests to assert the new lifecycle: `tests/test_scene_preview_widget_refresh_lifecycle.py` gains a test that repeated status/audit refreshes with an unchanged filtered payload do not create extra preparations/revisions, and `tests/test_scene3d_full_payload_handoff.py` was updated to follow the extracted status/audit helper.

### Testing
- Ran `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py` and it passed. 
- Ran `python3 -m pytest tests/test_workcell_builder_product_view_defaults.py` and it passed. 
- Ran `python3 -m pytest tests/test_scene_preview_widget_refresh_lifecycle.py` and it passed (including the new status-refresh regression test). 
- Ran `python3 -m pytest tests/test_scene3d_full_payload_handoff.py` and it passed, and the full focused suite completed with all tests green (22 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a88d80618833180a3b38100c05b18)