### PR TITLE
Fix Humble workspace discovery guard package anchor

### DIFF
--- a/scripts/verify_workspace_discovery.sh
+++ b/scripts/verify_workspace_discovery.sh
@@ -4,15 +4,10 @@ set -euo pipefail
 WORKSPACE_ROOT="${WORKSPACE_ROOT:-$(pwd)}"
 SRC_DIR="${SRC_DIR:-$WORKSPACE_ROOT/src}"
 CANONICAL_REPO="$SRC_DIR/easy_manipulation_deployment"
-CANONICAL_ANCHOR="$CANONICAL_REPO/workcell_builder/package.xml"
 REQUIRED_PACKAGES=(workcell_builder ur5_2f_test workbench_description)
 
 if [[ ! -d "$SRC_DIR" ]]; then
   echo "Workspace src directory not found: $SRC_DIR" >&2
-  exit 1
-fi
-if [[ ! -f "$CANONICAL_ANCHOR" ]]; then
-  echo "Missing main repository anchor: expected $CANONICAL_ANCHOR" >&2
   exit 1
 fi
 if ! command -v colcon >/dev/null 2>&1; then
@@ -63,4 +58,21 @@ for pkg in "${REQUIRED_PACKAGES[@]}"; do
   fi
 done
 
-echo "Workspace validation passed: main repository anchor is present, colcon discovered required packages exactly once, and package names are unique."
+repo_real="$(realpath "$CANONICAL_REPO")"
+workcell_builder_path="${seen[workcell_builder]}"
+workcell_builder_real="$(realpath "$workcell_builder_path")"
+if [[ ! -f "$workcell_builder_real/package.xml" ]]; then
+  echo "Discovered workcell_builder path is missing package.xml: $workcell_builder_real/package.xml" >&2
+  exit 1
+fi
+case "$workcell_builder_real" in
+  "$repo_real"|"$repo_real"/*) ;;
+  *)
+    echo "Discovered workcell_builder path is outside easy_manipulation_deployment checkout: $workcell_builder_real" >&2
+    echo "Expected within: $repo_real" >&2
+    echo "Command: colcon list --base-paths $SRC_DIR" >&2
+    exit 1
+    ;;
+esac
+
+echo "Workspace validation passed: colcon discovered required packages exactly once, workcell_builder resolves inside easy_manipulation_deployment, and package names are unique."

--- a/tests/test_workspace_layout_assets_scenes_aliases.py
+++ b/tests/test_workspace_layout_assets_scenes_aliases.py
@@ -62,7 +62,7 @@ def _run_verify(
 
 def _create_canonical_repo(ws: Path) -> Path:
     repo = ws / "src" / "easy_manipulation_deployment"
-    _write_package_xml(repo / "workcell_builder" / "package.xml", "workcell_builder")
+    _write_package_xml(repo / "workcell_builder" / "workcell_builder" / "package.xml", "workcell_builder")
     _write_package_xml(repo / "scenes" / "ur5_2f_test" / "package.xml", "ur5_2f_test")
     _write_package_xml(repo / "assets" / "environment" / "workbench_description" / "package.xml", "workbench_description")
     return repo
@@ -92,7 +92,7 @@ def test_verify_workspace_discovery_accepts_canonical_layout_without_aliases(tmp
     result = _run_verify(
         tmp_path,
         [
-            ("workcell_builder", repo / "workcell_builder"),
+            ("workcell_builder", repo / "workcell_builder" / "workcell_builder"),
             ("ur5_2f_test", repo / "scenes" / "ur5_2f_test"),
             ("workbench_description", repo / "assets" / "environment" / "workbench_description"),
         ],
@@ -108,15 +108,23 @@ def test_verify_workspace_discovery_accepts_canonical_layout_without_aliases(tmp
     assert (tmp_path / "colcon-count.txt").read_text(encoding="utf-8").strip() == "1"
 
 
-def test_verify_workspace_discovery_rejects_missing_main_repository_anchor(tmp_path):
+def test_verify_workspace_discovery_rejects_workcell_builder_outside_checkout(tmp_path):
     ws = tmp_path / "ws"
-    repo = ws / "src" / "easy_manipulation_deployment"
-    repo.mkdir(parents=True)
-    result = _run_verify(tmp_path, [])
+    repo = _create_canonical_repo(ws)
+    external_repo = ws / "src" / "external_workcell_builder"
+    _write_package_xml(external_repo / "package.xml", "workcell_builder")
+    result = _run_verify(
+        tmp_path,
+        [
+            ("workcell_builder", external_repo),
+            ("ur5_2f_test", repo / "scenes" / "ur5_2f_test"),
+            ("workbench_description", repo / "assets" / "environment" / "workbench_description"),
+        ],
+    )
 
     assert result.returncode != 0
-    assert "Missing main repository anchor" in result.stderr
-    assert str(repo / "workcell_builder" / "package.xml") in result.stderr
+    assert "Discovered workcell_builder path is outside easy_manipulation_deployment checkout" in result.stderr
+    assert str(external_repo) in result.stderr
 
 
 def test_verify_workspace_discovery_rejects_missing_required_package(tmp_path):
@@ -125,7 +133,7 @@ def test_verify_workspace_discovery_rejects_missing_required_package(tmp_path):
     result = _run_verify(
         tmp_path,
         [
-            ("workcell_builder", repo / "workcell_builder"),
+            ("workcell_builder", repo / "workcell_builder" / "workcell_builder"),
             ("ur5_2f_test", repo / "scenes" / "ur5_2f_test"),
         ],
     )
@@ -142,7 +150,7 @@ def test_verify_workspace_discovery_rejects_duplicate_packages(tmp_path):
     result = _run_verify(
         tmp_path,
         [
-            ("workcell_builder", repo / "workcell_builder"),
+            ("workcell_builder", repo / "workcell_builder" / "workcell_builder"),
             ("ur5_2f_test", repo / "scenes" / "ur5_2f_test"),
             ("workbench_description", repo / "assets" / "environment" / "workbench_description"),
             ("workbench_description", duplicate_repo),
@@ -156,8 +164,9 @@ def test_verify_workspace_discovery_rejects_duplicate_packages(tmp_path):
 def test_verify_workspace_discovery_static_markers_present():
     text = Path('scripts/verify_workspace_discovery.sh').read_text(encoding='utf-8')
     assert 'CANONICAL_REPO="$SRC_DIR/easy_manipulation_deployment"' in text
-    assert 'CANONICAL_ANCHOR="$CANONICAL_REPO/workcell_builder/package.xml"' in text
-    assert 'Missing main repository anchor' in text
+    assert 'CANONICAL_ANCHOR' not in text
+    assert 'Missing main repository anchor' not in text
+    assert 'workcell_builder/package.xml' not in text
     assert 'colcon list --base-paths "$SRC_DIR"' in text
     assert 'Duplicate package discovered' in text
     assert 'REQUIRED_PACKAGES=(workcell_builder ur5_2f_test workbench_description)' in text


### PR DESCRIPTION
### Motivation
- The workspace verifier made a hard-coded physical-path assumption for `workcell_builder/package.xml` that fails when the package is nested at `workcell_builder/workcell_builder/package.xml`; this broke Humble workspace validation.
- The change must rely solely on `colcon list --base-paths "$SRC_DIR"` as the source of truth and avoid introducing any new hard-coded package.xml locations.

### Description
- Removed the stale `CANONICAL_ANCHOR` pre-check from `scripts/verify_workspace_discovery.sh` so the script no longer requires a guessed `workcell_builder/package.xml` path.
- Continued to use the single `colcon list --base-paths "$SRC_DIR"` discovery result and require the packages `workcell_builder`, `ur5_2f_test`, and `workbench_description` exactly once from that discovery.
- Added a discovered-path guard for `workcell_builder` that verifies a `package.xml` exists at the discovered path and that the resolved path is inside the `easy_manipulation_deployment` checkout (using `realpath`).
- Preserved duplicate-package detection and clear missing-package errors, and updated verifier tests to reproduce the real nested `workcell_builder/workcell_builder` layout and to reject a discovered `workcell_builder` outside the checkout.

### Testing
- Ran `bash -n scripts/verify_workspace_discovery.sh` and the syntax check passed.
- Ran `python3 -m pytest tests/test_workspace_layout_assets_scenes_aliases.py -q` and the focused verifier tests passed (9 passed).
- Executed a simulated Humble guard invocation with a stubbed `colcon` and a nested `workcell_builder/workcell_builder` layout and observed the verifier progress past the previous anchor failure to a successful validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d20f5634083318095b21ce38d437f)