### PR TITLE
Shrink lower diagnostics to maximise Product View

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -2628,18 +2628,21 @@ void MainWindow::setup_studio_shell()
   auto * bottom_status_bar = new QFrame(scene_builder);
   bottom_status_bar->setObjectName("sceneBuilderBottomStatusBar");
   auto * bottom_status_layout = new QHBoxLayout(bottom_status_bar);
-  bottom_status_layout->setContentsMargins(8, 4, 8, 4);
-  scene_builder_selection_summary_label_ = new QLabel("Selection: none", bottom_status_bar);
-  scene_builder_selection_summary_label_->setObjectName("sceneBuilderSelectionSummary");
-  scene_builder_status_message_label_ = new QLabel("Ready: Product View preview-only; fake hardware remains default.", bottom_status_bar);
+  bottom_status_layout->setContentsMargins(8, 2, 8, 2);
+  bottom_status_layout->setSpacing(8);
+  scene_builder_status_message_label_ = new QLabel("Ready", bottom_status_bar);
   scene_builder_status_message_label_->setObjectName("sceneBuilderLatestStatus");
-  scene_builder_status_message_label_->setTextInteractionFlags(Qt::TextSelectableByMouse);
-  scene_builder_issue_count_label_ = new QLabel("Warnings: 0 | Errors: 0", bottom_status_bar);
+  scene_builder_status_message_label_->setWordWrap(false);
+  scene_builder_status_message_label_->setToolTip("Ready");
+  scene_builder_status_message_label_->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
+  scene_builder_issue_count_label_ = new QLabel(bottom_status_bar);
   scene_builder_issue_count_label_->setObjectName("sceneBuilderIssueCount");
+  scene_builder_issue_count_label_->setVisible(false);
+  scene_builder_issue_count_label_->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
   scene_builder_log_toggle_button_ = new QPushButton("Logs", bottom_status_bar);
   scene_builder_log_toggle_button_->setObjectName("sceneBuilderLogsButton");
+  scene_builder_log_toggle_button_->setCheckable(true);
   scene_builder_log_toggle_button_->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-  bottom_status_layout->addWidget(scene_builder_selection_summary_label_);
   bottom_status_layout->addWidget(scene_builder_status_message_label_, 1);
   bottom_status_layout->addWidget(scene_builder_issue_count_label_);
   bottom_status_layout->addWidget(scene_builder_log_toggle_button_);
@@ -3002,7 +3005,9 @@ void MainWindow::setup_studio_shell()
   auto * log_head = new QHBoxLayout();
   log_head->addWidget(new QLabel("Activity Log", log_card));
   auto * copy_log = new QPushButton("Copy", log_card);
+  copy_log->setObjectName("sceneBuilderLogCopyButton");
   auto * clear_log = new QPushButton("Clear", log_card);
+  clear_log->setObjectName("sceneBuilderLogClearButton");
   log_head->addStretch(1);
   log_head->addWidget(copy_log, 0, Qt::AlignRight);
   log_head->addWidget(clear_log, 0, Qt::AlignRight);
@@ -3045,7 +3050,8 @@ void MainWindow::setup_studio_shell()
     const bool show = !scene_builder_log_panel_->isVisible();
     scene_builder_log_panel_->setVisible(show);
     studio_log_->setVisible(show);
-    scene_builder_log_toggle_button_->setText(show ? "Hide Logs" : "Logs");
+    scene_builder_log_toggle_button_->setChecked(show);
+    scene_builder_log_toggle_button_->setText("Logs");
   });
   connect_button(empty_new_cell, &MainWindow::open_new_scene_creation_flow);
   connect_button(dash_new_cell, &MainWindow::open_new_scene_creation_flow);
@@ -4014,7 +4020,6 @@ void MainWindow::refresh_selected_scene_item_labels(const SelectedSceneItemState
   advanced_lines << QString("Grasp frame: %1").arg(selected_scene_state_.valid ? selected_scene_state_.grasp_frame_summary : QStringLiteral("unknown"));
   advanced_lines << QString("Launch status: %1").arg(selected_scene_state_.valid ? (selected_scene_state_.launchable ? "ready" : "blocked") : QStringLiteral("(none)"));
   if (!state.valid) {
-    if (scene_builder_selection_summary_label_) scene_builder_selection_summary_label_->setText("Selection: none");
     inspector_label_->setText("No item selected");
     inspector_label_->setToolTip(selected_scene_state_.valid ? selected_scene_state_.path : QString());
     live_coordinate_label_->setText("No item selected");
@@ -4045,7 +4050,6 @@ void MainWindow::refresh_selected_scene_item_labels(const SelectedSceneItemState
     (generated_or_preview_contract ? QStringLiteral("Locked preview item") : QStringLiteral("Locked item cannot be edited"));
   const bool is_locked_urdf_preview = state.locked && role.contains("urdf", Qt::CaseInsensitive);
   const QString locked_line = state.locked ? QString("locked_reason: %1").arg(state.lock_reason.isEmpty() ? QStringLiteral("item is locked") : state.lock_reason) : QStringLiteral("locked: no");
-  if (scene_builder_selection_summary_label_) scene_builder_selection_summary_label_->setText(QString("Selection: %1 (%2)").arg(display, role));
   inspector_label_->setText(QString("%1\nType: %2\nState: %3").arg(display, state.type.isEmpty() ? type_class : state.type, selection_contract_label));
   inspector_label_->setToolTip(display);
   advanced_lines << QString("Selected item name: %1").arg(display);
@@ -4576,22 +4580,30 @@ void MainWindow::append_studio_log(const QString & message)
   if (studio_log_) {
     studio_log_->append(message);
   }
-  if (scene_builder_status_message_label_) scene_builder_status_message_label_->setText(message);
-  static int warning_count = 0;
-  static int error_count = 0;
+  if (scene_builder_status_message_label_) {
+    const QString concise = message.trimmed().isEmpty() ? QStringLiteral("Ready") : message.simplified();
+    scene_builder_status_message_label_->setToolTip(concise);
+    const int elide_width = qMax(220, scene_builder_status_message_label_->width());
+    scene_builder_status_message_label_->setText(scene_builder_status_message_label_->fontMetrics().elidedText(concise, Qt::ElideRight, elide_width));
+  }
   const QString lowered = message.toLower();
   if (lowered.contains("error") || lowered.contains("failed") || lowered.contains("blocker")) {
-    ++error_count;
-    if (scene_builder_log_panel_ && studio_log_) {
-      scene_builder_log_panel_->setVisible(true);
-      studio_log_->setVisible(true);
-      if (scene_builder_log_toggle_button_) scene_builder_log_toggle_button_->setText("Hide Logs");
-    }
+    ++scene_builder_error_count_;
   } else if (lowered.contains("warn")) {
-    ++warning_count;
+    ++scene_builder_warning_count_;
   }
   if (scene_builder_issue_count_label_) {
-    scene_builder_issue_count_label_->setText(QString("Warnings: %1 | Errors: %2").arg(warning_count).arg(error_count));
+    const QStringList parts = {
+      scene_builder_error_count_ > 0 ? QStringLiteral("%1 %2").arg(scene_builder_error_count_).arg(scene_builder_error_count_ == 1 ? QStringLiteral("error") : QStringLiteral("errors")) : QString(),
+      scene_builder_warning_count_ > 0 ? QStringLiteral("%1 %2").arg(scene_builder_warning_count_).arg(scene_builder_warning_count_ == 1 ? QStringLiteral("warning") : QStringLiteral("warnings")) : QString()
+    };
+    QStringList visible_parts;
+    for (const QString & part : parts) if (!part.isEmpty()) visible_parts << part;
+    scene_builder_issue_count_label_->setText(visible_parts.join(QStringLiteral(" · ")));
+    scene_builder_issue_count_label_->setVisible(!visible_parts.isEmpty());
+  }
+  if (scene_builder_log_toggle_button_) {
+    scene_builder_log_toggle_button_->setProperty("hasIssues", scene_builder_warning_count_ > 0 || scene_builder_error_count_ > 0);
   }
   statusBar()->showMessage(message);
 }

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -697,9 +697,10 @@ private:
   QTabWidget * scene_builder_inspector_tabs_{ nullptr };
   QPushButton * scene_builder_log_toggle_button_{ nullptr };
   QFrame * scene_builder_log_panel_{ nullptr };
-  QLabel * scene_builder_selection_summary_label_{ nullptr };
   QLabel * scene_builder_status_message_label_{ nullptr };
   QLabel * scene_builder_issue_count_label_{ nullptr };
+  int scene_builder_warning_count_{ 0 };
+  int scene_builder_error_count_{ 0 };
   bool scene_builder_log_collapsed_{ false };
   QToolButton * preview_more_actions_button_{ nullptr };
   QToolButton * validation_more_actions_button_{ nullptr };

--- a/workcell_builder/workcell_builder/test/scene_preview_widget_ui_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene_preview_widget_ui_test.cpp
@@ -377,3 +377,64 @@ TEST(SceneBuilderWorkspaceSource, FocusModeHidesPanelsWithoutReloadingProductVie
   EXPECT_FALSE(focus_block.contains(QStringLiteral("request_embedded_web_product_view_refresh")));
   EXPECT_FALSE(focus_block.contains(QStringLiteral("reload_meshes")));
 }
+
+TEST(SceneBuilderWorkspaceSource, CompactBottomStatusBarUsesSingleRowAndExistingLogDrawer)
+{
+  QFile source(QStringLiteral("workcell_builder/workcell_builder/gui/mainwindow.cpp"));
+  if (!source.exists()) source.setFileName(QStringLiteral("../workcell_builder/gui/mainwindow.cpp"));
+  ASSERT_TRUE(source.open(QIODevice::ReadOnly | QIODevice::Text));
+  const QString text = QString::fromUtf8(source.readAll());
+
+  const int bar_index = text.indexOf(QStringLiteral("sceneBuilderBottomStatusBar"));
+  ASSERT_GE(bar_index, 0);
+  const QString bar_block = text.mid(bar_index, 1900);
+  EXPECT_EQ(text.count(QStringLiteral("sceneBuilderBottomStatusBar")), 1);
+  EXPECT_EQ(text.count(QStringLiteral("sceneBuilderLatestStatus")), 1);
+  EXPECT_EQ(text.count(QStringLiteral("sceneBuilderLogDrawer")), 1);
+  EXPECT_FALSE(text.contains(QStringLiteral("sceneBuilderSelectionSummary")));
+  EXPECT_FALSE(bar_block.contains(QStringLiteral("Selection:")));
+  EXPECT_FALSE(bar_block.contains(QStringLiteral("Warnings: 0 | Errors: 0")));
+  EXPECT_FALSE(bar_block.contains(QStringLiteral("Product View preview-only; fake hardware remains default")));
+  EXPECT_TRUE(bar_block.contains(QStringLiteral("new QHBoxLayout")));
+  EXPECT_TRUE(bar_block.contains(QStringLiteral("setContentsMargins(8, 2, 8, 2)")));
+  EXPECT_TRUE(bar_block.contains(QStringLiteral("setWordWrap(false)")));
+  EXPECT_TRUE(bar_block.contains(QStringLiteral("setVisible(false)")));
+  EXPECT_TRUE(bar_block.contains(QStringLiteral("setCheckable(true)")));
+
+  const int append_index = text.indexOf(QStringLiteral("void MainWindow::append_studio_log"));
+  ASSERT_GE(append_index, 0);
+  const QString append_block = text.mid(append_index, 2300);
+  EXPECT_TRUE(append_block.contains(QStringLiteral("message.simplified()")));
+  EXPECT_TRUE(append_block.contains(QStringLiteral("setToolTip(concise)")));
+  EXPECT_TRUE(append_block.contains(QStringLiteral("elidedText(concise, Qt::ElideRight")));
+  EXPECT_TRUE(append_block.contains(QStringLiteral("scene_builder_warning_count_")));
+  EXPECT_TRUE(append_block.contains(QStringLiteral("scene_builder_error_count_")));
+  EXPECT_TRUE(append_block.contains(QStringLiteral("lowered.contains(\"warn\")")));
+  EXPECT_TRUE(append_block.contains(QStringLiteral("lowered.contains(\"error\")")));
+  EXPECT_TRUE(append_block.contains(QStringLiteral("lowered.contains(\"failed\")")));
+  EXPECT_TRUE(append_block.contains(QStringLiteral("setVisible(!visible_parts.isEmpty())")));
+  EXPECT_FALSE(append_block.contains(QStringLiteral("scene_builder_log_panel_->setVisible(true)")));
+
+  const int toggle_index = text.indexOf(QStringLiteral("connect_button(scene_builder_log_toggle_button_"));
+  ASSERT_GE(toggle_index, 0);
+  const QString toggle_block = text.mid(toggle_index, 650);
+  EXPECT_TRUE(toggle_block.contains(QStringLiteral("const bool show = !scene_builder_log_panel_->isVisible()")));
+  EXPECT_TRUE(toggle_block.contains(QStringLiteral("scene_builder_log_panel_->setVisible(show)")));
+  EXPECT_TRUE(toggle_block.contains(QStringLiteral("studio_log_->setVisible(show)")));
+  EXPECT_TRUE(toggle_block.contains(QStringLiteral("setChecked(show)")));
+  EXPECT_TRUE(toggle_block.contains(QStringLiteral("setText(\"Logs\")")));
+  EXPECT_FALSE(toggle_block.contains(QStringLiteral("new QTextEdit")));
+  EXPECT_FALSE(toggle_block.contains(QStringLiteral("clear()")));
+
+  EXPECT_EQ(text.count(QStringLiteral("sceneBuilderLogCopyButton")), 1);
+  EXPECT_EQ(text.count(QStringLiteral("sceneBuilderLogClearButton")), 1);
+  EXPECT_EQ(text.count(QStringLiteral("connect_button(clear_log")), 1);
+  EXPECT_EQ(text.count(QStringLiteral("connect_button(copy_log")), 1);
+
+  const int focus_index = text.indexOf(QStringLiteral("scene_builder_focus_3d_action_"));
+  ASSERT_GE(focus_index, 0);
+  const QString focus_block = text.mid(focus_index, 2200);
+  EXPECT_FALSE(focus_block.contains(QStringLiteral("sceneBuilderBottomStatusBar")));
+  EXPECT_FALSE(focus_block.contains(QStringLiteral("scene_builder_log_panel_->setVisible")));
+  EXPECT_FALSE(focus_block.contains(QStringLiteral("request_embedded_web_product_view_refresh")));
+}


### PR DESCRIPTION
### Motivation

- Reduce the tall Scene Builder lower diagnostics area so the Product View receives nearly all vertical space. 
- Preserve access to the existing Activity Log while hiding detailed diagnostics unless requested. 
- Remove duplicated scene/selection/readiness text from the bottom area and keep authoritative info in the Inspector and header.

### Description

- Replaced the multi-line bottom banner with a single compact status row in `workcell_builder/workcell_builder/gui/mainwindow.cpp`, removing the permanent selection summary and long readiness text and adding a concise `sceneBuilderLatestStatus` label that elides long messages and exposes the full text via tooltip. 
- Made the issue count label hidden when zero and formatted counts compactly (`errors`/`warnings`) driven from existing log messages via new session-local counters added to `workcell_builder/workcell_builder/gui/mainwindow.h`. 
- Kept the existing Activity Log drawer (`sceneBuilderLogDrawer`) and Copy/Clear actions, made the `Logs` button checkable and tied its checked state to the drawer visibility so toggling reuses the same drawer without recreating entries. 
- Updated `append_studio_log` to set the concise status row text (with eliding), increment warning/error counters based on message content, and update the compact issue indicator without auto-opening the drawer on every warning. 
- Added a focused source-level Qt UI regression test `TEST(SceneBuilderWorkspaceSource, CompactBottomStatusBarUsesSingleRowAndExistingLogDrawer)` in `workcell_builder/workcell_builder/test/scene_preview_widget_ui_test.cpp` that asserts a single bottom row, eliding behaviour, zero-count hiding, severity-derived counts, Logs toggle wiring, Copy/Clear single wiring, and Focus 3D View compatibility. 

### Testing

- Ran repository checks: `git diff --check`, `git diff --stat`, and `git diff --numstat` which passed and show 3 files changed with additions/deletions within requested limits. 
- Added a focused Qt source test (no test binary execution in this environment) located in `workcell_builder/workcell_builder/test/scene_preview_widget_ui_test.cpp` that validates the source wiring and UI contracts. 
- Attempted to run the focused Qt test via the normal ROS/colcon path, but execution was blocked because `/opt/ros/humble/setup.bash` is not available in this container so `colcon test` could not be executed; static checks remain green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5df0dd624883319bebe1f8cf585a58)