### PR TITLE
Prevent Scene Builder header controls from overlapping

### DIFF
--- a/tests/test_workcell_studio_shell_labels.py
+++ b/tests/test_workcell_studio_shell_labels.py
@@ -19,3 +19,35 @@ def test_workcell_studio_labels_present_in_source():
         'Readiness',
     ]:
         assert token in source, f'Missing UI token: {token}'
+
+
+
+def test_scene_builder_header_controls_are_layout_owned_and_short():
+    source = Path('workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text(encoding='utf-8')
+    header = source[
+        source.index('void MainWindow::build_studio_header_actions()'):
+        source.index('void MainWindow::refresh_scene_bundle_export_panel()')
+    ]
+
+    assert 'scenes_open_button->setText("Files");' in header
+    assert 'top_bar->addWidget(scenes_open_button);' in header
+    assert 'scenes_open_button->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);' in header
+    assert 'scenes_open_button->move(' not in header
+    assert 'scenes_open_button->setGeometry(' not in header
+
+    assert 'product_view_help_label->setText("Product View");' in header or '"Product View",\n    this' in header
+    assert 'rviz_truth_preview_help_label = new QLabel("RViz / MoveIt Preview", this);' in header
+    assert 'product_view_help_label->setWordWrap(false);' in header
+    assert 'rviz_truth_preview_help_label->setWordWrap(false);' in header
+    assert 'Native Scene3D compatibility preview: lightweight editable layout preview; not guaranteed RViz-equivalent.' in header
+    assert 'new QLabel(\n    "Native Scene3D compatibility preview: lightweight editable layout preview; not guaranteed RViz-equivalent.",' not in header
+    assert 'new QLabel(\n    "RViz Truth Preview: authoritative generated scene preview using ROS/MoveIt/RViz stack.",' not in header
+
+    for connection in [
+        'connect(action_workspace_open_scene_builder_, &QAction::triggered',
+        'connect(action_generate_yaml_, &QAction::triggered',
+        'connect(action_generate_task_intent_, &QAction::triggered',
+        'connect(action_generate_package_, &QAction::triggered',
+        'connect(action_simulate_plan_preview_, &QAction::triggered',
+    ]:
+        assert connection in header

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -1975,7 +1975,7 @@ void MainWindow::setup_studio_shell()
   dl->addWidget(dashboard_middle_split, 1);
   
   auto * scene_builder = new QWidget(studio_pages_); auto * sl=new QVBoxLayout(scene_builder);
-  scene_builder_title_=new QLabel("<h2>Scene Builder</h2>"); scene_builder_title_->setProperty("studioTitle", true); sl->addWidget(scene_builder_title_);
+  scene_builder_title_=new QLabel("<h2>Scene Builder</h2>"); scene_builder_title_->setProperty("studioTitle", true); scene_builder_title_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred); sl->addWidget(scene_builder_title_);
   auto * scene_header_row = new QHBoxLayout();
   scene_builder_preview_chip_ = new QLabel("Preview: Unavailable", scene_builder); scene_builder_preview_chip_->setObjectName("sceneStatusChip");
   scene_builder_launch_chip_ = new QLabel("Launch Artifacts: Missing", scene_builder); scene_builder_launch_chip_->setObjectName("sceneStatusChip");
@@ -3117,7 +3117,9 @@ void MainWindow::build_studio_header_actions()
     top_bar->addWidget(button);
   }
   auto * scenes_open_button = new QToolButton(this);
-  scenes_open_button->setText("Scenes");
+  scenes_open_button->setText("Files");
+  scenes_open_button->setToolTip("Open Scene Builder and scene file generation actions.");
+  scenes_open_button->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
   scenes_open_button->setPopupMode(QToolButton::InstantPopup);
   auto * scenes_open_menu = new QMenu(scenes_open_button);
   scenes_open_menu->addAction(action_workspace_open_scene_builder_);
@@ -3142,15 +3144,17 @@ void MainWindow::build_studio_header_actions()
   auto * product_view_help_label = new QLabel(
     "Web3D Product View",
     this);
+  product_view_help_label->setText("Product View");
   product_view_help_label->setToolTip("Embedded Web3D Product View is active; use the viewer surface for product framing and overlay controls.");
 #else
   auto * product_view_help_label = new QLabel(
-    "Native Scene3D compatibility preview: lightweight editable layout preview; not guaranteed RViz-equivalent.",
+    "Product View",
     this);
-  product_view_help_label->setToolTip("Native compatibility wording is shown only when WebEngine is unavailable and the native fallback is active.");
+  product_view_help_label->setToolTip("Native Scene3D compatibility preview: lightweight editable layout preview; not guaranteed RViz-equivalent.");
 #endif
-  product_view_help_label->setWordWrap(true);
+  product_view_help_label->setWordWrap(false);
   product_view_help_label->setObjectName("studioProductViewHelpLabel");
+  product_view_help_label->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
   top_bar->addWidget(product_view_help_label);
   auto * more_button = new QToolButton(this);
   more_button->setText("More");
@@ -3168,11 +3172,11 @@ void MainWindow::build_studio_header_actions()
   more_menu->addAction(action_diagnostics_copy_build_launch_commands_);
   more_button->setMenu(more_menu);
   top_bar->addWidget(more_button);
-  auto * rviz_truth_preview_help_label = new QLabel(
-    "RViz Truth Preview: authoritative generated scene preview using ROS/MoveIt/RViz stack.",
-    this);
-  rviz_truth_preview_help_label->setWordWrap(true);
+  auto * rviz_truth_preview_help_label = new QLabel("RViz / MoveIt Preview", this);
+  rviz_truth_preview_help_label->setToolTip("Authoritative generated scene preview using the ROS/MoveIt/RViz stack.");
+  rviz_truth_preview_help_label->setWordWrap(false);
   rviz_truth_preview_help_label->setObjectName("studioRvizTruthPreviewHelpLabel");
+  rviz_truth_preview_help_label->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
   top_bar->addWidget(rviz_truth_preview_help_label);
 }
 


### PR DESCRIPTION
### Motivation
- Fix header overlap and long-label wrapping in the Scene Builder top bar at normal desktop widths without redesigning the header.
- Ensure every visible header control is owned by a Qt layout and uses sensible size policies so widgets do not float or overlap.
- Preserve all existing actions, menus and signal connections while keeping long explanatory copy available via tooltip.

### Description
- Set the Scene Builder page title `scene_builder_title_` to use `QSizePolicy::Expanding` so the title consumes available space inside its layout (`workcell_builder/workcell_builder/gui/mainwindow.cpp`).
- Replace the floating/overlapping `Scenes` control with a layout-owned `Files` `QToolButton`, add a short tooltip, and give it `QSizePolicy::Minimum` sizing so it stays inside the toolbar while preserving its existing menu/actions (`mainwinodw.cpp`).
- Shorten visible preview labels to `Product View` and `RViz / MoveIt Preview`, disable word-wrap for those labels, and move the longer explanatory text into tooltips; set `QSizePolicy::Minimum` on those labels to avoid consuming header space (`mainwindow.cpp`).
- Preserve all existing signal/action connections and existing menu behavior; no launch, runtime, hardware, or generation logic was changed.
- Added a focused source regression test `test_scene_builder_header_controls_are_layout_owned_and_short` in `tests/test_workcell_studio_shell_labels.py` to assert layout ownership, short visible labels, and the presence of existing `connect(...)` calls.

### Testing
- Ran `git diff --check` to validate no whitespace or index issues and it passed.
- Ran the focused test with `python3 -m pytest tests/test_workcell_studio_shell_labels.py::test_scene_builder_header_controls_are_layout_owned_and_short` and it passed.
- ROS build was not executed because the ROS Humble environment was not available in this CI/container (`/opt/ros/humble/setup.bash` was missing), so `colcon build` was skipped.
- No GUI visual/manual acceptance was performed because the environment is headless; changes are UI-only and intentionally minimal to reduce risk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5cf5b46dd883318df3c583b74231ca)