### PR TITLE
Harden embedded Product View server identity and startup

### DIFF
--- a/tests/test_scene_preview_widget_lifecycle_cancellation.py
+++ b/tests/test_scene_preview_widget_lifecycle_cancellation.py
@@ -47,3 +47,25 @@ def test_async_web_callbacks_guard_their_captured_request_identity():
     assert "if (!embedded_web_identity_is_current(identity)) return;" in editor
     assert "[this, identity]" in editor_poll
     assert "if (embedded_web_identity_is_current(identity)) poll_embedded_editor_events();" in editor_poll
+
+
+def test_web_request_identity_binds_root_and_selected_port_for_every_async_gate():
+    identity = HDR[HDR.index("struct EmbeddedWebRequestIdentity"):HDR.index("struct EmbeddedWebPreparationDiagnostic")]
+    assert "QString absolute_repo_root;" in identity
+    assert "int selected_server_port" in identity
+    assert "absolute_repo_root == other.absolute_repo_root" in identity
+    assert "selected_server_port == other.selected_server_port" in identity
+
+    probes = _between("void ScenePreviewWidget::start_embedded_web_server_probes", "void ScenePreviewWidget::fail_embedded_web_server_probe")
+    assert "identity.absolute_repo_root != repo_root" in probes
+    assert "identity.selected_server_port != port" in probes
+    assert "load_prepared_embedded_web_scene(identity);" in probes
+
+    server = _between("void ScenePreviewWidget::start_owned_embedded_web_server", "void ScenePreviewWidget::cancel_embedded_web_lifecycle")
+    assert '"--directory", repo_root' in server
+    assert "identity.selected_server_port != port" in server
+    assert "&QProcess::started" in server
+
+    browser = _between("void ScenePreviewWidget::load_prepared_embedded_web_scene", "#ifdef WORKCELL_BUILDER_HAS_WEBENGINE")
+    assert "identity.selected_server_port <= 0" in browser
+    assert "viewer_url.setPort(identity.selected_server_port);" in browser

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -16,6 +16,8 @@
 #include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QTimer>
+#include <QTcpServer>
+#include <QHostAddress>
 #include <QProcessEnvironment>
 #include <QRegularExpression>
 #include <QUrlQuery>
@@ -693,7 +695,8 @@ void ScenePreviewWidget::set_embedded_product_view_state(EmbeddedProductViewStat
 void ScenePreviewWidget::start_embedded_web_server_probes(
   const EmbeddedWebRequestIdentity & identity, int port, quint64 navigation_token, const QString & repo_root)
 {
-  if (!embedded_web_identity_is_current(identity) || port != embedded_web_server_port_) return;
+  if (!embedded_web_identity_is_current(identity) || identity.absolute_repo_root != repo_root ||
+      identity.selected_server_port != port || port <= 0) return;
   const QString marker_path = QStringLiteral("workcell_studio_web/viewer/workcell_runtime_marker.json");
   QFile marker(QDir(repo_root).filePath(marker_path));
   if (!marker.open(QIODevice::ReadOnly) || marker.readAll().trimmed().isEmpty()) {
@@ -713,7 +716,7 @@ void ScenePreviewWidget::run_embedded_web_server_probes(
   const EmbeddedWebRequestIdentity & identity, int port, quint64 navigation_token)
 {
   const auto current = [this, &identity, port, navigation_token]() {
-    return embedded_web_identity_is_current(identity) && port == embedded_web_server_port_ && embedded_web_server_probe_.identity == identity &&
+    return embedded_web_identity_is_current(identity) && identity.selected_server_port == port && embedded_web_server_probe_.identity == identity &&
       embedded_web_server_probe_.port == port && embedded_web_server_probe_.navigation_token == navigation_token;
   };
   if (!current() || embedded_web_server_probe_.terminal_recorded) return;
@@ -735,7 +738,7 @@ void ScenePreviewWidget::run_embedded_web_server_probes(
     const QUrl url(QStringLiteral("http://127.0.0.1:%1/%2").arg(port).arg(path));
     QNetworkReply * reply = embedded_web_network_manager_->get(QNetworkRequest(url));
     connect(reply, &QNetworkReply::finished, this, [this, identity, port, navigation_token, path, reply]() {
-      const bool current = embedded_web_identity_is_current(identity) && port == embedded_web_server_port_ && embedded_web_server_probe_.identity == identity &&
+      const bool current = embedded_web_identity_is_current(identity) && identity.selected_server_port == port && embedded_web_server_probe_.identity == identity &&
         embedded_web_server_probe_.port == port && embedded_web_server_probe_.navigation_token == navigation_token;
       if (!current || embedded_web_server_probe_.terminal_recorded) { reply->deleteLater(); return; }
       const int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
@@ -763,12 +766,19 @@ void ScenePreviewWidget::run_embedded_web_server_probes(
         load_prepared_embedded_web_scene(identity);
         return;
       }
+      if (!embedded_web_server_is_owned_) {
+        // Never reuse or terminate an untrusted endpoint. A marker mismatch
+        // receives an alternate port; a refused endpoint may be claimed.
+        select_owned_embedded_web_server(identity,
+          !embedded_web_server_probe_.failure_detail.contains(QStringLiteral("marker does not match")));
+        return;
+      }
       if (!embedded_web_server_probe_.retryable_failure) {
         fail_embedded_web_server_probe(identity, port, navigation_token, embedded_web_server_probe_.failure_detail);
         return;
       }
       QTimer::singleShot(200, this, [this, identity, port, navigation_token]() {
-        if (!embedded_web_identity_is_current(identity) || port != embedded_web_server_port_ || embedded_web_server_probe_.identity != identity ||
+        if (!embedded_web_identity_is_current(identity) || identity.selected_server_port != port || embedded_web_server_probe_.identity != identity ||
             embedded_web_server_probe_.port != port || embedded_web_server_probe_.navigation_token != navigation_token) return;
         run_embedded_web_server_probes(identity, port, navigation_token);
       });
@@ -779,7 +789,7 @@ void ScenePreviewWidget::run_embedded_web_server_probes(
 void ScenePreviewWidget::fail_embedded_web_server_probe(
   const EmbeddedWebRequestIdentity & identity, int port, quint64 navigation_token, const QString & detail)
 {
-  if (!embedded_web_identity_is_current(identity) || port != embedded_web_server_port_ || embedded_web_server_probe_.identity != identity ||
+  if (!embedded_web_identity_is_current(identity) || identity.selected_server_port != port || embedded_web_server_probe_.identity != identity ||
       embedded_web_server_probe_.port != port || embedded_web_server_probe_.navigation_token != navigation_token ||
       embedded_web_server_probe_.terminal_recorded) return;
   embedded_web_server_probe_.terminal_recorded = true;
@@ -791,13 +801,63 @@ void ScenePreviewWidget::fail_embedded_web_server_probe(
 
 void ScenePreviewWidget::ensure_embedded_web_server_started(const QString & repo_root, const EmbeddedWebRequestIdentity & identity)
 {
-  if (repo_root.trimmed().isEmpty() || !embedded_web_identity_is_current(identity)) return;
-  const int port = embedded_web_server_port_;
+  if (repo_root.trimmed().isEmpty() || repo_root != identity.absolute_repo_root ||
+      identity.selected_server_port <= 0 || !embedded_web_identity_is_current(identity)) return;
+  const int port = identity.selected_server_port;
+  const quint64 navigation_token = ++embedded_web_navigation_token_;
+  // This probe is for an endpoint whose ownership is not yet established.
+  // An old owned process remains tracked separately and is never confused with
+  // a listener discovered at the configured port.
+  embedded_web_server_is_owned_ = false;
+  embedded_web_server_probe_ = EmbeddedWebServerProbe{identity, port, navigation_token};
+  // Probe the configured/default endpoint first; it is reusable only after all
+  // resources and the repository marker have been verified.
+  start_embedded_web_server_probes(identity, port, navigation_token, repo_root);
+}
+
+void ScenePreviewWidget::select_owned_embedded_web_server(
+  const EmbeddedWebRequestIdentity & identity, bool use_current_port)
+{
+  if (!embedded_web_identity_is_current(identity)) return;
+  int port = identity.selected_server_port;
+  if (!use_current_port) {
+    QTcpServer socket;
+    if (!socket.listen(QHostAddress::LocalHost, 0)) {
+      fail_embedded_web_server_probe(identity, identity.selected_server_port, embedded_web_navigation_token_,
+        QStringLiteral("could not select an alternate loopback port: %1").arg(socket.errorString()));
+      return;
+    }
+    port = socket.serverPort();
+  }
+  EmbeddedWebRequestIdentity owned_identity = identity;
+  owned_identity.selected_server_port = port;
+  // This is a new immutable active request. Delayed callbacks from the
+  // untrusted endpoint are now stale before any owned process is launched.
+  embedded_web_active_identity_ = owned_identity;
+  embedded_web_server_port_ = port;
+  embedded_web_server_probe_ = EmbeddedWebServerProbe{};
+  start_owned_embedded_web_server(owned_identity);
+}
+
+void ScenePreviewWidget::start_owned_embedded_web_server(const EmbeddedWebRequestIdentity & identity)
+{
+  if (!embedded_web_identity_is_current(identity) || identity.absolute_repo_root.isEmpty() || identity.selected_server_port <= 0) return;
+  const QString repo_root = identity.absolute_repo_root;
+  const int port = identity.selected_server_port;
   const quint64 navigation_token = ++embedded_web_navigation_token_;
   embedded_web_server_probe_ = EmbeddedWebServerProbe{identity, port, navigation_token};
   if (embedded_web_server_process_ && embedded_web_server_process_->state() != QProcess::NotRunning) {
-    start_embedded_web_server_probes(identity, port, navigation_token, repo_root);
-    return;
+    // This is an earlier owned request, never an arbitrary listener. Retire it
+    // before replacing it; callbacks remain guarded by their old identity.
+    disconnect(embedded_web_server_process_, nullptr, this, nullptr);
+    embedded_web_server_process_->terminate();
+    if (!embedded_web_server_process_->waitForFinished(1000)) {
+      embedded_web_server_process_->kill();
+      embedded_web_server_process_->waitForFinished(1000);
+    }
+    embedded_web_server_process_->deleteLater();
+    embedded_web_server_process_ = nullptr;
+    embedded_web_server_is_owned_ = false;
   }
   embedded_web_server_lifecycle_ = EmbeddedWebServerLifecycle::ServerStarting;
   set_embedded_product_view_state(EmbeddedProductViewState::StartingServer, QStringLiteral("server_starting"));
@@ -806,25 +866,25 @@ void ScenePreviewWidget::ensure_embedded_web_server_started(const QString & repo
   embedded_web_server_is_owned_ = true;
   QProcess * const process = embedded_web_server_process_;
   process->setProgram(QStringLiteral("python3"));
-  process->setArguments(QStringList{"-m", "http.server", QString::number(port), "--bind", "127.0.0.1"});
+  process->setArguments(QStringList{"-m", "http.server", QString::number(port), "--bind", "127.0.0.1", "--directory", repo_root});
   process->setWorkingDirectory(repo_root);
   process->setProcessEnvironment(QProcessEnvironment::systemEnvironment());
   process->setProcessChannelMode(QProcess::MergedChannels);
   connect(process, &QProcess::started, this, [this, identity, port, navigation_token, process, repo_root]() {
-    if (process != embedded_web_server_process_ || !embedded_web_identity_is_current(identity) || port != embedded_web_server_port_ ||
+    if (process != embedded_web_server_process_ || !embedded_web_identity_is_current(identity) || identity.selected_server_port != port ||
         embedded_web_server_probe_.identity != identity || embedded_web_server_probe_.port != port ||
         embedded_web_server_probe_.navigation_token != navigation_token) return;
     emit studio_log_requested(QStringLiteral("Embedded Product View server_starting milestone: port=%1.").arg(port));
     start_embedded_web_server_probes(identity, port, navigation_token, repo_root);
   });
   connect(process, qOverload<int, QProcess::ExitStatus>(&QProcess::finished), this, [this, identity, port, navigation_token, process](int exit_code, QProcess::ExitStatus) {
-    if (process != embedded_web_server_process_ || !embedded_web_identity_is_current(identity) || port != embedded_web_server_port_ ||
+    if (process != embedded_web_server_process_ || !embedded_web_identity_is_current(identity) || identity.selected_server_port != port ||
         embedded_web_server_probe_.identity != identity || embedded_web_server_probe_.port != port ||
         embedded_web_server_probe_.navigation_token != navigation_token) return;
     fail_embedded_web_server_probe(identity, port, navigation_token, QStringLiteral("local server exited with code %1: %2").arg(exit_code).arg(QString::fromUtf8(process->readAll()).trimmed().left(240)));
   });
   connect(process, &QProcess::errorOccurred, this, [this, identity, port, navigation_token, process](QProcess::ProcessError error) {
-    if (process != embedded_web_server_process_ || !embedded_web_identity_is_current(identity) || port != embedded_web_server_port_ ||
+    if (process != embedded_web_server_process_ || !embedded_web_identity_is_current(identity) || identity.selected_server_port != port ||
         embedded_web_server_probe_.identity != identity || embedded_web_server_probe_.port != port ||
         embedded_web_server_probe_.navigation_token != navigation_token) return;
     fail_embedded_web_server_probe(identity, port, navigation_token,
@@ -940,6 +1000,12 @@ ScenePreviewWidget::EmbeddedWebRequestIdentity ScenePreviewWidget::embedded_web_
     identity.absolute_scene_dir = QDir::cleanPath(info.exists() ?
       (info.canonicalFilePath().isEmpty() ? info.absoluteFilePath() : info.canonicalFilePath()) : info.absoluteFilePath());
   }
+  // Resolve the repository before publishing the request identity.  Every
+  // asynchronous callback therefore has the exact root it is allowed to use.
+  identity.absolute_repo_root = resolve_embedded_web_repo_root(identity.absolute_scene_dir);
+  // Each refresh starts by probing the configured loopback endpoint.  An
+  // alternate port, when needed, replaces the active immutable identity.
+  identity.selected_server_port = 8765;
   identity.payload_fingerprint = preview_payload_fingerprint_;
   identity.payload_revision = static_cast<quint64>(preview_payload_revision_);
   identity.generation = generation;
@@ -955,9 +1021,10 @@ QString ScenePreviewWidget::embedded_web_preparation_diagnostic_key(const Embedd
 {
   // Include the complete immutable request identity, not merely the scene name:
   // a same-scene payload update must retain its own terminal diagnostic.
-  return QStringLiteral("%1|%2|%3|%4|%5")
-    .arg(identity.scene_id, identity.absolute_scene_dir, QString::fromLatin1(identity.payload_fingerprint.toHex()))
-    .arg(identity.payload_revision).arg(identity.generation);
+  return QStringLiteral("%1|%2|%3|%4|%5|%6|%7")
+    .arg(identity.scene_id, identity.absolute_scene_dir, identity.absolute_repo_root,
+         QString::fromLatin1(identity.payload_fingerprint.toHex()))
+    .arg(identity.selected_server_port).arg(identity.payload_revision).arg(identity.generation);
 }
 
 void ScenePreviewWidget::append_embedded_web_prepare_output(QProcess * process, bool standard_error)
@@ -1066,13 +1133,14 @@ void ScenePreviewWidget::start_embedded_web_prepare(const EmbeddedWebRequestIden
       .arg(selected_scene_dir, scene_id));
     return;
   }
-  const QString repo_root = resolve_embedded_web_repo_root(selected_scene_dir);
+  const QString repo_root = identity.absolute_repo_root;
   if (repo_root.isEmpty()) {
     const QString detail = QStringLiteral("could not find a Workcell Studio repo root with viewer, scene-prep script, and scenes markers");
     activate_native_compatibility_preview(detail);
     emit studio_log_requested(QStringLiteral("Embedded Web 3D Product View unavailable: could not find a Workcell Studio repo root with required markers from selected scene, environment override, or fallback application paths."));
     return;
   }
+  if (!embedded_web_identity_is_current(identity) || repo_root != identity.absolute_repo_root) return;
   // Keep a working compatibility viewport visible until Web3D has completed
   // its readiness handshake.  A retry must not briefly replace usable content.
   embedded_web_repo_root_ = repo_root;
@@ -1098,16 +1166,20 @@ void ScenePreviewWidget::start_embedded_web_prepare(const EmbeddedWebRequestIden
   embedded_web_preparation_process_keys_.insert(process, diagnostic_key);
   embedded_web_prepare_started_at_ = QDateTime::currentDateTimeUtc();
   connect(process, &QProcess::started, this, [this, identity, process]() {
+    if (!embedded_web_identity_is_current(identity)) return;
     const QString key = embedded_web_preparation_process_keys_.value(process);
     if (auto diagnostic = embedded_web_preparation_diagnostics_.find(key); diagnostic != embedded_web_preparation_diagnostics_.end()) diagnostic->started = true;
   });
-  connect(process, &QProcess::readyReadStandardOutput, this, [this, process]() {
+  connect(process, &QProcess::readyReadStandardOutput, this, [this, identity, process]() {
+    if (!embedded_web_identity_is_current(identity)) return;
     append_embedded_web_prepare_output(process, false);
   });
-  connect(process, &QProcess::readyReadStandardError, this, [this, process]() {
+  connect(process, &QProcess::readyReadStandardError, this, [this, identity, process]() {
+    if (!embedded_web_identity_is_current(identity)) return;
     append_embedded_web_prepare_output(process, true);
   });
   connect(process, &QProcess::errorOccurred, this, [this, identity, process](QProcess::ProcessError error) {
+    if (!embedded_web_identity_is_current(identity)) return;
     record_embedded_web_prepare_terminal(identity, process, QStringLiteral("process_error"), process->exitStatus(), process->exitCode(),
       QStringLiteral("qprocess_error=%1").arg(static_cast<int>(error)));
   });
@@ -1353,13 +1425,14 @@ void ScenePreviewWidget::load_prepared_embedded_web_scene(const EmbeddedWebReque
     emit studio_log_requested(QStringLiteral("Embedded Product View ignored stale prepared scene %1 rev %2; current scene is %3 rev %4.").arg(identity.scene_id).arg(identity.generation).arg(preview_scene_name_).arg(embedded_web_request_generation_));
     return;
   }
-  if (embedded_web_server_lifecycle_ != EmbeddedWebServerLifecycle::ServerReady) return;
+  if (embedded_web_server_lifecycle_ != EmbeddedWebServerLifecycle::ServerReady ||
+      identity.absolute_repo_root.isEmpty() || identity.selected_server_port <= 0) return;
   const QString web_scene_url_path = QStringLiteral("build/workcell_studio_web_scene/%1.web_scene.json").arg(identity.scene_id);
   const QString builder_revision = QString::number(identity.payload_revision);
   QUrl viewer_url;
   viewer_url.setScheme(QStringLiteral("http"));
   viewer_url.setHost(QStringLiteral("127.0.0.1"));
-  viewer_url.setPort(embedded_web_server_port_);
+  viewer_url.setPort(identity.selected_server_port);
   viewer_url.setPath(QStringLiteral("/workcell_studio_web/viewer/index.html"));
   QUrlQuery viewer_query;
   viewer_query.addQueryItem(QStringLiteral("scene"), web_scene_url_path);

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -341,6 +341,11 @@ private:
   {
     QString scene_id;
     QString absolute_scene_dir;
+    // These are part of the immutable request, rather than mutable server
+    // state, so delayed network/process/browser callbacks cannot cross a
+    // repository or port change.
+    QString absolute_repo_root;
+    int selected_server_port{ 0 };
     QByteArray payload_fingerprint;
     quint64 payload_revision{ 0 };
     quint64 generation{ 0 };
@@ -348,6 +353,7 @@ private:
     bool matches_context(const EmbeddedWebRequestIdentity & other) const
     {
       return scene_id == other.scene_id && absolute_scene_dir == other.absolute_scene_dir &&
+        absolute_repo_root == other.absolute_repo_root && selected_server_port == other.selected_server_port &&
         payload_fingerprint == other.payload_fingerprint && payload_revision == other.payload_revision;
     }
     bool operator==(const EmbeddedWebRequestIdentity & other) const
@@ -391,6 +397,8 @@ private:
     const QString & outcome, QProcess::ExitStatus exit_status, int exit_code, const QString & detail = QString());
   QString embedded_web_preparation_diagnostic_key(const EmbeddedWebRequestIdentity & identity) const;
   void ensure_embedded_web_server_started(const QString & repo_root, const EmbeddedWebRequestIdentity & identity);
+  void start_owned_embedded_web_server(const EmbeddedWebRequestIdentity & identity);
+  void select_owned_embedded_web_server(const EmbeddedWebRequestIdentity & identity, bool use_current_port);
   void start_embedded_web_server_probes(const EmbeddedWebRequestIdentity & identity, int port, quint64 navigation_token,
     const QString & repo_root);
   void run_embedded_web_server_probes(const EmbeddedWebRequestIdentity & identity, int port, quint64 navigation_token);

--- a/workcell_builder/workcell_builder/test/scene_preview_widget_ui_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene_preview_widget_ui_test.cpp
@@ -193,6 +193,31 @@ TEST(ScenePreviewWidgetUi, EquivalentPreviewContextsPrepareProductViewOnlyOnce)
 }
 
 #ifdef WORKCELL_BUILDER_HAS_WEBENGINE
+TEST(ScenePreviewWidgetUi, EmbeddedWebNavigationRequiresVerifiedServerReadiness)
+{
+  ASSERT_NE(ensure_app(), nullptr);
+
+  ScenePreviewWidget widget;
+  widget.preview_scene_name_ = QStringLiteral("ur5_2f_test");
+  widget.embedded_web_request_generation_ = 1;
+  ScenePreviewWidget::EmbeddedWebRequestIdentity identity;
+  identity.scene_id = QStringLiteral("ur5_2f_test");
+  identity.absolute_repo_root = QDir::currentPath();
+  identity.selected_server_port = 18765;
+  identity.payload_revision = 1;
+  identity.generation = widget.embedded_web_request_generation_;
+  widget.embedded_web_active_identity_ = identity;
+  widget.embedded_web_has_active_identity_ = true;
+
+  widget.embedded_web_server_lifecycle_ = ScenePreviewWidget::EmbeddedWebServerLifecycle::ServerProbing;
+  widget.load_prepared_embedded_web_scene(identity);
+  EXPECT_TRUE(widget.embedded_web_expected_viewer_url_.isEmpty());
+
+  widget.embedded_web_server_lifecycle_ = ScenePreviewWidget::EmbeddedWebServerLifecycle::ServerReady;
+  widget.load_prepared_embedded_web_scene(identity);
+  EXPECT_EQ(widget.embedded_web_expected_viewer_url_.port(), identity.selected_server_port);
+}
+
 TEST(ScenePreviewWidgetUi, EmbeddedWebViewerUrlPreservesScenePathAndPayloadRevision)
 {
   ASSERT_NE(ensure_app(), nullptr);
@@ -207,6 +232,8 @@ TEST(ScenePreviewWidgetUi, EmbeddedWebViewerUrlPreservesScenePathAndPayloadRevis
 
     ScenePreviewWidget::EmbeddedWebRequestIdentity identity;
     identity.scene_id = QStringLiteral("ur5_2f_test");
+    identity.absolute_repo_root = QDir::currentPath();
+    identity.selected_server_port = 8765;
     identity.payload_revision = revision;
     identity.generation = widget.embedded_web_request_generation_;
     widget.load_prepared_embedded_web_scene(identity);


### PR DESCRIPTION
### Motivation
- Prevent stale or untrusted loopback servers from being reused by binding each embedded-web request to the resolved absolute repository root and a selected loopback port. 
- Ensure browser navigation only happens after the server for the specific request is verified ready for that repository and scene. 
- Avoid killing or navigating to unrelated processes discovered listening on a preferred port by selecting and launching an owned server when appropriate. 
- Make asynchronous callbacks robust against request/scene changes by including immutable identity fields for repo/port in every readiness/process/probe gate.

### Description
- Extended `EmbeddedWebRequestIdentity` (`scene_preview_widget.h`) with `absolute_repo_root` and `selected_server_port` and included them in identity matching logic. 
- Resolve the repository root and set a default probe port in `embedded_web_request_identity()` and only build the viewer URL from the verified `selected_server_port` after readiness checks in `load_prepared_embedded_web_scene()`. 
- Probe the configured/default loopback endpoint first and verify `workcell_runtime_marker.json` plus required viewer and scene resources before navigating; if the marker mismatches, never reuse or terminate that external listener. 
- When the preferred endpoint cannot be reused, pick/claim an alternate ephemeral loopback port and start an owned local server with an explicit working directory using `python3 -m http.server <port> --bind 127.0.0.1 --directory <absolute_repo_root>` via the new `start_owned_embedded_web_server()` and `select_owned_embedded_web_server()` helpers. 
- Guard all server-probe, prepare-process, readiness-polling, and WebEngine load callbacks with the enriched immutable request identity so stale callbacks cannot navigate, change status, or stop the wrong process. 
- Tests updated/added: Qt unit `EmbeddedWebNavigationRequiresVerifiedServerReadiness` (in `workcell_builder/test/scene_preview_widget_ui_test.cpp`) and Python policy tests extended (in `tests/test_scene_preview_widget_lifecycle_cancellation.py`) to assert root/port binding and server directory binding.

### Testing
- Ran focused Python tests: `python3 -m pytest tests/test_scene_preview_widget_lifecycle_cancellation.py tests/test_scene_preview_widget_preparation_diagnostics.py tests/test_scene_preview_widget_refresh_lifecycle.py tests/test_scene_preview_widget_native_compatibility_lifecycle.py tests/test_workcell_builder_product_view_defaults.py -q`, all tests passed (`18 passed`).
- Confirmed existing static checks: `git diff --check` produced no warnings. 
- Verified new and existing Qt/C++ unit tests (where exercised in this environment) that assert URL construction and navigation gating were updated to include `absolute_repo_root` and `selected_server_port`. 
- Note: a full ROS/Qt build and an integrated WebEngine runtime run were not executed in this container; recommend running the normal CI build/`colcon` steps and a WebEngine-enabled runtime smoke test in an environment with display support before landing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b5b7f4a50833182b1c045cec84f0c)