### PR TITLE
Keep Web3D selected on transient Product View failures and add bounded automatic recovery

### DIFF
--- a/tests/test_scene_preview_widget_refresh_lifecycle.py
+++ b/tests/test_scene_preview_widget_refresh_lifecycle.py
@@ -148,3 +148,65 @@ def test_selected_scene_status_refreshes_leave_the_committed_product_payload_ide
     assert "set_preview_items" not in audit_block
     assert "fit_product_view();" in audit_block
     assert "set_preview_status_summary" in audit_block
+
+
+def test_transient_web3d_runtime_failures_keep_web3d_selected_and_never_activate_qt3d():
+    failure_handler_start = CPP.index("void ScenePreviewWidget::handle_embedded_web_runtime_failure")
+    server_start = CPP.index("void ScenePreviewWidget::ensure_embedded_web_server_started", failure_handler_start)
+    failure_handler = CPP[failure_handler_start:server_start]
+
+    assert "native_compatibility_fallback_active_ = false;" in failure_handler
+    assert 'mode_selector_->setItemText(0, QStringLiteral("Web3D Product View"))' in failure_handler
+    assert "embedded_web_view_->setVisible(true);" in failure_handler
+    assert "compatibility_scene3d_viewport_->setVisible(false);" in failure_handler
+    assert 'embedded_fit_button_->setText(QStringLiteral("Retry"))' in failure_handler
+    assert "activate_native_compatibility_preview" not in failure_handler
+
+    for marker in (
+        "browser failed to load Product View page",
+        "browser render process terminated",
+        "viewer JavaScript failed",
+    ):
+        marker_index = CPP.index(marker)
+        block = CPP[max(0, marker_index - 700):marker_index + 1800]
+        assert "handle_embedded_web_runtime_failure" in block
+        assert "activate_native_compatibility_preview" not in block
+
+    server_probe_start = CPP.index("void ScenePreviewWidget::fail_embedded_web_server_probe")
+    server_probe_end = CPP.index("QString ScenePreviewWidget::embedded_web_recovery_key", server_probe_start)
+    server_probe_block = CPP[server_probe_start:server_probe_end]
+    assert "handle_embedded_web_runtime_failure(identity, navigation_token, detail);" in server_probe_block
+    assert "activate_native_compatibility_preview" not in server_probe_block
+
+    for marker in ("local server exited with code", "local server startup failure"):
+        marker_index = CPP.index(marker)
+        block = CPP[max(0, marker_index - 700):marker_index + 700]
+        assert "fail_embedded_web_server_probe" in block
+
+
+def test_web3d_runtime_recovery_is_bounded_to_one_attempt_per_request_identity():
+    key_start = CPP.index("QString ScenePreviewWidget::embedded_web_recovery_key")
+    handler_start = CPP.index("void ScenePreviewWidget::handle_embedded_web_runtime_failure", key_start)
+    key_block = CPP[key_start:handler_start]
+    handler_end = CPP.index("void ScenePreviewWidget::ensure_embedded_web_server_started", handler_start)
+    handler = CPP[handler_start:handler_end]
+
+    assert "payload_fingerprint.toHex()" in key_block
+    assert "identity.generation" not in key_block
+    assert "navigation_token" not in key_block
+    assert "embedded_web_automatic_recovery_attempts_.contains(recovery_key)" in handler
+    assert "embedded_web_automatic_recovery_attempts_.insert(recovery_key)" in handler
+    assert "request_embedded_web_product_view_refresh(true);" in handler
+    assert handler.count("request_embedded_web_product_view_refresh(true);") == 1
+    assert "automatic recovery already attempted" in handler
+
+
+def test_explicit_legacy_backend_selection_still_uses_native_scene3d():
+    constructor_backend_start = CPP.index("const QString requested_product_view_backend")
+    constructor_backend_end = CPP.index("#else", constructor_backend_start)
+    backend_block = CPP[constructor_backend_start:constructor_backend_end]
+
+    assert "native_scene3d_explicitly_requested" in backend_block
+    assert 'requested_product_view_backend == QStringLiteral("native_scene3d")' in backend_block
+    assert "product_view_backend_ = ProductViewBackend::NativeScene3D;" in backend_block
+    assert 'simple_3d_view_->setObjectName("scene3dViewportWidget");' in backend_block

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -427,9 +427,7 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
       if (!ok) {
         const QString detail = QStringLiteral("browser failed to load Product View page for scene %1; viewer URL: %2; expected JSON: %3")
           .arg(identity.scene_id, expected_viewer_url.toString(), embedded_web_prepare_output_path_);
-        // set_embedded_product_view_state(EmbeddedProductViewState::Failed, detail) is intentionally replaced by native compatibility fallback.
-        embedded_web_view_->setVisible(false);
-        activate_native_compatibility_preview(detail);
+        handle_embedded_web_runtime_failure(identity, navigation_token, detail);
         emit studio_log_requested(QStringLiteral("Embedded Product View load failed. %1").arg(detail));
         return;
       }
@@ -437,6 +435,15 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
         QStringLiteral("browser loaded; waiting for viewer readiness"));
       start_embedded_web_readiness_polling(identity, navigation_token, embedded_web_prepare_output_path_, expected_viewer_url.toString());
     });
+    connect(embedded_web_view_->page(), &QWebEnginePage::renderProcessTerminated, this,
+      [this](QWebEnginePage::RenderProcessTerminationStatus status, int exit_code) {
+        const EmbeddedWebRequestIdentity identity = embedded_web_loading_identity_;
+        const quint64 navigation_token = embedded_web_loading_navigation_token_;
+        const QString detail = QStringLiteral("browser render process terminated for Product View scene %1; status=%2 exit_code=%3; viewer URL: %4")
+          .arg(identity.scene_id).arg(static_cast<int>(status)).arg(exit_code).arg(embedded_web_expected_viewer_url_.toString());
+        handle_embedded_web_runtime_failure(identity, navigation_token, detail);
+        emit studio_log_requested(QStringLiteral("Embedded Product View render-process termination. %1").arg(detail));
+      });
     simple_3d_view_ = embedded_web_view_;
   } else {
     product_view_backend_ = ProductViewBackend::NativeScene3D;
@@ -534,7 +541,13 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
   });
   connect(embedded_undo_button_, &QPushButton::clicked, this, [this](){ run_embedded_editor_command(QStringLiteral("window.__WORKCELL_EDITOR_API_V1__&&window.__WORKCELL_EDITOR_API_V1__.undo()")); });
   connect(embedded_redo_button_, &QPushButton::clicked, this, [this](){ run_embedded_editor_command(QStringLiteral("window.__WORKCELL_EDITOR_API_V1__&&window.__WORKCELL_EDITOR_API_V1__.redo()")); });
-  connect(embedded_fit_button_, &QPushButton::clicked, this, [this](){ run_embedded_editor_command(QStringLiteral("window.__WORKCELL_EDITOR_API_V1__&&window.__WORKCELL_EDITOR_API_V1__.fitScene()")); });
+  connect(embedded_fit_button_, &QPushButton::clicked, this, [this](){
+    if (embedded_product_view_state_ == EmbeddedProductViewState::Failed) {
+      request_embedded_web_product_view_refresh(true);
+      return;
+    }
+    run_embedded_editor_command(QStringLiteral("window.__WORKCELL_EDITOR_API_V1__&&window.__WORKCELL_EDITOR_API_V1__.fitScene()"));
+  });
   connect(overlays_selector_, qOverload<int>(&QComboBox::currentIndexChanged), this, [this](int){
     auto *v = active_native_viewport();
     const QString choice = overlays_selector_->currentText();
@@ -684,6 +697,10 @@ void ScenePreviewWidget::set_embedded_product_view_state(EmbeddedProductViewStat
   embedded_product_view_state_ = state;
   embedded_editor_polling_ = (state == EmbeddedProductViewState::Ready);
   if (state == EmbeddedProductViewState::Failed) embedded_web_last_error_ = detail;
+  if (embedded_fit_button_ && state != EmbeddedProductViewState::Failed) {
+    embedded_fit_button_->setText(QStringLiteral("Fit"));
+    embedded_fit_button_->setToolTip(QString());
+  }
   if (state == EmbeddedProductViewState::Failed && !detail.trimmed().isEmpty()) {
     emit studio_log_requested(QStringLiteral("Embedded Product View failure: %1").arg(detail));
   }
@@ -801,7 +818,48 @@ void ScenePreviewWidget::fail_embedded_web_server_probe(
   embedded_web_server_lifecycle_ = EmbeddedWebServerLifecycle::ServerNotStarted;
   emit studio_log_requested(QStringLiteral("Embedded Product View server terminal diagnostic: scene=%1 generation=%2 port=%3 navigation=%4 detail=%5")
     .arg(identity.scene_id).arg(identity.generation).arg(port).arg(navigation_token).arg(detail));
-  activate_native_compatibility_preview(detail);
+  handle_embedded_web_runtime_failure(identity, navigation_token, detail);
+}
+
+QString ScenePreviewWidget::embedded_web_recovery_key(const EmbeddedWebRequestIdentity & identity) const
+{
+  // Bound automatic recovery by logical navigation/request identity, not by the
+  // retry generation number.  A forced retry keeps the same scene/payload key,
+  // so a second failure leaves Web3D selected and exposes the manual Retry path.
+  return QStringLiteral("%1|%2|%3|%4|%5")
+    .arg(identity.scene_id, identity.absolute_scene_dir, identity.absolute_repo_root,
+         QString::fromLatin1(identity.payload_fingerprint.toHex()))
+    .arg(identity.payload_revision);
+}
+
+void ScenePreviewWidget::handle_embedded_web_runtime_failure(
+  const EmbeddedWebRequestIdentity & identity, quint64 navigation_token, const QString & detail)
+{
+#ifndef WORKCELL_BUILDER_HAS_WEBENGINE
+  Q_UNUSED(identity); Q_UNUSED(navigation_token); Q_UNUSED(detail);
+#else
+  if (!embedded_web_identity_is_current(identity) || navigation_token != embedded_web_navigation_token_) return;
+  native_compatibility_fallback_active_ = false;
+  embedded_web_last_error_ = detail;
+  set_embedded_product_view_state(EmbeddedProductViewState::Failed, detail);
+  if (mode_selector_) mode_selector_->setItemText(0, QStringLiteral("Web3D Product View"));
+  if (embedded_web_view_) embedded_web_view_->setVisible(true);
+  if (compatibility_scene3d_viewport_) compatibility_scene3d_viewport_->setVisible(false);
+  if (embedded_fit_button_) {
+    embedded_fit_button_->setText(QStringLiteral("Retry"));
+    embedded_fit_button_->setToolTip(QStringLiteral("Retry loading the embedded Web3D Product View. Details remain available in Studio Log."));
+  }
+  refresh_mode_and_state();
+
+  const QString recovery_key = embedded_web_recovery_key(identity);
+  if (!embedded_web_automatic_recovery_attempts_.contains(recovery_key)) {
+    embedded_web_automatic_recovery_attempts_.insert(recovery_key);
+    emit studio_log_requested(QStringLiteral("Embedded Product View automatic recovery attempt 1/1: %1").arg(detail));
+    request_embedded_web_product_view_refresh(true);
+    return;
+  }
+  emit studio_log_requested(QStringLiteral("Embedded Product View automatic recovery already attempted for this request; leaving Web3D selected with Retry available. %1").arg(detail));
+#endif
 }
 
 void ScenePreviewWidget::ensure_embedded_web_server_started(const QString & repo_root, const EmbeddedWebRequestIdentity & identity)
@@ -1343,7 +1401,7 @@ void ScenePreviewWidget::poll_embedded_web_readiness(const EmbeddedWebRequestIde
     const QString detail = QStringLiteral(
       "startup timed out after 45s for scene %1; viewer URL: %2; expected JSON: %3; last observed boot status: %4")
       .arg(identity.scene_id, viewer_url, expected_json_path, embedded_web_last_boot_status_.isEmpty() ? QStringLiteral("unavailable") : embedded_web_last_boot_status_);
-    activate_native_compatibility_preview(detail);
+    handle_embedded_web_runtime_failure(identity, navigation_token, detail);
     emit studio_log_requested(QStringLiteral("Embedded Product View readiness timeout. %1").arg(detail));
     return;
   }
@@ -1389,7 +1447,7 @@ void ScenePreviewWidget::poll_embedded_web_readiness(const EmbeddedWebRequestIde
         .arg(failed_stage.isEmpty() ? QStringLiteral("unknown_stage") : failed_stage,
              fatal_error.isEmpty() ? QStringLiteral("unknown error") : fatal_error,
              fatal_stack.isEmpty() ? QString() : QStringLiteral("; stack: %1").arg(fatal_stack.left(500)));
-      activate_native_compatibility_preview(detail);
+      handle_embedded_web_runtime_failure(identity, navigation_token, detail);
       emit studio_log_requested(QStringLiteral("Embedded Product View JavaScript failure for scene %1.\nStage: %2\nFatal error: %3\nStack excerpt:\n%4")
         .arg(identity.scene_id,
              failed_stage.isEmpty() ? QStringLiteral("unknown_stage") : failed_stage,

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -409,6 +409,9 @@ private:
   void run_embedded_web_server_probes(const EmbeddedWebRequestIdentity & identity, int port, quint64 navigation_token);
   void fail_embedded_web_server_probe(const EmbeddedWebRequestIdentity & identity, int port, quint64 navigation_token,
     const QString & detail);
+  QString embedded_web_recovery_key(const EmbeddedWebRequestIdentity & identity) const;
+  void handle_embedded_web_runtime_failure(const EmbeddedWebRequestIdentity & identity, quint64 navigation_token,
+    const QString & detail);
   void load_prepared_embedded_web_scene(const EmbeddedWebRequestIdentity & identity);
   void start_embedded_web_readiness_polling(const EmbeddedWebRequestIdentity & identity, quint64 navigation_token, const QString & expected_json_path, const QString & viewer_url);
   void poll_embedded_web_readiness(const EmbeddedWebRequestIdentity & identity, quint64 navigation_token, const QString & expected_json_path, const QString & viewer_url);
@@ -491,6 +494,7 @@ private:
   bool pending_embedded_web_request_{ false };
   quint64 embedded_web_request_generation_{ 0 };
   bool pending_embedded_web_force_{ false };
+  QSet<QString> embedded_web_automatic_recovery_attempts_;
   bool backend_startup_diagnostic_emitted_{ false };
   PreviewContext preview_context_;
   QString embedded_web_last_error_;


### PR DESCRIPTION
### Motivation

- Avoid silently switching to the native compatibility Scene3D when the embedded Web3D viewer transiently fails (load failures, render-process termination, server exit, or JS `scene_failed`).
- Preserve the selected Web3D Product View and provide an explicit, compact `Retry` affordance while exposing logs and a single bounded automatic recovery attempt per logical request identity.
- Ensure explicit legacy/native backend opt-in and the WebEngine-unavailable fallback remain unchanged.

### Description

- Route embedded Web3D runtime failures through a new handler `handle_embedded_web_runtime_failure(...)` instead of calling `activate_native_compatibility_preview(...)` in transient failure paths, keeping the embedded Web3D widget visible and setting an explicit failed state. (modified `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp` and header)
- Add recovery-keying and one bounded automatic retry per logical navigation/payload identity via `embedded_web_recovery_key(...)` and tracking set `embedded_web_automatic_recovery_attempts_`, so only a single forced retry is attempted automatically; further failures leave Web3D selected and expose the manual Retry action. (header + cpp)
- Keep existing/compact Retry action by reusing the embedded Fit button as `Retry` when in the failed Web3D state and restore it when the state clears. (cpp)
- Wire `QWebEnginePage::renderProcessTerminated`, readiness timeout, JS `scene_failed`/`failed` callbacks, and embedded server terminal diagnostics to the new failed-state handler so all transient runtime failures share the same behavior. (cpp)
- Tests updated/added to assert the new behavior and bounds: `tests/test_scene_preview_widget_refresh_lifecycle.py` now verifies that render-process termination routes to recovery-attempt logic at most once, Web3D stays selected with `Retry` shown on failure, Qt3D/native compatibility is not activated for transient failures, and explicit legacy backend selection remains functional.

Files changed:
- workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
- workcell_builder/workcell_builder/gui/scene_preview_widget.h
- tests/test_scene_preview_widget_refresh_lifecycle.py

### Testing

- Ran the targeted unit/regression tests: `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py tests/test_scene_preview_widget_refresh_lifecycle.py`; all tests passed (15 tests).
- Confirmed the added lifecycle/static assertions in `tests/test_scene_preview_widget_refresh_lifecycle.py` succeed and validate the new recovery and UI behavior.
- Verified `git diff --check` prior to preparing PR metadata (no whitespace errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e260691388331b2447644e18959d6)