### PR TITLE
Use repository package discovery for web-scene package:// mesh resolution

### DIFF
--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -34,6 +34,11 @@ try:
 except ImportError:  # pragma: no cover - exercised only in minimal envs
     yaml = None  # type: ignore
 
+try:
+    from scripts.workcell_visual_asset_resolver import discover_package_map
+except ImportError:  # pragma: no cover - direct script execution fallback
+    from workcell_visual_asset_resolver import discover_package_map
+
 SCHEMA_VERSION = "workcell_studio_web_scene/v1"
 INPUTS = {
     "scene_manifest": "scene_manifest.yaml",
@@ -249,18 +254,24 @@ def _resolve_package_uri(uri: str, repo_root: Path) -> Tuple[Optional[Path], str
         return None, package or "package", None, f"Invalid or unsafe package URI: {uri}"
     if rel.suffix.lower() not in SUPPORTED_MESH_SUFFIXES:
         return None, package, None, f"Unsupported mesh format for {uri}; supported formats are .stl, .dae, and .obj."
+
     stage_rel = Path(package, *rel_parts)
+    package_map = discover_package_map(repo_root)
+    package_dir = package_map.get(package)
+    if package_dir is not None:
+        candidate = (package_dir / rel).resolve()
+        if not _is_relative_to(candidate, package_dir.resolve()):
+            return None, package, None, f"Invalid or unsafe package URI: {uri}"
+        if candidate.is_file():
+            return candidate, package, stage_rel, None
+        return None, package, None, f"Package mesh file does not exist: {uri}"
+
+    # Keep AMENT/share probing as a fallback for ROS packages that are not
+    # described by a package.xml under the repository discovery roots.
     for root in _package_share_roots(repo_root):
         direct = (root / package / rel).resolve()
         if _is_relative_to(direct, root) and direct.is_file():
             return direct, package, stage_rel, None
-        if root.exists():
-            for pkg_dir in root.rglob(package):
-                if not pkg_dir.is_dir():
-                    continue
-                candidate = (pkg_dir / rel).resolve()
-                if _is_relative_to(candidate, root) and candidate.is_file():
-                    return candidate, package, stage_rel, None
     return None, package, None, f"Could not resolve package mesh URI: {uri}"
 
 
@@ -321,6 +332,8 @@ def _staging_failure_status(warnings: Sequence[str]) -> str:
         return "unsupported_format"
     if "unsafe" in text or "escaped" in text:
         return "unsafe_path"
+    if "mesh file does not exist" in text:
+        return "missing_file"
     if "unsupported" in text and ("scheme" in text or "file uri host" in text):
         return "unsupported_scheme"
     return "resolve_failed"

--- a/tests/test_workcell_studio_web_mesh_staging.py
+++ b/tests/test_workcell_studio_web_mesh_staging.py
@@ -320,3 +320,117 @@ def test_ur5_2f_export_with_asset_staging_reduces_unresolved_package_fallback_ca
 
     assert len(_fallback_causes(staged_payload)) < len(_fallback_causes(unstaged_payload))
     assert any("package://" in cause for cause in _fallback_causes(unstaged_payload))
+
+
+def _repo_discovered_package(root: Path, package: str, rel: str, contents: str = "solid pkg\nendsolid pkg\n") -> Path:
+    pkg_dir = root / "assets" / "end_effectors" / "nested" / package
+    (pkg_dir).mkdir(parents=True, exist_ok=True)
+    (pkg_dir / "package.xml").write_text(
+        f"<package format=\"3\"><name>{package}</name><version>0.0.0</version><description>test</description><maintainer email=\"test@example.com\">Test</maintainer><license>Apache-2.0</license></package>\n",
+        encoding="utf-8",
+    )
+    mesh = pkg_dir / rel
+    mesh.parent.mkdir(parents=True, exist_ok=True)
+    mesh.write_text(contents, encoding="utf-8")
+    return mesh
+
+
+def test_nested_repo_package_mesh_uri_uses_package_discovery(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    mesh = _repo_discovered_package(tmp_path, "nested_tool_description", "meshes/visual/finger.dae", "<COLLADA></COLLADA>\n")
+    package_uri = "package://nested_tool_description/meshes/visual/finger.dae"
+    scene = _scene(tmp_path, "nested_package_scene", [{"id": "finger", "category": "tool", "mesh_uri": package_uri}])
+
+    payload = _export_with_prefix(monkeypatch, scene, tmp_path / "out" / "scene.web_scene.json", None)
+    item = _item(payload, "finger")
+
+    assert item["mesh_staging_status"] == "staged"
+    assert item["resolved_source_path"] == str(mesh.relative_to(tmp_path)).replace("/", "/")
+    assert item["original_package_uri"] == package_uri
+    assert item["mesh_uri"] == "build/workcell_studio_web_scene/assets/nested_package_scene/nested_tool_description/meshes/visual/finger.dae"
+    assert (tmp_path / item["mesh_uri"]).read_text(encoding="utf-8") == "<COLLADA></COLLADA>\n"
+
+
+def test_package_uri_with_url_encoded_spaces_is_staged(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    mesh = _repo_discovered_package(tmp_path, "space_pkg", "meshes/visual/gripper jaw.dae", "<COLLADA></COLLADA>\n")
+    scene = _scene(tmp_path, "space_scene", [{"id": "jaw", "category": "tool", "mesh_uri": "package://space_pkg/meshes/visual/gripper%20jaw.dae"}])
+
+    payload = _export_with_prefix(monkeypatch, scene, tmp_path / "out" / "scene.web_scene.json", None)
+    item = _item(payload, "jaw")
+
+    assert item["mesh_staging_status"] == "staged"
+    assert item["resolved_source_path"] == str(mesh.relative_to(tmp_path)).replace("/", "/")
+    assert item["mesh_uri"].endswith("/space_pkg/meshes/visual/gripper jaw.dae")
+    assert (tmp_path / item["mesh_uri"]).is_file()
+
+
+def test_package_uri_accepts_uppercase_and_lowercase_dae_suffixes(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    _repo_discovered_package(tmp_path, "case_pkg", "meshes/visual/upper.DAE", "<COLLADA>upper</COLLADA>\n")
+    _repo_discovered_package(tmp_path, "case_pkg", "meshes/visual/lower.dae", "<COLLADA>lower</COLLADA>\n")
+    scene = _scene(
+        tmp_path,
+        "case_scene",
+        [
+            {"id": "upper", "category": "asset", "mesh_uri": "package://case_pkg/meshes/visual/upper.DAE"},
+            {"id": "lower", "category": "asset", "mesh_uri": "package://case_pkg/meshes/visual/lower.dae"},
+        ],
+    )
+
+    payload = _export_with_prefix(monkeypatch, scene, tmp_path / "out" / "scene.web_scene.json", None)
+
+    assert _item(payload, "upper")["mesh_staging_status"] == "staged"
+    assert _item(payload, "upper")["mesh_format"] == "dae"
+    assert _item(payload, "upper")["mesh_uri"].endswith("upper.DAE")
+    assert _item(payload, "lower")["mesh_staging_status"] == "staged"
+    assert _item(payload, "lower")["mesh_format"] == "dae"
+    assert _item(payload, "lower")["mesh_uri"].endswith("lower.dae")
+
+
+def test_unknown_package_and_package_traversal_keep_explicit_failure_statuses(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    scene = _scene(
+        tmp_path,
+        "package_failure_scene",
+        [
+            {"id": "unknown", "category": "asset", "mesh_uri": "package://unknown_pkg/meshes/missing.dae"},
+            {"id": "traversal", "category": "asset", "mesh_uri": "package://unknown_pkg/../secret.dae"},
+        ],
+    )
+
+    payload = _export_with_prefix(monkeypatch, scene, tmp_path / "out" / "scene.web_scene.json", None)
+
+    assert _item(payload, "unknown")["mesh_staging_status"] == "resolve_failed"
+    assert "Could not resolve package mesh URI" in _item(payload, "unknown")["mesh_resolve_warning"]
+    assert _item(payload, "traversal")["mesh_staging_status"] == "unsafe_path"
+    assert _item(payload, "traversal")["mesh_uri"] == "package://unknown_pkg/../secret.dae"
+
+
+def test_staged_url_maps_to_intended_file_under_scene_asset_root(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    mesh = _repo_discovered_package(tmp_path, "map_pkg", "meshes/visual/part.dae", "<COLLADA>mapped</COLLADA>\n")
+    scene = _scene(tmp_path, "mapped_scene", [{"id": "mapped", "category": "asset", "mesh_uri": "package://map_pkg/meshes/visual/part.dae"}])
+
+    payload = _export_with_prefix(monkeypatch, scene, tmp_path / "out" / "scene.web_scene.json", None)
+    item = _item(payload, "mapped")
+    staged = (tmp_path / item["mesh_url"]).resolve()
+    asset_root = (tmp_path / "build" / "workcell_studio_web_scene" / "assets" / "mapped_scene").resolve()
+
+    assert item["mesh_staging_status"] == "staged"
+    assert item["mesh_staged_path"] == item["mesh_url"] == item["mesh_uri"]
+    assert staged.relative_to(asset_root)
+    assert staged.read_text(encoding="utf-8") == mesh.read_text(encoding="utf-8")
+
+
+def test_known_package_missing_mesh_file_reports_missing_file(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    _repo_discovered_package(tmp_path, "known_missing_pkg", "meshes/visual/existing.dae", "<COLLADA></COLLADA>\n")
+    scene = _scene(tmp_path, "known_missing_scene", [{"id": "missing", "category": "asset", "mesh_uri": "package://known_missing_pkg/meshes/visual/missing.dae"}])
+
+    payload = _export_with_prefix(monkeypatch, scene, tmp_path / "out" / "scene.web_scene.json", None)
+    item = _item(payload, "missing")
+
+    assert item["mesh_staging_status"] == "missing_file"
+    assert "Package mesh file does not exist" in item["mesh_resolve_warning"]
+    assert item["mesh_uri"] == "package://known_missing_pkg/meshes/visual/missing.dae"


### PR DESCRIPTION
### Motivation
- Improve package:// mesh resolution in the web-scene exporter so nested repository packages found via the repo package discovery map are resolved instead of relying only on fixed directory probing.
- Preserve the existing browser staging contract and safety semantics for mesh staging and diagnostics while reducing false unresolved-package fallbacks.
- Keep the change small and focused to avoid scene-specific behavior and preserve fake-hardware and export safety defaults.

### Description
- Updated `_resolve_package_uri()` to import and use the repository `discover_package_map()` behavior for package lookup before falling back to AMENT/share probing, while still retaining AMENT/share probing as a fallback and respecting path containment checks. 
- When a discovered package exists but the mesh file is missing, return an explicit missing-file diagnostic instead of a generic unresolved failure, and keep suffix checks and traversal detection intact.
- Preserved the staging contract in `_stage_visual_meshes()` so `original_mesh_uri`, `original_package_uri`, and `original_source_path` remain unchanged and only emit `mesh_url` / `mesh_staged_path` after a safe on-disk resolution; diagnostics are not overwritten by browser URLs.
- Added focused unit tests in `tests/test_workcell_studio_web_mesh_staging.py` that validate nested-repo package discovery, URL-encoded paths with spaces, uppercase/lowercase `.DAE` handling, unknown-package and traversal failure behaviors, staged URL mapping under `build/workcell_studio_web_scene/assets/<scene>/`, and known-package missing-file reporting.

### Testing
- Compiled the modified exporter and resolver with `python3 -m py_compile` and the compile step passed.
- Ran `pytest` for core GUI/product-view tests (`tests/test_scene3d_product_overlay_filtering.py` and `tests/test_workcell_builder_product_view_defaults.py`) and these passed.
- Ran the new and focused mesh-staging tests in `tests/test_workcell_studio_web_mesh_staging.py` (new cases for nested packages, url-encoded names, case-insensitive DAE, unknown package/traversal, staged mapping, and known-package missing file) and they passed.
- Observed that running the entire `tests/test_workcell_studio_web_mesh_staging.py` file initially produced 3 failures unrelated to the package-discovery change (assertions about bundled viewer JS strings and a missing canonical `expanded_scene_preview.urdf` for the `ur5_2f_test` refresh path); those failures are pre-existing / environment-canonical-scene blockers and were not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5de13aaea083319aa208c9860468ff)