### PR TITLE
Suppress duplicate Product View refresh navigation

### DIFF
--- a/tests/test_scene_preview_widget_refresh_lifecycle.py
+++ b/tests/test_scene_preview_widget_refresh_lifecycle.py
@@ -30,13 +30,20 @@ class RefreshLifecycle:
         self.backend_switches = []
         self.camera_state = {"target": [1, 2, 3], "distance": 4}
         self.camera_resets = 0
+        self.suppression_logs = []
+        self._last_suppression_key = None
 
     def request(self, key, force=False):
         if not force and ((self.active and key == self.active[0]) or (self.pending and key == self.pending[0])):
+            suppression_key = key
+            if self._last_suppression_key != suppression_key:
+                self.suppression_logs.append("Duplicate Product View navigation suppressed")
+                self._last_suppression_key = suppression_key
             return
         if force:
             self.active = None
             self.pending = None
+        self._last_suppression_key = None
         self.generation += 1
         request = (key, self.generation)
         self.active = request
@@ -127,7 +134,7 @@ def test_one_manual_refresh_invalidates_once_and_creates_one_retry():
     assert lifecycle.pending == (key, 2)
 
 
-def test_repeated_identical_metadata_refreshes_do_not_prepare_navigate_switch_or_reset_camera():
+def test_three_identical_refreshes_prepare_navigate_load_once_and_emit_one_suppression_group():
     lifecycle = RefreshLifecycle()
     key = RequestKey(
         "ur5_2f_test",
@@ -138,34 +145,25 @@ def test_repeated_identical_metadata_refreshes_do_not_prepare_navigate_switch_or
         7,
     )
     lifecycle.request(key)
+    lifecycle.request(key)
+    lifecycle.request(key)
     lifecycle.start_pending()
-    before = (
-        len(lifecycle.started),
-        len(lifecycle.navigations),
-        len(lifecycle.backend_switches),
-        dict(lifecycle.camera_state),
-        lifecycle.camera_resets,
-        lifecycle.active,
-    )
 
-    lifecycle.request(key)
-    lifecycle.request(key)
-    lifecycle.request(key)
-
-    assert len(lifecycle.started) - before[0] == 0
-    assert len(lifecycle.navigations) - before[1] == 0
-    assert len(lifecycle.backend_switches) - before[2] == 0
-    assert lifecycle.camera_state == before[3]
-    assert lifecycle.camera_resets == before[4]
-    assert lifecycle.active == before[5]
+    assert lifecycle.generation == 1
+    assert lifecycle.started == [(key, 1)]
+    assert lifecycle.navigations == [(key, 1)]
+    assert lifecycle.backend_switches == []
+    assert lifecycle.camera_resets == 1
+    assert lifecycle.suppression_logs == ["Duplicate Product View navigation suppressed"]
 
 
 def test_cpp_coalesces_before_generation_and_retires_stale_process_before_ui_work():
     refresh_start = CPP.index("void ScenePreviewWidget::request_embedded_web_product_view_refresh")
     identity_start = CPP.index("ScenePreviewWidget::EmbeddedWebRequestIdentity", refresh_start)
     refresh = CPP[refresh_start:identity_start]
-    assert refresh.index("matches_context(request_key)") < refresh.index("++embedded_web_request_generation_")
-    assert "duplicate navigation suppressed" in refresh
+    assert refresh.index("matches_effective_request(request_key)") < refresh.index("++embedded_web_request_generation_")
+    assert "Duplicate Product View navigation suppressed" in refresh
+    assert "embedded_web_last_suppressed_duplicate_key_ != suppression_key" in refresh
     assert "const PreviewContext normalized_context = normalized_preview_context(preview_context_);" in CPP
     assert "identity.product_view_backend =" in CPP
     assert "identity.generated_web_scene_path =" in CPP

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -970,6 +970,7 @@ void ScenePreviewWidget::cancel_embedded_web_lifecycle(bool stop_owned_server)
   pending_embedded_web_identity_ = EmbeddedWebRequestIdentity{};
   pending_embedded_web_request_ = false;
   pending_embedded_web_force_ = false;
+  embedded_web_last_suppressed_duplicate_key_.clear();
   embedded_editor_polling_ = false;
   embedded_web_readiness_deadline_ = QDateTime();
   embedded_web_last_boot_status_.clear();
@@ -1033,16 +1034,22 @@ void ScenePreviewWidget::request_embedded_web_product_view_refresh(bool force)
 
   // Automatic payload/context notifications are coalesced before they can
   // consume a generation or replace the active callback identity.
-  if (!force && ((embedded_web_has_active_identity_ && embedded_web_active_identity_.matches_context(request_key)) ||
-                 (pending_embedded_web_request_ && pending_embedded_web_identity_.matches_context(request_key)))) {
-    emit studio_log_requested(QStringLiteral("Embedded Product View duplicate navigation suppressed: scene=%1 payload_revision=%2 backend=%3 json=%4 fingerprint=%5.")
-      .arg(request_key.scene_id)
-      .arg(request_key.payload_revision)
-      .arg(request_key.product_view_backend)
-      .arg(request_key.generated_web_scene_path)
-      .arg(QString::fromLatin1(request_key.payload_fingerprint.toHex().left(12))));
+  if (!force && ((embedded_web_has_active_identity_ && embedded_web_active_identity_.matches_effective_request(request_key)) ||
+                 (pending_embedded_web_request_ && pending_embedded_web_identity_.matches_effective_request(request_key)))) {
+    const QString suppression_key = embedded_web_effective_request_key(request_key);
+    if (embedded_web_last_suppressed_duplicate_key_ != suppression_key) {
+      embedded_web_last_suppressed_duplicate_key_ = suppression_key;
+      emit studio_log_requested(QStringLiteral("Duplicate Product View navigation suppressed: scene=%1 payload_revision=%2 backend=%3 json=%4 fingerprint=%5.")
+        .arg(request_key.scene_id)
+        .arg(request_key.payload_revision)
+        .arg(request_key.product_view_backend)
+        .arg(request_key.generated_web_scene_path)
+        .arg(QString::fromLatin1(request_key.payload_fingerprint.toHex().left(12))));
+    }
     return;
   }
+
+  embedded_web_last_suppressed_duplicate_key_.clear();
 
   // Refresh Preview is deliberately the sole forced path.  It retires the
   // previous lifecycle, then creates one fresh generation and one retry.
@@ -1098,6 +1105,15 @@ QString ScenePreviewWidget::embedded_web_preparation_diagnostic_key(const Embedd
     .arg(identity.scene_id, identity.absolute_scene_dir, identity.absolute_repo_root,
          QString::fromLatin1(identity.payload_fingerprint.toHex()))
     .arg(identity.selected_server_port).arg(identity.payload_revision).arg(identity.generation);
+}
+
+QString ScenePreviewWidget::embedded_web_effective_request_key(const EmbeddedWebRequestIdentity & identity) const
+{
+  return QStringLiteral("%1|%2|%3|%4|%5|%6|%7")
+    .arg(identity.scene_id, identity.absolute_scene_dir, identity.absolute_repo_root,
+         identity.product_view_backend, identity.generated_web_scene_path,
+         QString::fromLatin1(identity.payload_fingerprint.toHex()))
+    .arg(identity.payload_revision);
 }
 
 void ScenePreviewWidget::append_embedded_web_prepare_output(QProcess * process, bool standard_error)
@@ -1663,11 +1679,15 @@ void ScenePreviewWidget::set_preview_context(const PreviewContext & context)
   const bool context_changed = !preview_contexts_equal(preview_context_, normalized);
   if (!context_changed) return;
 
+  const EmbeddedWebRequestIdentity previous_effective_identity = embedded_web_request_identity(0);
   const QString effective_scene_name = normalized.scene_id.isEmpty() ?
     QStringLiteral("No scene") : normalized.scene_id;
   const bool scene_name_changed = preview_scene_name_ != effective_scene_name;
-  if (context_changed) cancel_embedded_web_lifecycle(false);
   preview_context_ = normalized;
+  const EmbeddedWebRequestIdentity next_effective_identity = embedded_web_request_identity(0);
+  if (!previous_effective_identity.matches_effective_request(next_effective_identity)) {
+    cancel_embedded_web_lifecycle(false);
+  }
   root_resolution_summary_keys_.clear();
   if (!normalized.scene_id.isEmpty()) {
     set_preview_scene_name(normalized.scene_id);

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -353,12 +353,16 @@ private:
     quint64 payload_revision{ 0 };
     quint64 generation{ 0 };
 
-    bool matches_context(const EmbeddedWebRequestIdentity & other) const
+    bool matches_effective_request(const EmbeddedWebRequestIdentity & other) const
     {
       return scene_id == other.scene_id && absolute_scene_dir == other.absolute_scene_dir &&
-        absolute_repo_root == other.absolute_repo_root && selected_server_port == other.selected_server_port &&
-        product_view_backend == other.product_view_backend && generated_web_scene_path == other.generated_web_scene_path &&
+        absolute_repo_root == other.absolute_repo_root && product_view_backend == other.product_view_backend &&
+        generated_web_scene_path == other.generated_web_scene_path &&
         payload_fingerprint == other.payload_fingerprint && payload_revision == other.payload_revision;
+    }
+    bool matches_context(const EmbeddedWebRequestIdentity & other) const
+    {
+      return matches_effective_request(other) && selected_server_port == other.selected_server_port;
     }
     bool operator==(const EmbeddedWebRequestIdentity & other) const
     {
@@ -404,6 +408,7 @@ private:
   void record_embedded_web_prepare_terminal(const EmbeddedWebRequestIdentity & identity, QProcess * process,
     const QString & outcome, QProcess::ExitStatus exit_status, int exit_code, const QString & detail = QString());
   QString embedded_web_preparation_diagnostic_key(const EmbeddedWebRequestIdentity & identity) const;
+  QString embedded_web_effective_request_key(const EmbeddedWebRequestIdentity & identity) const;
   void ensure_embedded_web_server_started(const QString & repo_root, const EmbeddedWebRequestIdentity & identity);
   void start_owned_embedded_web_server(const EmbeddedWebRequestIdentity & identity);
   void select_owned_embedded_web_server(const EmbeddedWebRequestIdentity & identity, bool use_current_port);
@@ -497,6 +502,7 @@ private:
   bool pending_embedded_web_request_{ false };
   quint64 embedded_web_request_generation_{ 0 };
   bool pending_embedded_web_force_{ false };
+  QString embedded_web_last_suppressed_duplicate_key_;
   QSet<QString> embedded_web_automatic_recovery_attempts_;
   bool backend_startup_diagnostic_emitted_{ false };
   PreviewContext preview_context_;


### PR DESCRIPTION
### Motivation
- Reduce redundant embedded Web3D work by coalescing automatic refresh notifications that refer to the same effective Product View payload so preparation, navigation, and URDF load do not repeat needlessly.
- Preserve current callback identity semantics that remain port-sensitive while preventing metadata/hierarchy/inspector updates from restaging assets when the effective request is unchanged.
- Emit a single, clear diagnostic per suppressed duplicate group to aid debugging without log spam.

### Description
- Introduced `matches_effective_request()` and retained `matches_context()` on `EmbeddedWebRequestIdentity` so the effective content identity (scene, repo, scene dir, backend, generated web scene path, payload fingerprint, and revision) can be compared separately from the port-sensitive callback identity. (header and struct changes in `scene_preview_widget.h`).
- Added `embedded_web_effective_request_key()` and `embedded_web_last_suppressed_duplicate_key_` to group duplicate suppressions and log `Duplicate Product View navigation suppressed` once per suppressed group. (new function and member in `scene_preview_widget.cpp`/`.h`).
- Modified `request_embedded_web_product_view_refresh()` to form the effective identity before allocating a generation and to suppress duplicates using the effective identity comparison, clearing the suppression key when a real request proceeds. (logic change in `scene_preview_widget.cpp`).
- Updated `set_preview_context()` to compare the previous and next effective identities and only cancel/restage the embedded Web3D lifecycle when the effective request changed, avoiding needless restaging on metadata-only context changes. (logic change in `scene_preview_widget.cpp`).
- Updated the refresh lifecycle regression test `tests/test_scene_preview_widget_refresh_lifecycle.py` to assert three identical refresh requests produce one preparation/navigation/load lifecycle and record one suppression diagnostic group.

### Testing
- Ran the focused lifecycle test with `python3 -m pytest tests/test_scene_preview_widget_refresh_lifecycle.py` which passed.
- Ran the broader unit test subset with `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py tests/test_scene_preview_widget_refresh_lifecycle.py` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e3ad57300833188a1e3081f8546fc)