### PR TITLE
Preserve Web3D `scene_failed` on required tool mesh failures and expose final failed mesh details

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -1780,6 +1780,99 @@ def test_viewer_rotate_cancels_on_selection_mode_and_scene_change_without_yaml_w
     assert "metadata" not in object_change_body.lower()
 
 
+
+def test_expanded_urdf_tool_mesh_failure_keeps_status_scene_failed_not_shell_ready():
+    js_path = VIEWER / "viewer.js"
+    harness = r"""
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+let source = fs.readFileSync(process.argv[1], 'utf8').replace(/boot\(\);\s*$/, '');
+const element = () => ({
+  hidden: false,
+  checked: false,
+  disabled: false,
+  textContent: '',
+  className: '',
+  innerHTML: '',
+  classList: { toggle() {} },
+  setAttribute() {},
+  querySelector() { return { textContent: '' }; },
+  appendChild() {},
+  addEventListener() {},
+  getBoundingClientRect() { return { width: 800, height: 600, left: 0, top: 0 }; },
+});
+const context = {
+  console,
+  assert,
+  window: { location: { search: '' }, dispatchEvent() {}, parent: { postMessage() {} } },
+  document: { getElementById() { return element(); }, createElement() { return element(); } },
+  CustomEvent: function CustomEvent(type, init) { return { type, ...init }; },
+  URLSearchParams,
+  requestAnimationFrame() { return 0; },
+};
+vm.createContext(context);
+vm.runInContext(source + `
+populateObjectList = () => {};
+updateLabels = () => {};
+resetView = () => {};
+renderSceneSummary = () => updateViewerStatus();
+state.sourceWebSceneFile = 'build/workcell_studio_web_scene/ur5_2f_test.web_scene.json';
+state.sceneJson = {
+  scene: { id: 'ur5_2f_test' },
+  robot_preview: { mode: 'expanded_urdf_loader', urdf_url: 'assets/ur5_2f_test/scene.urdf' },
+  robots: [{ id: 'ur5', role: 'robot', category: 'robot', mesh_contract_category: 'robot' }],
+  tools: [{ id: 'robotiq_2f', role: 'end_effector', category: 'tool', display_name: 'Robotiq 2F', mesh_contract_category: 'tool', mesh_load_required: true, mesh_uri: 'assets/ur5_2f_test/robotiq/robotiq_85_gripper_visual.dae' }],
+  assets: [{ id: 'workbench', category: 'environment', mesh_contract_category: 'table', mesh_uri: 'assets/ur5_2f_test/table.stl' }],
+  sensors: [{ id: 'camera', category: 'camera', mesh_contract_category: 'camera', mesh_uri: 'assets/ur5_2f_test/realsense.stl' }],
+};
+const items = collectItems(state.sceneJson);
+beginWeb3dSceneReadiness(items);
+failExpandedUrdfReadiness(new Error('HTTP 404 loading required Robotiq tool mesh'), {
+  robot_urdf_url: 'assets/ur5_2f_test/scene.urdf',
+  robot_missing_meshes: ['build/workcell_studio_web_scene/assets/ur5_2f_test/robotiq/robotiq_85_gripper_visual.dae: HTTP 404'],
+  robot_failed_visual_count: 1,
+  robotFailedVisualCount: 1,
+}, {
+  required_category: 'attached_tool_gripper',
+  link: 'gripper_base_link',
+  url: 'build/workcell_studio_web_scene/assets/ur5_2f_test/robotiq/robotiq_85_gripper_visual.dae',
+  uri: 'package://robotiq_85_description/meshes/visual/robotiq_85_gripper_visual.dae',
+  path: 'package://robotiq_85_description/meshes/visual/robotiq_85_gripper_visual.dae',
+});
+let status = updateViewerStatus();
+assert.strictEqual(status.web3d_readiness_state, 'scene_failed');
+assert.strictEqual(status.web3dReadinessState, 'scene_failed');
+assert.strictEqual(status.viewer_boot_state, 'scene_failed');
+assert.strictEqual(status.final_lifecycle_state, 'scene_failed');
+assert.strictEqual(status.tool_status, 'failed');
+assert.strictEqual(status.failed_required_item_count > 0, true);
+assert.strictEqual(status.final_failed_url, 'build/workcell_studio_web_scene/assets/ur5_2f_test/robotiq/robotiq_85_gripper_visual.dae');
+assert.strictEqual(status.finalFailedUrl, status.final_failed_url);
+assert.strictEqual(status.final_failed_link, 'gripper_base_link');
+assert.strictEqual(status.readiness_failure.link, 'gripper_base_link');
+assert.strictEqual(status.readiness_failure.url, status.final_failed_url);
+assert.ok(status.readiness_failure.robot_missing_meshes[0].includes('robotiq_85_gripper_visual.dae'));
+assert.ok(status.readiness_failure.reason.includes('Robotiq tool mesh'));
+emitWeb3dReadinessState('server_ready', { http_status: 200 });
+status = updateViewerStatus();
+assert.strictEqual(status.web3d_readiness_state, 'scene_failed');
+assert.strictEqual(status.web3dReadinessState, 'scene_failed');
+assert.notStrictEqual(status.web3d_readiness_state, 'scene_ready');
+assert.notStrictEqual(status.web3dReadinessState, 'scene_ready');
+assert.strictEqual(status.readiness_failure.url, status.final_failed_url);
+`, context);
+"""
+    result = subprocess.run(
+        ["node", "-e", harness, str(js_path)],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert result.stderr == ""
+
 def test_viewer_emits_explicit_web3d_readiness_states_and_required_categories():
     js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
     assert "'server_ready'" in js
@@ -1791,6 +1884,7 @@ def test_viewer_emits_explicit_web3d_readiness_states_and_required_categories():
     assert "function maybeEmitSceneReady()" in js
     assert "if (readinessState === 'scene_ready')" in js
     assert "if (state.web3dReadiness.emittedSceneReady)" in js
+    assert "state.web3dReadiness.failed && state.web3dReadiness.state === 'scene_failed'" in js
     assert "pending.add('robot_arm:expanded_urdf_loader')" in js
     assert "pending.add('attached_tool_gripper:expanded_urdf_loader')" in js
     assert "emitWeb3dReadinessState('scene_loading'" in js

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -72,6 +72,9 @@ const EXPECTED_GENERATED_URDF_DIAGNOSTIC_LINKS = [
 const WEB3D_REQUIRED_CATEGORIES = ['robot_arm', 'attached_tool_gripper', 'workbench_support_surface', 'configured_camera'];
 function emitWeb3dReadinessState(readinessState, detail = {}) {
   state.web3dReadiness = state.web3dReadiness || { state: 'server_ready', emittedSceneReady: false, required: {}, pending: new Set(), failed: false, failure: null };
+  if (state.web3dReadiness.failed && state.web3dReadiness.state === 'scene_failed' && readinessState !== 'scene_failed') {
+    return updateViewerStatus();
+  }
   if (readinessState === 'scene_ready') {
     if (state.web3dReadiness.emittedSceneReady) return window.__WORKCELL_VIEWER_STATUS__;
     state.web3dReadiness.emittedSceneReady = true;
@@ -753,6 +756,10 @@ function updateViewerStatus() {
     pending_required_loads: Array.from(state.web3dReadiness?.pending || []),
     pendingRequiredLoads: Array.from(state.web3dReadiness?.pending || []),
     ...structuredWeb3dReadinessFields(state.web3dReadiness?.state || 'server_ready'),
+    final_failed_url: state.web3dReadiness?.failure?.url || state.web3dReadiness?.failure?.final_failed_url || '',
+    finalFailedUrl: state.web3dReadiness?.failure?.url || state.web3dReadiness?.failure?.finalFailedUrl || '',
+    final_failed_link: state.web3dReadiness?.failure?.link || state.web3dReadiness?.failure?.link_name || '',
+    finalFailedLink: state.web3dReadiness?.failure?.link || state.web3dReadiness?.failure?.linkName || '',
     readiness_failure: state.web3dReadiness?.failure || null,
     readinessFailure: state.web3dReadiness?.failure || null,
   };


### PR DESCRIPTION
### Motivation
- The viewer could be driven from a later non-scene lifecycle signal (e.g. shell/server `server_ready` HTTP 200) and inadvertently mask an earlier required mesh failure for declared tools such as Robotiq, which hides real readiness problems. 
- Tests/embedded consumers need an explicit failure surface showing which required mesh/link/url caused the blocked scene readiness so the builder can surface actionable diagnostics.

### Description
- Prevent `emitWeb3dReadinessState` from allowing subsequent non-`scene_failed` state transitions to overwrite an existing `scene_failed` caused by a required mesh failure by returning early when `state.web3dReadiness.failed` is set. 
- Add final failed mesh/link fields to the viewer status payload via `updateViewerStatus` as `final_failed_url`/`finalFailedUrl` and `final_failed_link`/`finalFailedLink` and ensure `readiness_failure` still contains structured diagnostics. 
- Add a regression test `test_expanded_urdf_tool_mesh_failure_keeps_status_scene_failed_not_shell_ready` in `tests/test_workcell_studio_web_viewer_static.py` that simulates an expanded-URDF Robotiq/end-effector mesh 404 and asserts `web3d_readiness_state` remains `scene_failed`, diagnostics include the failed link and URL, and a later `server_ready` signal (HTTP 200) does not flip the scene to `scene_ready`.

### Testing
- Ran the new regression test and related viewer static tests with `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py::test_expanded_urdf_tool_mesh_failure_keeps_status_scene_failed_not_shell_ready` and the targeted test group, and they all passed. 
- Ran the entire `tests/test_workcell_studio_web_viewer_static.py` suite to validate static viewer contract changes, and it passed. 
- Verified `git diff --check` and no lint-like diffs were produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e488bffb08331817dd418377e6393)