### PR TITLE
Defer Product View initial fit to terminal scene_ready and restrict fit bounds to physical geometry

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -437,6 +437,75 @@ def test_viewer_product_theme_is_scene_independent():
         assert scene_name not in init_body
     assert "sceneId()" not in init_body
 
+
+def test_viewer_initial_fit_waits_for_terminal_scene_ready_once():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+
+    readiness_body = js.split("function emitWeb3dReadinessState", 1)[1].split("function readinessCategoryForItem", 1)[0]
+    assert "if (readinessState === 'scene_ready')" in readiness_body
+    assert "if (state.web3dReadiness.emittedSceneReady) return window.__WORKCELL_VIEWER_STATUS__;" in readiness_body
+    assert "state.web3dReadiness.emittedSceneReady = true;" in readiness_body
+    assert "if (readinessState === 'scene_ready') triggerInitialCameraFitAfterSceneReady();" in readiness_body
+
+    scene_ready_body = js.split("function maybeEmitSceneReady()", 1)[1].split("const el = {", 1)[0]
+    assert "if (readiness.pending?.size === 0) emitWeb3dReadinessState('scene_ready'" in scene_ready_body
+
+    trigger_body = js.split("function triggerInitialCameraFitAfterSceneReady()", 1)[1].split("function scheduleInitialCameraFitRetry", 1)[0]
+    assert "return attemptInitialCameraFit({ allowRetry: false });" in trigger_body
+
+    fit_body = js.split("function attemptInitialCameraFit", 1)[1].split("function triggerInitialCameraFitAfterSceneReady", 1)[0]
+    assert "if (!fit || fit.done || fit.userControlled || fit.sceneKey !== stableSceneCameraKey()) return false;" in fit_body
+    assert "fit.done = true;" in fit_body
+
+
+def test_viewer_initial_fit_not_reframed_per_mesh_load_but_manual_fit_remains():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+
+    try_load_body = js.split("async function tryLoadMesh", 1)[1].split("function collectItems", 1)[0]
+    assert "loadAsync(loadUrl)" in try_load_body
+    assert "frameScene(bounds)" not in try_load_body
+    assert "attemptInitialCameraFit" not in try_load_body
+    assert "scheduleInitialCameraFitRetry" not in try_load_body
+
+    expanded_body = js.split("function loadExpandedUrdfRobotPreview", 1)[1].split("function renderFrameDebugOverlays", 1)[0]
+    assert "onRobotLoaded" in expanded_body
+    assert "onRobotMeshLoaded" in expanded_body
+    assert "attemptInitialCameraFit" not in expanded_body
+    assert "scheduleInitialCameraFitRetry" not in expanded_body
+
+    render_scene_body = js.split("function renderScene(items)", 1)[1].split("function loadExpandedUrdfRobotPreview", 1)[0]
+    assert "tryLoadMesh(item, rendered, fallback);" in render_scene_body
+    assert "maybeEmitSceneReady();" in render_scene_body
+    assert "attemptInitialCameraFit" not in render_scene_body
+
+    reset_body = js.split("function resetView", 1)[1].split("function reportFitSelectionFallback", 1)[0]
+    assert "if (userInitiated) markCameraUserControlled();" in reset_body
+    assert "const physical = collectPhysicalVisibleBounds(state.three.scene);" in reset_body
+    assert "frameScene(physical.bounds)" in reset_body
+    assert "el.resetView.addEventListener('click', resetView)" in js
+    assert "fitScene: () => { resetView(); return editorState(); }" in js
+
+
+def test_viewer_initial_fit_bounds_use_visible_physical_geometry_only():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+
+    assert "function isInitialFitPhysicalGeometryItem(item, identity = '')" in js
+    physical_body = js.split("function isInitialFitPhysicalGeometryItem", 1)[1].split("function isPhysicalBoundsHelperObject", 1)[0]
+    for token in ["'robot'", "'tool'", "'table'", "'camera'", "'object'", "conveyor", "bin", "workbench", "configured camera"]:
+        assert token in physical_body
+
+    helper_body = js.split("function isPhysicalBoundsHelperObject", 1)[1].split("function isRobotPrimitiveFallbackObject", 1)[0]
+    for token in [
+        "object.isGridHelper || object.isAxesHelper",
+        "selection_outline",
+        "exclude_from_fit_bounds",
+        "DEBUG_OVERLAY_TOKEN_RE.test(identity)",
+        "return !isInitialFitPhysicalGeometryItem(item, identity);",
+    ]:
+        assert token in helper_body
+    for token in ["robot reach", "camera fov", "pick zone", "place zone", "warning badge", "helper", "diagnostic"]:
+        assert token in js
+
 def test_repository_does_not_track_generated_web_scene_outputs_under_source_paths():
     result = subprocess.run(
         ["git", "ls-files", "*.web_scene.json"],
@@ -1159,15 +1228,17 @@ def test_expanded_urdf_assembly_roots_are_first_class_physical_fit_bounds():
         assert token in status_body
 
 
-def test_expanded_urdf_robot_preview_fits_once_after_ready_not_per_mesh_callback():
+def test_expanded_urdf_robot_preview_defers_initial_fit_until_scene_ready():
     js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
     preview_body = js.split("function loadExpandedUrdfRobotPreview", 1)[1].split("function linkNameOfItem", 1)[0]
     loaded_body = preview_body.split("onRobotLoaded: result =>", 1)[1].split("onRobotMeshLoaded", 1)[0]
     mesh_loaded_body = preview_body.split("onRobotMeshLoaded: () =>", 1)[1].split("onRobotMeshLoadError", 1)[0]
 
-    assert "attemptInitialCameraFit()" in loaded_body
+    assert "completeExpandedUrdfReadiness(result)" in loaded_body
+    assert "attemptInitialCameraFit" not in loaded_body
     assert "renderSceneSummary()" in mesh_loaded_body
-    assert "scheduleInitialCameraFitRetry()" in mesh_loaded_body
+    assert "scheduleInitialCameraFitRetry" not in mesh_loaded_body
+    assert "attemptInitialCameraFit" not in mesh_loaded_body
 
 
 def test_expanded_urdf_robot_assembly_stays_locked_single_root_and_legacy_rows_suppressed():

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -84,6 +84,7 @@ function emitWeb3dReadinessState(readinessState, detail = {}) {
     state.web3dReadiness.failure = eventDetail;
   }
   const status = updateViewerStatus();
+  if (readinessState === 'scene_ready') triggerInitialCameraFitAfterSceneReady();
   window.dispatchEvent?.(new CustomEvent('workcell:web3d_readiness', { detail: { state: readinessState, ...eventDetail, status } }));
   window.parent?.postMessage?.({ type: 'workcell_web3d_readiness', state: readinessState, ...eventDetail, status }, '*');
   return status;
@@ -1721,8 +1722,6 @@ async function tryLoadMesh(item, rendered, fallback) {
     trackMeshLoadAttempt(item, 'loaded', loadUrl, '');
     setRenderInfo(rendered, 'mesh_loaded', uri, '');
     diagnoseLoadedMeshBounds(item, visualRoot, rendered, validationBounds);
-    const bounds = computeFitBounds();
-    if (bounds) frameScene(bounds);
     refreshMeshLoadUi(rendered);
     requiredReadinessCompleteForItem(item);
   } catch (err) {
@@ -2113,13 +2112,19 @@ function physicalBoundsIdentityFor(object) {
 function physicalBoundsItemFor(object, nearestItem = null) {
   return object?.userData?.item || nearestItem || object?.userData || {};
 }
+function isInitialFitPhysicalGeometryItem(item, identity = '') {
+  const category = meshContractCategoryOf(item);
+  if (['robot', 'tool', 'table', 'camera', 'object'].includes(category)) return true;
+  return /\b(robot|arm|manipulator|ur3|ur5|ur10|universal robot|base link|shoulder|wrist|tool|gripper|end effector|eef|suction|robotiq|airpick|camera body|configured camera|sensor body|conveyor|object|workpiece|part|product|bin|tray|support surface|table|tabletop|workbench|fixture|pallet)\b/.test(identity);
+}
 function isPhysicalBoundsHelperObject(object, item, identity) {
   if (!object || object.visible === false) return true;
   if (object.isGridHelper || object.isAxesHelper) return true;
   if (object.userData?.selection_outline === true || object.userData?.selection_highlight === true) return true;
   if (object.userData?.exclude_from_physical_bounds === true || object.userData?.exclude_from_fit_bounds === true) return true;
   if (item?.exclude_from_physical_bounds === true || item?.exclude_from_fit_bounds === true) return true;
-  return DEBUG_OVERLAY_TOKEN_RE.test(identity);
+  if (DEBUG_OVERLAY_TOKEN_RE.test(identity)) return true;
+  return !isInitialFitPhysicalGeometryItem(item, identity);
 }
 function isRobotPrimitiveFallbackObject(object, item, identity) {
   const visualSource = String(item?.active_visual_source || object?.userData?.active_visual_source || '').toLowerCase();
@@ -2597,6 +2602,9 @@ function attemptInitialCameraFit({ allowRetry = true } = {}) {
   }
   return false;
 }
+function triggerInitialCameraFitAfterSceneReady() {
+  return attemptInitialCameraFit({ allowRetry: false });
+}
 function scheduleInitialCameraFitRetry() {
   const fit = state.initialCameraFit;
   if (!fit || fit.done || fit.userControlled || fit.pendingRetry || fit.attempts >= 2) return;
@@ -2686,7 +2694,6 @@ function renderScene(items) {
   renderFrameDebugOverlays();
   populateObjectList();
   updateLabels();
-  attemptInitialCameraFit();
   renderSceneSummary();
   maybeEmitSceneReady();
 }
@@ -2747,11 +2754,9 @@ function loadExpandedUrdfRobotPreview(preview) {
       if (!failIfCanonicalRequiredVisualSetInvalid()) completeExpandedUrdfReadiness(result);
       refreshInitialPoseActionState();
       renderSceneSummary();
-      attemptInitialCameraFit();
     },
     onRobotMeshLoaded: () => {
       renderSceneSummary();
-      scheduleInitialCameraFitRetry();
     },
     onRobotMeshLoadError: (err, uri, detail) => { failExpandedUrdfReadiness(err, state.robotUrdfPreviewDiagnostics, detail || { uri }); renderSceneSummary(); },
     onRobotError: (err, diagnostics) => {


### PR DESCRIPTION
### Motivation
- Prevent repeated camera jumps during scene load by running the automatic initial fit only after the scene reaches the terminal `scene_ready` state when all required physical items and expanded robot/tool have loaded.
- Ensure the automatic fit frames only real physical geometry (robot, attached tool/gripper, table/workbench, camera, conveyor, object, bin) and excludes overlays/helpers (reach/FOV/zones/warnings) while preserving manual Reset/Fit behavior.

### Description
- Trigger the initial automatic fit from the readiness lifecycle by calling a new `triggerInitialCameraFitAfterSceneReady()` from `emitWeb3dReadinessState` when `readinessState === 'scene_ready'`, and guard it with the existing `emittedSceneReady` flag so it runs at most once per stable scene.
- Stop calling `frameScene(bounds)` and avoid calling `attemptInitialCameraFit()` from per-mesh callbacks by removing the immediate refit in `tryLoadMesh` and removing automatic refits/scheduling inside expanded-URDF callbacks in `loadExpandedUrdfRobotPreview`.
- Tighten bounding-geometry selection by adding `isInitialFitPhysicalGeometryItem(item, identity)` and updating `isPhysicalBoundsHelperObject` so fit-bound collection uses only visible physical geometry categories and identities and excludes debug/overlay tokens and helper objects.
- Remove the direct `attemptInitialCameraFit()` invocation from `renderScene` and provide a small wrapper `triggerInitialCameraFitAfterSceneReady()` that calls `attemptInitialCameraFit({ allowRetry: false })` when `scene_ready` is emitted.
- Update static-viewer tests in `tests/test_workcell_studio_web_viewer_static.py` to assert that the automatic initial fit runs only after `scene_ready`, is not triggered per-mesh or per-URDF-mesh callback, that manual Reset/Fit still refits, and that the new physical-geometry filter helpers exist.

### Testing
- Ran `git diff --check` with no issues reported.
- Ran the static/unit suite with `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py tests/test_workcell_studio_web_viewer_static.py` and all tests passed (`78 passed`).
- Ran the modified viewer static tests directly with `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py` and they passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e3969294883319f397d0af1346aba)