### PR TITLE
Prevent physical scene assets from disappearing in Product View

### DIFF
--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -43,7 +43,7 @@ INPUTS = {
     "visual_mesh_index": "generated/scene_visual_mesh_index.json",
 }
 SUPPORTED_MESH_SUFFIXES = {".stl", ".dae", ".obj"}
-MESH_URI_FIELDS = ("mesh_uri", "package_uri", "mesh_path", "source_path", "resolved_source_path")
+MESH_URI_FIELDS = ("mesh_uri", "package_uri", "mesh_path", "source_path", "resolved_source_path", "filepath")
 ROBOTIQ_85_VISUAL_MESHES = {
     "gripper_base_link": "robotiq_85_base_link.dae",
     "gripper_finger1_knuckle_link": "robotiq_85_knuckle_link.dae",
@@ -1276,10 +1276,67 @@ def _annotate_parent_to_child_poses(generated: Dict[str, List[Json]]) -> None:
             "parent_joint_origin": "web_export_parent_world_inverse_times_child_world",
         })
 
+
+
+def _iter_declared_physical_entries(data: Mapping[str, Any]) -> Iterable[Tuple[str, Mapping[str, Any], str]]:
+    """Yield authored physical scene entries through one shared path.
+
+    Scene files have evolved from top-level objects/assets to nested
+    environment sections and layout items.  Product View should classify helpers
+    explicitly, but unfamiliar tangible declarations still need an exported
+    record instead of disappearing because the section name is not special-cased.
+    """
+    roots: List[Tuple[str, Mapping[str, Any]]] = []
+    layout = _as_map(data.get("layout"))
+    if layout:
+        roots.append((INPUTS["layout"], layout))
+    env = _as_map(data.get("environment"))
+    if env:
+        roots.extend([(INPUTS["environment"], env), (INPUTS["environment"], _as_map(env.get("environment")))])
+    cell = _as_map(data.get("cell_definition"))
+    if cell:
+        roots.extend([(INPUTS["cell_definition"], cell), (INPUTS["cell_definition"], _as_map(cell.get("environment")))])
+
+    seen: set[Tuple[str, str, int]] = set()
+    for source, root in roots:
+        for key in ("items", "support_surfaces", "assets", "sensors", "objects", "placed_objects", "tools", "zones"):
+            value = root.get(key)
+            entries: Iterable[Tuple[str, Any]]
+            if isinstance(value, Mapping):
+                entries = value.items()
+            else:
+                entries = ((str(i), raw) for i, raw in enumerate(_as_list(value)))
+            for entry_key, raw in entries:
+                if not isinstance(raw, Mapping):
+                    continue
+                ident = (source, key, id(raw))
+                if ident in seen:
+                    continue
+                seen.add(ident)
+                item = dict(raw)
+                item.setdefault("id", str(_first_present(raw.get("id"), raw.get("name"), entry_key)))
+                item.setdefault("source_section", key)
+                # Legacy EMD object declarations often bury their visual mesh under
+                # links.<link>.visual.geometry.filepath; expose it to the normal
+                # resolver/stager without adding section-specific render logic.
+                links = raw.get("links")
+                if isinstance(links, Mapping) and not _has_mesh_reference(item):
+                    for link_name, link in links.items():
+                        geom = _as_map(_as_map(_as_map(link).get("visual")).get("geometry"))
+                        mesh = geom.get("filepath") or geom.get("mesh_uri") or geom.get("mesh_path")
+                        if isinstance(mesh, str) and mesh:
+                            item["mesh_path"] = mesh
+                            item.setdefault("link", str(link_name))
+                            scale = _as_map(geom.get("scale"))
+                            if scale:
+                                item.setdefault("mesh_scale", [scale.get("scale_x", 1), scale.get("scale_y", 1), scale.get("scale_z", 1)])
+                            break
+                yield key, item, source
+
 def _authored_item(raw: Mapping[str, Any], source: str, index: int, scene_dir: Path) -> Json:
     fields = (
-        "id", "type", "role", "category", "display_name", "frame", "pose", "pose_xyz", "pose_rpy", "dimensions",
-        "geometry_type", "primitive_geometry_type", "mesh_uri", "package_uri", "source_path", "mesh_path", "material",
+        "id", "type", "role", "category", "display_name", "source_section", "link", "object_name", "frame", "pose", "pose_xyz", "pose_rpy", "dimensions",
+        "geometry_type", "primitive_geometry_type", "mesh_uri", "package_uri", "source_path", "mesh_path", "filepath", "material",
         "layout_item_ref", "support_surface_ref", "task_zone_ref", "scale", "mesh_scale", "perception_mode", "runtime_enforced", "runtime_commanded",
         "support_surface_kind", "support_kind", "semantic_type", "top_surface_z_m", "topSurfaceZM", "support_surface_height_m", "supportSurfaceHeightM",
         "expected_support_footprint_m", "support_footprint_m", "footprint_m", "footprint", "table_height", "table_top_z", "surface_height_m",
@@ -1295,26 +1352,21 @@ def _authored_item(raw: Mapping[str, Any], source: str, index: int, scene_dir: P
 
 def _authored_sections(data: Dict[str, Any], scene_dir: Path, warnings: List[Json]) -> Dict[str, List[Json]]:
     sections = {"assets": [], "sensors": [], "zones": []}
-    counter = 0
-    layout = _as_map(data.get("layout"))
-    layout_items = _as_list(layout.get("items"))
-    if data.get("layout") is not None and "items" not in layout:
+    if data.get("layout") is not None and "items" not in _as_map(data.get("layout")):
         _warn(warnings, "layout_items_missing", "layout/workcell_studio_layout.yaml has no items list.", INPUTS["layout"])
-    for raw in layout_items:
-        if isinstance(raw, Mapping):
-            item = _authored_item(raw, INPUTS["layout"], counter, scene_dir)
-            counter += 1
-            sections[_section_from_item(raw) if _section_from_item(raw) in sections else "assets"].append(item)
-
-    env = _as_map(data.get("environment"))
-    env_root = _as_map(env.get("environment"))
-    for key in ("support_surfaces", "assets", "sensors", "zones"):
-        for raw in _as_list(env_root.get(key)):
-            if isinstance(raw, Mapping):
-                item = _authored_item(raw, INPUTS["environment"], counter, scene_dir)
-                counter += 1
-                section = "sensors" if key == "sensors" or _section_from_item(raw) == "sensors" else ("zones" if key == "zones" or _is_helper(raw) else "assets")
-                sections[section].append(item)
+    for counter, (source_section, raw, source) in enumerate(_iter_declared_physical_entries(data)):
+        item = _authored_item(raw, source, counter, scene_dir)
+        item["source_section"] = source_section
+        item["active_visual_source"] = "declared_mesh" if _has_mesh_reference(item) else ("declared_primitive" if _item_local_bounds(item) is not None else "declared_physical_metadata")
+        item.setdefault("source_layer", "editable_authored_physical")
+        item["provenance"].update({"source_section": source, "active_visual_source": source, "source_layer": source})
+        section = _section_from_item(item)
+        if source_section == "sensors" or section == "sensors":
+            sections["sensors"].append(item)
+        elif source_section == "zones" or _is_helper(item):
+            sections["zones"].append(item)
+        else:
+            sections["assets"].append(item)
     return sections
 
 
@@ -1458,7 +1510,15 @@ def _suppress_unresolved_placeholder_robot_visuals(generated: Dict[str, List[Jso
         generated[section] = kept
 
 def _sort_items(items: List[Json]) -> List[Json]:
-    return sorted(items, key=lambda x: (str(x.get("source_kind", "")), str(x.get("category", "")), str(x.get("role", "")), str(x.get("id", ""))))
+    deduped: List[Json] = []
+    seen: set[Tuple[str, str, str, bool]] = set()
+    for item in items:
+        key = (str(item.get("id", "")), str(item.get("source_kind", "")), str(item.get("source_section", "")), _has_mesh_reference(item))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(item)
+    return sorted(deduped, key=lambda x: (str(x.get("source_kind", "")), str(x.get("category", "")), str(x.get("role", "")), str(x.get("id", ""))))
 
 
 def _has_mesh_reference(item: Mapping[str, Any]) -> bool:
@@ -1886,7 +1946,7 @@ def _drop_shadowed_metadata_primitives(items: List[Json], generated_items: List[
         if item.get("source_kind") == "generated_preview" or _has_mesh_reference(item):
             kept.append(item)
             continue
-        text = _identity_text(item)
+        text = " ".join(str(item.get(key, "")).lower() for key in ("id", "display_name", "type", "role", "category", "mesh_uri", "mesh_path", "source_path", "package_uri"))
         if any(token in text for token in tokens):
             continue
         kept.append(item)

--- a/tests/test_export_workcell_studio_web_scene.py
+++ b/tests/test_export_workcell_studio_web_scene.py
@@ -921,3 +921,81 @@ def test_robot_preview_relative_mesh_urls_resolve_without_duplicate_build_direct
         resolved = urlparse(urljoin(preview_url, mesh)).path
         assert resolved == f"/build/workcell_studio_web_scene/{mesh}"
         assert "build/workcell_studio_web_scene/build/workcell_studio_web_scene" not in resolved
+
+
+def test_export_shared_physical_iterator_covers_legacy_sections_and_failures(tmp_path):
+    scene = tmp_path / "scene"
+    (scene / "layout").mkdir(parents=True)
+    (scene / "generated").mkdir()
+    mesh_dir = scene / "meshes"
+    mesh_dir.mkdir()
+    (mesh_dir / "tray.stl").write_text("solid tray\nendsolid tray\n", encoding="utf-8")
+    (scene / "scene_manifest.yaml").write_text(yaml.safe_dump({"scene": {"name": "physical_coverage"}}), encoding="utf-8")
+    (scene / "cell_definition.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "objects": [
+                    {
+                        "id": "cell_fixture",
+                        "type": "fixture",
+                        "pose_xyz": [0.2, 0.1, 0.3],
+                        "dimensions": [0.1, 0.2, 0.05],
+                    }
+                ]
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    (scene / "environment.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "assets": [{"id": "tray", "type": "tray", "mesh_uri": "meshes/tray.stl", "pose_xyz": [0.4, 0.1, 0.2]}],
+                "objects": {
+                    "legacy_bin": {
+                        "type": "bin",
+                        "links": {"bin_link": {"visual": {"geometry": {"filepath": "missing/bin.stl"}}}},
+                    }
+                },
+                "environment": {
+                    "zones": [{"id": "pick_helper", "role": "pick_zone", "category": "safety_zone", "dimensions": [1, 1, 1]}]
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    (scene / "layout/workcell_studio_layout.yaml").write_text(yaml.safe_dump({"items": []}), encoding="utf-8")
+    (scene / "generated/scene_visual_mesh_index.json").write_text(
+        json.dumps(
+            {
+                "visual_items": [
+                    {
+                        "id": "generated_tray_mesh",
+                        "category": "asset",
+                        "role": "tray",
+                        "mesh_uri": "meshes/tray.stl",
+                        "pose": {"xyz": [0.4, 0.1, 0.2], "rpy": [0, 0, 0]},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = exporter.build_web_scene(scene, stage_assets=True, output_path=tmp_path / "out.web_scene.json")
+    assets = {item["id"]: item for item in payload["assets"]}
+    assert {"tray", "legacy_bin", "cell_fixture", "generated_tray_mesh"} <= set(assets)
+    assert assets["tray"]["source_section"] == "assets"
+    assert assets["tray"]["active_visual_source"] == "declared_mesh"
+    assert assets["tray"]["pose_xyz"] == [0.4, 0.1, 0.2]
+    assert assets["legacy_bin"]["type"] == "bin"
+    assert assets["legacy_bin"]["link"] == "bin_link"
+    assert assets["legacy_bin"]["mesh_path"] == "missing/bin.stl"
+    assert assets["legacy_bin"]["mesh_staging_status"] == "resolve_failed"
+    assert "Mesh file does not exist" in assets["legacy_bin"]["mesh_resolve_warning"]
+    assert assets["cell_fixture"]["source_section"] == "objects"
+    assert assets["cell_fixture"]["active_visual_source"] == "declared_primitive"
+    assert any(item["id"] == "pick_helper" for item in payload["zones"])
+    assert "pick_helper" not in assets
+    assert sum(1 for item in payload["assets"] if item.get("id") == "generated_tray_mesh") == 1


### PR DESCRIPTION
### Motivation
- Fix a shared Web3D export path where authored physical items (fixtures, trays, bins, etc.) could be silently omitted or mis-classified and therefore not appear in Product View. 
- Ensure authored physical declarations from layout, environment, and cell-definition inputs are consistently exported so the viewer either renders them or reports an explicit asset-resolution failure. 

### Description
- Added a single shared authored-physical iterator `_iter_declared_physical_entries` that walks layout, top-level environment, nested environment, and cell-definition sections (`items`, `support_surfaces`, `assets`, `sensors`, `objects`, `placed_objects`, `tools`, `zones`) and exposes each physical entry for downstream export processing. (modified `scripts/export_workcell_studio_web_scene.py`)
- Preserve authored identity and visual metadata for exported items by feeding iterator rows into `_authored_item` and updating `_authored_sections` to record `source_section`, `active_visual_source`, `source_layer`, `link`, `mesh_path/filepath` and other provenance fields. (modified `scripts/export_workcell_studio_web_scene.py`)
- Route legacy nested visual geometry declarations (e.g., `links.<link>.visual.geometry.filepath`) into the existing mesh resolver/stager so missing/unsafe/unsupported meshes surface as structured failure metadata instead of disappearing. (modified `scripts/export_workcell_studio_web_scene.py`)
- Add `filepath` to recognized mesh URI fields so legacy keys are considered by the mesh resolver. (modified `scripts/export_workcell_studio_web_scene.py`)
- Reduce duplicate exported rows by deduping on `(id, source_kind, source_section, has_mesh)` in `_sort_items` and tighten the primitive shadow suppression text-matching so unrelated authored physical items are not dropped. (modified `scripts/export_workcell_studio_web_scene.py`)
- Add a focused regression test `test_export_shared_physical_iterator_covers_legacy_sections_and_failures` that verifies authored physical items from multiple legacy/nested sections appear in the exported web scene, that unresolved mesh files remain present with explicit failure reasons, that helper zones remain in `zones`, and that generated visual rows do not duplicate authored items. (added test in `tests/test_export_workcell_studio_web_scene.py`)

### Testing
- Ran `python3 -m pytest tests/test_export_workcell_studio_web_scene.py -q` and the exporter unit test suite passed (18 tests) including the new regression test. (PASS)
- Ran a lightweight supported-scene exporter summary across the canonical supported scenes (`ur5_2f_test`, `ur5_3f_test`, `ur10_2f_test`, `ur3_suction_test`, `ur5_airpick4_test`, `suction_test`, `ur5_2f_sorting_test`, `ur5_2f_builder_pick_place_demo`) to ensure declared authored items are exported and duplicate visual count is zero; results showed exported authored items present and zero duplicates for inspected scenes. (PASS)
- Performed git diff checks (`git diff --check`, `git diff --stat`, `git diff --numstat`) and changes are within requested limits (2 files changed, insertions/deletions within bounds). (PASS)
- Observed unrelated viewer/static expectations and mesh-staging smoke tests failing in a combined run: `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py -q` reported an unrelated static viewer assertion (viewer bundle content expectations) and portions of `tests/test_workcell_studio_web_mesh_staging.py` exercised canonical expanded-URDF staging requirements for `ur5_2f_test` that are orthogonal to this exporter change; these failures are existing/static contract expectations and not caused by the authored-physical export logic. (NOT FIXED / UNRELATED)

If additional follow-up is required, the next small PR can adjust viewer static contract expectations or the expanded-URDF staging guard separately; this change intentionally focuses only on authored physical-item coverage and honest failure reporting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ddb3389248331b7c9e915c889b2fa)