### PR TITLE
Set Product View to an RViz-style neutral background

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -378,8 +378,8 @@ def test_viewer_product_workspace_uses_central_light_palette_for_scene_and_css()
 
     assert "const PRODUCT_VIEW_LIGHT_PALETTE = Object.freeze({" in js
     for token in [
-        "workspaceBackground: 0xe9edf1",
-        "rendererClearColor: 0xe9edf1",
+        "workspaceBackground: 0xeef1f4",
+        "rendererClearColor: 0xeef1f4",
         "gridMajor: 0x8996a3",
         "gridMinor: 0xc3cbd3",
         "labelText: 0x123040",
@@ -391,8 +391,12 @@ def test_viewer_product_workspace_uses_central_light_palette_for_scene_and_css()
         assert token in js
     assert "scene.background = new THREE.Color(PRODUCT_VIEW_LIGHT_PALETTE.workspaceBackground);" in init_body
     assert "renderer.setClearColor(PRODUCT_VIEW_LIGHT_PALETTE.rendererClearColor, 1);" in init_body
+    assert "scene.background = new THREE.Color(0xe9edf1);" not in js
+    assert "setClearColor(0xe9edf1" not in js
+    assert "new THREE.Fog(0xe9edf1" not in js
     assert "scene.background = new THREE.Color(0x0b1018);" not in js
     assert "setClearColor(0x0b1018" not in js
+    assert "new THREE.Fog(0x0b1018" not in js
     assert "Fog" not in js and ".fog" not in js
 
     assert "--workspace-bg: #e9edf1;" in css
@@ -410,7 +414,7 @@ def test_viewer_product_grid_uses_visible_major_minor_palette_colours():
     js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
     init_body = js.split("function initThree()", 1)[1].split("function animate()", 1)[0]
 
-    assert "workspaceBackground: 0xe9edf1" in js
+    assert "workspaceBackground: 0xeef1f4" in js
     assert "gridMajor: 0x8996a3" in js
     assert "gridMinor: 0xc3cbd3" in js
     assert "new THREE.GridHelper(5, 20, PRODUCT_VIEW_LIGHT_PALETTE.gridMajor, PRODUCT_VIEW_LIGHT_PALETTE.gridMinor)" in init_body

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -8,8 +8,8 @@ let loadRobotPreview;
 let applyRobotJointPreview;
 
 const PRODUCT_VIEW_LIGHT_PALETTE = Object.freeze({
-  workspaceBackground: 0xe9edf1,
-  rendererClearColor: 0xe9edf1,
+  workspaceBackground: 0xeef1f4,
+  rendererClearColor: 0xeef1f4,
   gridMajor: 0x8996a3,
   gridMinor: 0xc3cbd3,
   labelText: 0x123040,


### PR DESCRIPTION
### Motivation
- Ensure the Web3D Product View workspace background matches the neutral light colour `#eef1f4` while preserving existing rendering, materials, lighting, loaders, and scene content.

### Description
- Updated `PRODUCT_VIEW_LIGHT_PALETTE.workspaceBackground` and `PRODUCT_VIEW_LIGHT_PALETTE.rendererClearColor` from `0xe9edf1` to `0xeef1f4` in `workcell_studio_web/viewer/viewer.js` and adjusted the focused static test in `tests/test_workcell_studio_web_viewer_static.py` to expect the new palette value and guard against stale/dark literals; `scene.background` and `renderer.setClearColor(...)` remain wired to the central palette.

### Testing
- Ran `node --check workcell_studio_web/viewer/viewer.js` and `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py`, and the test run passed (all tests in that suite succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e3e5af92c83318bc34a156f73de21)