### PR TITLE
Fix Humble Jammy rosdep dependency resolution

### DIFF
--- a/.github/workflows/humble-ci.yml
+++ b/.github/workflows/humble-ci.yml
@@ -122,6 +122,7 @@ jobs:
           set -o pipefail
           ./src/easy_manipulation_deployment/scripts/ensure_rosdep_overrides.sh
           ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh
+          ./src/easy_manipulation_deployment/scripts/ensure_taskflow_cmake_package.sh --export >> "$GITHUB_ENV"
           rosdep update
           if ! rosdep install --from-paths src --ignore-src -yr --rosdistro humble \
             --skip-keys "qt_advanced_docking tesseract_visualization"; then

--- a/scripts/diagnose_rosdep_workspace.py
+++ b/scripts/diagnose_rosdep_workspace.py
@@ -89,6 +89,9 @@ def main() -> int:
     print(f"  discovered source packages: {len(packages)}")
     if skip_keys:
         print(f"  skipped rosdep keys: {', '.join(sorted(skip_keys))}")
+    if not packages:
+        print(f"No source packages discovered under {args.src}; check source import and workspace layout before rosdep.", file=sys.stderr)
+        return 1
 
     unresolved = []
     for key in sorted(declared):

--- a/scripts/rosdep_overrides.yaml
+++ b/scripts/rosdep_overrides.yaml
@@ -187,7 +187,28 @@ tesseract_rosutils:
     noble: [ros-jazzy-tesseract-rosutils]
 
 taskflow:
-  ubuntu: [libtaskflow-dev]
+  ubuntu:
+    # Jammy has no libtaskflow-dev provider; the pinned header-only source
+    # checkout is imported from dependencies/emd_epd_ws.repos and exported with
+    # scripts/ensure_taskflow_cmake_package.sh before build.
+    jammy: []
+    noble: [libtaskflow-dev]
+
+libtaskflow-cpp-dev:
+  ubuntu:
+    # Requested by the imported tesseract_planning package.xml. Ubuntu 22.04
+    # has no apt package for this rosdep key, so Humble/Jammy uses the pinned
+    # source checkout imported from dependencies/emd_epd_ws.repos instead.
+    jammy: []
+    noble: [libtaskflow-cpp-dev]
+
+gperftools:
+  ubuntu:
+    # Requested as a test dependency by imported tesseract_planning. Explicitly
+    # install libunwind-15-dev on Jammy so libgoogle-perftools-dev's unwind
+    # alternative does not collide with LLVM's libunwind-14-dev in Humble CI.
+    jammy: [google-perftools, libunwind-15-dev, libgoogle-perftools-dev]
+    noble: [google-perftools, libgoogle-perftools-dev]
 
 trajopt_sqp:
   ubuntu:

--- a/tests/test_humble_build_regressions.py
+++ b/tests/test_humble_build_regressions.py
@@ -323,3 +323,53 @@ def test_rosdep_diagnostics_reports_source_providers_and_declaring_packages(tmp_
     assert "SOURCE source_only_dep: provided by" in output
     assert "declared by" in output and "consumer/package.xml" in output
     assert "SKIP skipped_dep" in output
+
+
+def test_humble_rosdep_overrides_resolve_jammy_taskflow_and_gperftools_without_changing_jazzy():
+    text = Path("scripts/rosdep_overrides.yaml").read_text()
+    assert "libtaskflow-cpp-dev:" in text
+    assert "jammy: []" in text
+    assert "noble: [libtaskflow-cpp-dev]" in text
+    assert "taskflow:\n  ubuntu:" in text
+    assert "noble: [libtaskflow-dev]" in text
+    assert "gperftools:" in text
+    assert "jammy: [google-perftools, libunwind-15-dev, libgoogle-perftools-dev]" in text
+    assert "noble: [google-perftools, libgoogle-perftools-dev]" in text
+    assert "libunwind-15-dev on Jammy" in text
+    assert "imported tesseract_planning" in text
+
+
+def test_humble_ci_exports_source_taskflow_cmake_package_before_build():
+    text = Path(".github/workflows/humble-ci.yml").read_text()
+    assert "ensure_taskflow_cmake_package.sh --export >> \"$GITHUB_ENV\"" in text
+    assert text.index("ensure_taskflow_cmake_package.sh --export") < text.index("rosdep install --from-paths src --ignore-src -yr --rosdistro humble")
+
+
+def test_rosdep_diagnostics_fails_when_no_source_packages_discovered(tmp_path, monkeypatch, capsys):
+    import importlib.util
+
+    script = Path("scripts/diagnose_rosdep_workspace.py")
+    spec = importlib.util.spec_from_file_location("diagnose_rosdep_workspace_empty", script)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    src = tmp_path / "src"
+    src.mkdir()
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            str(script),
+            "--src",
+            str(src),
+            "--rosdistro",
+            "humble",
+            "--os-codename",
+            "jammy",
+        ],
+    )
+
+    assert module.main() == 1
+    captured = capsys.readouterr()
+    assert "discovered source packages: 0" in captured.out
+    assert "No source packages discovered" in captured.err


### PR DESCRIPTION
### Motivation
- Humble CI rosdep failed on Ubuntu 22.04 (Jammy) because `libtaskflow`/`libtaskflow-cpp-dev` and `gperftools` keys had no usable Jammy providers, blocking dependency install and causing builds to skip.
- The workspace relies on imported source overlays (Taskflow pinned headers and Tesseract/TrajOpt stack), so Jammy-specific overrides are required without changing Jazzy/Noble behaviour.
- Rosdep diagnostics could silently report 0 discovered source packages; this should be treated as an error to avoid hiding broken source imports/workspace layout problems.

### Description
- Added Jammy-safe rosdep overrides in `scripts/rosdep_overrides.yaml` so `taskflow` and `libtaskflow-cpp-dev` resolve to the imported/pinned source checkout on Jammy (`jammy: []`) while preserving Noble/Jazzy binary mappings. 
- Added a `gperftools` override mapping for Jammy to explicitly request `google-perftools`, `libunwind-15-dev`, and `libgoogle-perftools-dev` to avoid the unresolved/conflicting `libunwind-dev` provider on Jammy. 
- Updated Humble CI workflow to export the Taskflow CMake package (`ensure_taskflow_cmake_package.sh --export >> "$GITHUB_ENV"`) before running `rosdep` so the header-only source Taskflow is visible to later build steps. 
- Tightened `scripts/diagnose_rosdep_workspace.py` to treat `discovered source packages: 0` as an error and return non-zero, providing clearer diagnostics when source imports/layouts fail. 
- Added focused regression tests in `tests/test_humble_build_regressions.py` validating the new Jammy rosdep mappings, CI export ordering, and the diagnostics behaviour for an empty discovered-package set.

### Testing
- Ran targeted pytest selection for the new/affected tests: `tests/test_humble_build_regressions.py::test_humble_rosdep_overrides_resolve_jammy_taskflow_and_gperftools_without_changing_jazzy`, `::test_humble_ci_exports_source_taskflow_cmake_package_before_build`, `::test_rosdep_diagnostics_fails_when_no_source_packages_discovered`, and `::test_rosdep_diagnostics_reports_source_providers_and_declaring_packages`; all four passed. 
- Verified `scripts/rosdep_overrides.yaml` parses as YAML and contains the expected Jammy mappings for `gperftools`, `libtaskflow-cpp-dev`, and `taskflow`. 
- Performed shell syntax checks (`bash -n`) for `scripts/ensure_taskflow_cmake_package.sh`, `scripts/ensure_rosdep_overrides.sh`, and `scripts/verify_workspace_discovery.sh`, which passed. 
- Ran a wider pytest run that included other tests; an unrelated pre-existing static assertion in `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp` (expecting `QTcpSocket` while current source uses `QTcpServer`) caused a failure, which was not changed in this PR to keep scope minimal. 
- Not executed in this environment: full `rosdep install --from-paths src --ignore-src -yr --rosdistro humble`, `colcon build`, and ROS launch validation because `rosdep`/ROS 2 Humble/`colcon` are not available in the current container; CI validation should confirm those end-to-end steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d03ab732c8331b451c569e4016dca)