### PR TITLE
Resolve URDF package meshes through staged Web3D assets

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -161,6 +161,61 @@ def test_viewer_includes_mesh_loader_references_and_safe_mesh_uri_logic():
         assert unsafe_token in js
 
 
+def test_urdf_renderer_resolves_package_meshes_to_staged_scene_assets():
+    js = (VIEWER / "urdf_robot_renderer.js").read_text(encoding="utf-8")
+    assert "function resolvePackageMeshUri(uri, sceneId, diagnostics)" in js
+    assert "raw.startsWith('package://')" in js
+    assert "context?.sceneId" in js
+    assert "build/workcell_studio_web_scene/assets/${encodeURIComponent(scene)}/${encodeURIComponent(packageName)}/${safeParts.join('/')}" in js
+    assert "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae" not in js
+    assert "robotiq_85_description" not in js
+    assert "ur_description" not in js
+    assert "ur5_2f_test" not in js
+    assert "URDF package mesh resolved:" in js
+    assert "URDF package mesh rejected:" in js
+
+
+def test_urdf_renderer_rejects_unsafe_package_mesh_sources():
+    js = (VIEWER / "urdf_robot_renderer.js").read_text(encoding="utf-8")
+    package_body = js.split("function resolvePackageMeshUri", 1)[1].split("function normalizeMeshUri", 1)[0]
+    for token in [
+        "if (!scene)",
+        "if (!/^[A-Za-z][A-Za-z0-9_]*$/.test(packageName))",
+        "if (!parts.length)",
+        "if (!part)",
+        "decoded === '.'",
+        "decoded === '..'",
+        "decoded.includes('\\0')",
+        "decoded.includes('/')",
+        "decoded.includes('\\\\')",
+        "decodedAgain !== decoded",
+        "/^(?:file|https?):\\/\\//i.test(packagePath)",
+        "/^[A-Za-z]:[\\\\/]/.test(packagePath)",
+        "/^[A-Za-z][A-Za-z0-9+.-]*:/.test(decoded)",
+    ]:
+        assert token in package_body
+    for rejected_uri in [
+        "package://pkg/../secret",
+        "package://pkg/%2e%2e/secret",
+        "package://pkg/%2Fetc/passwd",
+        "package://pkg/C:/secret",
+        "file:///tmp/mesh.dae",
+        "http://example.com/mesh.dae",
+    ]:
+        assert rejected_uri not in js
+
+
+def test_urdf_renderer_passes_loaded_scene_id_without_changing_staged_meshes():
+    renderer = (VIEWER / "urdf_robot_renderer.js").read_text(encoding="utf-8")
+    viewer = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    normalize_body = renderer.split("function normalizeMeshUri", 1)[1].split("function meshExtension", 1)[0]
+    assert "return resolvePackageMeshUri(raw, context?.sceneId, diagnostics);" in normalize_body
+    assert "const diagnostic = context?.meshUriDiagnostic?.({ mesh_uri: raw, mesh_staging_status: 'staged' });" in normalize_body
+    assert "return diagnostic?.uri || raw;" in normalize_body
+    preview_call = viewer.split("const previewResult = loadRobotPreview(preview, {", 1)[1].split("onRobotLoaded", 1)[0]
+    assert "sceneId: sceneId()," in preview_call
+
+
 def test_viewer_applies_mesh_local_transform_only_below_object_roots():
     js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
     for token in [

--- a/workcell_studio_web/viewer/urdf_robot_renderer.js
+++ b/workcell_studio_web/viewer/urdf_robot_renderer.js
@@ -10,12 +10,55 @@ function repoUrl(context, uri) {
   return context?.repoRootRelativeUrl ? context.repoRootRelativeUrl(uri) : uri;
 }
 
+function safeDecodeUriSegment(segment) {
+  try {
+    return decodeURIComponent(segment);
+  } catch (_) {
+    return null;
+  }
+}
+
+function rejectPackageMeshUri(reason, diagnostics) {
+  diagnostics.robot_missing_meshes.push(`URDF package mesh rejected: ${reason}`);
+  return '';
+}
+
+function resolvePackageMeshUri(uri, sceneId, diagnostics) {
+  const raw = String(uri || '').trim();
+  if (!raw.startsWith('package://')) return '';
+  const scene = String(sceneId || '').trim();
+  if (!scene) return rejectPackageMeshUri('missing scene ID', diagnostics);
+  const packagePath = raw.slice('package://'.length);
+  if (packagePath.startsWith('/') || /^(?:file|https?):\/\//i.test(packagePath) || /^[A-Za-z]:[\\/]/.test(packagePath)) {
+    return rejectPackageMeshUri(raw, diagnostics);
+  }
+  const parts = packagePath.split('/');
+  const packageName = parts.shift() || '';
+  if (!/^[A-Za-z][A-Za-z0-9_]*$/.test(packageName)) return rejectPackageMeshUri(raw, diagnostics);
+  if (!parts.length) return rejectPackageMeshUri(raw, diagnostics);
+  const safeParts = [];
+  for (const part of parts) {
+    if (!part) return rejectPackageMeshUri(raw, diagnostics);
+    const decoded = safeDecodeUriSegment(part);
+    if (!decoded || decoded === '.' || decoded === '..' || decoded.includes('\0') || decoded.includes('/') || decoded.includes('\\') || /^[A-Za-z]:[\\/]/.test(decoded) || /^[A-Za-z][A-Za-z0-9+.-]*:/.test(decoded)) {
+      return rejectPackageMeshUri(raw, diagnostics);
+    }
+    if (decoded.includes('%')) {
+      const decodedAgain = safeDecodeUriSegment(decoded);
+      if (decodedAgain !== decoded) return rejectPackageMeshUri(raw, diagnostics);
+    }
+    safeParts.push(encodeURIComponent(decoded));
+  }
+  const resolved = `build/workcell_studio_web_scene/assets/${encodeURIComponent(scene)}/${encodeURIComponent(packageName)}/${safeParts.join('/')}`;
+  diagnostics.robot_package_mesh_resolutions.push(`URDF package mesh resolved: ${raw} -> ${resolved}`);
+  return resolved;
+}
+
 function normalizeMeshUri(path, context, diagnostics) {
   const raw = String(path || '').trim();
   if (!raw) return '';
   if (raw.startsWith('package://')) {
-    diagnostics.robot_missing_meshes.push(`${raw}: package:// URI was not staged for static web loading`);
-    return '';
+    return resolvePackageMeshUri(raw, context?.sceneId, diagnostics);
   }
   const diagnostic = context?.meshUriDiagnostic?.({ mesh_uri: raw, mesh_staging_status: 'staged' });
   return diagnostic?.uri || raw;
@@ -414,6 +457,7 @@ export function loadRobotPreview(previewConfig, rendererContext = {}) {
     robotColladaRootNormalizationCount: 0,
     robot_collada_mesh_diagnostics: [],
     robotColladaMeshDiagnostics: [],
+    robot_package_mesh_resolutions: [],
     robot_descendant_render_mesh_diagnostics: [],
     robotDescendantRenderMeshDiagnostics: [],
     skipped_legacy_generated_urdf_visual_count: rendererContext?.skippedLegacyGeneratedUrdfVisualCount || 0,

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -2555,6 +2555,7 @@ function loadExpandedUrdfRobotPreview(preview) {
     return { root: null, links: new Map(), joints: new Map(), diagnostics, ready: Promise.resolve(null) };
   }
   const previewResult = loadRobotPreview(preview, {
+    sceneId: sceneId(),
     scene: state.three.scene,
     assemblyRoots: state.assemblyRoots,
     repoRootRelativeUrl,


### PR DESCRIPTION
### Motivation
- Prevent the URDF loader from requesting bare `package://` URLs from the browser by resolving package URIs to the staged web-scene asset root for the currently loaded scene.
- Ensure package mesh requests use the already-staged path `build/workcell_studio_web_scene/assets/<scene-id>/<package>/<path>` and reject unsafe or traversing URIs.

### Description
- Added a dedicated resolver `resolvePackageMeshUri(uri, sceneId, diagnostics)` that validates `package://` URIs, rejects unsafe/encoded traversal or absolute schemes, and returns a safe encoded staged path under `build/workcell_studio_web_scene/assets/`.
- Wired the loaded web-scene ID into the renderer context by passing `sceneId: sceneId()` from `viewer.js` into `loadRobotPreview` so the resolver uses the active scene ID rather than a hardcoded value.
- Integrated the resolver into the existing mesh normalization path by returning `resolvePackageMeshUri(...)` from `normalizeMeshUri()` for `package://` inputs and preserved existing staged-mesh diagnostic handling for non-package URIs.
- Added diagnostic bookkeeping `robot_package_mesh_resolutions` and concise success/rejection messages emitted to the existing diagnostics array when package URIs are resolved or rejected.
- Updated `tests/test_workcell_studio_web_viewer_static.py` with focused source-contract tests that assert package resolution to the staged path, scene-ID propagation, rejection of unsafe URIs, and preservation of existing staged-mesh logic.

### Testing
- Ran `node --check workcell_studio_web/viewer/urdf_robot_renderer.js` and `node --check workcell_studio_web/viewer/viewer.js`, both passed.
- Ran `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py`, all tests passed (`61 passed`).
- Performed `git diff --check`, `git diff --stat`, `git diff --numstat`, `git diff --name-only`, and reviewed `git status --short` before commit; no disallowed/generated files were staged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e2cb977f88331ae0f3d5bd77887b1)