### PR TITLE
Prevent old scene callbacks from corrupting Product View

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -222,6 +222,39 @@ def test_urdf_renderer_resolves_package_meshes_to_staged_scene_assets():
     assert "URDF package mesh rejected:" in js
 
 
+def test_expanded_urdf_robot_preview_callbacks_are_scene_current_guarded():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+    clear_body = js.split("function clearSceneObjects()", 1)[1].split("function renderScene(items)", 1)[0]
+    load_body = js.split("function loadExpandedUrdfRobotPreview(preview)", 1)[1].split("function linkNameOfItem(item)", 1)[0]
+
+    assert "let robotPreviewLoadToken = 0;" in js
+    assert "robotPreviewLoadToken += 1;" in clear_body
+    assert "state.assemblyRoots = [];" in clear_body
+    assert "state.objects = [];" in clear_body
+    assert "state.robotPreviewResult = null;" in clear_body
+    assert "state.robotUrdfPreviewDiagnostics = {};" in clear_body
+
+    assert "const loadToken = ++robotPreviewLoadToken;" in load_body
+    assert "const loadSceneId = sceneId();" in load_body
+    assert "loadToken === robotPreviewLoadToken && loadSceneId === sceneId()" in load_body
+    assert "sceneId: loadSceneId" in load_body
+    assert "if (callbackIsCurrent()) state.three.scene?.add?.(root);" in load_body
+    assert "if (callbackIsCurrent()) state.assemblyRoots.push(root);" in load_body
+    assert "Ignored stale robot preview callback: callback_scene=${loadSceneId} active_scene=${sceneId()}" in load_body
+
+    guard_token = "if (!callbackIsCurrent()) return ignoreStaleCallback();"
+    callback_mutations = {
+        "onRobotLoaded: result => {": "state.robotPreviewResult = result;",
+        "onRobotMeshLoaded: () => {": "renderSceneSummary();",
+        "onRobotMeshLoadError: (err, uri, detail) => {": "failExpandedUrdfReadiness(err, state.robotUrdfPreviewDiagnostics, detail || { uri });",
+        "onRobotError: (err, diagnostics) => {": "failExpandedUrdfReadiness(err, diagnostics || state.robotUrdfPreviewDiagnostics);",
+    }
+    for callback, mutation in callback_mutations.items():
+        section = load_body.split(callback, 1)[1].split("},", 1)[0]
+        assert guard_token in section
+        assert section.find(guard_token) < section.find(mutation)
+
+
 def test_urdf_renderer_rejects_unsafe_package_mesh_sources():
     js = (VIEWER / "urdf_robot_renderer.js").read_text(encoding="utf-8")
     package_body = js.split("function resolvePackageMeshUri", 1)[1].split("function normalizeMeshUri", 1)[0]
@@ -262,7 +295,7 @@ def test_urdf_renderer_passes_loaded_scene_id_without_changing_staged_meshes():
     assert "const diagnostic = context?.meshUriDiagnostic?.({ mesh_uri: raw, mesh_staging_status: 'staged' });" in normalize_body
     assert "return diagnostic?.uri || raw;" in normalize_body
     preview_call = viewer.split("const previewResult = loadRobotPreview(preview, {", 1)[1].split("onRobotLoaded", 1)[0]
-    assert "sceneId: sceneId()," in preview_call
+    assert "sceneId: loadSceneId," in preview_call
 
 
 
@@ -1910,7 +1943,7 @@ def test_required_gripper_mesh_failures_transition_scene_failed_with_url_and_lin
     assert "const eventDetail = { ...structured, ...detail, final_lifecycle_state: readinessState" in viewer
     assert "if (required) failWeb3dSceneReadiness(item, preflight.url || loadUrl" in viewer
     assert "http_status: preflight.http_status || null" in viewer
-    assert "onRobotMeshLoadError: (err, uri, detail) => { failExpandedUrdfReadiness" in viewer
+    assert "onRobotMeshLoadError: (err, uri, detail) => { if (!callbackIsCurrent()) return ignoreStaleCallback(); failExpandedUrdfReadiness" in viewer
     assert "function inferMeshLinkDetail(path)" in renderer
     assert "'gripper_base_link'" in renderer
     assert "context?.onRobotMeshLoadError?.(err, uri, { url, uri, path, ...inferMeshLinkDetail(path) })" in renderer

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -27,6 +27,7 @@ const MIN_FRAME_RADIUS = 1.2;
 const EMPTY_SCENE_MESSAGE = 'Scene contains no renderable robots, tools, assets, sensors, zones, items, or objects.';
 const FRAME_DISTANCE_MULTIPLIER = 2.7;
 const state = { sceneJson: null, sourceWebSceneFile: '', frameLookup: new Map(), resolvedFramePoses: new Map(), objects: [], assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, robotUrdfPreviewDiagnostics: {}, physicalAssemblyBounds: null, finalPhysicalFitBounds: null, selected: null, three: {}, animationId: null, lastFrameBounds: null, initialCameraFit: { sceneKey: '', done: false, attempts: 0, pendingRetry: null, userControlled: false }, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: new Map(), undoStack: [], redoStack: [], gizmoDragStart: null, directMoveDrag: null, directRotateDrag: null, editorMode: 'select', editorEvents: [], editorError: '', robotPreviewResult: null, initialPosePreview: { active: false, robotId: '', sceneKey: '' }, web3dReadiness: { state: 'server_ready', emittedSceneReady: false, required: {}, pending: new Set(), failed: false, failure: null } };
+let robotPreviewLoadToken = 0;
 const RESET_VIEW_TITLE = 'Fit Scene / Reset View: recomputes and reapplies the fitted workcell overview from renderable bounds.';
 const STAGED_MESH_ROOTS = [
   'build/workcell_studio_web_scene/assets/',
@@ -2634,6 +2635,7 @@ function clearLabels() {
 function clearSceneObjects() {
   const scene = state.three.scene;
   if (!scene) return;
+  robotPreviewLoadToken += 1;
   for (const root of state.assemblyRoots || []) scene.remove(root);
   for (const rendered of state.objects) scene.remove(rendered.object3d);
   clearLabels();
@@ -2641,6 +2643,7 @@ function clearSceneObjects() {
   state.assemblyRoots = [];
   state.robotAssemblyDiagnostics = [];
   state.robotAssemblyRenderDiagnostics = {};
+  state.robotUrdfPreviewDiagnostics = {};
   state.physicalAssemblyBounds = null;
   state.finalPhysicalFitBounds = null;
   state.resolvedFramePoses.clear();
@@ -2721,6 +2724,17 @@ function renderScene(items) {
 
 
 function loadExpandedUrdfRobotPreview(preview) {
+  const loadToken = ++robotPreviewLoadToken;
+  const loadSceneId = sceneId();
+  let staleCallbackLogged = false;
+  const callbackIsCurrent = () => loadToken === robotPreviewLoadToken && loadSceneId === sceneId();
+  const ignoreStaleCallback = () => {
+    if (!staleCallbackLogged) {
+      console.warn(`Ignored stale robot preview callback: callback_scene=${loadSceneId} active_scene=${sceneId()}`);
+      staleCallbackLogged = true;
+    }
+    return true;
+  };
   const diagnostics = state.robotUrdfPreviewDiagnostics = {
     robot_render_mode: 'expanded_urdf_loader',
     robot_preview_loaded: false,
@@ -2761,14 +2775,15 @@ function loadExpandedUrdfRobotPreview(preview) {
     return { root: null, links: new Map(), joints: new Map(), diagnostics, ready: Promise.resolve(null) };
   }
   const previewResult = loadRobotPreview(preview, {
-    sceneId: sceneId(),
-    scene: state.three.scene,
-    assemblyRoots: state.assemblyRoots,
+    sceneId: loadSceneId,
+    scene: { add: root => { if (callbackIsCurrent()) state.three.scene?.add?.(root); } },
+    assemblyRoots: { push: root => { if (callbackIsCurrent()) state.assemblyRoots.push(root); } },
     repoRootRelativeUrl,
     meshUriDiagnostic,
     rootName: `${sceneDisplayName()}_expanded_urdf_loader_robot`,
     skippedLegacyGeneratedUrdfVisualCount: diagnostics.skipped_legacy_generated_urdf_visual_count,
     onRobotLoaded: result => {
+      if (!callbackIsCurrent()) return ignoreStaleCallback();
       state.robotPreviewResult = result;
       state.robotUrdfPreviewDiagnostics = result.diagnostics;
       if (!failIfCanonicalRequiredVisualSetInvalid()) completeExpandedUrdfReadiness(result);
@@ -2776,10 +2791,12 @@ function loadExpandedUrdfRobotPreview(preview) {
       renderSceneSummary();
     },
     onRobotMeshLoaded: () => {
+      if (!callbackIsCurrent()) return ignoreStaleCallback();
       renderSceneSummary();
     },
-    onRobotMeshLoadError: (err, uri, detail) => { failExpandedUrdfReadiness(err, state.robotUrdfPreviewDiagnostics, detail || { uri }); renderSceneSummary(); },
+    onRobotMeshLoadError: (err, uri, detail) => { if (!callbackIsCurrent()) return ignoreStaleCallback(); failExpandedUrdfReadiness(err, state.robotUrdfPreviewDiagnostics, detail || { uri }); renderSceneSummary(); },
     onRobotError: (err, diagnostics) => {
+      if (!callbackIsCurrent()) return ignoreStaleCallback();
       failExpandedUrdfReadiness(err, diagnostics || state.robotUrdfPreviewDiagnostics);
       appendRuntimeWarning({}, preview?.urdf_url || '', `expanded_urdf_loader failed: ${err?.message || err}`, 'expanded_urdf_loader_failed');
       refreshWarnings();


### PR DESCRIPTION
### Motivation
- Asynchronous expanded-URDF robot-preview callbacks from a previous scene can mutate the currently active scene when loads are delayed, allowing stale robot/mesh callbacks to corrupt Product View state.

### Description
- Added a module-level monotonic `robotPreviewLoadToken` that is incremented on scene clear and at the start of each expanded-URDF preview load to identify the current load.
- Captured the load token and current `sceneId()` per-preview and added `callbackIsCurrent()` plus a single concise stale-callback diagnostic to ignore stale callbacks without further mutations.
- Passed the captured load scene ID into the URDF loader, guarded scene insertion (`scene.add`) and `assemblyRoots.push`, and guarded the callbacks `onRobotLoaded`, `onRobotMeshLoaded`, `onRobotMeshLoadError`, and `onRobotError` so they return early when stale; also reset `state.robotUrdfPreviewDiagnostics` and `state.robotPreviewResult` during the existing scene-clear path.
- Added a focused static test `test_expanded_urdf_robot_preview_callbacks_are_scene_current_guarded` to assert token capture, scene capture, callback guards, guarded insertion, and the reset cleanup, and updated a couple of related static expectations.

### Testing
- Ran `node --check workcell_studio_web/viewer/viewer.js` which passed.
- Ran `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py` after installing viewer dependencies with `npm ci --prefix workcell_studio_web/viewer`, and the suite passed (79 tests) on the modified files.
- Performed `git diff --check`, `git diff --numstat`, `git diff --stat`, and `git status --short` to validate diffs and working tree state; checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e4b2ec9908331b1eaa92fbc30414a)