### PR TITLE
Restore package-owned workcell_builder shell launcher

### DIFF
--- a/tests/test_workcell_builder_bare_launcher.py
+++ b/tests/test_workcell_builder_bare_launcher.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CMAKE = ROOT / "workcell_builder" / "workcell_builder" / "CMakeLists.txt"
+LAUNCHER = ROOT / "workcell_builder" / "workcell_builder" / "scripts" / "workcell_builder"
+
+
+def test_cmake_installs_bare_launcher_into_prefix_bin() -> None:
+    cmake = CMAKE.read_text(encoding="utf-8")
+    assert "install(PROGRAMS\n  scripts/workcell_builder\n  DESTINATION bin)" in cmake
+    assert "DESTINATION lib/${PROJECT_NAME}" in cmake
+
+
+def test_launcher_resolves_package_binary_and_forwards_arguments() -> None:
+    launcher = LAUNCHER.read_text(encoding="utf-8")
+    assert "${prefix_dir}/lib/workcell_builder/workcell_builder" in launcher
+    assert 'exec "${binary}" "$@"' in launcher
+    assert "ros2 run" not in launcher
+    assert "/home/user" not in launcher
+    assert "/home/ubuntu" not in launcher
+    assert "workcell_ws" not in launcher
+
+
+def test_launcher_executes_sibling_installed_binary(tmp_path: Path) -> None:
+    prefix = tmp_path / "install" / "workcell_builder"
+    bin_dir = prefix / "bin"
+    app_dir = prefix / "lib" / "workcell_builder"
+    bin_dir.mkdir(parents=True)
+    app_dir.mkdir(parents=True)
+
+    installed_launcher = bin_dir / "workcell_builder"
+    shutil.copyfile(LAUNCHER, installed_launcher)
+    installed_launcher.chmod(0o755)
+
+    installed_app = app_dir / "workcell_builder"
+    installed_app.write_text(
+        "#!/usr/bin/env bash\nprintf '%s\\n' \"$@\"\n",
+        encoding="utf-8",
+    )
+    installed_app.chmod(0o755)
+
+    result = subprocess.run(
+        [str(installed_launcher), "first", "two words", "--flag=value"],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PATH": os.environ.get("PATH", "")},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == ["first", "two words", "--flag=value"]
+
+
+def test_launcher_reports_missing_installed_binary(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "prefix" / "bin"
+    bin_dir.mkdir(parents=True)
+    installed_launcher = bin_dir / "workcell_builder"
+    shutil.copyfile(LAUNCHER, installed_launcher)
+    installed_launcher.chmod(0o755)
+
+    result = subprocess.run(
+        [str(installed_launcher)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 127
+    assert "missing or not executable" in result.stderr
+    assert "Rebuild the workcell_builder package" in result.stderr

--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -712,6 +712,10 @@ install(TARGETS workcell_builder
   DESTINATION lib/${PROJECT_NAME}
 )
 
+install(PROGRAMS
+  scripts/workcell_builder
+  DESTINATION bin)
+
 install(DIRECTORY templates
   DESTINATION share/${PROJECT_NAME})
 

--- a/workcell_builder/workcell_builder/scripts/workcell_builder
+++ b/workcell_builder/workcell_builder/scripts/workcell_builder
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+prefix_dir="$(cd -- "${script_dir}/.." && pwd -P)"
+binary="${prefix_dir}/lib/workcell_builder/workcell_builder"
+
+if [[ ! -x "${binary}" ]]; then
+  printf 'workcell_builder: installed application is missing or not executable: %s\n' "${binary}" >&2
+  printf 'Rebuild the workcell_builder package and source the workspace setup file, then try again.\n' >&2
+  exit 127
+fi
+
+exec "${binary}" "$@"


### PR DESCRIPTION
## Summary

Restore the bare `workcell_builder` shell command while preserving the existing ROS 2 executable used by:

```bash
ros2 run workcell_builder workcell_builder
```

## Root cause

The compiled target is correctly installed to:

```text
<prefix>/lib/workcell_builder/workcell_builder
```

That location is discoverable by `ros2 run`, but it is not itself a normal shell `PATH` entry. The package did not install a user-facing command into `<prefix>/bin`.

## Changes

- Add a package-owned Bash launcher installed as:

  ```text
  <prefix>/bin/workcell_builder
  ```

- Resolve the compiled application relative to the launcher prefix:

  ```text
  <prefix>/lib/workcell_builder/workcell_builder
  ```

- Forward all arguments unchanged with `exec ... "$@"`.
- Emit a concise error with exit code 127 if the installed application is missing.
- Keep the compiled target installation unchanged, so `ros2 run` remains supported.
- Add focused tests for the CMake install contract, path independence, argument forwarding, and missing-binary diagnostics.

## Validation performed

```bash
bash -n workcell_builder/workcell_builder/scripts/workcell_builder
python3 -m pytest tests/test_workcell_builder_bare_launcher.py -q
# 4 passed

git diff --check
```

The reconstructed CMake baseline was verified against the current Git blob before applying the four-line install change, and the final branch comparison contains only the intended three files.

## Not run here

A ROS 2 Humble `colcon build` and GUI launch were not available in this environment. After merging, validate locally with:

```bash
cd ~/workcell_ws
source /opt/ros/humble/setup.bash
colcon build --symlink-install --packages-select workcell_builder
source install/setup.bash

command -v workcell_builder
workcell_builder
ros2 run workcell_builder workcell_builder
```

No Web3D, RViz, MoveIt, scene-generation, launch, controller, or robot-motion behaviour is changed.