### PR TITLE
Validate canonical workspace discovery layout

### DIFF
--- a/scripts/verify_workspace_discovery.sh
+++ b/scripts/verify_workspace_discovery.sh
@@ -13,13 +13,32 @@ if ! command -v colcon >/dev/null 2>&1; then
   exit 1
 fi
 
-for alias in assets scenes; do
-  path="$SRC_DIR/$alias"
-  if [[ ! -L "$path" && ! -d "$path" ]]; then
-    echo "Missing workspace alias: $path" >&2
-    exit 1
-  fi
-done
+CANONICAL_REPO="$SRC_DIR/easy_manipulation_deployment"
+
+canonical_layout_valid=false
+if [[ -d "$CANONICAL_REPO" \
+  && -d "$CANONICAL_REPO/assets" \
+  && -d "$CANONICAL_REPO/scenes" \
+  && -f "$CANONICAL_REPO/workcell_builder/package.xml" \
+  && -f "$CANONICAL_REPO/scenes/ur5_2f_test/package.xml" ]]; then
+  canonical_layout_valid=true
+fi
+
+legacy_layout_valid=false
+if [[ -d "$SRC_DIR/assets" \
+  && -d "$SRC_DIR/scenes" \
+  && -f "$SRC_DIR/scenes/ur5_2f_test/package.xml" ]]; then
+  legacy_layout_valid=true
+fi
+
+if [[ "$canonical_layout_valid" == true ]]; then
+  layout_description="canonical repository layout at $CANONICAL_REPO"
+elif [[ "$legacy_layout_valid" == true ]]; then
+  layout_description="legacy workspace aliases at $SRC_DIR/assets and $SRC_DIR/scenes"
+else
+  echo "Missing workspace layout: expected canonical repo at $CANONICAL_REPO with assets/ and scenes/, or legacy aliases at $SRC_DIR/assets and $SRC_DIR/scenes." >&2
+  exit 1
+fi
 
 mapfile -t package_rows < <(colcon list --base-paths "$SRC_DIR" 2>/dev/null || true)
 if [[ ${#package_rows[@]} -eq 0 ]]; then
@@ -47,4 +66,4 @@ for pkg in "${required[@]}"; do
   [[ -n "${present[$pkg]:-}" ]] || { echo "Missing required package: $pkg" >&2; exit 1; }
 done
 
-echo "Workspace validation passed: aliases exist, packages are unique, and required packages are discoverable exactly once."
+echo "Workspace validation passed: $layout_description is present, packages are unique, and required packages are discoverable exactly once."

--- a/tests/test_workcell_golden_demo_acceptance_pack.py
+++ b/tests/test_workcell_golden_demo_acceptance_pack.py
@@ -47,4 +47,5 @@ def test_workspace_alias_policy_files_untouched_markers_present():
     verify = Path('scripts/verify_workspace_discovery.sh').read_text(encoding='utf-8')
     assert 'ensure_workspace_alias "assets"' in fix
     assert 'ensure_workspace_alias "scenes"' in fix
-    assert 'for alias in assets scenes' in verify
+    assert 'CANONICAL_REPO="$SRC_DIR/easy_manipulation_deployment"' in verify
+    assert 'Missing workspace layout: expected canonical repo at $CANONICAL_REPO' in verify

--- a/tests/test_workspace_layout_assets_scenes_aliases.py
+++ b/tests/test_workspace_layout_assets_scenes_aliases.py
@@ -21,7 +21,10 @@ def test_fix_workspace_layout_no_per_package_asset_symlink_creation():
 
 def test_verify_workspace_discovery_accepts_alias_layout():
     text = Path('scripts/verify_workspace_discovery.sh').read_text(encoding='utf-8')
-    assert 'for alias in assets scenes' in text
+    assert 'CANONICAL_REPO="$SRC_DIR/easy_manipulation_deployment"' in text
+    assert 'canonical repository layout at $CANONICAL_REPO' in text
+    assert 'legacy workspace aliases at $SRC_DIR/assets and $SRC_DIR/scenes' in text
+    assert 'Missing workspace layout: expected canonical repo at $CANONICAL_REPO' in text
     assert 'Duplicate package discovered' in text
     assert 'required=(easy_manipulation_deployment workcell_builder)' in text
 


### PR DESCRIPTION
### Motivation

- The workspace discovery script should accept the canonical repo layout under `src/easy_manipulation_deployment` instead of unconditionally requiring `src/assets` and `src/scenes` aliases.  
- The check must still allow the legacy alias layout when present and must give a clear error when neither layout is valid.  

### Description

- Introduced `CANONICAL_REPO="$SRC_DIR/easy_manipulation_deployment"` and added canonical-layout detection that requires the repo dir plus `assets/`, `scenes/`, `workcell_builder/package.xml`, and a sentinel scene package (`scenes/ur5_2f_test/package.xml`).  
- Kept legacy layout support but only mark it valid when both `"$SRC_DIR/assets"` and `"$SRC_DIR/scenes"` exist and the required scene package sentinel is present.  
- Replaced the previous unconditional `for alias in assets scenes` gate with layout-aware validation and updated the final success message to reference the detected layout instead of saying "aliases exist."  
- Preserved the `colcon list --base-paths "$SRC_DIR"` duplicate package-name detection and the required-package checks for `easy_manipulation_deployment` and `workcell_builder`, and adjusted tests to match the new policy.  

### Testing

- Ran `python3 -m pytest tests/test_workspace_layout_assets_scenes_aliases.py tests/test_workcell_golden_demo_acceptance_pack.py` and all tests passed.  
- Performed a syntax check with `bash -n scripts/verify_workspace_discovery.sh` which passed.  
- Exercised `scripts/verify_workspace_discovery.sh` with a fake `colcon` and temporary fixtures: a canonical-layout fixture (passed), a legacy-alias fixture (passed), and a no-layout fixture (failed with the expected clear missing-layout message).  
- Did not run the script against a full real ROS workspace because `colcon` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d14b3669483319c025718d13081b4)