### PR TITLE
Enforce expanded URDF viewer matrix invariants

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -1859,3 +1859,64 @@ def test_viewer_canonical_ur5_2f_required_visual_set():
     assert "if (count > 1) duplicate.push(link);" in validation_body
     assert "if (count === 0) missing.push(category);" in validation_body
     assert "if (count > 1) duplicate.push(category);" in validation_body
+
+def test_expanded_urdf_mode_marks_flattened_robot_tool_rows_diagnostic_only():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    render_body = js.split("function renderScene(items)", 1)[1].split("function loadExpandedUrdfRobotPreview", 1)[0]
+    assert "if (urdfPreviewActive) loadExpandedUrdfRobotPreview(state.sceneJson.robot_preview);" in render_body
+    assert "new Set(robotToolGeneratedUrdfItems)" in render_body
+    assert "expanded_urdf_loader_skip_flattened_row" in render_body
+    assert "expanded URDF mode renders robot/tool only through loadRobotPreview and URDFLoader" in render_body
+    assert render_body.index("loadExpandedUrdfRobotPreview(state.sceneJson.robot_preview)") < render_body.index("for (const item of items)")
+
+
+def test_urdf_renderer_compares_browser_matrix_world_to_exported_expected_matrices(tmp_path):
+    script = tmp_path / "matrix_parity.mjs"
+    script.write_text(
+        f"""
+import assert from 'node:assert/strict';
+import * as THREE from {str((VIEWER / 'node_modules/three/build/three.module.js')).__repr__()};
+import URDFLoader from {str((VIEWER / 'node_modules/urdf-loader/src/URDFLoader.js')).__repr__()};
+
+globalThis.window = {{}};
+const originalUrdfLoadAsync = URDFLoader.prototype.loadAsync;
+URDFLoader.prototype.loadAsync = async function loadAsyncStub() {{
+  const robot = new THREE.Group();
+  const base = new THREE.Group();
+  base.name = 'base_link';
+  base.position.set(1, 2, 3);
+  const visual = new THREE.Group();
+  visual.name = 'visual_0';
+  visual.position.set(0.25, 0, 0);
+  visual.add(new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), new THREE.MeshBasicMaterial()));
+  base.add(visual);
+  robot.add(base);
+  robot.links = {{ base_link: base }};
+  robot.joints = {{}};
+  robot.setJointValues = () => {{}};
+  return robot;
+}};
+
+try {{
+  const {{ loadRobotPreview }} = await import({str((VIEWER / 'urdf_robot_renderer.js')).__repr__()});
+  const expectedLink = new THREE.Matrix4().makeTranslation(1, 2, 3).elements;
+  const expectedVisual = new THREE.Matrix4().makeTranslation(1.25, 2, 3).elements;
+  const result = loadRobotPreview({{
+    urdf_url: 'robot.urdf',
+    expected_robot_link_world_matrices: {{ base_link: expectedLink }},
+    expected_robot_visual_wrapper_world_matrices: {{ base_link: expectedVisual }},
+  }});
+  await result.ready;
+  assert.equal(result.diagnostics.robot_matrix_world_parity.pass, true);
+  assert.equal(result.diagnostics.robot_matrix_world_parity.tolerance, 1e-5);
+  assert.equal(result.diagnostics.robot_matrix_world_parity.link.compared_count, 1);
+  assert.equal(result.diagnostics.robot_matrix_world_parity.visual_wrapper.compared_count, 1);
+  assert.equal(result.diagnostics.robot_matrix_world_parity.link.comparisons[0].max_abs_delta <= 1e-5, true);
+  assert.equal(result.diagnostics.robot_matrix_world_parity.visual_wrapper.comparisons[0].max_abs_delta <= 1e-5, true);
+}} finally {{
+  URDFLoader.prototype.loadAsync = originalUrdfLoadAsync;
+}}
+""",
+        encoding="utf-8",
+    )
+    subprocess.run(["node", str(script)], cwd=ROOT, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/workcell_studio_web/viewer/urdf_robot_renderer.js
+++ b/workcell_studio_web/viewer/urdf_robot_renderer.js
@@ -277,6 +277,97 @@ function vector3ToDiagnostics(value) {
   return value ? { x: Number(value.x), y: Number(value.y), z: Number(value.z) } : null;
 }
 
+
+function finiteMatrix16(value) {
+  if (Array.isArray(value) && value.length === 4 && value.every(row => Array.isArray(row) && row.length === 4)) {
+    const out = [];
+    for (let col = 0; col < 4; col += 1) {
+      for (let row = 0; row < 4; row += 1) out.push(Number(value[row][col]));
+    }
+    return out.every(Number.isFinite) ? out : null;
+  }
+  if (Array.isArray(value) && value.length === 16) {
+    const out = value.map(Number);
+    return out.every(Number.isFinite) ? out : null;
+  }
+  const matrix = value?.matrix_world || value?.matrixWorld || value?.expected_matrix || value?.expectedMatrix || null;
+  return matrix && matrix !== value ? finiteMatrix16(matrix) : null;
+}
+
+function matrixMaxAbsDelta(a, b) {
+  const ma = finiteMatrix16(a);
+  const mb = finiteMatrix16(b);
+  if (!ma || !mb) return Infinity;
+  return Math.max(...ma.map((value, index) => Math.abs(value - mb[index])));
+}
+
+function expectedMatrixMap(...sources) {
+  const out = new Map();
+  for (const source of sources) {
+    if (!source) continue;
+    if (Array.isArray(source)) {
+      for (const entry of source) {
+        const key = String(entry?.link_name || entry?.linkName || entry?.link || entry?.name || '').trim();
+        const matrix = finiteMatrix16(entry);
+        if (key && matrix) out.set(key, matrix);
+      }
+    } else if (typeof source === 'object') {
+      for (const [key, value] of Object.entries(source)) {
+        const matrix = finiteMatrix16(value);
+        if (key && matrix) out.set(key, matrix);
+      }
+    }
+  }
+  return out;
+}
+
+function compareMatrixDiagnostics(actualByLink, expectedByLink, tolerance = 1e-5) {
+  const comparisons = [];
+  let pass = true;
+  for (const [linkName, expectedMatrix] of expectedByLink.entries()) {
+    const actualEntry = actualByLink instanceof Map ? actualByLink.get(linkName) : actualByLink?.[linkName];
+    const actualMatrix = finiteMatrix16(actualEntry);
+    const maxAbsDelta = matrixMaxAbsDelta(expectedMatrix, actualMatrix);
+    const ok = Number.isFinite(maxAbsDelta) && maxAbsDelta <= tolerance;
+    pass = pass && ok;
+    comparisons.push({
+      link_name: linkName,
+      linkName,
+      max_abs_delta: maxAbsDelta,
+      maxAbsDelta,
+      tolerance,
+      pass: ok,
+      expected_matrix_world: expectedMatrix,
+      expectedMatrixWorld: expectedMatrix,
+      actual_matrix_world: actualMatrix,
+      actualMatrixWorld: actualMatrix,
+    });
+  }
+  return { pass, tolerance, compared_count: comparisons.length, comparedCount: comparisons.length, comparisons };
+}
+
+function collectMatrixParityDiagnostics(previewConfig, diagnostics) {
+  const tolerance = Number(previewConfig?.matrix_diagnostic_tolerance ?? previewConfig?.matrixDiagnosticTolerance ?? 1e-5);
+  const linkExpected = expectedMatrixMap(
+    previewConfig?.expected_robot_link_world_matrices,
+    previewConfig?.expectedRobotLinkWorldMatrices,
+    previewConfig?.robot_link_world_matrices_expected,
+    previewConfig?.robotLinkWorldMatricesExpected
+  );
+  const visualExpected = expectedMatrixMap(
+    previewConfig?.expected_robot_visual_wrapper_world_matrices,
+    previewConfig?.expectedRobotVisualWrapperWorldMatrices,
+    previewConfig?.robot_visual_wrapper_world_matrices_expected,
+    previewConfig?.robotVisualWrapperWorldMatricesExpected
+  );
+  const linkParity = compareMatrixDiagnostics(diagnostics.robot_link_world_matrices || {}, linkExpected, tolerance);
+  const visualActual = new Map((diagnostics.robot_visual_wrapper_world_matrices || []).map(entry => [String(entry?.link_name || entry?.linkName || '').trim(), entry]).filter(([key]) => key));
+  const visualParity = compareMatrixDiagnostics(visualActual, visualExpected, tolerance);
+  diagnostics.robot_matrix_world_parity = { tolerance, link: linkParity, visual_wrapper: visualParity, pass: linkParity.pass && visualParity.pass };
+  diagnostics.robotMatrixWorldParity = diagnostics.robot_matrix_world_parity;
+  return diagnostics.robot_matrix_world_parity;
+}
+
 function collectLinkMatrixDiagnostics(robot, links) {
   robot?.updateMatrixWorld?.(true);
   const out = {};
@@ -440,6 +531,7 @@ export function applyRobotJointPreview(result, jointValues = {}) {
   result.diagnostics.robotVisualWrapperWorldMatrices = result.diagnostics.robot_visual_wrapper_world_matrices;
   result.diagnostics.robot_descendant_render_mesh_diagnostics = collectDescendantRenderMeshDiagnostics(links);
   result.diagnostics.robotDescendantRenderMeshDiagnostics = result.diagnostics.robot_descendant_render_mesh_diagnostics;
+  collectMatrixParityDiagnostics(result?.previewConfig || {}, result.diagnostics);
   return result.diagnostics;
 }
 
@@ -492,7 +584,7 @@ export function loadRobotPreview(previewConfig, rendererContext = {}) {
     robotDescendantRenderMeshDiagnostics: [],
     skipped_legacy_generated_urdf_visual_count: rendererContext?.skippedLegacyGeneratedUrdfVisualCount || 0,
   };
-  const result = { root: null, links: new Map(), joints: new Map(), diagnostics, ready: null };
+  const result = { root: null, links: new Map(), joints: new Map(), diagnostics, ready: null, previewConfig };
 
   result.ready = (async () => {
     setLifecycleState(diagnostics, 'loading_urdf');
@@ -536,6 +628,7 @@ export function loadRobotPreview(previewConfig, rendererContext = {}) {
     diagnostics.robotVisualWrapperWorldMatrices = diagnostics.robot_visual_wrapper_world_matrices;
     diagnostics.robot_descendant_render_mesh_diagnostics = collectDescendantRenderMeshDiagnostics(robot.links);
     diagnostics.robotDescendantRenderMeshDiagnostics = diagnostics.robot_descendant_render_mesh_diagnostics;
+    collectMatrixParityDiagnostics(previewConfig, diagnostics);
     diagnostics.robot_collada_mesh_diagnostics = diagnostics.robot_collada_mesh_diagnostics || [];
     diagnostics.robotColladaMeshDiagnostics = diagnostics.robot_collada_mesh_diagnostics;
     const rootDiagnostics = linkRootDiagnostics(robot, robot.links);

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -2661,6 +2661,13 @@ function renderScene(items) {
   state.robotUrdfPreviewDiagnostics = {};
   const urdfPreviewActive = isExpandedUrdfRobotPreview(state.sceneJson?.robot_preview);
   const robotToolGeneratedUrdfItems = items.filter(isRobotToolGeneratedUrdfMeshVisualItem);
+  if (urdfPreviewActive) {
+    for (const item of robotToolGeneratedUrdfItems) {
+      item.workcell_web_render_pose_mode = 'expanded_urdf_loader_skip_flattened_row';
+      item.expanded_urdf_loader_skip_reason = 'expanded URDF mode renders robot/tool only through loadRobotPreview and URDFLoader; flattened row transforms are diagnostics only';
+      item.baked_world_visual_pose_diagnostic_only = Boolean(item.baked_world_visual_pose || item.expected_visual_pose || item.baked_world_visual_matrix || item.visual_origin || item.robot_world_pose);
+    }
+  }
   const assemblyBuild = urdfPreviewActive ? { handled: new Set(robotToolGeneratedUrdfItems), assemblies: [], renderDiagnostics: { skipped_flattened_urdf_visual_count: 0, assembled_hierarchy_rendered_mesh_count: 0, rendered_fk_visual_count: 0, skipped_legacy_generated_urdf_count: robotToolGeneratedUrdfItems.length, skipped_legacy_generated_urdf_visual_count: robotToolGeneratedUrdfItems.length, visible_duplicate_generated_urdf_count: 0, visible_tool0_fallback_count: 0, detached_robot_mesh_clusters: 0 } } : buildRobotAssemblies(items);
   state.robotAssemblyDiagnostics = assemblyBuild.assemblies;
   state.robotAssemblyRenderDiagnostics = assemblyBuild.renderDiagnostics || {};


### PR DESCRIPTION
### Motivation
- Ensure expanded-URDF preview renders robot and attached tool only via the URDFLoader path and avoid double-applying baked or flattened transforms to individual mesh rows.
- Provide deterministic browser/expected-matrix parity diagnostics so exported expected FK matrices can be compared against actual browser `matrixWorld` values with a tight tolerance.

### Description
- Mark generated robot/tool flattened mesh rows diagnostic-only when `robot_preview.mode` is an expanded URDF variant so those flattened rows are skipped for rendering and treated as diagnostics (`viewer.js`).
- Add matrix-parity utilities (`finiteMatrix16`, `matrixMaxAbsDelta`, `expectedMatrixMap`, `compareMatrixDiagnostics`, `collectMatrixParityDiagnostics`) and wire them into `loadRobotPreview()` and `applyRobotJointPreview()` so diagnostics publish `robot_matrix_world_parity` / `robotMatrixWorldParity` containing link and visual-wrapper comparison results (`urdf_robot_renderer.js`).
- Preserve the single-application transform chain for expanded URDF previews by delegating transform propagation to the URDFLoader and preventing baked/visual-origin/flattened transforms from being applied again to child visual rows in expanded mode (`viewer.js` change + small diagnostic flags on flattened rows).
- Add static/browser-style tests that assert flattened-row skipping in expanded URDF mode and validate the matrix parity diagnostic behavior with a default tolerance of `1e-5` (`tests/test_workcell_studio_web_viewer_static.py`).

### Testing
- Ran `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py -q` and the suite passed (75 tests).
- Ran `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py -q` and both passed (7 tests total).
- New matrix-parity checks exercise a Node.js stubbed URDF load to validate parity computation and are included in the updated static tests and passed during the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e4615108483318ebf9c2108652fe6)