### PR TITLE
Preview configured robot initial pose without commanding hardware

### DIFF
--- a/tests/test_initial_pose_preview_static.py
+++ b/tests/test_initial_pose_preview_static.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VIEWER = ROOT / "workcell_studio_web/viewer/viewer.js"
+RENDERER = ROOT / "workcell_studio_web/viewer/urdf_robot_renderer.js"
+INDEX = ROOT / "workcell_studio_web/viewer/index.html"
+
+
+def test_show_initial_pose_action_is_checkable_and_visual_only():
+    html = INDEX.read_text(encoding="utf-8")
+    js = VIEWER.read_text(encoding="utf-8")
+    assert 'id="show-initial-pose" type="checkbox" disabled' in html
+    assert 'Show Initial Pose' in html
+    assert 'Preview the selected robot at its configured initial joint pose. This does not command the robot.' in html
+    assert 'Initial pose preview' in html
+    forbidden = ['/joint_states', 'FollowJointTrajectory', 'MoveGroup', 'controller_manager', 'create_publisher', 'create_client']
+    preview_body = js.split('function toggleInitialPosePreview', 1)[1].split('function sceneDisplayName', 1)[0]
+    assert not any(token in preview_body for token in forbidden)
+
+
+def test_initial_pose_resolves_selected_robot_and_validates_joint_names():
+    js = VIEWER.read_text(encoding="utf-8")
+    assert 'function selectedRobotRecord()' in js
+    assert 'robots.length === 1' in js
+    assert 'robots.length > 1 && !selectedRobotRecord()' in js
+    assert 'function configuredInitialJointValues(robot)' in js
+    assert 'initial_joint_values' in js and 'configured_initial_positions' in js and 'initial_positions' in js
+    assert 'Initial pose has unknown joint' in js
+    assert 'Initial pose is missing joint' in js
+    assert 'Initial pose contains an invalid value' in js
+    assert '!joint?.isURDFMimicJoint && !joint?.mimicJoint' in js
+
+
+def test_initial_pose_uses_existing_renderer_fk_and_restores_normal_pose():
+    js = VIEWER.read_text(encoding="utf-8")
+    renderer = RENDERER.read_text(encoding="utf-8")
+    assert 'export function applyRobotJointPreview' in renderer
+    assert 'robot.setJointValues(jointValues)' in renderer
+    assert 'collectLinkMatrixDiagnostics(robot, links)' in renderer
+    assert 'collectVisualWrapperMatrixDiagnostics(links)' in renderer
+    assert 'collectDescendantRenderMeshDiagnostics(links)' in renderer
+    assert 'applyRobotJointPreview(state.robotPreviewResult, jointMap)' in js
+    assert 'applyRobotJointPreview?.(result, normalJointValues(selected.robot))' in js
+    assert 'state.dirtyTransforms' not in js.split('function toggleInitialPosePreview', 1)[1].split('function sceneDisplayName', 1)[0]
+    assert 'state.undoStack' not in js.split('function toggleInitialPosePreview', 1)[1].split('function sceneDisplayName', 1)[0]
+
+
+def test_initial_pose_preview_clears_on_scene_reload_and_keeps_camera_fit_out():
+    js = VIEWER.read_text(encoding="utf-8")
+    clear_body = js.split('function clearSceneObjects()', 1)[1].split('function renderScene(items)', 1)[0]
+    toggle_body = js.split('function toggleInitialPosePreview', 1)[1].split('function sceneDisplayName', 1)[0]
+    assert 'state.initialPosePreview = { active: false' in clear_body
+    assert 'el.showInitialPose.checked = false' in clear_body
+    assert 'attemptInitialCameraFit' not in toggle_body
+    assert 'resetView' not in toggle_body

--- a/workcell_studio_web/viewer/index.html
+++ b/workcell_studio_web/viewer/index.html
@@ -42,6 +42,10 @@
         <input id="debug-overlays-toggle" type="checkbox" />
         Show zones/debug overlays
       </label>
+      <label class="toolbar-toggle" title="Preview the selected robot at its configured initial joint pose. This does not command the robot.">
+        <input id="show-initial-pose" type="checkbox" disabled />
+        Show Initial Pose
+      </label>
     </div>
   </header>
 
@@ -68,6 +72,7 @@
     <section class="viewport-panel" aria-label="3D canvas area">
       <div id="error-state" class="state error" hidden></div>
       <div id="dirty-state" class="state dirty" hidden>Unsaved preview edits</div>
+      <div id="initial-pose-status" class="state preview-status" hidden>Initial pose preview</div>
       <canvas id="scene-canvas"></canvas>
       <div id="label-layer" class="label-layer" aria-hidden="true"></div>
     </section>

--- a/workcell_studio_web/viewer/urdf_robot_renderer.js
+++ b/workcell_studio_web/viewer/urdf_robot_renderer.js
@@ -344,6 +344,22 @@ function linkRootDiagnostics(robot, links) {
   return { roots, disconnected, duplicateLinks };
 }
 
+export function applyRobotJointPreview(result, jointValues = {}) {
+  const robot = result?.root;
+  if (!robot?.setJointValues) throw new Error('Product View is not ready');
+  robot.setJointValues(jointValues);
+  robot.updateMatrixWorld?.(true);
+  const links = Object.fromEntries(result.links || []);
+  result.diagnostics.robot_joint_values_applied = { ...jointValues };
+  result.diagnostics.robot_link_world_matrices = collectLinkMatrixDiagnostics(robot, links);
+  result.diagnostics.robotLinkWorldMatrices = result.diagnostics.robot_link_world_matrices;
+  result.diagnostics.robot_visual_wrapper_world_matrices = collectVisualWrapperMatrixDiagnostics(links);
+  result.diagnostics.robotVisualWrapperWorldMatrices = result.diagnostics.robot_visual_wrapper_world_matrices;
+  result.diagnostics.robot_descendant_render_mesh_diagnostics = collectDescendantRenderMeshDiagnostics(links);
+  result.diagnostics.robotDescendantRenderMeshDiagnostics = result.diagnostics.robot_descendant_render_mesh_diagnostics;
+  return result.diagnostics;
+}
+
 function jointTypeCounts(joints) {
   const counts = { fixed: 0, revolute: 0, continuous: 0, prismatic: 0, mimic: 0, other: 0 };
   for (const joint of Object.values(joints || {})) {

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -5,6 +5,7 @@ let ColladaLoader;
 let OBJLoader;
 let TransformControls;
 let loadRobotPreview;
+let applyRobotJointPreview;
 
 const PRODUCT_VIEW_WORKSPACE_BACKGROUND = 0xe9edf1;
 const PRODUCT_VIEW_GRID_MAJOR = 0x8996a3;
@@ -17,7 +18,7 @@ const LOCKED_EDIT_REASON = 'Locked/generated preview item; edit source layout/en
 const MIN_FRAME_RADIUS = 1.2;
 const EMPTY_SCENE_MESSAGE = 'Scene contains no renderable robots, tools, assets, sensors, zones, items, or objects.';
 const FRAME_DISTANCE_MULTIPLIER = 2.7;
-const state = { sceneJson: null, sourceWebSceneFile: '', frameLookup: new Map(), resolvedFramePoses: new Map(), objects: [], assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, robotUrdfPreviewDiagnostics: {}, physicalAssemblyBounds: null, finalPhysicalFitBounds: null, selected: null, three: {}, animationId: null, lastFrameBounds: null, initialCameraFit: { sceneKey: '', done: false, attempts: 0, pendingRetry: null, userControlled: false }, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: new Map(), undoStack: [], redoStack: [], gizmoDragStart: null, directMoveDrag: null, directRotateDrag: null, editorMode: 'select', editorEvents: [], editorError: '' };
+const state = { sceneJson: null, sourceWebSceneFile: '', frameLookup: new Map(), resolvedFramePoses: new Map(), objects: [], assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, robotUrdfPreviewDiagnostics: {}, physicalAssemblyBounds: null, finalPhysicalFitBounds: null, selected: null, three: {}, animationId: null, lastFrameBounds: null, initialCameraFit: { sceneKey: '', done: false, attempts: 0, pendingRetry: null, userControlled: false }, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: new Map(), undoStack: [], redoStack: [], gizmoDragStart: null, directMoveDrag: null, directRotateDrag: null, editorMode: 'select', editorEvents: [], editorError: '', robotPreviewResult: null, initialPosePreview: { active: false, robotId: '', sceneKey: '' } };
 const RESET_VIEW_TITLE = 'Fit Scene / Reset View: recomputes and reapplies the fitted workcell overview from renderable bounds.';
 const STAGED_MESH_ROOTS = [
   'build/workcell_studio_web_scene/assets/',
@@ -49,6 +50,8 @@ const el = {
   rotationSnap: document.getElementById('rotation-snap'),
   labelsToggle: document.getElementById('labels-toggle'),
   debugOverlaysToggle: document.getElementById('debug-overlays-toggle'),
+  showInitialPose: document.getElementById('show-initial-pose'),
+  initialPoseStatus: document.getElementById('initial-pose-status'),
   canvas: document.getElementById('scene-canvas'),
   labelLayer: document.getElementById('label-layer'),
   empty: document.getElementById('empty-state'),
@@ -59,6 +62,76 @@ const el = {
   summary: document.getElementById('scene-summary'),
 };
 
+
+
+function robotRecords() {
+  const records = asArray(state.sceneJson?.robots).concat(asArray(state.sceneJson?.robot_preview?.robots));
+  if (state.sceneJson?.robot_preview && !records.length) records.push(state.sceneJson.robot_preview);
+  return records.filter(r => r && (r.urdf_url || r.joint_values || r.initial_joint_values || r.initial_positions || r.configured_initial_positions));
+}
+function robotRecordId(robot, index = 0) { return String(robot?.id || robot?.robot_id || robot?.robot_instance_id || robot?.name || `robot_${index}`).trim(); }
+function selectedRobotRecord() {
+  const robots = robotRecords();
+  if (robots.length === 1) return { robot: robots[0], id: robotRecordId(robots[0], 0), automatic: true };
+  const selected = String(state.selected || '');
+  const found = robots.find((robot, index) => robotRecordId(robot, index) === selected);
+  return found ? { robot: found, id: selected, automatic: false } : null;
+}
+function configuredInitialJointValues(robot) {
+  return robot?.initial_joint_values || robot?.configured_initial_positions || robot?.initial_positions || robot?.joint_initial_positions || null;
+}
+function normalJointValues(robot) { return robot?.joint_values || {}; }
+function validateInitialJointMap(robot, result) {
+  const values = configuredInitialJointValues(robot);
+  if (!values || Array.isArray(values) || typeof values !== 'object') throw new Error('Initial pose is not configured');
+  const joints = Array.from((result?.joints || new Map()).entries());
+  if (!joints.length) throw new Error('Product View is not ready');
+  const movable = joints.filter(([, joint]) => !['fixed'].includes(String(joint?.jointType || '').toLowerCase()) && !joint?.isURDFMimicJoint && !joint?.mimicJoint);
+  const names = new Set();
+  for (const [name] of joints) { if (names.has(name)) throw new Error(`Initial pose has duplicate joint: ${name}`); names.add(name); }
+  for (const name of Object.keys(values)) {
+    if (!names.has(name)) throw new Error(`Initial pose has unknown joint: ${name}`);
+    if (!Number.isFinite(Number(values[name]))) throw new Error('Initial pose contains an invalid value');
+  }
+  for (const [name] of movable) if (!(name in values)) throw new Error(`Initial pose is missing joint: ${name}`);
+  return Object.fromEntries(Object.entries(values).map(([name, value]) => [name, Number(value)]));
+}
+function setInitialPosePreviewUi(active, message = '') {
+  if (el.initialPoseStatus) { el.initialPoseStatus.hidden = !active; el.initialPoseStatus.textContent = active ? 'Initial pose preview' : ''; }
+  if (message) pushEditorEvent('status', { message });
+}
+function refreshInitialPoseActionState() {
+  if (!el.showInitialPose) return;
+  const robots = robotRecords();
+  el.showInitialPose.disabled = robots.length === 0 || (robots.length > 1 && !selectedRobotRecord());
+}
+function clearInitialPosePreview({ message = '' } = {}) {
+  if (!state.initialPosePreview.active) { refreshInitialPoseActionState(); return; }
+  const selected = selectedRobotRecord();
+  const result = state.robotPreviewResult;
+  if (selected && result) applyRobotJointPreview?.(result, normalJointValues(selected.robot));
+  state.initialPosePreview = { active: false, robotId: '', sceneKey: '' };
+  if (el.showInitialPose) el.showInitialPose.checked = false;
+  setInitialPosePreviewUi(false, message || 'Initial pose preview ended');
+  refreshWarnings();
+}
+function toggleInitialPosePreview(checked) {
+  if (!checked) { clearInitialPosePreview(); return; }
+  try {
+    if (!state.robotPreviewResult?.root) throw new Error('Product View is not ready');
+    const selected = selectedRobotRecord();
+    if (!selected) throw new Error(robotRecords().length > 1 ? 'Select a robot to preview its initial pose' : 'Initial pose is not configured');
+    const jointMap = validateInitialJointMap(selected.robot, state.robotPreviewResult);
+    applyRobotJointPreview(state.robotPreviewResult, jointMap);
+    state.initialPosePreview = { active: true, robotId: selected.id, sceneKey: sceneId() };
+    setInitialPosePreviewUi(true, `Showing initial pose for ${selected.robot.name || selected.id}`);
+  } catch (err) {
+    if (el.showInitialPose) el.showInitialPose.checked = false;
+    state.initialPosePreview = { active: false, robotId: '', sceneKey: '' };
+    setInitialPosePreviewUi(false);
+    showError(err.message || String(err));
+  }
+}
 
 function sceneDisplayName() { return state.sceneJson?.scene?.id || state.sceneJson?.scene_id || state.sourceWebSceneFile || 'No scene loaded'; }
 function isGeneratedOrLockedItem(item) {
@@ -2260,6 +2333,10 @@ function clearSceneObjects() {
   state._fitBlockerWarnings = new Set();
   state._generatedUrdfFramePoseWarnings = new Set();
   state._supportSurfaceSemanticWarnings = new Set();
+  state.robotPreviewResult = null;
+  state.initialPosePreview = { active: false, robotId: '', sceneKey: '' };
+  if (el.showInitialPose) el.showInitialPose.checked = false;
+  setInitialPosePreviewUi(false);
   if (el.resetView) el.resetView.disabled = true;
   renderSceneSummary();
 }
@@ -2365,7 +2442,9 @@ function loadExpandedUrdfRobotPreview(preview) {
     rootName: `${sceneDisplayName()}_expanded_urdf_loader_robot`,
     skippedLegacyGeneratedUrdfVisualCount: diagnostics.skipped_legacy_generated_urdf_visual_count,
     onRobotLoaded: result => {
+      state.robotPreviewResult = result;
       state.robotUrdfPreviewDiagnostics = result.diagnostics;
+      refreshInitialPoseActionState();
       renderSceneSummary();
       attemptInitialCameraFit();
     },
@@ -2760,6 +2839,7 @@ function populateObjectList() {
 }
 
 function selectObject(id) {
+  const wasInitialPreviewActive = state.initialPosePreview.active;
   if (state.directMoveDrag && state.directMoveDrag.itemId !== (id || '')) cancelDirectMoveDrag('Move cancelled');
   if (state.directRotateDrag && state.directRotateDrag.itemId !== (id || '')) cancelDirectRotateDrag('Rotation cancelled');
   const previous = state.selected || '';
@@ -3165,6 +3245,7 @@ async function loadSceneUrl(rawUrl) {
 if (el.resetView) el.resetView.addEventListener('click', resetView);
 if (el.labelsToggle) el.labelsToggle.addEventListener('change', event => setLabelsVisible(event.target.checked));
 if (el.debugOverlaysToggle) el.debugOverlaysToggle.addEventListener('change', event => setDebugOverlaysVisible(event.target.checked));
+if (el.showInitialPose) el.showInitialPose.addEventListener('change', event => toggleInitialPosePreview(event.target.checked));
 if (el.undoEdit) el.undoEdit.addEventListener('click', undoPreviewEdit);
 if (el.redoEdit) el.redoEdit.addEventListener('click', redoPreviewEdit);
 if (el.clearEdits) el.clearEdits.addEventListener('click', clearPreviewEdits);
@@ -3225,6 +3306,7 @@ async function boot() {
     ColladaLoader = colladaModule.ColladaLoader;
     OBJLoader = objModule.OBJLoader;
     loadRobotPreview = urdfRobotRendererModule.loadRobotPreview;
+    applyRobotJointPreview = urdfRobotRendererModule.applyRobotJointPreview;
     initThree();
     setLabelsVisible(el.labelsToggle?.checked || false);
     setDebugOverlaysVisible(el.debugOverlaysToggle?.checked || false);


### PR DESCRIPTION
### Motivation

- Provide a safe, visual-only Product View action to preview a robot at its configured initial joint pose without issuing any runtime robot commands or changing scene files.

### Description

- Add a checkable `Show Initial Pose` control in the web viewer UI and a compact `Initial pose preview` status indicator next to the canvas (`workcell_studio_web/viewer/index.html`).
- Implement selected/only robot resolution and configured initial-joint lookup/validation in the viewer logic, with explicit error reporting for missing/unknown/duplicate/missing-movable/invalid joint entries (`workcell_studio_web/viewer/viewer.js`).
- Reuse the existing URDF/renderer FK path by adding `applyRobotJointPreview(result, jointValues)` to the URDF renderer so the preview applies joint values via `robot.setJointValues(...)` and updates link/tool visuals without publishing or altering scene state (`workcell_studio_web/viewer/urdf_robot_renderer.js`).
- Ensure preview activation installs a transient visual override and deactivation restores the normal authoritative displayed pose and clears stale preview state on scene reload (`workcell_studio_web/viewer/viewer.js`).
- Add focused static tests that assert the UI, mapping/validation rules, renderer reuse, non-mutating visual-only behaviour, and scene-reload clear semantics (`tests/test_initial_pose_preview_static.py`).

### Testing

- Ran `python3 -m pytest tests/test_initial_pose_preview_static.py` and all tests passed (4 passed).
- Ran `python3 -m pytest tests/test_initial_pose_preview_static.py tests/test_workcell_studio_web_viewer_static.py::test_viewer_has_expanded_urdf_loader_robot_preview_path` and both tests passed.
- Built the web viewer bundle with `npm run build:web3d --prefix workcell_studio_web/viewer` to validate the web3d build; build completed successfully.
- Ran the stale-bundle check `npm run check:stale-bundle --prefix workcell_studio_web/viewer` which reported the committed `dist` bundle would be stale after a rebuild; to keep the PR compact the rebuilt `dist` artifact was not committed (rebuild and commit the bundle in a follow-up if desired).
- Verified `git diff --check`, `git diff --stat`, `git diff --numstat`, and working-tree status for the changed files; changes are limited to the viewer sources and one focused test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e1433a7588331838854c5ce7c0a97)