### PR TITLE
Close canonical ur5_2f_test acceptance blocker

### DIFF
--- a/tests/test_workcell_builder_product_view_defaults.py
+++ b/tests/test_workcell_builder_product_view_defaults.py
@@ -85,8 +85,8 @@ def test_inspector_refresh_for_ur5_2f_test_uses_canonical_metadata_and_launch_pa
     mainwindow_cpp = MAINWINDOW_CPP.read_text()
     metadata_helper = mainwindow_cpp.split("static SelectedSceneMetadataSummary selected_scene_metadata_summary", 1)[1]
     metadata_helper = metadata_helper.split("static YAML::Node ensure_map_path", 1)[0]
-    refresh_helper = mainwindow_cpp.split("void MainWindow::refresh_scene_builder_selected_scene_ui()", 1)[1]
-    refresh_helper = refresh_helper.split("void MainWindow::refresh_create_starter_layout_action()", 1)[0]
+    metadata_panel_helper = mainwindow_cpp.split("void MainWindow::refresh_selected_scene_metadata_panel()", 1)[1]
+    metadata_panel_helper = metadata_panel_helper.split("void MainWindow::refresh_scene_builder_selection_state_ui()", 1)[0]
 
     assert "out.scene_name = QString::fromStdString(scene.scene_name);" in metadata_helper
     assert "out.scene_path = QString::fromStdString(scene.scene_dir.string());" in metadata_helper
@@ -94,10 +94,10 @@ def test_inspector_refresh_for_ur5_2f_test_uses_canonical_metadata_and_launch_pa
     assert "launch/demo.launch.py present" in metadata_helper
     assert '{"robot", "model"}' in metadata_helper
     assert "cell_definition.yaml" in metadata_helper
-    assert "metadata.scene_name" in refresh_helper
-    assert "metadata.scene_path" in refresh_helper
-    assert "metadata.robot" in refresh_helper
-    assert "metadata.launch" in refresh_helper
+    assert "metadata.scene_name" in metadata_panel_helper
+    assert "metadata.scene_path" in metadata_panel_helper
+    assert "metadata.robot" in metadata_panel_helper
+    assert "metadata.launch" in metadata_panel_helper
 
 
 def test_warning_chip_suppressed_for_clean_xacro_expanded_preview_payload() -> None:

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -5632,7 +5632,7 @@ void MainWindow::refresh_selected_scene_metadata_panel()
   if (index < 0 || index >= static_cast<int>(scene_browser_result_.scenes.size())) return;
   const auto & scene = scene_browser_result_.scenes[static_cast<size_t>(index)];
   const auto metadata = selected_scene_metadata_summary(scene);
-  const QString scene_path = selected_scene_path();
+  const QString scene_path = metadata.scene_path;
   const fs::path launch_path = scene.scene_dir / "launch" / "demo.launch.py";
   const bool launch_present = fs::exists(launch_path);
 
@@ -5648,7 +5648,7 @@ void MainWindow::refresh_selected_scene_metadata_panel()
     ? QStringLiteral("ready — required selected-scene metadata and launch/demo.launch.py are present")
     : QStringLiteral("warnings — %1").arg(warnings.join(QStringLiteral("; ")));
   const QString launch_text = launch_present
-    ? QStringLiteral("%1 (present)").arg(QString::fromStdString(launch_path.string()))
+    ? metadata.launch
     : QStringLiteral("launch/demo.launch.py missing at %1").arg(QString::fromStdString(launch_path.string()));
   const QString robot_text = QStringLiteral("%1 — %2").arg(metadata.robot, metadata.robot_source);
   const QString end_effector_text = QStringLiteral("%1 — %2").arg(metadata.end_effector, metadata.end_effector_source);


### PR DESCRIPTION
### Motivation
- A Product View / inspector regression caused the selected-scene metadata labels to drift away from the canonical metadata summary, breaking a focused unit test that verifies the inspector reads `cell_definition.yaml` and `launch/demo.launch.py` metadata for `ur5_2f_test`. 
- The change restores the inspector path to consume the canonical `SelectedSceneMetadataSummary` fields so UI labels remain aligned with generated scene metadata and readiness evidence.

### Description
- Use the canonical metadata fields when populating the Selected Scene metadata panel by reading `metadata.scene_path` and `metadata.launch` instead of constructing the scene path inline in `refresh_selected_scene_metadata_panel` in `workcell_builder/workcell_builder/gui/mainwindow.cpp`.
- Update the focused Product View unit test to assert the actual metadata-panel helper region (`refresh_selected_scene_metadata_panel`) rather than a larger refresh wrapper in `tests/test_workcell_builder_product_view_defaults.py`.
- Files changed: `workcell_builder/workcell_builder/gui/mainwindow.cpp` and `tests/test_workcell_builder_product_view_defaults.py`.

### Testing
- Ran the focused C++/UI static tests with `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py -q` and the updated suite passed (`7 passed`).
- Ran broader scene/layout tests `python3 -m pytest tests/test_workcell_builder_layout_semantic_roundtrip.py tests/test_workcell_studio_layout_persistence.py tests/test_scene_builder_roundtrip_acceptance.py tests/test_workcell_builder_visual_environment_layout_editor.py -q` and they passed (`11 passed`).
- Ran static scene validators `python3 scripts/validate_workcell_scene.py --scene-dir scenes/ur5_2f_test` and `python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json` which returned success/readiness `task_intent_ready_offline`.
- Known environmental blockers not changed by this PR: Web3D export that requires real `xacro` expansion is blocked in this container because `xacro` is unavailable, and `colcon`/ROS 2 Humble-based build and RViz/MoveIt launch were not executed here due to the environment lacking `/opt/ros/humble` and `colcon`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e16c55d908331be3bf94fe2e7f7b0)