### PR TITLE
Guard Collada root normalization boundary (no per-link 90° corrections)

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -1258,10 +1258,69 @@ def test_urdf_renderer_normalizes_collada_loader_root_transform_generically():
     js = (VIEWER / "urdf_robot_renderer.js").read_text(encoding="utf-8")
     assert "function normalizeRosColladaScene" in js
     assert "ColladaLoader(manager).load(url, dae => onDone(normalizeRosColladaScene(dae, uri, diagnostics))" in js
-    assert "upAxis === 'Z_UP' || upAxis === 'Y_UP'" in js
+    assert "upAxis === 'Z_UP' || (Number.isFinite(unitMeter)" in js
+    assert "upAxis === 'Z_UP' || upAxis === 'Y_UP'" not in js
     assert "robot_collada_root_normalization_count" in js
     assert "robot_descendant_render_mesh_diagnostics" in js
-    assert "shoulder_link" not in js.split("function normalizeRosColladaScene", 1)[1].split("function loadMesh", 1)[0]
+    collada_section = js.split("function normalizeRosColladaScene", 1)[1].split("function loadMesh", 1)[0]
+    assert "shoulder_link" not in collada_section
+    assert "Math.PI / 2" not in collada_section
+    assert "1.5707963267948966" not in collada_section
+    assert "rotateX" not in collada_section
+    assert "rotateY" not in collada_section
+    assert "rotateZ" not in collada_section
+
+
+def test_urdf_renderer_documents_single_ros_to_three_conversion_boundary():
+    js = (VIEWER / "urdf_robot_renderer.js").read_text(encoding="utf-8")
+    assert "ROS_TO_THREE_CONVERSION_BOUNDARY" in js
+    assert "DAE, STL, assembled URDF, and flattened fallback diagnostics" in js
+    assert "must not add per-link or per-mesh 90-degree corrections after ColladaLoader" in js
+    assert "Do not add a\n  // second hardcoded 90-degree correction to any link, mesh, baked world matrix" in js
+    assert "assembled URDF node, or flattened fallback diagnostic row" in js
+
+
+def test_urdf_renderer_collada_root_normalization_is_diagnostic_only_with_matrix_parity(tmp_path):
+    script = tmp_path / "collada_root_boundary.mjs"
+    script.write_text(
+        f"""
+import assert from 'node:assert/strict';
+import * as THREE from {str((VIEWER / 'node_modules/three/build/three.module.js')).__repr__()};
+import {{ normalizeRosColladaScene, ROS_TO_THREE_CONVERSION_BOUNDARY }} from {str((VIEWER / 'urdf_robot_renderer.js')).__repr__()};
+
+const diagnostics = {{
+  robot_collada_root_normalization_count: 0,
+  robotColladaRootNormalizationCount: 0,
+  robot_collada_mesh_diagnostics: [],
+}};
+const scene = new THREE.Group();
+scene.rotation.x = -Math.PI / 2;
+scene.add(new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), new THREE.MeshBasicMaterial()));
+const normalized = normalizeRosColladaScene({{ scene, asset: {{ upAxis: 'Z_UP', unit: 1 }} }}, 'base.dae', diagnostics);
+assert.equal(normalized, scene);
+assert.equal(diagnostics.robot_collada_root_normalization_count, 1);
+assert.equal(diagnostics.robotColladaRootNormalizationCount, 1);
+assert.equal(diagnostics.robot_collada_mesh_diagnostics[0].root_transform_normalized, true);
+assert.equal(scene.rotation.x, 0);
+assert.equal(scene.quaternion.x, 0);
+
+const visualWrapper = new THREE.Group();
+visualWrapper.position.set(1, 2, 3);
+visualWrapper.add(scene);
+visualWrapper.updateMatrixWorld(true);
+const expectedWrapper = new THREE.Matrix4().makeTranslation(1, 2, 3).elements;
+assert.deepEqual(Array.from(visualWrapper.matrixWorld.elements), Array.from(expectedWrapper));
+assert.equal(ROS_TO_THREE_CONVERSION_BOUNDARY.includes('DAE, STL, assembled URDF, and flattened fallback'), true);
+
+const authoredYUp = new THREE.Group();
+authoredYUp.rotation.x = -Math.PI / 2;
+normalizeRosColladaScene({{ scene: authoredYUp, asset: {{ upAxis: 'Y_UP', unit: 1 }} }}, 'authored-y-up.dae', diagnostics);
+assert.equal(diagnostics.robot_collada_root_normalization_count, 1);
+assert.equal(authoredYUp.rotation.x, -Math.PI / 2);
+""",
+        encoding="utf-8",
+    )
+    subprocess.run(["node", str(script)], cwd=ROOT, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
 
 def test_viewer_expanded_urdf_preview_helper_accepts_canonical_and_legacy_modes():

--- a/workcell_studio_web/viewer/urdf_robot_renderer.js
+++ b/workcell_studio_web/viewer/urdf_robot_renderer.js
@@ -5,6 +5,7 @@ import { ColladaLoader } from 'three/addons/loaders/ColladaLoader.js';
 import { OBJLoader } from 'three/addons/loaders/OBJLoader.js';
 
 const ROBOT_RENDER_MODE = 'expanded_urdf_loader';
+const ROS_TO_THREE_CONVERSION_BOUNDARY = 'URDFLoader owns the ROS visual frame and applies the one ROS-to-Three orientation boundary; DAE, STL, assembled URDF, and flattened fallback diagnostics must not add per-link or per-mesh 90-degree corrections after ColladaLoader.';
 
 function repoUrl(context, uri) {
   return context?.repoRootRelativeUrl ? context.repoRootRelativeUrl(uri) : uri;
@@ -155,17 +156,16 @@ function normalizeRosColladaScene(dae, uri, diagnostics) {
   const meshCount = countDescendantMeshes(scene);
   const rootHasMesh = Boolean(scene.isMesh);
 
-  // ROS/RViz import Collada through Assimp into the URDF visual frame.  Three's
-  // ColladaLoader can expose file-level up-axis or unit conversion as a transform
-  // on the returned dae.scene root.  urdf-loader has already applied the URDF
-  // visual origin and mesh scale to the visual wrapper, so leaving this loader
-  // root conversion in place rotates/scales the visible descendant meshes while
-  // wrapper/link FK diagnostics still look correct.  Neutralize only a loader
-  // root conversion that is derived from the Collada asset metadata; STL/OBJ and
-  // authored child-node transforms remain untouched.
+  // ROS-to-Three conversion boundary: URDFLoader owns the ROS visual frame for
+  // every mesh format (DAE, STL, assembled URDF, and flattened fallback rows).
+  // Three's ColladaLoader may expose file-level Z_UP or unit metadata as a
+  // transform on the returned dae.scene root before URDFLoader places the visual
+  // wrapper. Neutralize only that loader root metadata transform. Do not add a
+  // second hardcoded 90-degree correction to any link, mesh, baked world matrix,
+  // assembled URDF node, or flattened fallback diagnostic row.
   const hasLoaderRootConversion = !rootHasMesh
     && !isIdentityTransform(scene)
-    && (upAxis === 'Z_UP' || upAxis === 'Y_UP' || (Number.isFinite(unitMeter) && Math.abs(unitMeter - 1) > 1e-9));
+    && (upAxis === 'Z_UP' || (Number.isFinite(unitMeter) && Math.abs(unitMeter - 1) > 1e-9));
   if (!hasLoaderRootConversion) {
     diagnostics.robot_collada_mesh_diagnostics.push({
       uri,
@@ -545,6 +545,8 @@ function jointTypeCounts(joints) {
   }
   return counts;
 }
+
+export { normalizeRosColladaScene, ROS_TO_THREE_CONVERSION_BOUNDARY };
 
 export function loadRobotPreview(previewConfig, rendererContext = {}) {
   const diagnostics = {


### PR DESCRIPTION
### Motivation
- Prevent accidental extra hardcoded 90° rotations being applied after `ColladaLoader` by preserving the single ROS-to-Three conversion responsibility with `URDFLoader`.
- Keep `normalizeRosColladaScene()` limited to neutralizing loader-provided root transforms (Z_UP / unit conversions) and avoid touching authored root transforms such as Y_UP.
- Add static/browser tests to detect regressions that would bake per-link or per-mesh 90° corrections into diagnostics or world transforms.

### Description
- Narrowed the Collada root-normalization predicate in `workcell_studio_web/viewer/urdf_robot_renderer.js` so only loader-derived Z_UP or unit-to-meter conversions are neutralized and authored Y_UP roots are preserved.
- Documented the conversion boundary via a new `ROS_TO_THREE_CONVERSION_BOUNDARY` string and exported both `normalizeRosColladaScene` and `ROS_TO_THREE_CONVERSION_BOUNDARY` for test coverage and clarity.
- Ensured `robot_collada_root_normalization_count` remains diagnostic-only and does not get combined with baked world transforms or per-link adjustments.
- Added and updated tests in `tests/test_workcell_studio_web_viewer_static.py` to assert there are no hardcoded per-link 90° corrections after `ColladaLoader`, the conversion boundary is documented, and root normalization is diagnostic-only (including a Node-backed matrix-parity check).

### Testing
- Ran the full viewer static test suite with `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py -q` and all tests passed (`77 passed`).
- Added Node-based assertions in tests that executed successfully under the same test run to validate matrix-parity and diagnostic-only behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e46f7cb288331b6517f9522354732)