### PR TITLE
Author camera observation zones independently from pick zones

### DIFF
--- a/workcell_builder/workcell_builder/gui/object_placement_dialog.cpp
+++ b/workcell_builder/workcell_builder/gui/object_placement_dialog.cpp
@@ -136,6 +136,21 @@ ObjectPlacementDialog::ObjectPlacementDialog(QWidget * parent)
     task_zones_.push_back(zone);
     rebuild_table();
   });
+  mk("Create Observation Zone", [this]() {
+    auto cameras = load_camera_placements_from_environment_yaml(trim_copy(active_environment_yaml_path_), nullptr);
+    if (cameras.empty()) {
+      QMessageBox::warning(this, "Create Observation Zone", "Observation zone camera is unavailable");
+      return;
+    }
+    const auto suggestion = suggest_camera_observation_zone(cameras.front(), task_zones_);
+    if (!suggestion.ok) {
+      QMessageBox::warning(this, "Create Observation Zone", QString::fromStdString(suggestion.messages.empty() ? "Camera view does not intersect the work surface" : suggestion.messages.front()));
+      return;
+    }
+    task_zones_.push_back(suggestion.zone);
+    rebuild_table();
+    QMessageBox::information(this, "Create Observation Zone", QString::fromStdString(suggestion.messages.front()));
+  });
   mk("Edit Zone Pose", [this]() {
     const int row_index = task_zone_table_->currentRow();
     if (row_index < 0 || row_index >= static_cast<int>(task_zones_.size())) return;
@@ -442,7 +457,7 @@ void ObjectPlacementDialog::rebuild_table()
   for (int i = 0; i < static_cast<int>(task_zones_.size()); ++i) {
     const auto & z = task_zones_[static_cast<size_t>(i)];
     const std::array<QString, 13> vals = {
-      QString::fromStdString(z.id), QString::fromStdString(z.type), QString::number(z.x), QString::number(z.y), QString::number(z.z),
+      QString::fromStdString(z.id), QString::fromStdString(z.type == "camera_observation" ? "Camera Observation" : z.type), QString::number(z.x), QString::number(z.y), QString::number(z.z),
       QString::number(z.roll), QString::number(z.pitch), QString::number(z.yaw), QString::number(z.dim_x),
       QString::number(z.dim_y), QString::number(z.dim_z), QString::fromStdString(z.frame_id), QString::fromStdString(z.status)
     };

--- a/workcell_builder/workcell_builder/gui/object_placement_yaml_io.cpp
+++ b/workcell_builder/workcell_builder/gui/object_placement_yaml_io.cpp
@@ -1,5 +1,6 @@
 #include "object_placement_yaml_io.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <filesystem>
 #include <fstream>
@@ -225,6 +226,7 @@ std::vector<TaskZone> load_task_zones_from_environment_yaml(const std::string & 
       z.shape = n["shape"].as<std::string>("box");
       z.parent_frame = n["frame"].as<std::string>(n["parent_frame"].as<std::string>("world"));
       z.frame_id = n["frame_id"].as<std::string>("");
+      z.camera_id = n["camera_id"].as<std::string>(n["linked_camera"].as<std::string>(""));
       z.support_surface_ref = n["support_surface_ref"].as<std::string>("");
       z.object_ref = n["object_ref"].as<std::string>("");
       z.target_ref = n["target_ref"].as<std::string>("");
@@ -314,6 +316,7 @@ PlacedObjectYamlWriteResult save_task_zones_to_environment_yaml(const std::strin
       n["dimensions"].push_back(z.dim_y);
       n["dimensions"].push_back(z.dim_z);
       if (!z.frame_id.empty()) n["frame_id"] = z.frame_id;
+      if (!z.camera_id.empty()) n["camera_id"] = z.camera_id;
       if (!z.support_surface_ref.empty()) n["support_surface_ref"] = z.support_surface_ref;
       if (!z.object_ref.empty()) n["object_ref"] = z.object_ref;
       if (!z.target_ref.empty()) n["target_ref"] = z.target_ref;
@@ -346,6 +349,58 @@ PlacedObjectYamlWriteResult save_task_zones_to_environment_yaml(const std::strin
     r.warnings.push_back(std::string("failed to save task zones: ") + e.what());
   }
   return r;
+}
+
+bool can_create_observation_zone_for_camera(
+  const CameraPlacement * selected_camera, bool editable_scene, bool scene_writable)
+{
+  std::string warning;
+  return editable_scene && scene_writable && selected_camera &&
+    selected_camera->enabled && validate_camera_placement(*selected_camera, &warning);
+}
+
+ObservationZoneSuggestion suggest_camera_observation_zone(
+  const CameraPlacement & camera, const std::vector<TaskZone> & existing_zones, double work_surface_z)
+{
+  ObservationZoneSuggestion out;
+  if (!can_create_observation_zone_for_camera(&camera, true, true)) {
+    out.messages.push_back("Observation zone camera is unavailable");
+    return out;
+  }
+  const double cr = std::cos(camera.roll), sr = std::sin(camera.roll);
+  const double cp = std::cos(camera.pitch), sp = std::sin(camera.pitch);
+  const double cy = std::cos(camera.yaw), sy = std::sin(camera.yaw);
+  const double dx = -(cy * sp * cr + sy * sr);
+  const double dy = -(sy * sp * cr - cy * sr);
+  const double dz = -(cp * cr);
+  if (std::fabs(dz) < 1e-6 || ((work_surface_z - camera.z) / dz) <= 0.0) {
+    out.messages.push_back("Camera view does not intersect the work surface");
+    return out;
+  }
+  const double t = (work_surface_z - camera.z) / dz;
+  double width = 0.6, depth = 0.4;
+  if (camera.horizontal_fov_deg > 1.0 && camera.vertical_fov_deg > 1.0) {
+    width = std::clamp(2.0 * t * std::tan(camera.horizontal_fov_deg * 3.14159265358979323846 / 360.0), 0.05, 5.0);
+    depth = std::clamp(2.0 * t * std::tan(camera.vertical_fov_deg * 3.14159265358979323846 / 360.0), 0.05, 5.0);
+  } else {
+    out.messages.push_back("Observation zone uses default dimensions");
+  }
+  TaskZone z;
+  z.id = "camera_observation_1";
+  for (int i = 1;; ++i) {
+    z.id = "camera_observation_" + std::to_string(i);
+    if (std::none_of(existing_zones.begin(), existing_zones.end(), [&](const TaskZone & e){ return e.id == z.id; })) break;
+  }
+  z.type = "camera_observation";
+  z.role = "camera_observation";
+  z.shape = "box";
+  z.parent_frame = "world";
+  z.camera_id = camera.name;
+  z.x = camera.x + t * dx; z.y = camera.y + t * dy; z.z = work_surface_z;
+  z.yaw = camera.yaw; z.dim_x = width; z.dim_y = depth; z.dim_z = 0.02;
+  z.status = "Created observation zone for " + camera.name;
+  out.ok = true; out.zone = z; out.messages.push_back(z.status);
+  return out;
 }
 
 bool load_robot_tool_pose_from_environment_yaml(

--- a/workcell_builder/workcell_builder/gui/scene3d_visual_classification.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_visual_classification.cpp
@@ -31,6 +31,7 @@ QStringList canonical_helper_overlay_tokens()
     QStringLiteral("warning_anchor"),
     QStringLiteral("warning_badge"),
     QStringLiteral("camera_fov"),
+    QStringLiteral("camera_observation"),
     QStringLiteral("fov"),
     QStringLiteral("pick_coverage"),
     QStringLiteral("reachability"),

--- a/workcell_builder/workcell_builder/include/object_placement_model.hpp
+++ b/workcell_builder/workcell_builder/include/object_placement_model.hpp
@@ -54,6 +54,7 @@ struct TaskZone
   double roll{0.0}, pitch{0.0}, yaw{0.0};
   double dim_x{0.0}, dim_y{0.0}, dim_z{0.0};
   std::string frame_id;
+  std::string camera_id;
   std::string support_surface_ref;
   std::string object_ref;
   std::string target_ref;
@@ -70,6 +71,18 @@ std::string import_stl_to_asset_library(
   const std::string & stl_path,
   const std::string & repo_root,
   const std::string & managed_folder = "easy_manipulation_deployment/assets/environment/custom_meshes");
+struct ObservationZoneSuggestion
+{
+  bool ok{false};
+  TaskZone zone;
+  std::vector<std::string> messages;
+};
+
+bool can_create_observation_zone_for_camera(
+  const CameraPlacement * selected_camera, bool editable_scene, bool scene_writable);
+ObservationZoneSuggestion suggest_camera_observation_zone(
+  const CameraPlacement & camera, const std::vector<TaskZone> & existing_zones, double work_surface_z = 0.0);
+
 std::string serialize_placed_objects_to_environment_yaml(const std::vector<PlacedObject> & objects);
 std::vector<PlacedObject> parse_placed_objects_from_environment_yaml(const std::string & content);
 bool save_environment_layout(const std::string & output_path, const std::vector<PlacedObject> & objects);

--- a/workcell_builder/workcell_builder/include/object_placement_yaml_io.hpp
+++ b/workcell_builder/workcell_builder/include/object_placement_yaml_io.hpp
@@ -73,6 +73,7 @@ PlacedObjectYamlWriteResult save_task_zones_to_environment_yaml(
   const std::string & environment_yaml_path,
   const std::vector<TaskZone> & task_zones);
 
+
 bool load_robot_tool_pose_from_environment_yaml(
   const std::string & environment_yaml_path,
   RobotMountConfig * robot_mount,

--- a/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 
 #include <QApplication>
+#include <QFile>
+#include <QIODevice>
 
 #include "../gui/scene3d_viewport_widget.h"
 
@@ -84,6 +86,11 @@ TEST(Scene3DRenderRoleClassifier, DefaultProductFitIncludesPhysicalItemsAndExclu
   camera_fov.role = "camera_fov_cone";
   camera_fov.category = "diagnostic_overlay";
   EXPECT_FALSE(Scene3DViewportWidget::should_include_in_default_fit_for_test(camera_fov));
+
+  auto observation_zone = make_item("camera_observation_1");
+  observation_zone.role = "camera_observation";
+  observation_zone.category = "Task Zones";
+  EXPECT_FALSE(Scene3DViewportWidget::should_include_in_default_fit_for_test(observation_zone));
 
   auto reachability = make_item("reachability");
   reachability.role = "reachability_heatmap";
@@ -387,4 +394,28 @@ TEST(Scene3DRenderRoleClassifier, ValidStlAndDaePreviewItemsAreMeshSurfaceCandid
   EXPECT_FALSE(Scene3DViewportWidget::should_draw_as_wireframe_for_test(dae, ScenePreviewWidget::MeshPreviewMode::Auto));
   EXPECT_EQ(Scene3DViewportWidget::render_role_for_test(stl), "generated_urdf_mesh");
   EXPECT_EQ(Scene3DViewportWidget::render_role_for_test(dae), "generated_urdf_mesh");
+}
+
+TEST(CameraObservationZoneAuthoringSource, UsesIndependentTaskZoneModelAndProjection)
+{
+  QString root = QString::fromUtf8(__FILE__);
+  root = root.left(root.lastIndexOf(QStringLiteral("/test/")));
+  auto read = [](const QString & path) {
+    QFile file(path);
+    file.open(QIODevice::ReadOnly | QIODevice::Text);
+    return QString::fromUtf8(file.readAll());
+  };
+  const QString model = read(root + QStringLiteral("/include/object_placement_model.hpp"));
+  const QString yaml = read(root + QStringLiteral("/gui/object_placement_yaml_io.cpp"));
+  const QString dialog = read(root + QStringLiteral("/gui/object_placement_dialog.cpp"));
+  EXPECT_TRUE(model.contains(QStringLiteral("std::string camera_id;")));
+  EXPECT_TRUE(yaml.contains(QStringLiteral("camera_observation")));
+  EXPECT_TRUE(yaml.contains(QStringLiteral("z.camera_id = camera.name")));
+  EXPECT_FALSE(yaml.contains(QStringLiteral("pick_zone_id")));
+  EXPECT_TRUE(yaml.contains(QStringLiteral("Camera view does not intersect the work surface")));
+  EXPECT_TRUE(yaml.contains(QStringLiteral("Observation zone uses default dimensions")));
+  EXPECT_TRUE(yaml.contains(QStringLiteral("camera.x + t * dx")));
+  EXPECT_TRUE(yaml.contains(QStringLiteral("camera.y + t * dy")));
+  EXPECT_TRUE(dialog.contains(QStringLiteral("Create Observation Zone")));
+  EXPECT_FALSE(dialog.contains(QStringLiteral("robot_motion")));
 }


### PR DESCRIPTION
### Motivation
- Add an authoring primitive for an independent Camera Observation Zone so cameras can declare an observable work area that is separate from robot Pick/Place zones and suitable for future conveyor workflows.

### Description
- Add `camera_id` to the authoritative `TaskZone` model and round-trip support in the existing task-zone YAML reader/writer so observation zones persist in `environment.yaml` without introducing a second zone file. (changed: `object_placement_model.hpp`, `object_placement_yaml_io.cpp`/header)
- Implement `can_create_observation_zone_for_camera` and `suggest_camera_observation_zone` helpers that validate a selected camera, intersect the camera optical center ray with a work surface, derive initial footprint from FOV when available, and fall back to sane defaults when not. (changed: `object_placement_yaml_io.cpp`)
- Add a compact `Create Observation Zone` action to the existing Object Placement Manager UI that suggests and authors a `camera_observation` zone from the active camera placement and surfaces actionable status messages when unavailable. (changed: `object_placement_dialog.cpp`)
- Classify `camera_observation` as a helper/overlay token so Product View default framing and Fit Cell calculations exclude observation zones by default. (changed: `scene3d_visual_classification.cpp`)
- Add focused regression coverage that asserts the new model/schema tokens and Product View fit exclusion behavior for observation zones. (changed: `scene3d_render_role_classifier_test.cpp`)

### Testing
- Ran the Python UI-related tests: `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py`; 6 tests passed and 1 test failed (the failing test is an existing source-level assertion in `tests/test_workcell_builder_product_view_defaults.py::test_inspector_refresh_for_ur5_2f_test_uses_canonical_metadata_and_launch_path` and is unrelated to the observation-zone logic introduced here).
- C++ unit test execution via `colcon` could not be performed in the current environment because `colcon` is not available, so the C++ gtests were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e057cce6483319373006059da9d58)