### PR TITLE
Verify canonical workspace discovery and add regression tests

### DIFF
--- a/scripts/verify_workspace_discovery.sh
+++ b/scripts/verify_workspace_discovery.sh
@@ -13,13 +13,23 @@ if ! command -v colcon >/dev/null 2>&1; then
   exit 1
 fi
 
-for alias in assets scenes; do
-  path="$SRC_DIR/$alias"
-  if [[ ! -L "$path" && ! -d "$path" ]]; then
-    echo "Missing workspace alias: $path" >&2
-    exit 1
-  fi
-done
+REPO_DIR="$SRC_DIR/easy_manipulation_deployment"
+if [[ ! -d "$REPO_DIR" ]]; then
+  echo "Missing canonical repository layout: $REPO_DIR" >&2
+  exit 1
+fi
+if [[ ! -d "$REPO_DIR/assets" ]]; then
+  echo "Missing canonical layout/content: $REPO_DIR/assets" >&2
+  exit 1
+fi
+if [[ ! -f "$REPO_DIR/scenes/ur5_2f_test/package.xml" ]]; then
+  echo "Missing canonical layout/content: $REPO_DIR/scenes/ur5_2f_test/package.xml" >&2
+  exit 1
+fi
+if [[ ! -f "$REPO_DIR/workcell_builder/package.xml" ]]; then
+  echo "Missing canonical layout/content: $REPO_DIR/workcell_builder/package.xml" >&2
+  exit 1
+fi
 
 mapfile -t package_rows < <(colcon list --base-paths "$SRC_DIR" 2>/dev/null || true)
 if [[ ${#package_rows[@]} -eq 0 ]]; then
@@ -47,4 +57,4 @@ for pkg in "${required[@]}"; do
   [[ -n "${present[$pkg]:-}" ]] || { echo "Missing required package: $pkg" >&2; exit 1; }
 done
 
-echo "Workspace validation passed: aliases exist, packages are unique, and required packages are discoverable exactly once."
+echo "Workspace validation passed: canonical content exists, packages are unique, and required packages are discoverable exactly once."

--- a/tests/test_workspace_layout_assets_scenes_aliases.py
+++ b/tests/test_workspace_layout_assets_scenes_aliases.py
@@ -1,4 +1,60 @@
+import os
+import subprocess
 from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VERIFY_SCRIPT = REPO_ROOT / "scripts" / "verify_workspace_discovery.sh"
+
+
+def _write_package_xml(path: Path, name: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"<package format='3'><name>{name}</name><version>0.0.0</version>"
+        "<description>test</description>"
+        "<maintainer email='test@example.com'>Test</maintainer>"
+        "<license>Apache-2.0</license></package>\n",
+        encoding="utf-8",
+    )
+
+
+def _make_colcon_stub(bin_dir: Path, rows: list[tuple[str, Path]]) -> None:
+    lines = [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "if [[ ${1:-} != 'list' ]]; then exit 2; fi",
+    ]
+    lines.extend(f"printf '%s %s\\n' '{name}' '{path}'" for name, path in rows)
+    colcon = bin_dir / "colcon"
+    colcon.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    colcon.chmod(0o755)
+
+
+def _run_verify(
+    tmp_path: Path, rows: list[tuple[str, Path]]
+) -> subprocess.CompletedProcess[str]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _make_colcon_stub(bin_dir, rows)
+    env = os.environ.copy()
+    env["WORKSPACE_ROOT"] = str(tmp_path / "ws")
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    return subprocess.run(
+        [str(VERIFY_SCRIPT)],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _create_canonical_repo(ws: Path) -> Path:
+    repo = ws / "src" / "easy_manipulation_deployment"
+    (repo / "assets").mkdir(parents=True)
+    _write_package_xml(repo / "scenes" / "ur5_2f_test" / "package.xml", "ur5_2f_test")
+    _write_package_xml(repo / "workcell_builder" / "package.xml", "workcell_builder")
+    return repo
 
 
 def test_fix_workspace_layout_uses_assets_and_scenes_aliases():
@@ -19,9 +75,62 @@ def test_fix_workspace_layout_no_per_package_asset_symlink_creation():
     assert 'Linking repository package' not in text
 
 
-def test_verify_workspace_discovery_accepts_alias_layout():
+def test_verify_workspace_discovery_accepts_canonical_layout_without_aliases(tmp_path):
+    ws = tmp_path / "ws"
+    repo = _create_canonical_repo(ws)
+    result = _run_verify(
+        tmp_path,
+        [
+            ("easy_manipulation_deployment", repo),
+            ("workcell_builder", repo / "workcell_builder"),
+        ],
+    )
+
+    assert result.returncode == 0, result.stderr
+    output = result.stdout + result.stderr
+    assert "Missing workspace alias" not in output
+    assert not (ws / "src" / "assets").exists()
+    assert not (ws / "src" / "scenes").exists()
+
+
+def test_verify_workspace_discovery_rejects_missing_canonical_content(tmp_path):
+    ws = tmp_path / "ws"
+    repo = ws / "src" / "easy_manipulation_deployment"
+    repo.mkdir(parents=True)
+    _write_package_xml(repo / "workcell_builder" / "package.xml", "workcell_builder")
+    result = _run_verify(
+        tmp_path,
+        [
+            ("easy_manipulation_deployment", repo),
+            ("workcell_builder", repo / "workcell_builder"),
+        ],
+    )
+
+    assert result.returncode != 0
+    assert "Missing canonical layout/content" in result.stderr
+    assert str(repo / "assets") in result.stderr or str(repo / "scenes") in result.stderr
+
+
+def test_verify_workspace_discovery_rejects_duplicate_packages(tmp_path):
+    ws = tmp_path / "ws"
+    repo = _create_canonical_repo(ws)
+    duplicate_repo = ws / "src" / "duplicate_easy_manipulation_deployment"
+    duplicate_repo.mkdir(parents=True)
+    result = _run_verify(
+        tmp_path,
+        [
+            ("easy_manipulation_deployment", repo),
+            ("easy_manipulation_deployment", duplicate_repo),
+            ("workcell_builder", repo / "workcell_builder"),
+        ],
+    )
+
+    assert result.returncode != 0
+    assert "Duplicate package discovered" in result.stderr
+
+
+def test_verify_workspace_discovery_static_markers_present():
     text = Path('scripts/verify_workspace_discovery.sh').read_text(encoding='utf-8')
-    assert 'for alias in assets scenes' in text
     assert 'Duplicate package discovered' in text
     assert 'required=(easy_manipulation_deployment workcell_builder)' in text
 


### PR DESCRIPTION
### Motivation
- Replace the fragile alias-based check with a verifier that validates the canonical repository layout under `src/easy_manipulation_deployment` so workspace validation aligns with the repo source-of-truth. 
- Add regression tests that execute the verifier against temporary workspaces with a stub `colcon` on `PATH` to prevent future regressions. 
- Preserve duplicate-package detection and existing `fix_workspace_layout.sh` assertions so existing cleanup behavior remains tested.

### Description
- Change `scripts/verify_workspace_discovery.sh` to require `src/easy_manipulation_deployment` and to assert the presence of `assets/`, `scenes/ur5_2f_test/package.xml`, and `workcell_builder/package.xml` instead of the obsolete `for alias in assets scenes` alias loop. 
- Keep the `colcon list`-based package discovery, duplicate-package detection, and required-package checks intact while updating the final success message. 
- Add test helpers and regression cases to `tests/test_workspace_layout_assets_scenes_aliases.py`, including `_make_colcon_stub`, `_create_canonical_repo`, and `_run_verify`, and three test cases that cover (1) canonical layout passing without `src/assets`/`src/scenes` aliases, (2) missing canonical content failing with an explanatory stderr, and (3) duplicate package name discovery failing with a `Duplicate package discovered` error. 
- Retain the static-file assertions that validate `fix_workspace_layout.sh` behaviour.

### Testing
- Ran `python3 -m pytest tests/test_workspace_layout_assets_scenes_aliases.py` and all tests passed (`8 passed`).
- Ran `git diff --check` to ensure no whitespace or diff issues and it reported no problems.
- Verified the change is limited to the verifier script and tests and does not alter runtime launch files, controllers, or hardware-related defaults.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d15a564c08331b3c47697e1f44dad)