### PR TITLE
Improve Product View visibility with a light RViz-style theme

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -266,6 +266,46 @@ def test_viewer_ground_grid_is_ros_xy_not_threejs_default_xz_y_up():
     assert "grid.rotation.x = Math.PI / 2;" in init_body
 
 
+
+def test_viewer_product_workspace_uses_single_light_neutral_background():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    init_body = js.split("function initThree()", 1)[1].split("function animate()", 1)[0]
+
+    assert "const PRODUCT_VIEW_WORKSPACE_BACKGROUND = 0xe9edf1;" in js
+    assert "scene.background = new THREE.Color(PRODUCT_VIEW_WORKSPACE_BACKGROUND);" in init_body
+    assert "scene.background = new THREE.Color(0x0b1018);" not in js
+    assert js.count("PRODUCT_VIEW_WORKSPACE_BACKGROUND") == 2
+
+
+def test_viewer_product_grid_uses_distinct_subtle_major_minor_theme_colours():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    init_body = js.split("function initThree()", 1)[1].split("function animate()", 1)[0]
+
+    assert "const PRODUCT_VIEW_GRID_MAJOR = 0x8996a3;" in js
+    assert "const PRODUCT_VIEW_GRID_MINOR = 0xc3cbd3;" in js
+    assert "new THREE.GridHelper(5, 20, PRODUCT_VIEW_GRID_MAJOR, PRODUCT_VIEW_GRID_MINOR)" in init_body
+    assert "new THREE.GridHelper(5, 20, 0x3a4a5e, 0x263445)" not in js
+    assert "grid.name = 'ros_xy_ground_grid';" in init_body
+
+
+def test_viewer_product_theme_keeps_grid_controls_and_bounds_exclusions():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+
+    assert "if (el.resetView) el.resetView.addEventListener('click', resetView);" in js
+    assert "object.isGridHelper || object.isAxesHelper" in js
+    assert "object.userData?.selection_outline === true" in js
+    assert "camera.position.set(2.4, -2.8, 1.8);" in js
+    assert "fitSelection" not in js
+
+
+def test_viewer_product_theme_is_scene_independent():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    init_body = js.split("function initThree()", 1)[1].split("function animate()", 1)[0]
+
+    for scene_name in ["ur5_2f_test", "ur5_3f_test", "ur3_suction_test", "ur10_2f_test", "suction_test"]:
+        assert scene_name not in init_body
+    assert "sceneId()" not in init_body
+
 def test_repository_does_not_track_generated_web_scene_outputs_under_source_paths():
     result = subprocess.run(
         ["git", "ls-files", "*.web_scene.json"],

--- a/workcell_studio_web/viewer/style.css
+++ b/workcell_studio_web/viewer/style.css
@@ -1,14 +1,14 @@
 :root {
-  color-scheme: dark;
-  --bg: #10151d;
-  --panel: #18212d;
-  --panel-2: #202b39;
-  --text: #eef5ff;
-  --muted: #aeb9c8;
-  --accent: #62d2ff;
-  --warn: #ffc857;
-  --error: #ff6b6b;
-  --border: #334256;
+  color-scheme: light;
+  --bg: #e9edf1;
+  --panel: #f8fafc;
+  --panel-2: #eef2f6;
+  --text: #17202a;
+  --muted: #526173;
+  --accent: #0078a8;
+  --warn: #b26b00;
+  --error: #c43434;
+  --border: #c5ced8;
 }
 
 * { box-sizing: border-box; }
@@ -45,7 +45,7 @@ body {
   padding: 0.55rem 0.8rem;
   border: 1px solid var(--accent);
   border-radius: 0.5rem;
-  background: #123040;
+  background: #d7edf7;
   color: var(--text);
   cursor: pointer;
   white-space: nowrap;
@@ -60,7 +60,7 @@ body {
   padding: 0.55rem 0.8rem;
   white-space: nowrap;
 }
-.toolbar-button:not(:disabled):hover { border-color: var(--accent); background: #14364a; }
+.toolbar-button:not(:disabled):hover { border-color: var(--accent); background: #d7edf7; }
 .toolbar-button:disabled { cursor: not-allowed; opacity: 0.45; }
 
 .toolbar-number {
@@ -70,7 +70,7 @@ body {
   padding: 0.38rem 0.55rem;
   border: 1px solid var(--border);
   border-radius: 0.5rem;
-  background: rgba(32, 43, 57, 0.72);
+  background: rgba(248, 250, 252, 0.86);
   color: var(--muted);
   font-size: 0.78rem;
   white-space: nowrap;
@@ -80,7 +80,7 @@ body {
   padding: 0.25rem 0.3rem;
   border: 1px solid var(--border);
   border-radius: 0.3rem;
-  background: #0b1018;
+  background: #ffffff;
   color: var(--text);
 }
 .toolbar-toggle {
@@ -90,7 +90,7 @@ body {
   padding: 0.45rem 0.65rem;
   border: 1px solid var(--border);
   border-radius: 0.5rem;
-  background: rgba(32, 43, 57, 0.72);
+  background: rgba(248, 250, 252, 0.86);
   color: var(--muted);
   cursor: pointer;
   font-size: 0.86rem;
@@ -115,7 +115,7 @@ body {
 .details-panel { border-left: 1px solid var(--border); }
 h2 { margin: 0 0 0.75rem; font-size: 0.95rem; color: var(--accent); }
 
-.viewport-panel { position: relative; min-width: 0; background: #0b1018; }
+.viewport-panel { position: relative; min-width: 0; background: var(--bg); }
 #scene-canvas { width: 100%; height: 100%; display: block; }
 
 .label-layer {
@@ -132,23 +132,23 @@ h2 { margin: 0 0 0.75rem; font-size: 0.95rem; color: var(--accent); }
   top: 0;
   max-width: 10rem;
   padding: 0.16rem 0.42rem;
-  border: 1px solid rgba(98, 210, 255, 0.45);
+  border: 1px solid rgba(0, 120, 168, 0.45);
   border-radius: 999px;
-  background: rgba(11, 16, 24, 0.68);
+  background: rgba(248, 250, 252, 0.86);
   box-shadow: 0 0.2rem 0.8rem rgba(0, 0, 0, 0.22);
-  color: #d9f7ff;
+  color: #123040;
   font-size: 0.72rem;
   font-weight: 600;
   line-height: 1.25;
   overflow: hidden;
   text-overflow: ellipsis;
-  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.8);
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.75);
   white-space: nowrap;
 }
 .object-label.selected {
   border-color: var(--accent);
-  background: rgba(20, 54, 74, 0.82);
-  color: #ffffff;
+  background: rgba(0, 120, 168, 0.16);
+  color: #0b3345;
 }
 .state {
   padding: 0.75rem;
@@ -166,14 +166,14 @@ h2 { margin: 0 0 0.75rem; font-size: 0.95rem; color: var(--accent); }
   right: 1rem;
   color: #fff;
   border-color: var(--error);
-  background: rgba(106, 26, 35, 0.94);
+  background: rgba(139, 30, 45, 0.94);
 }
 .warning-item {
   margin: 0 0 0.5rem;
   padding: 0.55rem;
   border-left: 3px solid var(--warn);
-  background: #312914;
-  color: #ffe7a3;
+  background: #fff6dd;
+  color: #5f3a00;
 }
 
 .scene-summary {
@@ -197,7 +197,7 @@ h2 { margin: 0 0 0.75rem; font-size: 0.95rem; color: var(--accent); }
 .summary-grid span { color: var(--muted); }
 .summary-grid strong {
   max-width: 8rem;
-  color: #c9f2ff;
+  color: #0b5f80;
   font-size: 0.82rem;
   overflow: hidden;
   text-align: right;
@@ -214,7 +214,7 @@ h2 { margin: 0 0 0.75rem; font-size: 0.95rem; color: var(--accent); }
   background: var(--panel-2);
   cursor: pointer;
 }
-.object-list li:hover, .object-list li.selected { border-color: var(--accent); background: #14364a; }
+.object-list li:hover, .object-list li.selected { border-color: var(--accent); background: #d7edf7; }
 .object-list .object-group-heading {
   margin: 0.75rem 0 0.35rem;
   padding: 0.2rem 0.1rem;
@@ -237,7 +237,7 @@ h2 { margin: 0 0 0.75rem; font-size: 0.95rem; color: var(--accent); }
   padding: 0.12rem 0.35rem;
   border: 1px solid var(--border);
   border-radius: 999px;
-  color: #c9f2ff;
+  color: #0b5f80;
   font-size: 0.68rem;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -248,16 +248,16 @@ h2 { margin: 0 0 0.75rem; font-size: 0.95rem; color: var(--accent); }
   padding: 0.12rem 0.35rem;
   border: 1px solid var(--border);
   border-radius: 999px;
-  color: #d8f7df;
+  color: #176734;
   font-size: 0.68rem;
   line-height: 1.1;
 }
 .object-list .status-loaded, .object-list .status-mesh_loaded { color: #8df5a8; }
-.object-list .status-load_error, .object-list .status-missing_file, .object-list .status-unsafe_path, .object-list .status-unsupported_format, .object-list .status-unresolved_package_uri, .object-list .status-loader_failure, .object-list .status-url_not_served, .object-list .status-file_access_blocked, .object-list .status-required_mesh_failed_debug_fallback { color: #ffb4a8; border-color: rgba(255, 180, 168, 0.7); background: rgba(255, 43, 214, 0.12); }
+.object-list .status-load_error, .object-list .status-missing_file, .object-list .status-unsafe_path, .object-list .status-unsupported_format, .object-list .status-unresolved_package_uri, .object-list .status-loader_failure, .object-list .status-url_not_served, .object-list .status-file_access_blocked, .object-list .status-required_mesh_failed_debug_fallback { color: #9d2633; border-color: rgba(196, 52, 52, 0.45); background: rgba(196, 52, 52, 0.08); }
 .inspector-table { width: 100%; border-collapse: collapse; font-size: 0.86rem; }
 .inspector-table th, .inspector-table td { padding: 0.35rem 0.2rem; border-bottom: 1px solid var(--border); vertical-align: top; }
 .inspector-table th { width: 38%; text-align: left; color: var(--muted); font-weight: 600; }
-code { color: #c9f2ff; }
+code { color: #0b5f80; }
 
 @media (max-width: 900px) {
   .app-shell { grid-template-columns: 1fr; grid-template-rows: auto minmax(24rem, 1fr) auto; height: auto; }
@@ -272,20 +272,20 @@ code { color: #c9f2ff; }
   right: 1rem;
   top: 1rem;
   border-color: var(--warn);
-  background: rgba(49, 41, 20, 0.94);
-  color: #ffe7a3;
+  background: #fff6dd;
+  color: #5f3a00;
 }
 .transform-editor {
   margin-top: 0.85rem;
   padding: 0.75rem;
   border: 1px solid var(--border);
   border-radius: 0.5rem;
-  background: rgba(32, 43, 57, 0.72);
+  background: rgba(248, 250, 252, 0.86);
 }
 .transform-editor h3 { margin: 0 0 0.45rem; font-size: 0.9rem; color: var(--accent); }
 .edit-mode-active { border-left: 3px solid var(--accent); padding-left: 0.5rem; }
 .edit-note, .edit-lock-reason { margin: 0 0 0.65rem; color: var(--muted); font-size: 0.8rem; }
-.edit-lock-reason { color: #ffe7a3; }
+.edit-lock-reason { color: #5f3a00; }
 .transform-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.45rem; }
 .transform-grid label { color: var(--muted); font-size: 0.75rem; }
 .transform-grid input {
@@ -295,7 +295,7 @@ code { color: #c9f2ff; }
   padding: 0.35rem;
   border: 1px solid var(--border);
   border-radius: 0.35rem;
-  background: #0b1018;
+  background: #ffffff;
   color: var(--text);
 }
 .transform-grid input:disabled { cursor: not-allowed; opacity: 0.55; }

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -6,6 +6,10 @@ let OBJLoader;
 let TransformControls;
 let loadRobotPreview;
 
+const PRODUCT_VIEW_WORKSPACE_BACKGROUND = 0xe9edf1;
+const PRODUCT_VIEW_GRID_MAJOR = 0x8996a3;
+const PRODUCT_VIEW_GRID_MINOR = 0xc3cbd3;
+
 const SUPPORTED_SCHEMA_VERSION = 'workcell_studio_web_scene/v1';
 const EDIT_PATCH_SCHEMA_VERSION = 'workcell_studio_web_scene_edit_patch/v1';
 const VIEWER_VERSION = 'static_web_viewer_edit_patch_v1';
@@ -1636,21 +1640,21 @@ function initThree() {
     renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
     const scene = new THREE.Scene();
     scene.up.copy(ROS_Z_UP);
-    scene.background = new THREE.Color(0x0b1018);
+    scene.background = new THREE.Color(PRODUCT_VIEW_WORKSPACE_BACKGROUND);
     const camera = new THREE.PerspectiveCamera(55, 1, 0.01, 100);
     camera.up.copy(ROS_Z_UP);
     camera.position.set(2.4, -2.8, 1.8);
     const controls = new OrbitControls(camera, renderer.domElement);
     controls.object.up.copy(ROS_Z_UP);
     controls.enableDamping = true;
-    const grid = new THREE.GridHelper(5, 20, 0x3a4a5e, 0x263445);
+    const grid = new THREE.GridHelper(5, 20, PRODUCT_VIEW_GRID_MAJOR, PRODUCT_VIEW_GRID_MINOR);
     grid.name = 'ros_xy_ground_grid';
     grid.up.copy(ROS_Z_UP);
     grid.rotation.x = Math.PI / 2;
     scene.add(grid);
     scene.add(new THREE.AxesHelper(0.75));
-    scene.add(new THREE.HemisphereLight(0xffffff, 0x223344, 1.2));
-    const light = new THREE.DirectionalLight(0xffffff, 1.5); light.position.set(2, -3, 4); scene.add(light);
+    scene.add(new THREE.HemisphereLight(0xffffff, 0x8a96a3, 1.25));
+    const light = new THREE.DirectionalLight(0xffffff, 1.35); light.position.set(2, -3, 4); scene.add(light);
     const transformControls = new TransformControls(camera, renderer.domElement);
     transformControls.setMode('translate');
     transformControls.addEventListener('dragging-changed', event => {


### PR DESCRIPTION
### Motivation
- The embedded Product View used an excessively dark theme that reduced contrast for white/grey/metallic meshes, making inspection and editing harder. 
- The change is scoped to visual theme only and aims to provide a light neutral RViz-like workspace while preserving selection, grid controls, axes, and existing scene behavior. 

### Description
- Introduced `PRODUCT_VIEW_WORKSPACE_BACKGROUND`, `PRODUCT_VIEW_GRID_MAJOR`, and `PRODUCT_VIEW_GRID_MINOR` constants in `workcell_studio_web/viewer/viewer.js` and applied them to `scene.background` and the `THREE.GridHelper`, preserving grid size and ROS XY orientation. 
- Slightly adjusted existing `HemisphereLight` and `DirectionalLight` intensities to suit the lighter background without adding new lighting systems. 
- Reworked the viewer CSS `workcell_studio_web/viewer/style.css` variables and several overlay panel/label/warning colors to a light palette (`--bg: #e9edf1`) so in-view text and status panels remain readable. 
- Added focused static tests in `tests/test_workcell_studio_web_viewer_static.py` that assert a single neutral background constant, distinct grid major/minor colors, preserved grid/axes/bounds-exclusion logic, and scene-independence of the theme. 

### Testing
- Ran the focused Product View static tests with `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py -q -k 'product_theme or product_workspace or product_grid or ground_grid or collect_physical_visible_bounds or load_scene_url_sets_state_and_renders_items or selection'` and they passed (`7 passed, 44 deselected`). 
- A full run of the viewer static tests initially surfaced an unrelated assertion failure in a preexisting auto-frame helper test, but the focused Product View theme tests (the targeted validation for this change) passed successfully after the tweak. 
- No browser/runtime visual validation was performed in this non-interactive environment and should be performed manually against `scenes/ur5_2f_test` and one suction and one alternate UR scene as part of final acceptance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5dd9087710833194254a09302f14bc)