### PR TITLE
Enforce canonical workspace layout in verify script and update tests

### DIFF
--- a/scripts/verify_workspace_discovery.sh
+++ b/scripts/verify_workspace_discovery.sh
@@ -13,13 +13,23 @@ if ! command -v colcon >/dev/null 2>&1; then
   exit 1
 fi
 
-for alias in assets scenes; do
-  path="$SRC_DIR/$alias"
-  if [[ ! -L "$path" && ! -d "$path" ]]; then
-    echo "Missing workspace alias: $path" >&2
-    exit 1
-  fi
-done
+REPO_DIR="$SRC_DIR/easy_manipulation_deployment"
+if [[ ! -d "$REPO_DIR" ]]; then
+  echo "Missing canonical repository layout: $REPO_DIR" >&2
+  exit 1
+fi
+if [[ ! -d "$REPO_DIR/assets" ]]; then
+  echo "Missing canonical layout/content: $REPO_DIR/assets" >&2
+  exit 1
+fi
+if [[ ! -f "$REPO_DIR/scenes/ur5_2f_test/package.xml" ]]; then
+  echo "Missing canonical layout/content: $REPO_DIR/scenes/ur5_2f_test/package.xml" >&2
+  exit 1
+fi
+if [[ ! -f "$REPO_DIR/workcell_builder/package.xml" ]]; then
+  echo "Missing canonical layout/content: $REPO_DIR/workcell_builder/package.xml" >&2
+  exit 1
+fi
 
 mapfile -t package_rows < <(colcon list --base-paths "$SRC_DIR" 2>/dev/null || true)
 if [[ ${#package_rows[@]} -eq 0 ]]; then
@@ -47,4 +57,4 @@ for pkg in "${required[@]}"; do
   [[ -n "${present[$pkg]:-}" ]] || { echo "Missing required package: $pkg" >&2; exit 1; }
 done
 
-echo "Workspace validation passed: aliases exist, packages are unique, and required packages are discoverable exactly once."
+echo "Workspace validation passed: canonical content exists, packages are unique, and required packages are discoverable exactly once."

--- a/tests/test_workspace_layout_assets_scenes_aliases.py
+++ b/tests/test_workspace_layout_assets_scenes_aliases.py
@@ -1,4 +1,64 @@
+import os
+import shlex
+import subprocess
 from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VERIFY_SCRIPT = REPO_ROOT / "scripts" / "verify_workspace_discovery.sh"
+
+
+def _write_package_xml(path: Path, name: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"<package format='3'><name>{name}</name><version>0.0.0</version>"
+        "<description>test</description>"
+        "<maintainer email='test@example.com'>Test</maintainer>"
+        "<license>Apache-2.0</license></package>\n",
+        encoding="utf-8",
+    )
+
+
+def _make_colcon_stub(bin_dir: Path, rows: list[tuple[str, Path]]) -> None:
+    lines = [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "if [[ ${1:-} != 'list' ]]; then exit 2; fi",
+    ]
+    lines.extend(
+        f"printf '%s %s\\n' {shlex.quote(name)} {shlex.quote(str(path))}"
+        for name, path in rows
+    )
+    colcon = bin_dir / "colcon"
+    colcon.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    colcon.chmod(0o755)
+
+
+def _run_verify(
+    tmp_path: Path, rows: list[tuple[str, Path]]
+) -> subprocess.CompletedProcess[str]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _make_colcon_stub(bin_dir, rows)
+    env = os.environ.copy()
+    env["WORKSPACE_ROOT"] = str(tmp_path / "ws")
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    return subprocess.run(
+        [str(VERIFY_SCRIPT)],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _create_canonical_repo(ws: Path) -> Path:
+    repo = ws / "src" / "easy_manipulation_deployment"
+    (repo / "assets").mkdir(parents=True)
+    _write_package_xml(repo / "scenes" / "ur5_2f_test" / "package.xml", "ur5_2f_test")
+    _write_package_xml(repo / "workcell_builder" / "package.xml", "workcell_builder")
+    return repo
 
 
 def test_fix_workspace_layout_uses_assets_and_scenes_aliases():
@@ -19,9 +79,64 @@ def test_fix_workspace_layout_no_per_package_asset_symlink_creation():
     assert 'Linking repository package' not in text
 
 
-def test_verify_workspace_discovery_accepts_alias_layout():
+def test_verify_workspace_discovery_accepts_canonical_layout_without_aliases(tmp_path):
+    ws = tmp_path / "ws"
+    repo = _create_canonical_repo(ws)
+    result = _run_verify(
+        tmp_path,
+        [
+            ("easy_manipulation_deployment", repo),
+            ("workcell_builder", repo / "workcell_builder"),
+        ],
+    )
+
+    assert result.returncode == 0, result.stderr
+    output = result.stdout + result.stderr
+    assert "Missing workspace alias" not in output
+    assert str(ws / "src" / "assets") not in output
+    assert str(ws / "src" / "scenes") not in output
+    assert not (ws / "src" / "assets").exists()
+    assert not (ws / "src" / "scenes").exists()
+
+
+def test_verify_workspace_discovery_rejects_missing_canonical_content(tmp_path):
+    ws = tmp_path / "ws"
+    repo = ws / "src" / "easy_manipulation_deployment"
+    repo.mkdir(parents=True)
+    _write_package_xml(repo / "workcell_builder" / "package.xml", "workcell_builder")
+    result = _run_verify(
+        tmp_path,
+        [
+            ("easy_manipulation_deployment", repo),
+            ("workcell_builder", repo / "workcell_builder"),
+        ],
+    )
+
+    assert result.returncode != 0
+    assert "Missing canonical layout/content" in result.stderr
+    assert str(repo / "assets") in result.stderr or str(repo / "scenes") in result.stderr
+
+
+def test_verify_workspace_discovery_rejects_duplicate_packages(tmp_path):
+    ws = tmp_path / "ws"
+    repo = _create_canonical_repo(ws)
+    duplicate_repo = ws / "src" / "duplicate_easy_manipulation_deployment"
+    duplicate_repo.mkdir(parents=True)
+    result = _run_verify(
+        tmp_path,
+        [
+            ("easy_manipulation_deployment", repo),
+            ("easy_manipulation_deployment", duplicate_repo),
+            ("workcell_builder", repo / "workcell_builder"),
+        ],
+    )
+
+    assert result.returncode != 0
+    assert "Duplicate package discovered" in result.stderr
+
+
+def test_verify_workspace_discovery_static_markers_present():
     text = Path('scripts/verify_workspace_discovery.sh').read_text(encoding='utf-8')
-    assert 'for alias in assets scenes' in text
     assert 'Duplicate package discovered' in text
     assert 'required=(easy_manipulation_deployment workcell_builder)' in text
 


### PR DESCRIPTION
### Motivation
- Replace legacy reliance on workspace alias symlinks (`src/assets` and `src/scenes`) with checks for a canonical repository layout under `src/easy_manipulation_deployment` containing expected content.
- Ensure workspace discovery validation is stricter and more representative of the repository's canonical structure and that tests reflect the new expectations.

### Description
- Updated `scripts/verify_workspace_discovery.sh` to check for `src/easy_manipulation_deployment`, `assets` directory, `scenes/ur5_2f_test/package.xml`, and `workcell_builder/package.xml` instead of verifying `assets`/`scenes` aliases, and adjusted the success message accordingly.
- Retained package discovery and duplicate/required-package checks via `colcon list` and the existing uniqueness validation logic.
- Rewrote `tests/test_workspace_layout_assets_scenes_aliases.py` to add helpers (`_write_package_xml`, `_make_colcon_stub`, `_run_verify`, `_create_canonical_repo`) and new tests that assert acceptance of the canonical layout, rejection when canonical content is missing, detection of duplicate packages, and updated static marker expectations.

### Testing
- Ran the modified test file with `pytest tests/test_workspace_layout_assets_scenes_aliases.py` which invokes `scripts/verify_workspace_discovery.sh` via a `colcon` stub, and the tests passed.
- The new tests exercise positive and negative cases for canonical layout detection and duplicate package detection and all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d15a564c08331b3c47697e1f44dad)