### PR TITLE
Build embedded Product View URLs with QUrlQuery

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -18,6 +18,7 @@
 #include <QTimer>
 #include <QProcessEnvironment>
 #include <QRegularExpression>
+#include <QUrlQuery>
 #include <QJsonArray>
 #include <QCryptographicHash>
 #include <QDataStream>
@@ -1354,17 +1355,38 @@ void ScenePreviewWidget::load_prepared_embedded_web_scene(const EmbeddedWebReque
   }
   if (embedded_web_server_lifecycle_ != EmbeddedWebServerLifecycle::ServerReady) return;
   const QString web_scene_url_path = QStringLiteral("build/workcell_studio_web_scene/%1.web_scene.json").arg(identity.scene_id);
-  const QString viewer_url = QStringLiteral("http://127.0.0.1:%1/workcell_studio_web/viewer/index.html?scene=%2&builderRevision=%3")
-    .arg(embedded_web_server_port_)
-    .arg(QString::fromUtf8(QUrl::toPercentEncoding(web_scene_url_path)))
-    .arg(identity.generation) + QStringLiteral("&embedded=1");
+  const QString builder_revision = QString::number(identity.payload_revision);
+  QUrl viewer_url;
+  viewer_url.setScheme(QStringLiteral("http"));
+  viewer_url.setHost(QStringLiteral("127.0.0.1"));
+  viewer_url.setPort(embedded_web_server_port_);
+  viewer_url.setPath(QStringLiteral("/workcell_studio_web/viewer/index.html"));
+  QUrlQuery viewer_query;
+  viewer_query.addQueryItem(QStringLiteral("scene"), web_scene_url_path);
+  viewer_query.addQueryItem(QStringLiteral("builderRevision"), builder_revision);
+  viewer_query.addQueryItem(QStringLiteral("embedded"), QStringLiteral("1"));
+  viewer_url.setQuery(viewer_query);
+
+  const QUrlQuery decoded_viewer_query(viewer_url);
+  const QString decoded_scene_path = decoded_viewer_query.queryItemValue(QStringLiteral("scene"), QUrl::FullyDecoded);
+  const QString decoded_builder_revision = decoded_viewer_query.queryItemValue(
+    QStringLiteral("builderRevision"), QUrl::FullyDecoded);
+  const bool valid_scene_path = decoded_scene_path == web_scene_url_path;
+  const bool valid_builder_revision = QRegularExpression(QStringLiteral("^[0-9]+$"))
+    .match(decoded_builder_revision).hasMatch();
+  if (!valid_scene_path || !valid_builder_revision) {
+    const QString detail = QStringLiteral("Embedded Product View URL validation failed; using native compatibility preview.");
+    emit studio_log_requested(detail);
+    activate_native_compatibility_preview(detail);
+    return;
+  }
   embedded_web_readiness_deadline_ = QDateTime();
   embedded_web_last_boot_status_.clear();
   set_embedded_product_view_state(EmbeddedProductViewState::Loading);
   embedded_web_loading_identity_ = identity;
   embedded_web_loading_navigation_token_ = ++embedded_web_navigation_token_;
   embedded_web_server_lifecycle_ = EmbeddedWebServerLifecycle::BrowserLoading;
-  embedded_web_expected_viewer_url_ = QUrl(viewer_url);
+  embedded_web_expected_viewer_url_ = viewer_url;
   embedded_web_last_viewer_url_ = embedded_web_expected_viewer_url_.toString();
   embedded_web_view_->load(embedded_web_expected_viewer_url_);
 #endif

--- a/workcell_builder/workcell_builder/test/scene_preview_widget_ui_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene_preview_widget_ui_test.cpp
@@ -4,6 +4,7 @@
 #include <QComboBox>
 #include <QDir>
 #include <QTemporaryDir>
+#include <QUrlQuery>
 
 #define private public
 #include "scene_preview_widget.h"
@@ -192,6 +193,57 @@ TEST(ScenePreviewWidgetUi, EquivalentPreviewContextsPrepareProductViewOnlyOnce)
 }
 
 #ifdef WORKCELL_BUILDER_HAS_WEBENGINE
+TEST(ScenePreviewWidgetUi, EmbeddedWebViewerUrlPreservesScenePathAndPayloadRevision)
+{
+  ASSERT_NE(ensure_app(), nullptr);
+
+  const QList<quint64> revisions{1, 2, 3, 4, 9, 10, 12, 38, 125};
+  for (const quint64 revision : revisions) {
+    ScenePreviewWidget widget;
+    widget.preview_scene_name_ = QStringLiteral("ur5_2f_test");
+    widget.embedded_web_request_generation_ = 1;
+    widget.embedded_web_server_lifecycle_ = ScenePreviewWidget::EmbeddedWebServerLifecycle::ServerReady;
+    widget.embedded_web_server_port_ = 8765;
+
+    ScenePreviewWidget::EmbeddedWebRequestIdentity identity;
+    identity.scene_id = QStringLiteral("ur5_2f_test");
+    identity.payload_revision = revision;
+    identity.generation = widget.embedded_web_request_generation_;
+    widget.load_prepared_embedded_web_scene(identity);
+
+    const QString logical_scene_path = QStringLiteral("build/workcell_studio_web_scene/ur5_2f_test.web_scene.json");
+    const QString expected_revision = QString::number(revision);
+    const QUrl viewer_url = widget.embedded_web_expected_viewer_url_;
+    const QUrlQuery query(viewer_url);
+    const QList<QPair<QString, QString>> query_items = query.queryItems(QUrl::FullyDecoded);
+    const auto query_item_count = [&query_items](const QString & key) {
+      int count = 0;
+      for (const auto & item : query_items) {
+        if (item.first == key) ++count;
+      }
+      return count;
+    };
+    EXPECT_EQ(viewer_url.scheme(), QStringLiteral("http"));
+    EXPECT_EQ(viewer_url.host(), QStringLiteral("127.0.0.1"));
+    EXPECT_EQ(viewer_url.port(), 8765);
+    EXPECT_EQ(viewer_url.path(), QStringLiteral("/workcell_studio_web/viewer/index.html"));
+    EXPECT_EQ(query.queryItemValue(QStringLiteral("scene"), QUrl::FullyDecoded), logical_scene_path);
+    EXPECT_EQ(query.queryItemValue(QStringLiteral("builderRevision"), QUrl::FullyDecoded), expected_revision);
+    EXPECT_EQ(query.queryItemValue(QStringLiteral("embedded"), QUrl::FullyDecoded), QStringLiteral("1"));
+    EXPECT_EQ(query_item_count(QStringLiteral("scene")), 1);
+    EXPECT_EQ(query_item_count(QStringLiteral("builderRevision")), 1);
+    EXPECT_EQ(query_item_count(QStringLiteral("embedded")), 1);
+
+    const QString encoded_url = viewer_url.toString(QUrl::FullyEncoded);
+    EXPECT_EQ(encoded_url.indexOf(QStringLiteral("build1F")), -1);
+    EXPECT_EQ(encoded_url.indexOf(QStringLiteral("build2F")), -1);
+    EXPECT_EQ(encoded_url.indexOf(QStringLiteral("build3F")), -1);
+    EXPECT_EQ(encoded_url.indexOf(QStringLiteral("build4F")), -1);
+    EXPECT_EQ(encoded_url.indexOf(QStringLiteral("build12F")), -1);
+    EXPECT_EQ(encoded_url.indexOf(QStringLiteral("%252F")), -1);
+  }
+}
+
 TEST(ScenePreviewWidgetUi, PreparationFailureUsesPopulatedCompatibilityViewport)
 {
   ASSERT_NE(ensure_app(), nullptr);


### PR DESCRIPTION
### Motivation
- Prevent fragile, percent-encoded string concatenation when constructing the embedded Product View navigation URL and ensure the logical scene path is preserved unencoded. 
- Fail fast to the native compatibility viewport if the decoded query values are invalid, avoiding silent navigation to malformed URLs. 

### Description
- Replaced chained `QString::arg()` percent-encoding URL construction in `ScenePreviewWidget::load_prepared_embedded_web_scene()` with structured `QUrl` and `QUrlQuery` construction that sets the scheme to `http`, host to `127.0.0.1`, port to `embedded_web_server_port_`, path to `/workcell_studio_web/viewer/index.html`, and adds exactly the `scene`, `builderRevision`, and `embedded` query items. 
- Created the unencoded logical scene path `build/workcell_studio_web_scene/<scene_id>.web_scene.json` and passed it directly as the `scene` query item without manual slash-encoding. 
- Validated the fully decoded `scene` equals the unencoded logical scene path and that the fully decoded `builderRevision` matches `^[0-9]+$`; on failure emit a concise diagnostic and activate native compatibility mode without navigating. 
- Added a focused Qt unit test `EmbeddedWebViewerUrlPreservesScenePathAndPayloadRevision` in `workcell_builder/test/scene_preview_widget_ui_test.cpp` covering payload revisions `1, 2, 3, 4, 9, 10, 12, 38, 125`, asserting decoded values, single query-item presence, URL components, and absence of double-encoded fragments. 
- Files changed: `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp` and `workcell_builder/workcell_builder/test/scene_preview_widget_ui_test.cpp`.

### Testing
- Ran repository static checks including `git diff --check` and custom static assertions that verify the `QUrl`/`QUrlQuery` construction contract and absence of manual percent-encoding, which passed. 
- Executed Python-based static checks that confirmed the new `QUrlQuery` usage and the requested test coverage fragments, which passed. 
- Did not run the Qt/GTest target (`workcell_scene_preview_widget_ui_test`) in this environment because Qt development packages and `colcon`/build tooling were not available, so the added test was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b576ffff8833182240ba85dbd0e98)