### PR TITLE
Place assets by dragging them into Product View

### DIFF
--- a/tests/test_scene3d_asset_drag_drop_static.py
+++ b/tests/test_scene3d_asset_drag_drop_static.py
@@ -6,11 +6,18 @@ def test_scene3d_asset_drag_drop_tokens_exist():
     viewport_h = Path("workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h").read_text(encoding="utf-8")
     viewport_cpp = Path("workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp").read_text(encoding="utf-8")
 
-    assert "application/x-workcell-asset-catalog-item" in main_cpp
+    assert "application/x-workcell-studio-asset" in main_cpp
+    assert "application/x-workcell-studio-asset" in viewport_cpp
     assert "QDrag" in main_cpp and "QMimeData" in main_cpp
     assert "disabled_reason" in main_cpp and "Cannot place here" in main_cpp
+    drag_payload = main_cpp[main_cpp.index('payload["asset_id"] = e.asset_id'):main_cpp.index("auto * mime = new QMimeData()", main_cpp.index('payload["asset_id"] = e.asset_id'))]
+    assert 'payload["asset_id"] = e.asset_id' in drag_payload
+    assert "source_path" not in drag_payload
+    assert "CatalogRoleAssetId" in main_cpp
     assert "asset_drop_cb" in viewport_h
     assert "dragEnterEvent" in viewport_h and "dropEvent" in viewport_h
+    assert "drag_position_to_world_xy" in viewport_cpp
+    assert "snap_translation_value(hit.x(), snap_mode)" in viewport_cpp
     assert "Drop to place" in viewport_cpp
     assert "drag_asset_preview_visible_" in viewport_h
     assert "workcell_studio_next_id" in main_cpp

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -417,7 +417,8 @@ enum SceneTreeRoles {
   TreeRoleSourceLayer, TreeRoleActiveVisualSource, TreeRoleEditable, TreeRoleLocked, TreeRoleLinkedEditableLayout, TreeRoleVisualBackingStatus, TreeRoleGeneratedVisual, TreeRoleItemTypeClass,
   TreeRoleStableId, TreeRoleCameraId, TreeRoleFrameId, TreeRoleDetectionLabel, TreeRoleConfidence, TreeRoleTrackingId, TreeRoleSnapshotSourceFile, TreeRoleAlignmentWarning
 };
-enum AssetCatalogRoles { CatalogRoleIndex = Qt::UserRole, CatalogRolePlaceable = Qt::UserRole + 10, CatalogRoleSourcePath = Qt::UserRole + 11 };
+enum AssetCatalogRoles { CatalogRoleIndex = Qt::UserRole, CatalogRolePlaceable = Qt::UserRole + 10, CatalogRoleSourcePath = Qt::UserRole + 11, CatalogRoleAssetId = Qt::UserRole + 12 };
+static constexpr const char * kWorkcellStudioAssetMime = "application/x-workcell-studio-asset";
 
 
 
@@ -2295,13 +2296,20 @@ void MainWindow::setup_studio_shell()
       }
     };
     scene3d_viewport->asset_drop_cb = [this](const QJsonObject & payload, double x, double y, double, bool shift_drop) {
-        const QString category = payload.value("category").toString();
-        const QString display_name = payload.value("display_name").toString();
-        const QString source_path = payload.value("source_path").toString();
-        if (category.isEmpty() || display_name.isEmpty()) {
-          append_studio_log("Cannot place here: drag payload missing category/display name.");
+        const QString asset_id = payload.value("asset_id").toString().trimmed();
+        const auto match = std::find_if(asset_catalog_entries_.cbegin(), asset_catalog_entries_.cend(),
+          [&asset_id](const AssetCatalogEntry & e) { return e.asset_id == asset_id; });
+        if (asset_id.isEmpty() || match == asset_catalog_entries_.cend()) {
+          append_studio_log("Asset is no longer available");
           return;
         }
+        if (!match->disabled_reason.trimmed().isEmpty() || !match->editable) {
+          append_studio_log(QString("Cannot place asset '%1': %2").arg(asset_id, match->disabled_reason));
+          return;
+        }
+        const QString category = match->category;
+        const QString display_name = match->display_name;
+        const QString source_path = match->source_path;
         if (shift_drop && !configure_asset_placement_transform(category, display_name)) return;
         armed_asset_use_clicked_xy_ = true;
         armed_asset_x_m_ = x;
@@ -6235,16 +6243,9 @@ bool MainWindow::eventFilter(QObject * watched, QEvent * event)
         return true;
       }
       QJsonObject payload;
-      payload["asset_id"] = e.display_name.toLower().replace(" ", "_");
-      payload["display_name"] = e.display_name;
-      payload["category"] = e.category;
-      payload["type"] = e.asset_type;
-      payload["source_path"] = e.source_path;
-      payload["mesh_path"] = e.source_path.endsWith(".stl", Qt::CaseInsensitive) ? e.source_path : "";
-      payload["default_dimensions"] = e.dimensions;
-      payload["default_pose"] = e.default_pose;
+      payload["asset_id"] = e.asset_id;
       auto * mime = new QMimeData();
-      mime->setData("application/x-workcell-asset-catalog-item", QJsonDocument(payload).toJson(QJsonDocument::Compact));
+      mime->setData(kWorkcellStudioAssetMime, QJsonDocument(payload).toJson(QJsonDocument::Compact));
       auto * drag = new QDrag(asset_catalog_tree_);
       drag->setMimeData(mime);
       drag->exec(Qt::CopyAction);
@@ -11669,6 +11670,7 @@ void MainWindow::populate_asset_catalog()
     item->setData(0, CatalogRoleIndex, idx);
     item->setData(0, CatalogRolePlaceable, e.disabled_reason.trimmed().isEmpty() && e.editable);
     item->setData(0, CatalogRoleSourcePath, e.source_path);
+    item->setData(0, CatalogRoleAssetId, e.asset_id);
     item->setToolTip(0, QString("%1\nID: %2\nVisual: %3").arg(e.display_name, e.asset_id, e.visual_uri));
   }
   for (auto * parent : groups) parent->setExpanded(parent->childCount() > 0);

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -52,6 +52,7 @@
 namespace {
 constexpr int kMeshTriangleLimit = 1000000;
 constexpr double kWorkspaceLimitMeters = 1000.0;
+constexpr const char * kWorkcellStudioAssetMime = "application/x-workcell-studio-asset";
 
 [[maybe_unused]] QString snap_mode_label(Scene3DViewportWidget::SnapMode mode)
 {
@@ -2584,9 +2585,7 @@ void Scene3DViewportWidget::paintGL()
   }
   draw_viewport_quality_overlay(painter, visible_item_count, physical_item_count);
   if (drag_asset_preview_visible_) {
-    const double x = (drag_asset_screen_pos_.x() - width() * 0.5) / 50.0;
-    const double y = (height() * 0.6 - drag_asset_screen_pos_.y()) / 50.0;
-    draw_box(x, y, 0.0, 0.35, 0.35, 0.35, QColor(56, 189, 248, 120), true);
+    draw_box(drag_asset_world_pos_.x(), drag_asset_world_pos_.y(), drag_asset_world_pos_.z(), 0.35, 0.35, 0.35, QColor(56, 189, 248, 120), true);
     QToolTip::showText(mapToGlobal(drag_asset_screen_pos_), drag_asset_drop_status_, this);
   }
 }
@@ -4347,6 +4346,31 @@ void Scene3DViewportWidget::draw_frustum(const QColor & color, bool translucent)
   glBegin(GL_TRIANGLE_FAN); glVertex3f(camera_overlay.x, camera_overlay.y, camera_overlay.z); glVertex3f(ffl.x(), ffl.y(), ffl.z()); glVertex3f(ffr.x(), ffr.y(), ffr.z()); glVertex3f(fbr.x(), fbr.y(), fbr.z()); glVertex3f(fbl.x(), fbl.y(), fbl.z()); glVertex3f(ffl.x(), ffl.y(), ffl.z()); glEnd();
 }
 QPointF Scene3DViewportWidget::project_to_screen(double x, double y, double z) const { return QPointF(width() * 0.5 + x * 50.0, height() * 0.6 - y * 50.0 + z * 5.0); }
+bool Scene3DViewportWidget::drag_position_to_world_xy(const QPoint & pos, double z_m, double & out_x, double & out_y) const
+{
+  if (width() <= 0 || height() <= 0 || !std::isfinite(z_m)) return false;
+  QMatrix4x4 proj, view;
+  camera_matrices(proj, view);
+  const QMatrix4x4 inv = (proj * view).inverted();
+  const float ndc_x = (2.0f * static_cast<float>(pos.x()) / static_cast<float>(width())) - 1.0f;
+  const float ndc_y = 1.0f - (2.0f * static_cast<float>(pos.y()) / static_cast<float>(height()));
+  const QVector4D near_clip(ndc_x, ndc_y, -1.0f, 1.0f);
+  const QVector4D far_clip(ndc_x, ndc_y, 1.0f, 1.0f);
+  QVector4D near_world = inv * near_clip;
+  QVector4D far_world = inv * far_clip;
+  if (qFuzzyIsNull(near_world.w()) || qFuzzyIsNull(far_world.w())) return false;
+  near_world /= near_world.w();
+  far_world /= far_world.w();
+  const QVector3D origin = near_world.toVector3D();
+  const QVector3D dir = (far_world.toVector3D() - origin).normalized();
+  if (qAbs(dir.z()) < 1e-6f) return false;
+  const float t = (static_cast<float>(z_m) - origin.z()) / dir.z();
+  if (!std::isfinite(t) || t < 0.0f) return false;
+  const QVector3D hit = origin + dir * t;
+  out_x = snap_translation_value(hit.x(), snap_mode);
+  out_y = snap_translation_value(hit.y(), snap_mode);
+  return std::isfinite(out_x) && std::isfinite(out_y);
+}
 void Scene3DViewportWidget::camera_matrices(QMatrix4x4 & out_proj, QMatrix4x4 & out_view) const
 {
   const float aspect = height() > 0 ? static_cast<float>(width()) / static_cast<float>(height()) : 1.0f;
@@ -4802,16 +4826,29 @@ void Scene3DViewportWidget::keyPressEvent(QKeyEvent * e)
 
 void Scene3DViewportWidget::dragEnterEvent(QDragEnterEvent * event)
 {
-  if (event->mimeData() && event->mimeData()->hasFormat("application/x-workcell-asset-catalog-item")) event->acceptProposedAction();
+  if (!event->mimeData() || !event->mimeData()->hasFormat(kWorkcellStudioAssetMime)) return;
+  const QJsonObject payload = QJsonDocument::fromJson(event->mimeData()->data(kWorkcellStudioAssetMime)).object();
+  if (payload.value("asset_id").toString().trimmed().isEmpty()) return;
+  event->acceptProposedAction();
 }
 
 void Scene3DViewportWidget::dragMoveEvent(QDragMoveEvent * event)
 {
-  if (!event->mimeData() || !event->mimeData()->hasFormat("application/x-workcell-asset-catalog-item")) return;
-  const QByteArray payload = event->mimeData()->data("application/x-workcell-asset-catalog-item");
+  if (!event->mimeData() || !event->mimeData()->hasFormat(kWorkcellStudioAssetMime)) return;
+  const QByteArray payload = event->mimeData()->data(kWorkcellStudioAssetMime);
   drag_asset_payload_ = QJsonDocument::fromJson(payload).object();
-  drag_asset_label_ = drag_asset_payload_.value("display_name").toString("asset");
+  const QString asset_id = drag_asset_payload_.value("asset_id").toString().trimmed();
+  if (asset_id.isEmpty()) return;
+  double x = 0.0, y = 0.0;
+  if (!drag_position_to_world_xy(event->pos(), 0.0, x, y)) {
+    drag_asset_preview_visible_ = false;
+    drag_asset_drop_status_ = QStringLiteral("No valid workcell surface under the pointer");
+    update();
+    return;
+  }
+  drag_asset_label_ = asset_id;
   drag_asset_screen_pos_ = event->pos();
+  drag_asset_world_pos_ = QVector3D(x, y, 0.0f);
   drag_asset_preview_visible_ = true;
   drag_asset_drop_status_ = QStringLiteral("Drop to place %1").arg(drag_asset_label_);
   event->acceptProposedAction();
@@ -4826,11 +4863,15 @@ void Scene3DViewportWidget::dragLeaveEvent(QDragLeaveEvent *)
 
 void Scene3DViewportWidget::dropEvent(QDropEvent * event)
 {
-  if (!event->mimeData() || !event->mimeData()->hasFormat("application/x-workcell-asset-catalog-item")) return;
-  const QJsonObject payload = QJsonDocument::fromJson(event->mimeData()->data("application/x-workcell-asset-catalog-item")).object();
-  const QPoint p = event->pos();
-  const double x = snap_translation_value((p.x() - width() * 0.5) / 50.0, snap_mode);
-  const double y = snap_translation_value((height() * 0.6 - p.y()) / 50.0, snap_mode);
+  if (!event->mimeData() || !event->mimeData()->hasFormat(kWorkcellStudioAssetMime)) return;
+  const QJsonObject payload = QJsonDocument::fromJson(event->mimeData()->data(kWorkcellStudioAssetMime)).object();
+  double x = 0.0, y = 0.0;
+  if (payload.value("asset_id").toString().trimmed().isEmpty() || !drag_position_to_world_xy(event->pos(), 0.0, x, y)) {
+    drag_asset_preview_visible_ = false;
+    if (status_message_cb) status_message_cb(QStringLiteral("No valid workcell surface under the pointer"));
+    update();
+    return;
+  }
   const double z = 0.0;
   const bool shift_drop = (event->keyboardModifiers() & Qt::ShiftModifier);
   if (asset_drop_cb) asset_drop_cb(payload, x, y, z, shift_drop);

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -193,6 +193,7 @@ private:
   bool pick_item_at_screen(const QPoint & pos, QString & out_id, QString & out_role, QString * out_tooltip = nullptr) const;
   bool pick_gizmo_axis_at_screen(const QPoint & pos, QString & out_axis, double * out_score = nullptr) const;
   bool pick_gizmo_rotation_ring_at_screen(const QPoint & pos, QString & out_axis, double * out_score = nullptr) const;
+  bool drag_position_to_world_xy(const QPoint & pos, double z_m, double & out_x, double & out_y) const;
   ItemBounds item_bounds_for_role(const ScenePreviewWidget::PreviewItem & item) const;
   bool mesh_world_bounds_for_item(const ScenePreviewWidget::PreviewItem & item, ItemBounds & out_bounds) const;
   bool ray_intersects_aabb(const QVector3D & ray_origin, const QVector3D & ray_dir,
@@ -325,6 +326,7 @@ private:
   QString drag_asset_label_;
   QString drag_asset_drop_status_;
   QPoint drag_asset_screen_pos_;
+  QVector3D drag_asset_world_pos_{ 0.0f, 0.0f, 0.0f };
   QJsonObject drag_asset_payload_;
   QString last_camera_fit_target_{ "scene" };
   QVector3D last_camera_fit_bounds_min_{ 0.0f, 0.0f, 0.0f };


### PR DESCRIPTION
### Motivation
- Make scene authoring faster and more intuitive by enabling dragging a catalog asset into Product View and placing it at the drop position using the existing placement flow.
- Ensure the drag transfers a stable catalog asset ID only, re-resolves the asset on drop, and preserves existing safety/validation/snap semantics.
- Provide a transient placement preview that follows the pointer on the world XY plane and cancels/commits cleanly without creating interim authored objects.

### Description
- Introduced an internal MIME type `application/x-workcell-studio-asset`, added `CatalogRoleAssetId`, and updated Asset Library drags to include only the stable `asset_id` in the payload.
- Extended `Scene3DViewportWidget` to accept only the internal MIME type, compute pointer-to-world XY via a new `drag_position_to_world_xy` helper that uses the active camera matrices and ray-plane intersection, and render the transient preview at the computed world position reusing `snap_translation_value`.
- Kept placement commit on the existing path by resolving the dragged `asset_id` in `MainWindow::asset_drop_cb`, validating placeability/editability, then converging on `arm_place_asset_mode` + `commit_armed_asset_placement` so a single authored object, one Undo entry, hierarchy/Inspector selection and dirty state are created.
- Added/updated focused static coverage in `tests/test_scene3d_asset_drag_drop_static.py` to assert the new MIME token, stable-ID payload, catalog role, world-ray mapping helper, and snap reuse.

### Testing
- Ran `python3 -m pytest tests/test_scene3d_asset_drag_drop_static.py` and it passed.
- Ran `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py` which produced 6 passing tests and a single pre-existing static expectation failure in `test_inspector_refresh_for_ur5_2f_test_uses_canonical_metadata_and_launch_path` unrelated to the drag/drop changes.
- Verified `git diff --check`, `git diff --stat`, and `git diff --numstat` for this change set and confirmed the change count and line deltas are within the requested limits (4 files changed, additions and deletions kept small).
- Safety: no launch files, URDF/xacro, controllers, or real-hardware defaults were modified and fake-hardware-first safety remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e0254998c8331871685a5d43cf0ef)