### PR TITLE
Use colcon package discovery for Humble CI workspace guard

### DIFF
--- a/scripts/verify_workspace_discovery.sh
+++ b/scripts/verify_workspace_discovery.sh
@@ -3,9 +3,16 @@ set -euo pipefail
 
 WORKSPACE_ROOT="${WORKSPACE_ROOT:-$(pwd)}"
 SRC_DIR="${SRC_DIR:-$WORKSPACE_ROOT/src}"
+CANONICAL_REPO="$SRC_DIR/easy_manipulation_deployment"
+CANONICAL_ANCHOR="$CANONICAL_REPO/workcell_builder/package.xml"
+REQUIRED_PACKAGES=(workcell_builder ur5_2f_test workbench_description)
 
 if [[ ! -d "$SRC_DIR" ]]; then
   echo "Workspace src directory not found: $SRC_DIR" >&2
+  exit 1
+fi
+if [[ ! -f "$CANONICAL_ANCHOR" ]]; then
+  echo "Missing main repository anchor: expected $CANONICAL_ANCHOR" >&2
   exit 1
 fi
 if ! command -v colcon >/dev/null 2>&1; then
@@ -13,57 +20,47 @@ if ! command -v colcon >/dev/null 2>&1; then
   exit 1
 fi
 
-CANONICAL_REPO="$SRC_DIR/easy_manipulation_deployment"
-
-canonical_layout_valid=false
-if [[ -d "$CANONICAL_REPO" \
-  && -d "$CANONICAL_REPO/assets" \
-  && -d "$CANONICAL_REPO/scenes" \
-  && -f "$CANONICAL_REPO/workcell_builder/package.xml" \
-  && -f "$CANONICAL_REPO/scenes/ur5_2f_test/package.xml" ]]; then
-  canonical_layout_valid=true
-fi
-
-legacy_layout_valid=false
-if [[ -d "$SRC_DIR/assets" \
-  && -d "$SRC_DIR/scenes" \
-  && -f "$SRC_DIR/scenes/ur5_2f_test/package.xml" ]]; then
-  legacy_layout_valid=true
-fi
-
-if [[ "$canonical_layout_valid" == true ]]; then
-  layout_description="canonical repository layout at $CANONICAL_REPO"
-elif [[ "$legacy_layout_valid" == true ]]; then
-  layout_description="legacy workspace aliases at $SRC_DIR/assets and $SRC_DIR/scenes"
-else
-  echo "Missing workspace layout: expected canonical repo at $CANONICAL_REPO with assets/ and scenes/, or legacy aliases at $SRC_DIR/assets and $SRC_DIR/scenes." >&2
+colcon_output=""
+if ! colcon_output="$(colcon list --base-paths "$SRC_DIR" 2>&1)"; then
+  echo "colcon package discovery failed under $SRC_DIR:" >&2
+  printf '%s\n' "$colcon_output" >&2
   exit 1
 fi
 
-mapfile -t package_rows < <(colcon list --base-paths "$SRC_DIR" 2>/dev/null || true)
+mapfile -t package_rows < <(printf '%s\n' "$colcon_output" | sed '/^[[:space:]]*$/d')
 if [[ ${#package_rows[@]} -eq 0 ]]; then
-  echo "No packages discovered under $SRC_DIR." >&2
+  echo "No packages discovered by: colcon list --base-paths $SRC_DIR" >&2
   exit 1
 fi
 
 declare -A seen=()
 declare -A present=()
 for row in "${package_rows[@]}"; do
-  name="${row%% *}"
-  path="${row#* }"
+  read -r name path _extra <<<"$row"
+  if [[ -z "${name:-}" || -z "${path:-}" ]]; then
+    echo "Invalid colcon list row: $row" >&2
+    exit 1
+  fi
   if [[ -n "${seen[$name]:-}" ]]; then
     echo "Duplicate package discovered: $name" >&2
     echo "  - ${seen[$name]}" >&2
     echo "  - $path" >&2
     exit 1
   fi
+  if [[ ! -f "$path/package.xml" ]]; then
+    echo "Discovered package path is missing package.xml: $name -> $path/package.xml" >&2
+    exit 1
+  fi
   seen[$name]="$path"
   present[$name]=1
 done
 
-required=(easy_manipulation_deployment workcell_builder)
-for pkg in "${required[@]}"; do
-  [[ -n "${present[$pkg]:-}" ]] || { echo "Missing required package: $pkg" >&2; exit 1; }
+for pkg in "${REQUIRED_PACKAGES[@]}"; do
+  if [[ -z "${present[$pkg]:-}" ]]; then
+    echo "Missing required package from colcon discovery: $pkg" >&2
+    echo "Command: colcon list --base-paths $SRC_DIR" >&2
+    exit 1
+  fi
 done
 
-echo "Workspace validation passed: $layout_description is present, packages are unique, and required packages are discoverable exactly once."
+echo "Workspace validation passed: main repository anchor is present, colcon discovered required packages exactly once, and package names are unique."

--- a/tests/test_workspace_layout_assets_scenes_aliases.py
+++ b/tests/test_workspace_layout_assets_scenes_aliases.py
@@ -23,7 +23,13 @@ def _make_colcon_stub(bin_dir: Path, rows: list[tuple[str, Path]]) -> None:
     lines = [
         "#!/usr/bin/env bash",
         "set -euo pipefail",
-        "if [[ ${1:-} != 'list' ]]; then exit 2; fi",
+        "if [[ ${1:-} != 'list' || ${2:-} != '--base-paths' || -z ${3:-} ]]; then exit 2; fi",
+        "count_file=\"${COLCON_STUB_COUNT_FILE:-}\"",
+        "if [[ -n \"$count_file\" ]]; then",
+        "  count=0",
+        "  [[ -f \"$count_file\" ]] && count=$(cat \"$count_file\")",
+        "  printf '%s\\n' $((count + 1)) > \"$count_file\"",
+        "fi",
     ]
     lines.extend(
         f"printf '%s %s\\n' {shlex.quote(name)} {shlex.quote(str(path))}"
@@ -43,6 +49,7 @@ def _run_verify(
     env = os.environ.copy()
     env["WORKSPACE_ROOT"] = str(tmp_path / "ws")
     env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    env["COLCON_STUB_COUNT_FILE"] = str(tmp_path / "colcon-count.txt")
     return subprocess.run(
         [str(VERIFY_SCRIPT)],
         cwd=REPO_ROOT,
@@ -55,9 +62,9 @@ def _run_verify(
 
 def _create_canonical_repo(ws: Path) -> Path:
     repo = ws / "src" / "easy_manipulation_deployment"
-    (repo / "assets").mkdir(parents=True)
-    _write_package_xml(repo / "scenes" / "ur5_2f_test" / "package.xml", "ur5_2f_test")
     _write_package_xml(repo / "workcell_builder" / "package.xml", "workcell_builder")
+    _write_package_xml(repo / "scenes" / "ur5_2f_test" / "package.xml", "ur5_2f_test")
+    _write_package_xml(repo / "assets" / "environment" / "workbench_description" / "package.xml", "workbench_description")
     return repo
 
 
@@ -85,8 +92,9 @@ def test_verify_workspace_discovery_accepts_canonical_layout_without_aliases(tmp
     result = _run_verify(
         tmp_path,
         [
-            ("easy_manipulation_deployment", repo),
             ("workcell_builder", repo / "workcell_builder"),
+            ("ur5_2f_test", repo / "scenes" / "ur5_2f_test"),
+            ("workbench_description", repo / "assets" / "environment" / "workbench_description"),
         ],
     )
 
@@ -97,24 +105,33 @@ def test_verify_workspace_discovery_accepts_canonical_layout_without_aliases(tmp
     assert str(ws / "src" / "scenes") not in output
     assert not (ws / "src" / "assets").exists()
     assert not (ws / "src" / "scenes").exists()
+    assert (tmp_path / "colcon-count.txt").read_text(encoding="utf-8").strip() == "1"
 
 
-def test_verify_workspace_discovery_rejects_missing_canonical_content(tmp_path):
+def test_verify_workspace_discovery_rejects_missing_main_repository_anchor(tmp_path):
     ws = tmp_path / "ws"
     repo = ws / "src" / "easy_manipulation_deployment"
     repo.mkdir(parents=True)
-    _write_package_xml(repo / "workcell_builder" / "package.xml", "workcell_builder")
+    result = _run_verify(tmp_path, [])
+
+    assert result.returncode != 0
+    assert "Missing main repository anchor" in result.stderr
+    assert str(repo / "workcell_builder" / "package.xml") in result.stderr
+
+
+def test_verify_workspace_discovery_rejects_missing_required_package(tmp_path):
+    ws = tmp_path / "ws"
+    repo = _create_canonical_repo(ws)
     result = _run_verify(
         tmp_path,
         [
-            ("easy_manipulation_deployment", repo),
             ("workcell_builder", repo / "workcell_builder"),
+            ("ur5_2f_test", repo / "scenes" / "ur5_2f_test"),
         ],
     )
 
     assert result.returncode != 0
-    assert "Missing canonical layout/content" in result.stderr
-    assert str(repo / "assets") in result.stderr or str(repo / "scenes") in result.stderr
+    assert "Missing required package from colcon discovery: workbench_description" in result.stderr
 
 
 def test_verify_workspace_discovery_rejects_duplicate_packages(tmp_path):
@@ -125,9 +142,10 @@ def test_verify_workspace_discovery_rejects_duplicate_packages(tmp_path):
     result = _run_verify(
         tmp_path,
         [
-            ("easy_manipulation_deployment", repo),
-            ("easy_manipulation_deployment", duplicate_repo),
             ("workcell_builder", repo / "workcell_builder"),
+            ("ur5_2f_test", repo / "scenes" / "ur5_2f_test"),
+            ("workbench_description", repo / "assets" / "environment" / "workbench_description"),
+            ("workbench_description", duplicate_repo),
         ],
     )
 
@@ -138,11 +156,13 @@ def test_verify_workspace_discovery_rejects_duplicate_packages(tmp_path):
 def test_verify_workspace_discovery_static_markers_present():
     text = Path('scripts/verify_workspace_discovery.sh').read_text(encoding='utf-8')
     assert 'CANONICAL_REPO="$SRC_DIR/easy_manipulation_deployment"' in text
-    assert 'canonical repository layout at $CANONICAL_REPO' in text
-    assert 'legacy workspace aliases at $SRC_DIR/assets and $SRC_DIR/scenes' in text
-    assert 'Missing workspace layout: expected canonical repo at $CANONICAL_REPO' in text
+    assert 'CANONICAL_ANCHOR="$CANONICAL_REPO/workcell_builder/package.xml"' in text
+    assert 'Missing main repository anchor' in text
+    assert 'colcon list --base-paths "$SRC_DIR"' in text
     assert 'Duplicate package discovered' in text
-    assert 'required=(easy_manipulation_deployment workcell_builder)' in text
+    assert 'REQUIRED_PACKAGES=(workcell_builder ur5_2f_test workbench_description)' in text
+    assert '$CANONICAL_REPO/assets' not in text
+    assert '$CANONICAL_REPO/scenes' not in text
 
 
 def test_curated_asset_tokens_present():


### PR DESCRIPTION
### Motivation
- Humble CI was failing after rosdep because the workspace guard assumed `assets/` and `scenes/` were direct children of the canonical repo, causing false "Missing workspace layout" failures. 
- The intent is to make the reproducibility guard rely on the repository's actual colcon-discovered packages rather than guessed filesystem layout. 

### Description
- Replace the old guessed-layout checks with a single main repository anchor check at `src/easy_manipulation_deployment/workcell_builder/package.xml` and remove hard-coded `assets/`/`scenes/` existence checks. 
- Run `colcon list --base-paths src` once, parse its output, validate each discovered package path contains `package.xml`, and preserve duplicate-name detection with clear error messages. 
- Require discovery of the real packages `workcell_builder`, `ur5_2f_test`, and `workbench_description` (fail if a required package is missing or discovered more than once). 
- Update the focused verifier tests to stub `colcon list --base-paths` realistically (including invocation tracking) and adjust assertions to cover: canonical layout without aliases, missing main anchor, missing required package, and duplicate discovered packages. 
- Modified files: `scripts/verify_workspace_discovery.sh` and `tests/test_workspace_layout_assets_scenes_aliases.py` (kept changes small and focused). 

### Testing
- Ran a syntax check: `bash -n scripts/verify_workspace_discovery.sh` (passed). 
- Ran the focused verifier suite: `python3 -m pytest tests/test_workspace_layout_assets_scenes_aliases.py -q` (9 passed). 
- Verified the script fails clearly on missing anchor, missing required package, and duplicate package cases via updated tests (all assertions passed). 
- Note: full Humble/Jazzy CI was not run locally; this change is intended to unblock the Humble workflow so `colcon build` can run in CI where full verification will occur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d1d1e88d083319b2bad7350700e87)