### PR TITLE
Add trustworthy physical bounds for Product View

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -1015,3 +1015,78 @@ def test_expanded_urdf_robot_assembly_stays_locked_single_root_and_legacy_rows_s
     assert ready_body.count("rendererContext?.scene?.add?.(robot)") == 1
     assert ready_body.count("rendererContext?.assemblyRoots?.push?.(robot)") == 1
     assert "world/root fixed chain -> URDF joint origin -> joint value -> link frame" in renderer
+
+
+def test_collect_physical_visible_bounds_filters_product_view_geometry():
+    js_path = VIEWER / "viewer.js"
+    harness = r'''
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+let source = fs.readFileSync(process.argv[1], 'utf8').replace(/boot\(\);\s*$/, '');
+class MockVector3 {
+  constructor(x = 0, y = 0, z = 0) { this.x = x; this.y = y; this.z = z; }
+}
+class MockBox3 {
+  constructor(min, max) {
+    if (max) { this.min = { ...min }; this.max = { ...max }; }
+    else { this.min = { x: Infinity, y: Infinity, z: Infinity }; this.max = { x: -Infinity, y: -Infinity, z: -Infinity }; }
+  }
+  isEmpty() { return this.min.x > this.max.x || this.min.y > this.max.y || this.min.z > this.max.z; }
+  union(box) {
+    this.min.x = Math.min(this.min.x, box.min.x); this.min.y = Math.min(this.min.y, box.min.y); this.min.z = Math.min(this.min.z, box.min.z);
+    this.max.x = Math.max(this.max.x, box.max.x); this.max.y = Math.max(this.max.y, box.max.y); this.max.z = Math.max(this.max.z, box.max.z);
+    return this;
+  }
+  setFromObject(object) { this.min = { ...object.mockBounds.min }; this.max = { ...object.mockBounds.max }; return this; }
+  getSize(target) { target.x = this.max.x - this.min.x; target.y = this.max.y - this.min.y; target.z = this.max.z - this.min.z; return target; }
+  getCenter(target) { target.x = (this.min.x + this.max.x) / 2; target.y = (this.min.y + this.max.y) / 2; target.z = (this.min.z + this.max.z) / 2; return target; }
+  clone() { return new MockBox3(this.min, this.max); }
+}
+const element = () => ({ hidden: false, checked: false, disabled: false, textContent: '', className: '', innerHTML: '', classList: { toggle() {} }, setAttribute() {}, querySelector() { return { textContent: '' }; }, appendChild() {}, addEventListener() {}, getBoundingClientRect() { return { width: 800, height: 600, left: 0, top: 0 }; } });
+const sandbox = { console, assert, MockVector3, MockBox3, window: { location: { search: '' } }, document: { getElementById() { return element(); }, createElement() { return element(); } }, URLSearchParams, requestAnimationFrame() { return 0; } };
+vm.createContext(sandbox);
+vm.runInContext(source + `
+THREE = { Vector3: MockVector3, Box3: MockBox3 };
+function root(children = []) { return { visible: true, children, userData: {}, updateWorldMatrix() {} }; }
+function mesh(id, min, max, userData = {}) { return { isMesh: true, visible: true, children: [], name: id, mockBounds: { min, max }, userData }; }
+const physical = mesh('table', { x: 1, y: 2, z: 3 }, { x: 2, y: 3, z: 4 }, { item: { id: 'workbench', category: 'table', source_layer: 'editable_layout' } });
+let result = collectPhysicalVisibleBounds(root([physical]));
+assert.strictEqual(result.count, 1);
+assert.deepStrictEqual(result.bounds_json.min, { x: 1, y: 2, z: 3 });
+assert.deepStrictEqual(result.bounds_json.max, { x: 2, y: 3, z: 4 });
+
+const hidden = mesh('hidden', { x: -100, y: -100, z: -100 }, { x: -90, y: -90, z: -90 }, { item: { id: 'hidden_part', category: 'object' } });
+hidden.visible = false;
+const grid = mesh('grid', { x: -50, y: -50, z: 0 }, { x: 50, y: 50, z: 0 }, {}); grid.isGridHelper = true;
+const axes = mesh('axes', { x: -50, y: -50, z: 0 }, { x: 50, y: 50, z: 50 }, {}); axes.isAxesHelper = true;
+const zone = mesh('pick_zone', { x: -20, y: -20, z: 0 }, { x: 20, y: 20, z: 1 }, { item: { id: 'pick_zone', category: 'safety_zone', source_layer: 'editable_layout' } });
+const outline = mesh('selection', { x: -10, y: -10, z: -10 }, { x: 10, y: 10, z: 10 }, { selection_outline: true, item: { id: 'selection_outline', role: 'selection_highlight' } });
+result = collectPhysicalVisibleBounds(root([physical, hidden, grid, axes, zone, outline]));
+assert.strictEqual(result.count, 1);
+assert.deepStrictEqual(result.bounds_json.min, { x: 1, y: 2, z: 3 });
+
+const fallback = mesh('robot_box', { x: -100, y: -1, z: 0 }, { x: -90, y: 1, z: 2 }, { item: { id: 'robot_fallback', role: 'robot', source_layer: 'primitive_fallback', active_visual_source: 'primitive_fallback' } });
+const generated = mesh('robot_mesh', { x: 0, y: 0, z: 0 }, { x: 1, y: 1, z: 1 }, { item: { id: 'ur5_mesh', role: 'robot', source_layer: 'locked_generated_urdf_visual', active_visual_source: 'mesh_preview' } });
+result = collectPhysicalVisibleBounds(root([fallback, generated]));
+assert.strictEqual(result.count, 1);
+assert.deepStrictEqual(result.bounds_json.min, { x: 0, y: 0, z: 0 });
+
+result = collectPhysicalVisibleBounds(root([]));
+assert.strictEqual(result.count, 0);
+assert.strictEqual(result.bounds, null);
+assert.strictEqual(result.bounds_json, null);
+
+const finite = collectPhysicalVisibleBounds(root([physical])).bounds_json;
+for (const section of ['min', 'max', 'center', 'dimensions']) for (const value of Object.values(finite[section])) assert.strictEqual(Number.isFinite(value), true);
+`, sandbox);
+'''
+    result = subprocess.run(
+        ["node", "-e", harness, str(js_path)],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert result.stderr == ""

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -1695,6 +1695,82 @@ function animate() {
   updateLabels();
 }
 
+
+function physicalBoundsIdentityFor(object) {
+  const item = object?.userData?.item || {};
+  return [
+    object?.userData?.source_layer,
+    object?.userData?.active_visual_source,
+    object?.userData?.role,
+    object?.userData?.category,
+    object?.userData?.id,
+    object?.userData?.display_name,
+    object?.userData?.status,
+    object?.userData?.mesh_load_warning,
+    item?.source_layer,
+    item?.active_visual_source,
+    item?.role,
+    item?.category,
+    item?.type,
+    item?.id,
+    item?.display_name,
+    item?.status,
+    item?.mesh_load_warning,
+    ...(Array.isArray(item?.warnings) ? item.warnings : []),
+    itemLabel(item || {}),
+  ].map(value => String(value || '').toLowerCase().replace(/[_-]+/g, ' ')).join(' ');
+}
+function physicalBoundsItemFor(object, nearestItem = null) {
+  return object?.userData?.item || nearestItem || object?.userData || {};
+}
+function isPhysicalBoundsHelperObject(object, item, identity) {
+  if (!object || object.visible === false) return true;
+  if (object.isGridHelper || object.isAxesHelper) return true;
+  if (object.userData?.selection_outline === true || object.userData?.selection_highlight === true) return true;
+  if (object.userData?.exclude_from_physical_bounds === true || object.userData?.exclude_from_fit_bounds === true) return true;
+  if (item?.exclude_from_physical_bounds === true || item?.exclude_from_fit_bounds === true) return true;
+  return DEBUG_OVERLAY_TOKEN_RE.test(identity);
+}
+function isRobotPrimitiveFallbackObject(object, item, identity) {
+  const visualSource = String(item?.active_visual_source || object?.userData?.active_visual_source || '').toLowerCase();
+  const sourceLayer = String(item?.source_layer || object?.userData?.source_layer || '').toLowerCase();
+  return /primitive fallback|fallback/.test(identity) && /robot|arm|manipulator|ur3|ur5|ur10|universal robot|base link|shoulder|wrist/.test(identity)
+    && (visualSource.includes('primitive_fallback') || visualSource.includes('fallback') || sourceLayer.includes('primitive_fallback'));
+}
+function collectPhysicalVisibleBounds(root, options = {}) {
+  if (!root || !THREE?.Box3) return { count: 0, bounds: null, bounds_json: null };
+  root.updateWorldMatrix?.(true, true);
+  const bounds = new THREE.Box3();
+  const candidates = [];
+  let hasGeneratedRobotMesh = false;
+  const visit = (node, nearestItem = null) => {
+    if (!node || node.visible === false) return;
+    const item = physicalBoundsItemFor(node, nearestItem);
+    const identity = physicalBoundsIdentityFor(node);
+    const nextNearestItem = node?.userData?.item || nearestItem;
+    const isRenderable = node.isMesh || node.isLine || node.isLineSegments || node.isPoints || node.isSprite;
+    if (isRenderable && !isPhysicalBoundsHelperObject(node, item, identity)) {
+      const visualSource = String(item?.active_visual_source || node?.userData?.active_visual_source || '').toLowerCase();
+      const isGenerated = /generated|urdf/.test(identity);
+      const isRobot = /robot|arm|manipulator|ur3|ur5|ur10|universal robot|base link|shoulder|wrist/.test(identity);
+      if (isGenerated && isRobot && /mesh|generated urdf visual|mesh preview/.test(visualSource.replace(/_/g, ' '))) hasGeneratedRobotMesh = true;
+      candidates.push({ node, item, identity });
+    }
+    for (const child of node.children || []) visit(child, nextNearestItem);
+  };
+  visit(root);
+  let count = 0;
+  for (const candidate of candidates) {
+    if (hasGeneratedRobotMesh && isRobotPrimitiveFallbackObject(candidate.node, candidate.item, candidate.identity)) continue;
+    const nodeBounds = finiteBox3(new THREE.Box3().setFromObject(candidate.node));
+    if (!nodeBounds) continue;
+    bounds.union(nodeBounds);
+    count += 1;
+  }
+  const finite = count ? finiteBox3(bounds) : null;
+  return { count: finite ? count : 0, bounds: finite, bounds_json: box3ToJson(finite) };
+}
+
 function visibleRenderableBounds(object) {
   if (!object || object.visible === false) return null;
   object.updateWorldMatrix(true, true);


### PR DESCRIPTION
### Motivation
- Camera fitting sometimes includes helper/diagnostic objects (grids, zones, labels, primitive fallbacks) and we need a single reliable helper that returns bounds for visible physical workcell geometry only.
- The function must rely on existing scene identity metadata and avoid mutating scene objects or camera state.

### Description
- Added small identity/item helpers and `collectPhysicalVisibleBounds(root, options)` to `workcell_studio_web/viewer/viewer.js` which traverses visible descendants, uses metadata tokens (`source_layer`, `active_visual_source`, `role`, `category`, `id`, `display_name`, `status`, `warnings`, `mesh_load_warning`) and returns finite product-geometry bounds while excluding helpers and diagnostics.
- The helper excludes invisible objects, `GridHelper`/`AxesHelper`, selection outlines/highlights, debug/helper overlay tokens, zones, camera FOVs, and suppresses primitive robot fallback boxes when a generated robot mesh is present, without changing camera or scene state.
- Added focused static coverage in `tests/test_workcell_studio_web_viewer_static.py` that validates inclusion of physical meshes, exclusion of hidden/grid/axes/helper/selection objects, suppression of primitive robot fallback when generated robot mesh exists, empty-scene handling, and that returned bounds have finite numeric values.

### Testing
- Ran `git diff --check` which reported no problems before committing and static checks passed.
- Ran `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py -q` and the test suite passed (`46 passed`), including the new focused tests for `collectPhysicalVisibleBounds`.
- Changed files and line totals: `workcell_studio_web/viewer/viewer.js`: +76 / -0; `tests/test_workcell_studio_web_viewer_static.py`: +75 / -0; total 2 files changed, +151 / -0.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5dd43986e08331910118911cd8d247)