### PR TITLE
Associate camera observations with independent Pick Zones

### DIFF
--- a/workcell_builder/workcell_builder/gui/object_placement_yaml_io.cpp
+++ b/workcell_builder/workcell_builder/gui/object_placement_yaml_io.cpp
@@ -13,6 +13,12 @@ namespace
 {
 constexpr double kSuspiciousPositionMagnitudeMeters = 100.0;
 
+const TaskZone * find_task_zone_by_id(const std::vector<TaskZone> & zones, const std::string & id)
+{
+  auto it = std::find_if(zones.begin(), zones.end(), [&](const TaskZone & z){ return z.id == id; });
+  return it == zones.end() ? nullptr : &*it;
+}
+
 YAML::Node to_yaml_pose(const PlacedObject & o)
 {
   YAML::Node pose;
@@ -297,6 +303,60 @@ std::vector<TaskZone> load_task_zones_from_environment_yaml(const std::string & 
   return out;
 }
 
+std::vector<TaskZoneLink> load_task_zone_links_from_environment_yaml(
+  const std::string & path, const std::vector<TaskZone> & zones, std::vector<std::string> * warnings)
+{
+  std::vector<TaskZoneLink> out;
+  try {
+    YAML::Node root = YAML::LoadFile(path);
+    auto arr = root["task_zone_links"];
+    if (!arr) return out;
+    if (!arr.IsSequence()) { if (warnings) warnings->push_back("task_zone_links exists but is not a sequence; ignoring"); return out; }
+    for (const auto & n : arr) {
+      if (!n.IsMap()) { if (warnings) warnings->push_back("malformed task_zone_links entry skipped"); continue; }
+      TaskZoneLink link;
+      link.id = n["id"].as<std::string>("");
+      link.type = n["type"].as<std::string>("");
+      link.source_zone_id = n["source_zone_id"].as<std::string>("");
+      link.target_zone_id = n["target_zone_id"].as<std::string>("");
+      link.enabled = n["enabled"].as<bool>(true);
+      link.status = n["status"].as<std::string>("");
+      std::string warning;
+      link.resolved = validate_observation_to_pick_link(link, zones, out, &warning);
+      if (!link.resolved && warnings) warnings->push_back(warning);
+      out.push_back(link);
+    }
+  } catch (const std::exception & e) {
+    if (warnings) warnings->push_back(std::string("task_zone_links yaml parse warning: ") + e.what());
+  }
+  return out;
+}
+
+PlacedObjectYamlWriteResult save_task_zone_links_to_environment_yaml(
+  const std::string & path, const std::vector<TaskZoneLink> & links)
+{
+  PlacedObjectYamlWriteResult r; r.path_written = path;
+  try {
+    YAML::Node root;
+    if (std::filesystem::exists(path)) root = YAML::LoadFile(path);
+    YAML::Node arr(YAML::NodeType::Sequence);
+    for (const auto & l : links) {
+      YAML::Node n;
+      n["id"] = l.id; n["type"] = l.type;
+      n["source_zone_id"] = l.source_zone_id; n["target_zone_id"] = l.target_zone_id;
+      n["enabled"] = l.enabled;
+      if (!l.status.empty()) n["status"] = l.status;
+      arr.push_back(n);
+    }
+    root["task_zone_links"] = arr;
+    std::ofstream out(path); out << root;
+    r.ok = out.good(); r.objects_saved = links.size();
+  } catch (const std::exception & e) {
+    r.warnings.push_back(std::string("failed to save task zone links: ") + e.what());
+  }
+  return r;
+}
+
 PlacedObjectYamlWriteResult save_task_zones_to_environment_yaml(const std::string & path, const std::vector<TaskZone> & zones)
 {
   PlacedObjectYamlWriteResult r; r.path_written = path;
@@ -353,6 +413,59 @@ PlacedObjectYamlWriteResult save_task_zones_to_environment_yaml(const std::strin
     r.warnings.push_back(std::string("failed to save task zones: ") + e.what());
   }
   return r;
+}
+
+
+bool is_camera_observation_zone(const TaskZone & zone)
+{
+  return zone.type == "camera_observation" || zone.role == "camera_observation";
+}
+
+bool is_pick_task_zone(const TaskZone & zone)
+{
+  return zone.type == "pick" || zone.type == "pick_zone" || zone.role == "pick";
+}
+
+bool validate_observation_to_pick_link(
+  const TaskZoneLink & link, const std::vector<TaskZone> & zones,
+  const std::vector<TaskZoneLink> & existing_links, std::string * warning)
+{
+  if (link.type != "observation_to_pick") { if (warning) *warning = "unsupported task zone link type"; return false; }
+  if (link.source_zone_id.empty() || link.target_zone_id.empty()) { if (warning) *warning = "Observation-to-Pick link source or target is unavailable"; return false; }
+  if (link.source_zone_id == link.target_zone_id) { if (warning) *warning = "Observation-to-Pick link cannot target itself"; return false; }
+  const TaskZone * source = find_task_zone_by_id(zones, link.source_zone_id);
+  if (!source) { if (warning) *warning = "Observation-to-Pick link source is unavailable"; return false; }
+  const TaskZone * target = find_task_zone_by_id(zones, link.target_zone_id);
+  if (!target) { if (warning) *warning = "Observation-to-Pick link target is unavailable"; return false; }
+  if (!is_camera_observation_zone(*source)) { if (warning) *warning = "Observation-to-Pick link source must be a Camera Observation Zone"; return false; }
+  if (!is_pick_task_zone(*target)) { if (warning) *warning = "Observation-to-Pick link target must be a Pick Zone"; return false; }
+  int duplicates = 0;
+  for (const auto & existing : existing_links) {
+    if (existing.enabled && existing.type == link.type && existing.source_zone_id == link.source_zone_id &&
+      existing.target_zone_id == link.target_zone_id) ++duplicates;
+  }
+  if (duplicates > 1) { if (warning) *warning = "duplicate active Observation-to-Pick link"; return false; }
+  return true;
+}
+
+std::vector<TaskZoneLink> set_observation_pick_link(
+  std::vector<TaskZoneLink> links, const std::string & source_zone_id, const std::string & target_zone_id,
+  const std::vector<TaskZone> & zones, std::string * warning)
+{
+  links.erase(std::remove_if(links.begin(), links.end(), [&](const TaskZoneLink & l){
+    return l.type == "observation_to_pick" && l.source_zone_id == source_zone_id;
+  }), links.end());
+  if (target_zone_id.empty()) return links;
+  TaskZoneLink link;
+  link.id = "observation_to_pick_" + std::to_string(links.size() + 1);
+  link.type = "observation_to_pick";
+  link.source_zone_id = source_zone_id;
+  link.target_zone_id = target_zone_id;
+  link.enabled = true;
+  link.status = "Linked — tracking and timing not yet configured";
+  links.push_back(link);
+  if (!validate_observation_to_pick_link(link, zones, links, warning)) links.pop_back();
+  return links;
 }
 
 TaskZoneDefaults default_task_zone_dimensions() { return TaskZoneDefaults{}; }

--- a/workcell_builder/workcell_builder/include/object_placement_model.hpp
+++ b/workcell_builder/workcell_builder/include/object_placement_model.hpp
@@ -44,6 +44,17 @@ struct CameraPlacement
   std::string status;
 };
 
+struct TaskZoneLink
+{
+  std::string id;
+  std::string type;
+  std::string source_zone_id;
+  std::string target_zone_id;
+  bool enabled{true};
+  bool resolved{true};
+  std::string status;
+};
+
 struct TaskZone
 {
   std::string id;
@@ -96,6 +107,14 @@ struct TaskZoneDefaults
 TaskZoneDefaults default_task_zone_dimensions();
 TaskZoneDefaults default_pick_zone_dimensions();
 bool validate_task_zone_dimensions(const TaskZone & zone, std::string * warning = nullptr);
+bool is_camera_observation_zone(const TaskZone & zone);
+bool is_pick_task_zone(const TaskZone & zone);
+bool validate_observation_to_pick_link(
+  const TaskZoneLink & link, const std::vector<TaskZone> & zones,
+  const std::vector<TaskZoneLink> & existing_links = {}, std::string * warning = nullptr);
+std::vector<TaskZoneLink> set_observation_pick_link(
+  std::vector<TaskZoneLink> links, const std::string & source_zone_id, const std::string & target_zone_id,
+  const std::vector<TaskZone> & zones, std::string * warning = nullptr);
 bool can_create_pick_zone_for_robots(
   const std::vector<std::string> & robot_ids, std::string * message = nullptr);
 bool can_create_place_zone_for_robots(

--- a/workcell_builder/workcell_builder/include/object_placement_yaml_io.hpp
+++ b/workcell_builder/workcell_builder/include/object_placement_yaml_io.hpp
@@ -73,6 +73,15 @@ PlacedObjectYamlWriteResult save_task_zones_to_environment_yaml(
   const std::string & environment_yaml_path,
   const std::vector<TaskZone> & task_zones);
 
+std::vector<TaskZoneLink> load_task_zone_links_from_environment_yaml(
+  const std::string & environment_yaml_path,
+  const std::vector<TaskZone> & task_zones,
+  std::vector<std::string> * warnings = nullptr);
+
+PlacedObjectYamlWriteResult save_task_zone_links_to_environment_yaml(
+  const std::string & environment_yaml_path,
+  const std::vector<TaskZoneLink> & task_zone_links);
+
 
 bool load_robot_tool_pose_from_environment_yaml(
   const std::string & environment_yaml_path,

--- a/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
@@ -585,3 +585,92 @@ TEST(IndependentPickZoneAuthoring, SaveReloadPreservesRobotAndNoCameraLink)
   EXPECT_DOUBLE_EQ(loaded.front().z, 0.75);
   EXPECT_FALSE(loaded.front().visible);
 }
+
+TEST(ObservationToPickZoneLinks, ValidateSaveReloadAndIndependence)
+{
+  using namespace workcell_builder;
+  TaskZone obs; obs.id = "camera_observation_1"; obs.type = "camera_observation"; obs.role = "camera_observation";
+  obs.x = 0.1; obs.y = 0.2; obs.z = 0.3; obs.dim_x = 0.4; obs.dim_y = 0.5; obs.dim_z = 0.6;
+  TaskZone pick; pick.id = "pick_zone_1"; pick.type = "pick"; pick.role = "pick";
+  pick.x = 1.1; pick.y = 1.2; pick.z = 1.3; pick.dim_x = 0.7; pick.dim_y = 0.8; pick.dim_z = 0.9;
+  TaskZone place; place.id = "place_zone_1"; place.type = "place"; place.role = "place";
+  std::vector<TaskZone> zones{obs, pick, place};
+
+  std::string warning;
+  auto links = set_observation_pick_link({}, obs.id, pick.id, zones, &warning);
+  ASSERT_EQ(links.size(), 1u);
+  EXPECT_EQ(links.front().type, "observation_to_pick");
+  EXPECT_EQ(links.front().source_zone_id, obs.id);
+  EXPECT_EQ(links.front().target_zone_id, pick.id);
+  EXPECT_TRUE(links.front().enabled);
+  EXPECT_TRUE(validate_observation_to_pick_link(links.front(), zones, links, &warning));
+  EXPECT_NE(links.front().status.find("tracking and timing not yet configured"), std::string::npos);
+  EXPECT_EQ(obs.x, 0.1);
+  EXPECT_EQ(pick.x, 1.1);
+
+  const QString path = QDir::tempPath() + QStringLiteral("/observation_pick_links_environment.yaml");
+  QFile::remove(path);
+  ASSERT_TRUE(save_task_zones_to_environment_yaml(path.toStdString(), zones).ok);
+  ASSERT_TRUE(save_task_zone_links_to_environment_yaml(path.toStdString(), links).ok);
+  QFile file(path);
+  ASSERT_TRUE(file.open(QIODevice::ReadOnly | QIODevice::Text));
+  const QString yaml = QString::fromUtf8(file.readAll());
+  EXPECT_TRUE(yaml.contains(QStringLiteral("task_zone_links:")));
+  EXPECT_TRUE(yaml.contains(QStringLiteral("type: observation_to_pick")));
+  EXPECT_TRUE(yaml.contains(QStringLiteral("source_zone_id: camera_observation_1")));
+  EXPECT_TRUE(yaml.contains(QStringLiteral("target_zone_id: pick_zone_1")));
+  EXPECT_FALSE(yaml.contains(QStringLiteral("conveyor_speed")));
+  EXPECT_FALSE(yaml.contains(QStringLiteral("arrival")));
+  EXPECT_FALSE(yaml.contains(QStringLiteral("robot_motion")));
+  EXPECT_FALSE(yaml.contains(QStringLiteral("/workspace/")));
+
+  std::vector<std::string> warnings;
+  const auto loaded = load_task_zone_links_from_environment_yaml(path.toStdString(), zones, &warnings);
+  ASSERT_EQ(loaded.size(), 1u);
+  EXPECT_TRUE(loaded.front().resolved);
+  EXPECT_EQ(loaded.front().source_zone_id, obs.id);
+  EXPECT_EQ(loaded.front().target_zone_id, pick.id);
+  EXPECT_TRUE(warnings.empty());
+
+  TaskZoneLink invalid = links.front();
+  invalid.target_zone_id = place.id;
+  EXPECT_FALSE(validate_observation_to_pick_link(invalid, zones, {}, &warning));
+  EXPECT_EQ(warning, "Observation-to-Pick link target must be a Pick Zone");
+}
+
+TEST(ObservationToPickZoneLinks, CardinalityChangeRemovalAndMissingReferenceWarnings)
+{
+  using namespace workcell_builder;
+  TaskZone obs1; obs1.id = "camera_observation_1"; obs1.type = "camera_observation"; obs1.role = "camera_observation";
+  TaskZone obs2 = obs1; obs2.id = "camera_observation_2";
+  TaskZone pick1; pick1.id = "pick_zone_1"; pick1.type = "pick"; pick1.role = "pick";
+  TaskZone pick2 = pick1; pick2.id = "pick_zone_2";
+  std::vector<TaskZone> zones{obs1, obs2, pick1, pick2};
+
+  std::string warning;
+  auto links = set_observation_pick_link({}, obs1.id, pick1.id, zones, &warning);
+  links = set_observation_pick_link(links, obs1.id, pick1.id, zones, &warning);
+  ASSERT_EQ(links.size(), 1u);
+  links = set_observation_pick_link(links, obs2.id, pick1.id, zones, &warning);
+  ASSERT_EQ(links.size(), 2u);
+  links = set_observation_pick_link(links, obs1.id, pick2.id, zones, &warning);
+  ASSERT_EQ(links.size(), 2u);
+  auto obs1_link = std::find_if(links.begin(), links.end(), [](const TaskZoneLink & l){ return l.source_zone_id == "camera_observation_1"; });
+  ASSERT_NE(obs1_link, links.end());
+  EXPECT_EQ(obs1_link->target_zone_id, pick2.id);
+  links = set_observation_pick_link(links, obs1.id, "", zones, &warning);
+  EXPECT_EQ(links.size(), 1u);
+  EXPECT_EQ(links.front().source_zone_id, obs2.id);
+
+  TaskZoneLink bad; bad.id = "bad"; bad.type = "observation_to_pick"; bad.source_zone_id = obs1.id; bad.target_zone_id = "missing_pick";
+  const QString path = QDir::tempPath() + QStringLiteral("/observation_pick_missing_target.yaml");
+  QFile::remove(path);
+  ASSERT_TRUE(save_task_zone_links_to_environment_yaml(path.toStdString(), {bad}).ok);
+  std::vector<std::string> warnings;
+  const auto loaded = load_task_zone_links_from_environment_yaml(path.toStdString(), zones, &warnings);
+  ASSERT_EQ(loaded.size(), 1u);
+  EXPECT_FALSE(loaded.front().resolved);
+  ASSERT_FALSE(warnings.empty());
+  EXPECT_NE(warnings.front().find("target is unavailable"), std::string::npos);
+  EXPECT_EQ(zones.size(), 4u);
+}


### PR DESCRIPTION
### Motivation

- Introduce a persisted, semantic relationship so Camera Observation Zones can be authoritatively associated with downstream Pick Zones without coupling their spatial transforms or implying execution/timing behavior. 
- Provide a minimal on-disk model and validation so inspector editing, save/reopen, Undo/Redo and missing-reference diagnostics can be implemented safely later.

### Description

- Added a new `TaskZoneLink` model to represent relationships (`id`, `type`, `source_zone_id`, `target_zone_id`, `enabled`, `resolved`, `status`) in `object_placement_model.hpp`.
- Implemented validation and helper functions `validate_observation_to_pick_link` and `set_observation_pick_link` plus type predicates `is_camera_observation_zone`/`is_pick_task_zone` in `object_placement_yaml_io.cpp` to enforce allowed source/target types, prevent self-links and duplicates, and produce user-facing status strings.
- Added YAML persistence for `task_zone_links` with `load_task_zone_links_from_environment_yaml` and `save_task_zone_links_to_environment_yaml` in the existing environment YAML reader/writer so links are saved alongside `task_zones` without embedding transform data.
- Added focused unit tests exercising creation, validation, save/reload, cardinality changes, duplicate prevention, missing-reference warnings, and ensuring no conveyor/timing/robot-motion metadata is produced in `scene3d_render_role_classifier_test.cpp`.

Changed files (key):
- `workcell_builder/workcell_builder/include/object_placement_model.hpp` (add `TaskZoneLink` and function declarations)
- `workcell_builder/workcell_builder/include/object_placement_yaml_io.hpp` (add link load/save declarations)
- `workcell_builder/workcell_builder/gui/object_placement_yaml_io.cpp` (link validation, load/save helpers)
- `workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp` (new focused tests)

Safety notes: no runtime execution, launch files, URDF/xacro, robot motion, conveyor timing, or perception/tracking behavior was added or modified; the change records intent only and avoids storing absolute paths or transforms inside links.

### Testing

- Ran Python test subset: `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py`, which resulted in 6 tests passing and 1 failing; the failing assertion is a pre-existing product-view metadata expectation that `metadata.scene_name` appears inside `refresh_scene_builder_selected_scene_ui` (this failure is unrelated to the new link YAML contract and appears to be a stale assertion in product-view metadata tests).
- Verified `git diff --check`, `git diff --stat` and local diff sizing stayed within requested limits (file/line count and size constraints).
- Attempted to build the C++ test target for the new test (`workcell_scene3d_render_role_classifier_test`) but the container lacks `ament_cmake`, so the CMake/test build could not be completed here; CI or a ROS/Humble-enabled dev environment with `ament_cmake` installed is required to compile and run the new C++ unit tests.

If CI/build agents run the C++ tests, the new tests exercise save/load and validation semantics for observation→pick links; follow-up work will add the Inspector UI wiring, optional visual overlay, and the single Undo/Redo command integration using the existing Canvas/Inspector edit command path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e123ea6bc83318596e95c6f2c1cb8)