### PR TITLE
Unify Product View light palette

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -267,23 +267,49 @@ def test_viewer_ground_grid_is_ros_xy_not_threejs_default_xz_y_up():
 
 
 
-def test_viewer_product_workspace_uses_single_light_neutral_background():
+def test_viewer_product_workspace_uses_central_light_palette_for_scene_and_css():
     js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    css = (VIEWER / "style.css").read_text(encoding="utf-8")
     init_body = js.split("function initThree()", 1)[1].split("function animate()", 1)[0]
 
-    assert "const PRODUCT_VIEW_WORKSPACE_BACKGROUND = 0xe9edf1;" in js
-    assert "scene.background = new THREE.Color(PRODUCT_VIEW_WORKSPACE_BACKGROUND);" in init_body
+    assert "const PRODUCT_VIEW_LIGHT_PALETTE = Object.freeze({" in js
+    for token in [
+        "workspaceBackground: 0xe9edf1",
+        "rendererClearColor: 0xe9edf1",
+        "gridMajor: 0x8996a3",
+        "gridMinor: 0xc3cbd3",
+        "labelText: 0x123040",
+        "labelSurface: 0xf8fafc",
+        "overlaySurface: 0xfff6dd",
+        "errorSurface: 0xffeef0",
+        "errorAccent: 0xc43434",
+    ]:
+        assert token in js
+    assert "scene.background = new THREE.Color(PRODUCT_VIEW_LIGHT_PALETTE.workspaceBackground);" in init_body
+    assert "renderer.setClearColor(PRODUCT_VIEW_LIGHT_PALETTE.rendererClearColor, 1);" in init_body
     assert "scene.background = new THREE.Color(0x0b1018);" not in js
-    assert js.count("PRODUCT_VIEW_WORKSPACE_BACKGROUND") == 2
+    assert "setClearColor(0x0b1018" not in js
+    assert "Fog" not in js and ".fog" not in js
+
+    assert "--workspace-bg: #e9edf1;" in css
+    assert "body {" in css and "background: var(--bg);" in css
+    assert ".app-shell" in css and "background: var(--workspace-bg);" in css
+    assert ".viewport-panel { position: relative; min-width: 0; background: var(--workspace-bg); }" in css
+    assert "#scene-canvas { width: 100%; height: 100%; display: block; background: var(--workspace-bg); }" in css
+    assert "color: #123040;" in css
+    assert "background: rgba(248, 250, 252, 0.86);" in css
+    assert "background: var(--error-surface);" in css
+    assert "background: rgba(139, 30, 45, 0.94);" not in css
 
 
-def test_viewer_product_grid_uses_distinct_subtle_major_minor_theme_colours():
+def test_viewer_product_grid_uses_visible_major_minor_palette_colours():
     js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
     init_body = js.split("function initThree()", 1)[1].split("function animate()", 1)[0]
 
-    assert "const PRODUCT_VIEW_GRID_MAJOR = 0x8996a3;" in js
-    assert "const PRODUCT_VIEW_GRID_MINOR = 0xc3cbd3;" in js
-    assert "new THREE.GridHelper(5, 20, PRODUCT_VIEW_GRID_MAJOR, PRODUCT_VIEW_GRID_MINOR)" in init_body
+    assert "workspaceBackground: 0xe9edf1" in js
+    assert "gridMajor: 0x8996a3" in js
+    assert "gridMinor: 0xc3cbd3" in js
+    assert "new THREE.GridHelper(5, 20, PRODUCT_VIEW_LIGHT_PALETTE.gridMajor, PRODUCT_VIEW_LIGHT_PALETTE.gridMinor)" in init_body
     assert "new THREE.GridHelper(5, 20, 0x3a4a5e, 0x263445)" not in js
     assert "grid.name = 'ros_xy_ground_grid';" in init_body
 

--- a/workcell_studio_web/viewer/style.css
+++ b/workcell_studio_web/viewer/style.css
@@ -1,6 +1,7 @@
 :root {
   color-scheme: light;
-  --bg: #e9edf1;
+  --workspace-bg: #e9edf1;
+  --bg: var(--workspace-bg);
   --panel: #f8fafc;
   --panel-2: #eef2f6;
   --text: #17202a;
@@ -8,6 +9,8 @@
   --accent: #0078a8;
   --warn: #b26b00;
   --error: #c43434;
+  --error-surface: #ffeef0;
+  --overlay-surface: #fff6dd;
   --border: #c5ced8;
 }
 
@@ -104,6 +107,7 @@ body {
   grid-template-columns: minmax(13rem, 18rem) 1fr minmax(16rem, 22rem);
   height: calc(100vh - 74px);
   min-height: 34rem;
+  background: var(--workspace-bg);
 }
 .object-panel, .details-panel {
   overflow: auto;
@@ -115,8 +119,8 @@ body {
 .details-panel { border-left: 1px solid var(--border); }
 h2 { margin: 0 0 0.75rem; font-size: 0.95rem; color: var(--accent); }
 
-.viewport-panel { position: relative; min-width: 0; background: var(--bg); }
-#scene-canvas { width: 100%; height: 100%; display: block; }
+.viewport-panel { position: relative; min-width: 0; background: var(--workspace-bg); }
+#scene-canvas { width: 100%; height: 100%; display: block; background: var(--workspace-bg); }
 
 .label-layer {
   position: absolute;
@@ -164,15 +168,15 @@ h2 { margin: 0 0 0.75rem; font-size: 0.95rem; color: var(--accent); }
   top: 1rem;
   left: 1rem;
   right: 1rem;
-  color: #fff;
+  color: #701b24;
   border-color: var(--error);
-  background: rgba(139, 30, 45, 0.94);
+  background: var(--error-surface);
 }
 .warning-item {
   margin: 0 0 0.5rem;
   padding: 0.55rem;
   border-left: 3px solid var(--warn);
-  background: #fff6dd;
+  background: var(--overlay-surface);
   color: #5f3a00;
 }
 
@@ -272,7 +276,7 @@ code { color: #0b5f80; }
   right: 1rem;
   top: 1rem;
   border-color: var(--warn);
-  background: #fff6dd;
+  background: var(--overlay-surface);
   color: #5f3a00;
 }
 .transform-editor {

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -7,9 +7,17 @@ let TransformControls;
 let loadRobotPreview;
 let applyRobotJointPreview;
 
-const PRODUCT_VIEW_WORKSPACE_BACKGROUND = 0xe9edf1;
-const PRODUCT_VIEW_GRID_MAJOR = 0x8996a3;
-const PRODUCT_VIEW_GRID_MINOR = 0xc3cbd3;
+const PRODUCT_VIEW_LIGHT_PALETTE = Object.freeze({
+  workspaceBackground: 0xe9edf1,
+  rendererClearColor: 0xe9edf1,
+  gridMajor: 0x8996a3,
+  gridMinor: 0xc3cbd3,
+  labelText: 0x123040,
+  labelSurface: 0xf8fafc,
+  overlaySurface: 0xfff6dd,
+  errorSurface: 0xffeef0,
+  errorAccent: 0xc43434,
+});
 
 const SUPPORTED_SCHEMA_VERSION = 'workcell_studio_web_scene/v1';
 const EDIT_PATCH_SCHEMA_VERSION = 'workcell_studio_web_scene_edit_patch/v1';
@@ -971,7 +979,7 @@ function logRequiredMeshFailure(item, meshUrl, error) {
 }
 function failedMeshDebugMaterial() {
   return new THREE.MeshBasicMaterial({
-    color: 0xff2bd6,
+    color: PRODUCT_VIEW_LIGHT_PALETTE.errorAccent,
     wireframe: true,
     transparent: true,
     opacity: 0.82,
@@ -980,7 +988,7 @@ function failedMeshDebugMaterial() {
   });
 }
 function failedMeshDebugEdgeMaterial() {
-  return new THREE.LineBasicMaterial({ color: 0xff2bd6, transparent: true, opacity: 1 });
+  return new THREE.LineBasicMaterial({ color: PRODUCT_VIEW_LIGHT_PALETTE.errorAccent, transparent: true, opacity: 1 });
 }
 function styleFailedMeshDebugFallback(fallback, item, reason) {
   fallback.visible = true;
@@ -1828,14 +1836,15 @@ function initThree() {
     renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
     const scene = new THREE.Scene();
     scene.up.copy(ROS_Z_UP);
-    scene.background = new THREE.Color(PRODUCT_VIEW_WORKSPACE_BACKGROUND);
+    scene.background = new THREE.Color(PRODUCT_VIEW_LIGHT_PALETTE.workspaceBackground);
+    renderer.setClearColor(PRODUCT_VIEW_LIGHT_PALETTE.rendererClearColor, 1);
     const camera = new THREE.PerspectiveCamera(55, 1, 0.01, 100);
     camera.up.copy(ROS_Z_UP);
     camera.position.set(2.4, -2.8, 1.8);
     const controls = new OrbitControls(camera, renderer.domElement);
     controls.object.up.copy(ROS_Z_UP);
     controls.enableDamping = true;
-    const grid = new THREE.GridHelper(5, 20, PRODUCT_VIEW_GRID_MAJOR, PRODUCT_VIEW_GRID_MINOR);
+    const grid = new THREE.GridHelper(5, 20, PRODUCT_VIEW_LIGHT_PALETTE.gridMajor, PRODUCT_VIEW_LIGHT_PALETTE.gridMinor);
     grid.name = 'ros_xy_ground_grid';
     grid.up.copy(ROS_Z_UP);
     grid.rotation.x = Math.PI / 2;


### PR DESCRIPTION
### Motivation
- Make the Product View visuals consistent by centralising light-theme colors for the workspace, renderer clear color, grid, labels, overlays, and error surfaces. 
- Ensure the 3D canvas (Three.js scene and renderer) and surrounding UI CSS use the same light workspace background and avoid dark fog/clear-color that hides meshes or forces materials white.

### Description
- Introduced a single frozen palette `PRODUCT_VIEW_LIGHT_PALETTE` that contains `workspaceBackground`, `rendererClearColor`, `gridMajor`, `gridMinor`, `labelText`, `labelSurface`, `overlaySurface`, `errorSurface`, and `errorAccent` in `workcell_studio_web/viewer/viewer.js`.
- Applied the palette to the Three.js scene and renderer by setting both `scene.background = new THREE.Color(...)` and `renderer.setClearColor(...)`, and routed the `GridHelper` colours through the palette.
- Replaced the previous bright magenta debug-fallback materials with the palette `errorAccent` and kept loader-provided materials intact (no forced whitening of imported materials).
- Updated `workcell_studio_web/viewer/style.css` to use a workspace CSS variable (`--workspace-bg`) for `body`, `.app-shell`, `.viewport-panel`, and `#scene-canvas` so the UI background matches the scene; also added light `--error-surface` and `--overlay-surface` values to keep error/overlay surfaces readable rather than dark full-viewport overlays.
- Adjusted static test expectations in `tests/test_workcell_studio_web_viewer_static.py` to assert use of the central palette for JS and CSS and to assert absence of dark fog/clear-color regressions.

### Testing
- Ran the static viewer test suite with `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py -q`, which completed successfully and all tests passed (`58 passed`).
- The modified tests assert the new `PRODUCT_VIEW_LIGHT_PALETTE` tokens are present and that scene background, renderer clear color, grid colours, and CSS backgrounds use the central light palette and avoid dark overlays.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e2a27b3a483319f374098ad5ab245)