### PR TITLE
Restore Qt5 build after Scene Builder feature merges

### DIFF
--- a/tests/test_humble_build_regressions.py
+++ b/tests/test_humble_build_regressions.py
@@ -373,3 +373,15 @@ def test_rosdep_diagnostics_fails_when_no_source_packages_discovered(tmp_path, m
     captured = capsys.readouterr()
     assert "discovered source packages: 0" in captured.out
     assert "No source packages discovered" in captured.err
+
+
+def test_mainwindow_qt5_scene_builder_regressions_are_fixed():
+    text = Path("workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text()
+    assert "trimmed('_')" not in text
+    assert "build_workcell_studio_canvas_model(s.scene_dir, QString::fromStdString(s.scene_name))" not in text
+    assert "stem = stem.trimmed();" in text
+    assert "stem.startsWith(QLatin1Char('_'))" in text
+    assert "stem.remove(0, 1);" in text
+    assert "stem.endsWith(QLatin1Char('_'))" in text
+    assert "stem.chop(1);" in text
+    assert "build_workcell_studio_canvas_model(s.scene_dir, s.scene_name)" in text

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -11578,7 +11578,13 @@ QString safe_import_stl_stem(const QString & name)
   QString stem = QFileInfo(name).completeBaseName().toLower();
   stem.replace(QRegularExpression("[^a-z0-9_-]+"), "_");
   stem.replace(QRegularExpression("_+"), "_");
-  stem = stem.trimmed().trimmed('_');
+  stem = stem.trimmed();
+  while (stem.startsWith(QLatin1Char('_'))) {
+    stem.remove(0, 1);
+  }
+  while (stem.endsWith(QLatin1Char('_'))) {
+    stem.chop(1);
+  }
   if (stem.isEmpty() || stem == "." || stem == "..") return QString();
   return stem;
 }
@@ -12343,7 +12349,7 @@ std::vector<MainWindow::RecommendedWorkflowAction> MainWindow::resolve_recommend
     return actions;
   }
   const auto & s = scene_browser_result_.scenes[(size_t)selected_scene_index_];
-  const auto canvas_model = workcell_builder::build_workcell_studio_canvas_model(s.scene_dir, QString::fromStdString(s.scene_name));
+  const auto canvas_model = workcell_builder::build_workcell_studio_canvas_model(s.scene_dir, s.scene_name);
   const bool canonical_path_match = (canonical_scene_path_string(s.scene_dir) == canonical_scene_path_string(fs::path(selected_scene_path().toStdString())));
   const LayoutStateModel layout_state = derive_layout_state_model(s.scene_dir, canvas_model, canonical_path_match);
   const bool derived_layout_ready = !layout_dirty_ && (


### PR DESCRIPTION
### Motivation
- Fix two fatal Qt5/C++ build blockers in `workcell_builder`: the invalid Qt5 expression `trimmed('_')` in `safe_import_stl_stem` and an unnecessary `QString` conversion when calling `build_workcell_studio_canvas_model`, both of which prevented local builds.

### Description
- Replace `stem = stem.trimmed().trimmed('_');` with Qt5-compatible logic that trims whitespace and then removes leading and trailing underscores using `startsWith(QLatin1Char('_'))`/`remove(0,1)` and `endsWith(QLatin1Char('_'))`/`chop(1)` while preserving existing sanitisation steps in `safe_import_stl_stem` in `workcell_builder/workcell_builder/gui/mainwindow.cpp`.
- Change the canvas-model invocation to pass the existing `std::string` `s.scene_name` directly to `workcell_builder::build_workcell_studio_canvas_model` in `resolve_recommended_workflow_actions()` to match the required signature.
- Add a focused regression test `test_mainwindow_qt5_scene_builder_regressions_are_fixed` to `tests/test_humble_build_regressions.py` that asserts the old `trimmed('_')` call and the incorrect `QString::fromStdString(s.scene_name)` conversion are absent and that the new Qt5-compatible stem logic and direct `s.scene_name` call are present.
- Files changed: `workcell_builder/workcell_builder/gui/mainwindow.cpp` and `tests/test_humble_build_regressions.py`.

### Testing
- Ran `git diff --check` and it passed with no whitespace/patch errors.
- Ran the focused test `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_humble_build_regressions.py::test_mainwindow_qt5_scene_builder_regressions_are_fixed` and it passed.
- Ran the full `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_humble_build_regressions.py` and it failed due to an existing, unrelated assertion expecting `#include <QTcpSocket>` in `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp`, which is outside the scope of this PR.
- Did not run `colcon build` because the container lacks ` /opt/ros/humble/setup.bash` and a local `workcell_ws`, so full ROS/Humble build validation was not performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e1c90e6d88331a252c71fb1be2d12)