### PR TITLE
Skip redundant src/assets|scenes aliases and add Humble CI preflight to avoid duplicate-package discovery

### DIFF
--- a/.github/workflows/humble-ci.yml
+++ b/.github/workflows/humble-ci.yml
@@ -112,6 +112,10 @@ jobs:
           fi
           vcs import --recursive --skip-existing src < src/easy_manipulation_deployment/dependencies/emd_epd_ws.repos
 
+      - name: Workspace package uniqueness preflight
+        working-directory: ws
+        run: ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh --layout-only
+
       - name: Install dependencies
         working-directory: ws
         run: |

--- a/scripts/fix_workspace_layout.sh
+++ b/scripts/fix_workspace_layout.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 WITH_GUI=${WITH_GUI:-0}
+LAYOUT_ONLY=${LAYOUT_ONLY:-0}
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --with-gui|--with-tesseract-qt)
@@ -13,13 +14,17 @@ while [[ $# -gt 0 ]]; do
     --without-gui)
       WITH_GUI=0
       ;;
+    --layout-only)
+      LAYOUT_ONLY=1
+      ;;
     -h|--help)
       cat <<'EOF'
-Usage: scripts/fix_workspace_layout.sh [--with-gui]
+Usage: scripts/fix_workspace_layout.sh [--with-gui] [--layout-only]
 
 Synchronize the workspace layout for this repository and gate optional GUI
 packages by default. Pass --with-gui to remove COLCON_IGNORE markers from
 src/tesseract_qt and src/qtadvanceddocking when those checkouts are present.
+Pass --layout-only to stop after workspace alias and duplicate-package checks.
 EOF
       exit 0
       ;;
@@ -130,6 +135,42 @@ prune_legacy_asset_package_symlinks() {
   done < <(find "$SRC_DIR" -mindepth 1 -maxdepth 1 -type l -print 2>/dev/null)
 }
 
+
+repo_exposed_through_src() {
+  local repo_resolved candidate candidate_resolved
+
+  repo_resolved="$(readlink -f "$REPO_DIR" 2>/dev/null || true)"
+  [[ -n "$repo_resolved" ]] || return 1
+
+  if [[ "$repo_resolved" == "$(readlink -f "$SRC_DIR" 2>/dev/null || echo "$SRC_DIR")"/* ]]; then
+    return 0
+  fi
+
+  while IFS= read -r candidate; do
+    candidate_resolved="$(readlink -f "$candidate" 2>/dev/null || true)"
+    if [[ -n "$candidate_resolved" && "$candidate_resolved" == "$repo_resolved" ]]; then
+      return 0
+    fi
+  done < <(find "$SRC_DIR" -mindepth 1 -maxdepth 1 \( -type d -o -type l \) -print 2>/dev/null)
+
+  return 1
+}
+
+remove_redundant_repo_alias() {
+  local alias_name="$1"
+  local target="$2"
+  local dest="$SRC_DIR/$alias_name"
+  local expected_resolved actual_resolved
+
+  [[ -L "$dest" ]] || return 0
+  expected_resolved="$(readlink -f "$target" 2>/dev/null || true)"
+  actual_resolved="$(readlink -f "$dest" 2>/dev/null || true)"
+  if [[ -n "$expected_resolved" && "$actual_resolved" == "$expected_resolved" ]]; then
+    echo "Removing redundant workspace alias: $dest -> $actual_resolved"
+    rm -f "$dest"
+  fi
+}
+
 ensure_workspace_alias() {
   local alias_name="$1"
   local target="$2"
@@ -166,25 +207,18 @@ ensure_workspace_alias() {
 }
 
 ensure_workspace_aliases() {
+  if repo_exposed_through_src; then
+    remove_redundant_repo_alias "assets" "$REPO_DIR/assets"
+    remove_redundant_repo_alias "scenes" "$REPO_DIR/scenes"
+    return
+  fi
+
   ensure_workspace_alias "assets" "$REPO_DIR/assets"
   ensure_workspace_alias "scenes" "$REPO_DIR/scenes"
 }
 
 ensure_workcell_builder_link_policy() {
-  local repo_exposed_in_src=0
-  if [[ "${REPO_DIR}" == "${SRC_DIR}/"* ]]; then
-    repo_exposed_in_src=1
-  else
-    local candidate
-    while IFS= read -r candidate; do
-      if [ "$(readlink -f "$candidate")" = "$(readlink -f "$REPO_DIR")" ]; then
-        repo_exposed_in_src=1
-        break
-      fi
-    done < <(find "$SRC_DIR" -mindepth 1 -maxdepth 1 \( -type d -o -type l \) -print 2>/dev/null)
-  fi
-
-  if [[ $repo_exposed_in_src -eq 1 ]]; then
+  if repo_exposed_through_src; then
     local legacy_link="$SRC_DIR/workcell_builder"
     if [ -L "$legacy_link" ] && [ "$(readlink -f "$legacy_link")" = "$(readlink -f "$REPO_DIR/workcell_builder/workcell_builder")" ]; then
       echo "Removing legacy workcell_builder symlink at ${legacy_link}"
@@ -321,25 +355,63 @@ ensure_workspace_aliases
 ensure_workcell_builder_link_policy
 set_gui_package_state
 
+discover_rosdep_package_paths() {
+  SRC_DIR="$SRC_DIR" python3 - <<'PY'
+import os
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+root = Path(os.environ["SRC_DIR"]).resolve()
+visited = set()
+ignore_markers = {"COLCON_IGNORE", "AMENT_IGNORE", "CATKIN_IGNORE"}
+
+
+def walk(path: Path):
+    try:
+        real = path.resolve()
+    except OSError:
+        return
+    if real in visited:
+        return
+    visited.add(real)
+    if any((path / marker).exists() for marker in ignore_markers):
+        return
+    pkg_xml = path / "package.xml"
+    if pkg_xml.is_file():
+        try:
+            name = (ET.parse(pkg_xml).getroot().findtext("name") or "").strip()
+        except Exception as exc:
+            print(f"warning: failed to parse {pkg_xml}: {exc}", file=sys.stderr)
+            name = ""
+        if name:
+            print(f"{name}\t{path}")
+    try:
+        children = sorted(path.iterdir(), key=lambda p: p.name)
+    except OSError:
+        return
+    for child in children:
+        if child.is_dir():
+            walk(child)
+
+
+walk(root)
+PY
+}
+
 check_duplicate_packages() {
   local -A seen=()
   local -a duplicates=()
-  local line name path
+  local name path
 
-  if ! command -v colcon >/dev/null 2>&1; then
-    echo "Error: colcon is required for duplicate package detection" >&2
-    exit 1
-  fi
-
-  while IFS= read -r line; do
-    name="${line%% *}"
-    path="${line#* }"
+  while IFS=$'\t' read -r name path; do
+    [[ -n "$name" ]] || continue
     if [[ -n "${seen[$name]:-}" ]]; then
       duplicates+=("$name: ${seen[$name]} | $path")
     else
       seen[$name]="$path"
     fi
-  done < <(colcon list --base-paths "$SRC_DIR" 2>/dev/null || true)
+  done < <(discover_rosdep_package_paths)
 
   if [[ ${#duplicates[@]} -gt 0 ]]; then
     echo "Duplicate package discovery detected:" >&2
@@ -360,8 +432,13 @@ summarize_workspace_layout() {
   echo "  $REPO_DIR"
   echo
   echo "Workspace aliases:"
-  echo "  src/assets -> $REPO_DIR/assets"
-  echo "  src/scenes -> $REPO_DIR/scenes"
+  if repo_exposed_through_src; then
+    echo "  src/assets: skipped (repository already discoverable under src)"
+    echo "  src/scenes: skipped (repository already discoverable under src)"
+  else
+    echo "  src/assets -> $REPO_DIR/assets"
+    echo "  src/scenes -> $REPO_DIR/scenes"
+  fi
   echo
   echo "Legacy asset package symlinks removed:"
   if [[ ${#LEGACY_ASSET_SYMLINKS_REMOVED[@]} -eq 0 ]]; then
@@ -376,13 +453,22 @@ summarize_workspace_layout() {
   echo "  duplicate package names: none"
   echo
   echo "Key status:"
-  echo "  assets alias: OK"
-  echo "  scenes alias: OK"
+  if repo_exposed_through_src; then
+    echo "  assets alias: skipped"
+    echo "  scenes alias: skipped"
+  else
+    echo "  assets alias: OK"
+    echo "  scenes alias: OK"
+  fi
   echo "  duplicate package check: OK"
 }
 
 check_duplicate_packages
 summarize_workspace_layout
+
+if [[ "$LAYOUT_ONLY" -eq 1 ]]; then
+  exit 0
+fi
 
 # Install core system dependencies (Boost graph/program_options/serialization and
 # TinyXML2) up front so users who only run this script still avoid

--- a/tests/test_fix_workspace_layout_duplicate_aliases.py
+++ b/tests/test_fix_workspace_layout_duplicate_aliases.py
@@ -1,0 +1,100 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def write_pkg(path: Path, name: str) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "package.xml").write_text(
+        f"""<package format=\"3\"><name>{name}</name><version>0.0.0</version><description>test</description><maintainer email=\"a@b.c\">t</maintainer><license>MIT</license></package>\n""",
+        encoding="utf-8",
+    )
+
+
+def make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    shutil.copytree("scripts", repo / "scripts")
+    write_pkg(repo, "easy_manipulation_deployment")
+    write_pkg(repo / "assets" / "ur_description", "ur_description")
+    write_pkg(repo / "scenes" / "ur5_2f_test", "ur5_2f_test")
+    return repo
+
+
+def run_layout(repo: Path, workspace: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["WORKSPACE_ROOT"] = str(workspace)
+    env["HOME"] = str(workspace.parent / "home")
+    return subprocess.run(
+        ["bash", str(repo / "scripts" / "fix_workspace_layout.sh"), "--layout-only"],
+        cwd=repo,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+
+def test_repo_linked_under_src_removes_redundant_aliases(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    ws = tmp_path / "ws"
+    src = ws / "src"
+    src.mkdir(parents=True)
+    (src / "easy_manipulation_deployment").symlink_to(repo, target_is_directory=True)
+    (src / "assets").symlink_to(repo / "assets", target_is_directory=True)
+    (src / "scenes").symlink_to(repo / "scenes", target_is_directory=True)
+
+    result = run_layout(repo, ws)
+
+    assert not (src / "assets").exists() and not (src / "assets").is_symlink()
+    assert not (src / "scenes").exists() and not (src / "scenes").is_symlink()
+    assert "assets alias: skipped" in result.stdout
+    assert "duplicate package check: OK" in result.stdout
+
+
+def test_repo_outside_src_still_creates_aliases(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    ws = tmp_path / "ws"
+    (ws / "src").mkdir(parents=True)
+
+    run_layout(repo, ws)
+
+    assert (ws / "src" / "assets").resolve() == (repo / "assets").resolve()
+    assert (ws / "src" / "scenes").resolve() == (repo / "scenes").resolve()
+
+
+def test_real_directories_are_never_deleted(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    ws = tmp_path / "ws"
+    src = ws / "src"
+    src.mkdir(parents=True)
+    (src / "easy_manipulation_deployment").symlink_to(repo, target_is_directory=True)
+    real_assets = src / "assets"
+    real_assets.mkdir()
+    marker = real_assets / "keep.txt"
+    marker.write_text("keep", encoding="utf-8")
+
+    run_layout(repo, ws)
+
+    assert marker.read_text(encoding="utf-8") == "keep"
+    assert real_assets.is_dir() and not real_assets.is_symlink()
+
+
+def test_repeated_execution_is_idempotent(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    ws = tmp_path / "ws"
+    src = ws / "src"
+    src.mkdir(parents=True)
+    (src / "easy_manipulation_deployment").symlink_to(repo, target_is_directory=True)
+    (src / "assets").symlink_to(repo / "assets", target_is_directory=True)
+    (src / "scenes").symlink_to(repo / "scenes", target_is_directory=True)
+
+    first = run_layout(repo, ws)
+    second = run_layout(repo, ws)
+
+    assert "duplicate package check: OK" in first.stdout
+    assert "duplicate package check: OK" in second.stdout
+    assert not (src / "assets").exists() and not (src / "assets").is_symlink()
+    assert not (src / "scenes").exists() and not (src / "scenes").is_symlink()


### PR DESCRIPTION
### Motivation
- Humble CI fails at the dependency-install step because rosdep follows both the repository link at `ws/src/easy_manipulation_deployment` and the workspace aliases `ws/src/assets` and `ws/src/scenes`, producing duplicate package names such as `ur_description` and `ur5_2f_test`.
- The smallest permanent fix is to detect repository layouts where the repo is already discoverable under `src` (directly or via a top-level symlink) and avoid creating redundant aliases that duplicate packages on the rosdep/colcon discovery path.
- The preflight should match how rosdep discovers `package.xml` files (following symlinks while avoiding revisits) so duplicate detection is robust before `rosdep install` runs.

### Description
- Added `--layout-only` support to `scripts/fix_workspace_layout.sh` to allow CI to run workspace alias and duplicate-package checks without performing full dependency/setup actions.
- Implemented `repo_exposed_through_src()` detection and `remove_redundant_repo_alias()` to skip creating (and to remove only redundant symlinks for) `src/assets` and `src/scenes` when the repository is already visible under `ws/src`; real directories are never removed. (`scripts/fix_workspace_layout.sh`)
- Replaced colcon-only duplicate-package detection with a rosdep-style `package.xml` walk (`discover_rosdep_package_paths`) that follows symlinks but deduplicates by realpath to match rosdep discovery semantics. (`scripts/fix_workspace_layout.sh`)
- Added a Humble CI preflight step that runs `./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh --layout-only` before `rosdep install` to catch duplicates early. (`.github/workflows/humble-ci.yml`)
- Added focused pytest coverage that validates: repo linked under `src` removes redundant aliases, repo outside `src` still creates aliases, real directories are never deleted, and repeated execution is idempotent. (`tests/test_fix_workspace_layout_duplicate_aliases.py`)

### Testing
- Ran `bash -n scripts/fix_workspace_layout.sh` which passed with no syntax errors. 
- Ran `python3 -m pytest tests/test_fix_workspace_layout_duplicate_aliases.py` and `python3 -m pytest tests/test_workspace_layout_assets_scenes_aliases.py` which both passed. 
- Verified an explicit temporary symlinked `ws/src/easy_manipulation_deployment` layout and confirmed a single discovered path per ROS package after `./scripts/fix_workspace_layout.sh --layout-only` (demonstration included in local test). 
- Ran full existing workspace/build regression tests where `tests/test_humble_build_regressions.py` mostly passed but one unrelated, pre-existing static test `test_scene_preview_widget_still_uses_qtcp_socket_for_server_probe` failed because it expects `#include <QTcpSocket>` in a GUI source file that was intentionally not modified by this change. 
- Ran `git diff --check` which passed; pushing the branch/triggering upstream GitHub CI could not be completed here due to missing repository credentials in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5cf29bb834833188c20ca0a39faa24)