### PR TITLE
Author Pick Zones independently from camera observation

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -357,7 +357,9 @@ if(BUILD_TESTING)
   ament_add_gtest(workcell_scene3d_render_role_classifier_test
     test/scene3d_render_role_classifier_test.cpp
     gui/scene3d_viewport_widget.cpp
-    gui/scene3d_visual_classification.cpp)
+    gui/scene3d_visual_classification.cpp
+    gui/object_placement_yaml_io.cpp
+    src_object_placement_model.cpp)
   ament_add_gtest(workcell_scene3d_ur5_baked_transform_test
     test/scene3d_ur5_baked_transform_test.cpp
     gui/scene3d_viewport_widget.cpp
@@ -439,6 +441,7 @@ if(BUILD_TESTING)
       Qt5::Widgets
       Qt5::OpenGL
       OpenGL::GL
+      yaml-cpp
     )
     target_include_directories(workcell_scene3d_render_role_classifier_test PRIVATE gui)
   endif()

--- a/workcell_builder/workcell_builder/gui/object_placement_dialog.cpp
+++ b/workcell_builder/workcell_builder/gui/object_placement_dialog.cpp
@@ -12,6 +12,7 @@
 #include <QPushButton>
 #include <QTextEdit>
 #include <QVBoxLayout>
+#include <algorithm>
 #include <array>
 #include <cctype>
 #include <fstream>
@@ -24,6 +25,7 @@
 #include <QClipboard>
 #include <QFormLayout>
 #include <QDoubleSpinBox>
+#include <yaml-cpp/yaml.h>
 
 namespace workcell_builder
 {
@@ -47,6 +49,24 @@ static std::string trim_copy(const std::string & input)
   while (e > b && std::isspace(static_cast<unsigned char>(input[e - 1]))) --e;
   return input.substr(b, e - b);
 }
+std::vector<std::string> robot_ids_from_environment(const std::string & path)
+{
+  std::vector<std::string> ids;
+  try {
+    YAML::Node root = YAML::LoadFile(path);
+    if (root["robot"] && root["robot"].IsMap()) {
+      const auto id = root["robot"]["id"].as<std::string>(root["robot"]["name"].as<std::string>(""));
+      if (!id.empty()) ids.push_back(id);
+    }
+    if (root["robots"] && root["robots"].IsSequence()) {
+      for (const auto & r : root["robots"]) {
+        const auto id = r["id"].as<std::string>(r["name"].as<std::string>(""));
+        if (!id.empty() && std::find(ids.begin(), ids.end(), id) == ids.end()) ids.push_back(id);
+      }
+    }
+  } catch (const std::exception &) {}
+  return ids;
+}
 }  // namespace
 
 ObjectPlacementDialog::ObjectPlacementDialog(QWidget * parent)
@@ -63,8 +83,8 @@ ObjectPlacementDialog::ObjectPlacementDialog(QWidget * parent)
 
   outer->addWidget(new QLabel("Task Zones", this));
   task_zone_table_ = new QTableWidget(this);
-  task_zone_table_->setColumnCount(13);
-  task_zone_table_->setHorizontalHeaderLabels({"ID", "Type", "X", "Y", "Z", "Roll", "Pitch", "Yaw", "Size X", "Size Y", "Size Z", "Frame", "Status / Warnings"});
+  task_zone_table_->setColumnCount(14);
+  task_zone_table_->setHorizontalHeaderLabels({"ID", "Type", "Robot", "X", "Y", "Z", "Roll", "Pitch", "Yaw", "Size X", "Size Y", "Size Z", "Frame", "Status / Warnings"});
   task_zone_table_->horizontalHeader()->setStretchLastSection(true);
   outer->addWidget(task_zone_table_);
 
@@ -122,12 +142,29 @@ ObjectPlacementDialog::ObjectPlacementDialog(QWidget * parent)
   });
 
 
-  mk("Add Pick Zone", [this]() {
-    TaskZone zone;
-    zone.id = QString("pick_zone_%1").arg(task_zones_.size() + 1).toStdString();
-    zone.type = "pick";
-    task_zones_.push_back(zone);
-    rebuild_table();
+  mk("Create Pick Zone", [this]() {
+    const auto robots = robot_ids_from_environment(trim_copy(active_environment_yaml_path_));
+    std::string message;
+    if (!can_create_pick_zone_for_robots(robots, &message)) {
+      QMessageBox::warning(this, "Create Pick Zone", QString::fromStdString(message));
+      return;
+    }
+    QString robot = QString::fromStdString(robots.front());
+    if (robots.size() > 1) {
+      QStringList choices; for (const auto & id : robots) choices << QString::fromStdString(id);
+      bool ok = false; robot = QInputDialog::getItem(this, "Create Pick Zone", "Robot", choices, 0, false, &ok);
+      if (!ok || robot.isEmpty()) return;
+    }
+    QDialog d(this); d.setWindowTitle("Create Pick Zone"); auto * layout = new QFormLayout(&d);
+    std::array<QDoubleSpinBox *, 4> spin{}; const std::array<const char *, 4> labels = {"Center X", "Center Y", "Surface Z", "Yaw"};
+    for (int i = 0; i < 4; ++i) { spin[static_cast<size_t>(i)] = new QDoubleSpinBox(&d); spin[static_cast<size_t>(i)]->setDecimals(6); spin[static_cast<size_t>(i)]->setRange(-100.0, 100.0); layout->addRow(labels[static_cast<size_t>(i)], spin[static_cast<size_t>(i)]); }
+    QDialogButtonBox buttons(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &d); layout->addRow(&buttons);
+    QObject::connect(&buttons, &QDialogButtonBox::accepted, &d, &QDialog::accept); QObject::connect(&buttons, &QDialogButtonBox::rejected, &d, &QDialog::reject);
+    if (d.exec() != QDialog::Accepted) { QMessageBox::information(this, "Create Pick Zone", "Pick Zone placement cancelled"); return; }
+    const auto suggestion = suggest_robot_pick_zone(robot.toStdString(), task_zones_, spin[0]->value(), spin[1]->value(), spin[2]->value(), spin[3]->value());
+    if (!suggestion.ok) { QMessageBox::warning(this, "Create Pick Zone", QString::fromStdString(suggestion.messages.empty() ? "Pick Zone robot is unavailable" : suggestion.messages.front())); return; }
+    task_zones_.push_back(suggestion.zone); rebuild_table();
+    QMessageBox::information(this, "Create Pick Zone", QString::fromStdString(suggestion.messages.front()));
   });
   mk("Add Place Zone", [this]() {
     TaskZone zone;
@@ -155,21 +192,24 @@ ObjectPlacementDialog::ObjectPlacementDialog(QWidget * parent)
     const int row_index = task_zone_table_->currentRow();
     if (row_index < 0 || row_index >= static_cast<int>(task_zones_.size())) return;
     auto & z = task_zones_[static_cast<size_t>(row_index)];
-    z.x = task_zone_table_->item(row_index, 2) ? task_zone_table_->item(row_index, 2)->text().toDouble() : z.x;
-    z.y = task_zone_table_->item(row_index, 3) ? task_zone_table_->item(row_index, 3)->text().toDouble() : z.y;
-    z.z = task_zone_table_->item(row_index, 4) ? task_zone_table_->item(row_index, 4)->text().toDouble() : z.z;
-    z.roll = task_zone_table_->item(row_index, 5) ? task_zone_table_->item(row_index, 5)->text().toDouble() : z.roll;
-    z.pitch = task_zone_table_->item(row_index, 6) ? task_zone_table_->item(row_index, 6)->text().toDouble() : z.pitch;
-    z.yaw = task_zone_table_->item(row_index, 7) ? task_zone_table_->item(row_index, 7)->text().toDouble() : z.yaw;
+    z.robot_id = task_zone_table_->item(row_index, 2) ? task_zone_table_->item(row_index, 2)->text().toStdString() : z.robot_id;
+    z.x = task_zone_table_->item(row_index, 3) ? task_zone_table_->item(row_index, 3)->text().toDouble() : z.x;
+    z.y = task_zone_table_->item(row_index, 4) ? task_zone_table_->item(row_index, 4)->text().toDouble() : z.y;
+    z.z = task_zone_table_->item(row_index, 5) ? task_zone_table_->item(row_index, 5)->text().toDouble() : z.z;
+    z.roll = task_zone_table_->item(row_index, 6) ? task_zone_table_->item(row_index, 6)->text().toDouble() : z.roll;
+    z.pitch = task_zone_table_->item(row_index, 7) ? task_zone_table_->item(row_index, 7)->text().toDouble() : z.pitch;
+    z.yaw = task_zone_table_->item(row_index, 8) ? task_zone_table_->item(row_index, 8)->text().toDouble() : z.yaw;
     rebuild_table();
   });
   mk("Edit Zone Size", [this]() {
     const int row_index = task_zone_table_->currentRow();
     if (row_index < 0 || row_index >= static_cast<int>(task_zones_.size())) return;
     auto & z = task_zones_[static_cast<size_t>(row_index)];
-    z.dim_x = task_zone_table_->item(row_index, 8) ? task_zone_table_->item(row_index, 8)->text().toDouble() : z.dim_x;
-    z.dim_y = task_zone_table_->item(row_index, 9) ? task_zone_table_->item(row_index, 9)->text().toDouble() : z.dim_y;
-    z.dim_z = task_zone_table_->item(row_index, 10) ? task_zone_table_->item(row_index, 10)->text().toDouble() : z.dim_z;
+    z.dim_x = task_zone_table_->item(row_index, 9) ? task_zone_table_->item(row_index, 9)->text().toDouble() : z.dim_x;
+    z.dim_y = task_zone_table_->item(row_index, 10) ? task_zone_table_->item(row_index, 10)->text().toDouble() : z.dim_y;
+    z.dim_z = task_zone_table_->item(row_index, 11) ? task_zone_table_->item(row_index, 11)->text().toDouble() : z.dim_z;
+    std::string warning;
+    if (!validate_task_zone_dimensions(z, &warning)) { QMessageBox::warning(this, "Edit Zone Size", QString::fromStdString(warning)); return; }
     rebuild_table();
   });
   mk("Save Task Zones to Scene YAML", [this]() {
@@ -456,12 +496,13 @@ void ObjectPlacementDialog::rebuild_table()
   task_zone_table_->setRowCount(static_cast<int>(task_zones_.size()));
   for (int i = 0; i < static_cast<int>(task_zones_.size()); ++i) {
     const auto & z = task_zones_[static_cast<size_t>(i)];
-    const std::array<QString, 13> vals = {
-      QString::fromStdString(z.id), QString::fromStdString(z.type == "camera_observation" ? "Camera Observation" : z.type), QString::number(z.x), QString::number(z.y), QString::number(z.z),
+    const std::array<QString, 14> vals = {
+      QString::fromStdString(z.id), QString::fromStdString(z.type == "camera_observation" ? "Camera Observation" : (z.type == "pick" ? "Pick Zone" : z.type)),
+      QString::fromStdString(z.robot_id), QString::number(z.x), QString::number(z.y), QString::number(z.z),
       QString::number(z.roll), QString::number(z.pitch), QString::number(z.yaw), QString::number(z.dim_x),
       QString::number(z.dim_y), QString::number(z.dim_z), QString::fromStdString(z.frame_id), QString::fromStdString(z.status)
     };
-    for (int c = 0; c < 13; ++c) task_zone_table_->setItem(i, c, new QTableWidgetItem(vals[static_cast<size_t>(c)]));
+    for (int c = 0; c < 14; ++c) task_zone_table_->setItem(i, c, new QTableWidgetItem(vals[static_cast<size_t>(c)]));
   }
 }
 

--- a/workcell_builder/workcell_builder/gui/object_placement_yaml_io.cpp
+++ b/workcell_builder/workcell_builder/gui/object_placement_yaml_io.cpp
@@ -227,10 +227,12 @@ std::vector<TaskZone> load_task_zones_from_environment_yaml(const std::string & 
       z.parent_frame = n["frame"].as<std::string>(n["parent_frame"].as<std::string>("world"));
       z.frame_id = n["frame_id"].as<std::string>("");
       z.camera_id = n["camera_id"].as<std::string>(n["linked_camera"].as<std::string>(""));
+      z.robot_id = n["robot_id"].as<std::string>(n["linked_robot"].as<std::string>(""));
       z.support_surface_ref = n["support_surface_ref"].as<std::string>("");
       z.object_ref = n["object_ref"].as<std::string>("");
       z.target_ref = n["target_ref"].as<std::string>("");
       z.enabled = n["enabled"].as<bool>(true);
+      z.visible = n["visible"].as<bool>(true);
       z.status = n["status"].as<std::string>("");
 
       auto pose_xyz_alias = n["pose_xyz"];
@@ -317,6 +319,7 @@ PlacedObjectYamlWriteResult save_task_zones_to_environment_yaml(const std::strin
       n["dimensions"].push_back(z.dim_z);
       if (!z.frame_id.empty()) n["frame_id"] = z.frame_id;
       if (!z.camera_id.empty()) n["camera_id"] = z.camera_id;
+      if (!z.robot_id.empty()) n["robot_id"] = z.robot_id;
       if (!z.support_surface_ref.empty()) n["support_surface_ref"] = z.support_surface_ref;
       if (!z.object_ref.empty()) n["object_ref"] = z.object_ref;
       if (!z.target_ref.empty()) n["target_ref"] = z.target_ref;
@@ -324,13 +327,14 @@ PlacedObjectYamlWriteResult save_task_zones_to_environment_yaml(const std::strin
         for (const auto & t : z.allowed_object_types) n["allowed_object_types"].push_back(t);
       }
       n["enabled"] = z.enabled;
+      n["visible"] = z.visible;
       if (!z.status.empty()) n["status"] = z.status;
       arr.push_back(n);
     }
 
     root["task_zones"] = arr;
     for (const auto & z : zones) {
-      const bool is_pick = z.role == "pick" || z.type == "pick_zone";
+      const bool is_pick = z.role == "pick" || z.type == "pick" || z.type == "pick_zone";
       const bool is_place = z.role == "place" || z.type == "place_zone";
       if (is_pick) {
         root["task"]["pick"]["source_ref"] = z.id;
@@ -349,6 +353,48 @@ PlacedObjectYamlWriteResult save_task_zones_to_environment_yaml(const std::strin
     r.warnings.push_back(std::string("failed to save task zones: ") + e.what());
   }
   return r;
+}
+
+PickZoneDefaults default_pick_zone_dimensions() { return PickZoneDefaults{}; }
+
+bool validate_task_zone_dimensions(const TaskZone & zone, std::string * warning)
+{
+  const bool ok = std::isfinite(zone.dim_x) && std::isfinite(zone.dim_y) && std::isfinite(zone.dim_z) &&
+    zone.dim_x > 0.0 && zone.dim_y > 0.0 && zone.dim_z > 0.0 &&
+    zone.dim_x <= 100.0 && zone.dim_y <= 100.0 && zone.dim_z <= 100.0;
+  if (!ok && warning) *warning = "Pick Zone dimensions must be positive";
+  return ok;
+}
+
+bool can_create_pick_zone_for_robots(const std::vector<std::string> & robot_ids, std::string * message)
+{
+  if (robot_ids.empty()) {
+    if (message) *message = "Add or select a robot before creating a Pick Zone";
+    return false;
+  }
+  if (message) *message = robot_ids.size() == 1 ? robot_ids.front() : "Choose a robot for the Pick Zone";
+  return true;
+}
+
+ObservationZoneSuggestion suggest_robot_pick_zone(
+  const std::string & robot_id, const std::vector<TaskZone> & existing_zones,
+  double world_x, double world_y, double surface_z, double yaw)
+{
+  ObservationZoneSuggestion out;
+  if (robot_id.empty()) { out.messages.push_back("Pick Zone robot is unavailable"); return out; }
+  TaskZone z;
+  for (int i = 1;; ++i) {
+    z.id = "pick_zone_" + std::to_string(i);
+    if (std::none_of(existing_zones.begin(), existing_zones.end(), [&](const TaskZone & e){ return e.id == z.id; })) break;
+  }
+  const auto d = default_pick_zone_dimensions();
+  z.type = "pick"; z.role = "pick"; z.shape = "box"; z.parent_frame = "world"; z.robot_id = robot_id;
+  z.x = world_x; z.y = world_y; z.z = surface_z; z.yaw = yaw; z.dim_x = d.width; z.dim_y = d.depth; z.dim_z = d.height;
+  z.status = "Robot association: " + robot_id + " — reachability not yet validated";
+  std::string warning;
+  if (!validate_task_zone_dimensions(z, &warning)) { out.messages.push_back(warning); return out; }
+  out.ok = true; out.zone = z; out.messages.push_back("Created Pick Zone for " + robot_id);
+  return out;
 }
 
 bool can_create_observation_zone_for_camera(

--- a/workcell_builder/workcell_builder/include/object_placement_model.hpp
+++ b/workcell_builder/workcell_builder/include/object_placement_model.hpp
@@ -40,6 +40,7 @@ struct CameraPlacement
   double near_m{0.15};
   double far_m{1.5};
   bool enabled{true};
+  bool visible{true};
   std::string status;
 };
 
@@ -55,11 +56,13 @@ struct TaskZone
   double dim_x{0.0}, dim_y{0.0}, dim_z{0.0};
   std::string frame_id;
   std::string camera_id;
+  std::string robot_id;
   std::string support_surface_ref;
   std::string object_ref;
   std::string target_ref;
   std::vector<std::string> allowed_object_types;
   bool enabled{true};
+  bool visible{true};
   std::string status;
 };
 
@@ -82,6 +85,21 @@ bool can_create_observation_zone_for_camera(
   const CameraPlacement * selected_camera, bool editable_scene, bool scene_writable);
 ObservationZoneSuggestion suggest_camera_observation_zone(
   const CameraPlacement & camera, const std::vector<TaskZone> & existing_zones, double work_surface_z = 0.0);
+
+struct PickZoneDefaults
+{
+  double width{0.40};
+  double depth{0.40};
+  double height{0.10};
+};
+
+PickZoneDefaults default_pick_zone_dimensions();
+bool validate_task_zone_dimensions(const TaskZone & zone, std::string * warning = nullptr);
+bool can_create_pick_zone_for_robots(
+  const std::vector<std::string> & robot_ids, std::string * message = nullptr);
+ObservationZoneSuggestion suggest_robot_pick_zone(
+  const std::string & robot_id, const std::vector<TaskZone> & existing_zones,
+  double world_x, double world_y, double surface_z, double yaw = 0.0);
 
 std::string serialize_placed_objects_to_environment_yaml(const std::vector<PlacedObject> & objects);
 std::vector<PlacedObject> parse_placed_objects_from_environment_yaml(const std::string & content);

--- a/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
@@ -3,8 +3,10 @@
 #include <QApplication>
 #include <QFile>
 #include <QIODevice>
+#include <QDir>
 
 #include "../gui/scene3d_viewport_widget.h"
+#include "../include/object_placement_yaml_io.hpp"
 
 namespace {
 QApplication * ensure_app()
@@ -418,4 +420,81 @@ TEST(CameraObservationZoneAuthoringSource, UsesIndependentTaskZoneModelAndProjec
   EXPECT_TRUE(yaml.contains(QStringLiteral("camera.y + t * dy")));
   EXPECT_TRUE(dialog.contains(QStringLiteral("Create Observation Zone")));
   EXPECT_FALSE(dialog.contains(QStringLiteral("robot_motion")));
+}
+
+TEST(IndependentPickZoneAuthoring, ModelYamlAndOverlayContract)
+{
+  using namespace workcell_builder;
+  std::string message;
+  EXPECT_FALSE(can_create_pick_zone_for_robots({}, &message));
+  EXPECT_EQ(message, "Add or select a robot before creating a Pick Zone");
+  EXPECT_TRUE(can_create_pick_zone_for_robots({"ur5"}, &message));
+  EXPECT_EQ(message, "ur5");
+  EXPECT_TRUE(can_create_pick_zone_for_robots({"ur5", "ur10"}, &message));
+  EXPECT_EQ(message, "Choose a robot for the Pick Zone");
+
+  std::vector<TaskZone> existing;
+  auto suggestion = suggest_robot_pick_zone("ur5", existing, 1.8, 0.2, 0.75, 0.3);
+  ASSERT_TRUE(suggestion.ok);
+  const auto & z = suggestion.zone;
+  EXPECT_EQ(z.type, "pick");
+  EXPECT_EQ(z.role, "pick");
+  EXPECT_EQ(z.robot_id, "ur5");
+  EXPECT_TRUE(z.camera_id.empty());
+  EXPECT_NEAR(z.x, 1.8, 1e-9);
+  EXPECT_NEAR(z.y, 0.2, 1e-9);
+  EXPECT_NEAR(z.z, 0.75, 1e-9);
+  const auto defaults = default_pick_zone_dimensions();
+  EXPECT_GT(defaults.width, 0.0);
+  EXPECT_GT(defaults.depth, 0.0);
+  EXPECT_GT(defaults.height, 0.0);
+  EXPECT_DOUBLE_EQ(z.dim_x, defaults.width);
+  EXPECT_DOUBLE_EQ(z.dim_y, defaults.depth);
+  EXPECT_DOUBLE_EQ(z.dim_z, defaults.height);
+
+  TaskZone bad = z;
+  bad.dim_x = 0.0;
+  EXPECT_FALSE(validate_task_zone_dimensions(bad, &message));
+  EXPECT_EQ(message, "Pick Zone dimensions must be positive");
+
+  auto item = make_item("pick_zone_1");
+  item.type = "pick";
+  item.role = "pick";
+  item.category = "Task Zones";
+  EXPECT_FALSE(Scene3DViewportWidget::should_include_in_default_fit_for_test(item));
+}
+
+TEST(IndependentPickZoneAuthoring, SaveReloadPreservesRobotAndNoCameraLink)
+{
+  using namespace workcell_builder;
+  const QString path = QDir::tempPath() + QStringLiteral("/pick_zone_contract_environment.yaml");
+  QFile::remove(path);
+  TaskZone z;
+  z.id = "pick_zone_1";
+  z.type = "pick";
+  z.role = "pick";
+  z.robot_id = "ur5";
+  z.x = 1.8; z.y = 0.2; z.z = 0.75; z.yaw = 0.3;
+  z.dim_x = 0.4; z.dim_y = 0.5; z.dim_z = 0.1;
+  z.enabled = true; z.visible = false;
+  auto result = save_task_zones_to_environment_yaml(path.toStdString(), {z});
+  ASSERT_TRUE(result.ok);
+  QFile file(path);
+  ASSERT_TRUE(file.open(QIODevice::ReadOnly | QIODevice::Text));
+  const QString yaml = QString::fromUtf8(file.readAll());
+  EXPECT_TRUE(yaml.contains(QStringLiteral("type: pick")));
+  EXPECT_TRUE(yaml.contains(QStringLiteral("robot_id: ur5")));
+  EXPECT_FALSE(yaml.contains(QStringLiteral("camera_id")));
+  EXPECT_FALSE(yaml.contains(QStringLiteral("observation_zone_id")));
+  EXPECT_FALSE(yaml.contains(QStringLiteral("/workspace/")));
+
+  std::vector<std::string> warnings;
+  const auto loaded = load_task_zones_from_environment_yaml(path.toStdString(), &warnings);
+  ASSERT_EQ(loaded.size(), 1u);
+  EXPECT_EQ(loaded.front().id, z.id);
+  EXPECT_EQ(loaded.front().type, "pick");
+  EXPECT_EQ(loaded.front().robot_id, "ur5");
+  EXPECT_TRUE(loaded.front().camera_id.empty());
+  EXPECT_DOUBLE_EQ(loaded.front().z, 0.75);
+  EXPECT_FALSE(loaded.front().visible);
 }


### PR DESCRIPTION
### Motivation
- Allow authors to define robot `pick` task-zones that are independent of camera Observation Zones and that persist as editable task overlays in the existing Workcell Builder flow.
- Provide a compact Create Pick Zone authoring flow that ties a zone to a robot's stable ID and uses world-space placement inputs rather than camera-derived placement.
- Preserve existing systems (task_zones YAML, overlay renderer, undo/redo, inspector) and avoid changing camera/observation, planning, or robot-motion behaviour.

### Description
- Extended the authoritative `TaskZone` model to include `robot_id` and `visible` and added centralized Pick Zone defaults and validation helpers (`PickZoneDefaults`, `default_pick_zone_dimensions`, `validate_task_zone_dimensions`, `can_create_pick_zone_for_robots`, `suggest_robot_pick_zone`). (edited: `workcell_builder/include/object_placement_model.hpp`, `workcell_builder/gui/object_placement_yaml_io.cpp`)
- Updated YAML reader/writer to round-trip `robot_id` and `visible`, to recognise `pick` typed zones, and to keep `task_zones` within the existing `environment.yaml` writer semantics. (edited: `workcell_builder/gui/object_placement_yaml_io.cpp`)
- Added a compact `Create Pick Zone` action in the existing `ObjectPlacementDialog` that: resolves robot IDs from `environment.yaml`, auto-selects the only robot, prompts a chooser for multiple robots, collects numeric world-space center/surface-height/yaw inputs, validates dimensions, creates a `pick` TaskZone, and reuses the existing task-zone table/Undo flow. (edited: `workcell_builder/gui/object_placement_dialog.cpp`)
- Made the existing zone editor table show the associated robot and label `pick` records as `Pick Zone`, and kept all persisted state editable via Inspector (no new writer or separate selection model). (edited: `workcell_builder/gui/object_placement_dialog.cpp`)
- Added focused unit coverage exercising robot-selection behaviour, pick-zone creation contract, YAML save/load preservation (no `camera_id` or observation link), fit-exclusion for overlays, and dimension validation; wired test target to include the new YAML/model sources. (edited: `workcell_builder/test/scene3d_render_role_classifier_test.cpp`, `workcell_builder/CMakeLists.txt`)

### Testing
- Ran repository checks: `git diff --check`, `git diff --stat`, `git diff --numstat`, and reviewed `git status --short`, all showed only the intended tracked files staged and within requested diff-size limits. 
- Ran focused Python unit tests via `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py`, which produced 6 passed and 1 failed test, where the single failure is an existing assertion unrelated to pick-zone changes (an expectation about `metadata.scene_name` in `refresh_scene_builder_selected_scene_ui`).
- Attempted to build the modified C++ test target with CMake, but an in-container build was not performed because the container environment lacks the project `build/` directory; the test target linkage was updated to include the YAML/model sources and `yaml-cpp` for local CI builds. 
- Committed changes on branch `codex/add-independent-pick-zone` with message `Add independent robot Pick Zones` and prepared this PR for review; safety checks confirm no robot-motion, planning, or launch/runtime behaviour was changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e0d91db7c8331abb6d6f8bfe01eee)