### PR TITLE
Simplify workflow rail while preserving detailed status

### DIFF
--- a/tests/test_workflow_rail_compact_rendering.py
+++ b/tests/test_workflow_rail_compact_rendering.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+import re
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MAINWINDOW_CPP = REPO_ROOT / "workcell_builder/workcell_builder/gui/mainwindow.cpp"
+MAINWINDOW_H = REPO_ROOT / "workcell_builder/workcell_builder/gui/mainwindow.h"
+
+
+def _refresh_body() -> str:
+    text = MAINWINDOW_CPP.read_text(encoding="utf-8")
+    m = re.search(r"void MainWindow::refresh_scene_workflow_rail\(\)\n\{(?P<body>.*?)\n\}\n\nvoid MainWindow::refresh_run_next_menu", text, re.S)
+    assert m, "refresh_scene_workflow_rail body not found"
+    return m.group("body")
+
+
+def test_workflow_rail_uses_compact_rows_with_details_tooltip_and_existing_recommendation():
+    body = _refresh_body()
+
+    assert "scene_workflow_compact_summary(step)" in body
+    assert "scene_workflow_details_tooltip(steps)" in body
+    assert "scene_workflow_rail_label_->setToolTip" in body
+    assert "format_scene_builder_status_text(step.detail).toHtmlEscaped()" not in body
+    assert "recommendation.label" in body
+    assert "resolve_recommended_workflow_actions()" in body
+    assert "resolve_recommended_workflow_action()" not in body
+
+    assert body.count("Details") <= 1
+    assert "<b>%1</b><br/>%2" in body
+
+
+def test_workflow_status_labels_preserve_warnings_and_avoid_missing_or_ready():
+    text = MAINWINDOW_CPP.read_text(encoding="utf-8")
+    status_fn = re.search(r"QString MainWindow::scene_workflow_status_text.*?\n\}", text, re.S).group(0)
+
+    assert 'SceneWorkflowStepStatus::Warning: return "Warnings"' in status_fn
+    assert 'return "Missing"' not in status_fn
+    assert 'return "Ready"' not in status_fn
+    for label in ("Done", "Needed", "Warnings", "Blocked"):
+        assert f'return "{label}"' in status_fn
+
+
+def test_workflow_card_has_sensible_min_width_and_long_details_not_inline():
+    text = MAINWINDOW_CPP.read_text(encoding="utf-8")
+    header = MAINWINDOW_H.read_text(encoding="utf-8")
+
+    assert "workflow_card->setMinimumWidth(260);" in text
+    assert "scene_workflow_rail_label_->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Minimum);" in text
+    assert "QString scene_workflow_compact_summary" in header
+    assert "QString scene_workflow_details_tooltip" in header

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -2474,13 +2474,17 @@ void MainWindow::setup_studio_shell()
   auto * right_layout = new QVBoxLayout(right_panel);
   auto * workflow_card = new QFrame(right_panel);
   workflow_card->setObjectName("studioCard");
+  workflow_card->setMinimumWidth(260);
   auto * workflow_card_layout = new QVBoxLayout(workflow_card);
   workflow_card_layout->addWidget(new QLabel("<b>Scene Builder Workflow</b>", workflow_card));
   scene_workflow_rail_label_ = new QLabel("Select a scene to view workflow steps.", workflow_card);
   scene_workflow_rail_label_->setWordWrap(true);
+  scene_workflow_rail_label_->setTextFormat(Qt::RichText);
+  scene_workflow_rail_label_->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Minimum);
   workflow_card_layout->addWidget(scene_workflow_rail_label_);
   scene_workflow_recommendation_label_ = new QLabel("Recommended next action updates as you progress.", workflow_card);
   scene_workflow_recommendation_label_->setWordWrap(true);
+  scene_workflow_recommendation_label_->setTextFormat(Qt::RichText);
   workflow_card_layout->addWidget(scene_workflow_recommendation_label_);
   scene_workflow_recommendation_button_ = new QPushButton("Open or create a scene", workflow_card);
   scene_workflow_recommendation_button_->setProperty("role", "primary");
@@ -11623,7 +11627,7 @@ QString MainWindow::scene_workflow_status_text(SceneWorkflowStepStatus status) c
 {
   switch (status) {
     case SceneWorkflowStepStatus::Done: return "Done";
-    case SceneWorkflowStepStatus::Current: return "Ready";
+    case SceneWorkflowStepStatus::Current: return "Needed";
     case SceneWorkflowStepStatus::NeedsAction: return "Needed";
     case SceneWorkflowStepStatus::Blocked: return "Blocked";
     case SceneWorkflowStepStatus::Warning: return "Warnings";
@@ -11641,6 +11645,48 @@ QString MainWindow::scene_workflow_status_chip(SceneWorkflowStepStatus status) c
   else if (status == SceneWorkflowStepStatus::Warning) bg = "#c2410c";
   return QString("<span style='color:#fff;background:%1;border-radius:10px;padding:2px 8px;font-size:11px;'>%2</span>")
     .arg(bg, scene_workflow_status_text(status));
+}
+
+
+QString MainWindow::scene_workflow_compact_summary(const SceneWorkflowStep & step) const
+{
+  QString detail = format_scene_builder_status_text(step.detail).trimmed();
+  if (detail.isEmpty() || step.status == SceneWorkflowStepStatus::Done) return QString();
+
+  const QString lower = detail.toLower();
+  if (lower.contains("stale")) return "Rerun validation";
+  if (lower.contains("validate") || lower.contains("offline validation")) return "Run scene validation";
+  if (lower.contains("save layout")) return "Save layout";
+  if (lower.contains("generate yaml") || lower.contains("cell_definition.yaml")) return "Generate YAML";
+  if (lower.contains("generate scene package") || lower.contains("launch artifacts") || lower.contains("scene urdf")) return "Generate package";
+  if (lower.contains("blocked by prerequisites")) return "Complete prerequisite";
+  if (lower.contains("visual review")) return "Review preview";
+  if (lower.contains("warning")) return "Review warnings";
+  if (lower.contains("select") || lower.contains("create a scene")) return "Select scene";
+  if (lower.contains("export")) return "Prepare export";
+  if (lower.contains("rviz") || lower.contains("moveit") || lower.contains("fake-hardware")) return "Prepare simulation";
+
+  QString summary = detail;
+  summary.replace('\n', ' ');
+  summary = summary.section('.', 0, 0).section(';', 0, 0).section(':', 0, 0).trimmed();
+  if (summary.size() > 46) summary = summary.left(43).trimmed() + "...";
+  return summary;
+}
+
+QString MainWindow::scene_workflow_details_tooltip(const std::vector<SceneWorkflowStep> & steps) const
+{
+  QStringList lines;
+  for (int i = 0; i < static_cast<int>(steps.size()); ++i) {
+    const auto & step = steps[static_cast<size_t>(i)];
+    const QString detail = format_scene_builder_status_text(step.detail).trimmed();
+    if (detail.isEmpty()) continue;
+    lines << QString("%1. %2 — %3: %4")
+      .arg(i + 1)
+      .arg(step.label)
+      .arg(scene_workflow_status_text(step.status))
+      .arg(detail);
+  }
+  return lines.join("\n\n");
 }
 
 MainWindow::RecommendedWorkflowAction MainWindow::resolve_recommended_workflow_action() const
@@ -11813,8 +11859,10 @@ void MainWindow::refresh_scene_workflow_rail()
   const auto steps = scene_workflow_steps();
   if (steps.empty()) {
     scene_workflow_rail_label_->setText("Select a scene to view workflow steps.");
+    scene_workflow_rail_label_->setToolTip(QString());
     if (scene_workflow_recommendation_label_) {
       scene_workflow_recommendation_label_->setText("Recommended next action appears after scene context is available.");
+      scene_workflow_recommendation_label_->setToolTip(QString());
     }
     if (scene_workflow_recommendation_button_) {
       scene_workflow_recommendation_button_->setText("Run Next: Open or create a scene");
@@ -11827,16 +11875,21 @@ void MainWindow::refresh_scene_workflow_rail()
   QString html;
   for (int i = 0; i < static_cast<int>(steps.size()); ++i) {
     const auto & step = steps[static_cast<size_t>(i)];
-    const QString detail = format_scene_builder_status_text(step.detail).toHtmlEscaped();
-    html += QString("%1. <span title='%4'>%2 %3</span><br/>")
-      .arg(i + 1)
-      .arg(step.label, scene_workflow_status_chip(step.status), detail);
+    const QString summary = scene_workflow_compact_summary(step).toHtmlEscaped();
+    html += QString("<div style='margin-bottom:6px;'><b>%1</b><br/>%2")
+      .arg(step.label.toHtmlEscaped(), scene_workflow_status_chip(step.status));
+    if (!summary.isEmpty()) {
+      html += QString("<br/><span style='color:#4b5563;'>%1</span>").arg(summary);
+    }
+    html += "</div>";
   }
   scene_workflow_rail_label_->setText(html);
+  scene_workflow_rail_label_->setToolTip(scene_workflow_details_tooltip(steps));
   const auto recommendations = resolve_recommended_workflow_actions();
   const auto recommendation = recommendations.empty() ? RecommendedWorkflowAction{} : recommendations.front();
   if (scene_workflow_recommendation_label_) {
-    scene_workflow_recommendation_label_->setText("<b>Next:</b> " + recommendation.explanatory_text);
+    scene_workflow_recommendation_label_->setText("<b>Next:</b> " + recommendation.label.toHtmlEscaped());
+    scene_workflow_recommendation_label_->setToolTip(recommendation.explanatory_text);
   }
   if (scene_workflow_recommendation_button_) {
     scene_workflow_recommendation_button_->setText(QString("Run Next: %1").arg(recommendation.label));

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -179,6 +179,8 @@ private:
     SceneWorkflowStepStatus ready_status = SceneWorkflowStepStatus::Done) const;
   QString scene_workflow_status_text(SceneWorkflowStepStatus status) const;
   QString scene_workflow_status_chip(SceneWorkflowStepStatus status) const;
+  QString scene_workflow_compact_summary(const SceneWorkflowStep & step) const;
+  QString scene_workflow_details_tooltip(const std::vector<SceneWorkflowStep> & steps) const;
   void refresh_scene_workflow_rail();
   QAction * scene_builder_action(const QString & key) const;
   void register_scene_builder_action(const QString & key, QAction * action);


### PR DESCRIPTION
### Motivation
- Improve readability of the right-side Scene Builder workflow rail at ~1366×768 so steps are quickly scannable and the recommended next action is visible. 
- Remove permanently rendered long paths, commands, and multi-line diagnostics from each step while keeping full technical details accessible. 
- Preserve the existing derived workflow/recommendation logic and visible status semantics for truthful reporting.

### Description
- Constrain the rail layout by setting a sensible minimum width and adjusting the rail label to use rich text and a compact size policy (`workflow_card->setMinimumWidth(260)`, `scene_workflow_rail_label_->setSizePolicy(...)`).
- Add `scene_workflow_compact_summary` and `scene_workflow_details_tooltip` (declared in `mainwindow.h` and implemented in `mainwindow.cpp`) and update `refresh_scene_workflow_rail()` to render each step as a compact title + status row with an optional one-line summary, while moving full step details into a tooltip. 
- Keep the recommendation resolution unchanged but present it succinctly in the rail using `recommendation.label` and attach the explanatory text as a tooltip so the derived recommendation logic is reused unchanged. 
- Adjust display text mapping so `SceneWorkflowStepStatus::Current` is shown as `Needed` in the rail presentation and preserve the `Warnings` label; no status-model or gate logic was changed. 
- Add a focused regression test `tests/test_workflow_rail_compact_rendering.py` that verifies compact rendering, tooltip-backed details, `Warnings` preservation, recommendation usage, and minimum-width / layout expectations.

### Testing
- Ran the focused unit tests: `python3 -m pytest tests/test_workflow_rail_compact_rendering.py`, which passed (3 tests). 
- Performed static checks: `git diff --check` (no whitespace/errors reported). 
- Did not run `colcon build` in this environment because `/opt/ros/humble/setup.bash` is not present, and no GUI runtime validation was performed in the headless container; runtime GUI smoke tests should be run in a ROS Humble workstation prior to merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d15f963548331b46c374becc2c62e)