### PR TITLE
Fix Product View cross-scene robot lifecycle guards

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -228,11 +228,11 @@ def test_expanded_urdf_robot_preview_callbacks_are_scene_current_guarded():
     load_body = js.split("function loadExpandedUrdfRobotPreview(preview)", 1)[1].split("function linkNameOfItem(item)", 1)[0]
 
     assert "let robotPreviewLoadToken = 0;" in js
-    assert "robotPreviewLoadToken += 1;" in clear_body
-    assert "state.assemblyRoots = [];" in clear_body
-    assert "state.objects = [];" in clear_body
-    assert "state.robotPreviewResult = null;" in clear_body
-    assert "state.robotUrdfPreviewDiagnostics = {};" in clear_body
+    assert "robotPreviewLoadToken += 1;" in js
+    assert "state.assemblyRoots = [];" in js
+    assert "state.objects = [];" in js
+    assert "state.robotPreviewResult = null;" in js
+    assert "state.robotUrdfPreviewDiagnostics = {};" in js
 
     assert "const loadToken = ++robotPreviewLoadToken;" in load_body
     assert "const loadSceneId = sceneId();" in load_body
@@ -254,6 +254,100 @@ def test_expanded_urdf_robot_preview_callbacks_are_scene_current_guarded():
         assert guard_token in section
         assert section.find(guard_token) < section.find(mutation)
 
+
+
+def test_expanded_urdf_stale_callbacks_cannot_mutate_new_scene_runtime_state():
+    js_path = VIEWER / "viewer.js"
+    harness = r'''
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+let source = fs.readFileSync(process.argv[1], 'utf8').replace(/boot\(\);\s*$/, '');
+const element = () => ({ hidden: false, checked: false, disabled: false, textContent: '', className: '', innerHTML: '', classList: { toggle() {} }, setAttribute() {}, querySelector() { return { textContent: '' }; }, appendChild() {}, addEventListener() {}, getBoundingClientRect() { return { width: 800, height: 600, left: 0, top: 0 }; } });
+const context = { console: { ...console, warn() {} }, assert, window: { dispatched: [], location: { search: '' }, dispatchEvent(event) { this.dispatched.push(event?.detail?.state); }, parent: { postMessage() {} } }, document: { getElementById() { return element(); }, createElement() { return element(); } }, URLSearchParams, CustomEvent: function CustomEvent(type, init) { return { type, detail: init?.detail || {} }; }, requestAnimationFrame() { return 0; }, setTimeout() { return 1; }, clearTimeout() {} };
+vm.createContext(context);
+vm.runInContext(source + `
+renderSceneSummary = () => updateViewerStatus();
+setInitialPosePreviewUi = () => {};
+refreshInitialPoseActionState = () => {};
+refreshWarnings = () => {};
+appendRuntimeWarning = () => {};
+failIfCanonicalRequiredVisualSetInvalid = () => false;
+let captured = [];
+loadRobotPreview = (preview, rendererContext) => {
+  const root = { name: preview.rootName || 'old_root', children: [], geometry: { dispose() {} }, material: { dispose() {} } };
+  captured.push({ preview, rendererContext, root });
+  return { root, links: new Map([['old_link', {}]]), joints: new Map([['old_joint', {}]]), diagnostics: { robot_preview_lifecycle_state: 'loading', robotPreviewLifecycleState: 'loading', scene: sceneId() }, ready: Promise.resolve(root) };
+};
+function makeSceneRecorder(id) { return { id, added: [], removed: [], add(root) { this.added.push(root); }, remove(root) { this.removed.push(root); } }; }
+function beginScene(id, sceneExists = true) {
+  state.sceneJson = { scene: { id }, robot_preview: { urdf_url: id + '.urdf', rootName: id + '_root' } };
+  state.three.scene = sceneExists ? makeSceneRecorder(id) : null;
+  state.web3dReadiness = { state: 'scene_loading', emittedSceneReady: false, required: { robot_arm: true, attached_tool_gripper: true, workbench_support_surface: true, configured_camera: true }, pending: new Set(['robot_arm:expanded_urdf_loader', 'attached_tool_gripper:expanded_urdf_loader']), failed: false, failure: null };
+}
+function dirtyOldState() {
+  state.robotPreviewResult = { stale: true };
+  state.robotUrdfPreviewDiagnostics = { stale: true };
+  state.robotAssemblyDiagnostics = [{ stale: true }];
+  state.robotAssemblyRenderDiagnostics = { stale: true };
+  state.resolvedFramePoses.set('old_frame', {});
+  state.frameLookup.set('old_link', {});
+  state.assemblyRoots = [{ name: 'previous_assembly_root' }];
+  state.objects = [{ object3d: { name: 'previous_flattened_fallback' }, item: { id: 'old' } }];
+}
+function fireOldCallbacks(capture) {
+  capture.rendererContext.scene.add(capture.root);
+  capture.rendererContext.assemblyRoots.push(capture.root);
+  capture.rendererContext.onRobotLoaded({ root: capture.root, diagnostics: { robot_preview_lifecycle_state: 'loaded', robotPreviewLifecycleState: 'loaded' } });
+  capture.rendererContext.onRobotMeshLoaded(capture.root);
+  capture.rendererContext.onRobotMeshLoadError(new Error('old mesh failed'), 'old.dae', { uri: 'old.dae' });
+  capture.rendererContext.onRobotError(new Error('old robot failed'), { robot_urdf_url: 'old.urdf' });
+}
+function assertOldCallbacksRejected(targetSceneId) {
+  assert.strictEqual(state.robotPreviewResult, null);
+  assert.deepStrictEqual(state.robotUrdfPreviewDiagnostics, {});
+  assert.deepStrictEqual(state.robotAssemblyDiagnostics, []);
+  assert.deepStrictEqual(state.robotAssemblyRenderDiagnostics, {});
+  assert.deepStrictEqual(Array.from(state.resolvedFramePoses.keys()), []);
+  assert.deepStrictEqual(Array.from(state.frameLookup.keys()), []);
+  assert.deepStrictEqual(state.assemblyRoots, []);
+  assert.deepStrictEqual(state.objects, []);
+  assert.strictEqual(state.web3dReadiness.state, 'server_ready');
+  assert.strictEqual(state.web3dReadiness.failed, false);
+  assert.strictEqual(state.web3dReadiness.emittedSceneReady, false);
+  assert.strictEqual(state.sceneJson.scene.id, targetSceneId);
+  assert.ok(!window.dispatched.includes('scene_ready'));
+  assert.ok(!window.dispatched.includes('scene_failed'));
+}
+function runSwitchScenario(targetSceneId) {
+  window.dispatched.length = 0; captured = [];
+  beginScene('ur5_2f_test', true);
+  loadExpandedUrdfRobotPreview(state.sceneJson.robot_preview);
+  const old = captured[0];
+  beginScene(targetSceneId, true);
+  dirtyOldState();
+  clearSceneObjects();
+  fireOldCallbacks(old);
+  assert.strictEqual(state.three.scene.id, targetSceneId);
+  assert.deepStrictEqual(state.three.scene.added, []);
+  assertOldCallbacksRejected(targetSceneId);
+}
+runSwitchScenario('suction_test');
+runSwitchScenario('ur5_3f_test');
+window.dispatched.length = 0; captured = [];
+beginScene('ur5_2f_test', true);
+loadExpandedUrdfRobotPreview(state.sceneJson.robot_preview);
+const oldWithoutScene = captured[0];
+beginScene('suction_test', false);
+dirtyOldState();
+clearSceneObjects();
+fireOldCallbacks(oldWithoutScene);
+assert.strictEqual(state.three.scene, null);
+assertOldCallbacksRejected('suction_test');
+`, context);
+'''
+    result = subprocess.run(["node", "-e", harness, str(js_path)], cwd=ROOT, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert result.stderr == ""
 
 def test_urdf_renderer_rejects_unsafe_package_mesh_sources():
     js = (VIEWER / "urdf_robot_renderer.js").read_text(encoding="utf-8")

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -2632,13 +2632,23 @@ if (el.resetView) {
 function clearLabels() {
   if (el.labelLayer) el.labelLayer.innerHTML = '';
 }
-function clearSceneObjects() {
-  const scene = state.three.scene;
-  if (!scene) return;
+function disposeOwnedObject3d(object3d, seen = new Set()) {
+  if (!object3d || seen.has(object3d)) return;
+  seen.add(object3d);
+  if (Array.isArray(object3d.children)) {
+    for (const child of [...object3d.children]) disposeOwnedObject3d(child, seen);
+  }
+  object3d.geometry?.dispose?.();
+  const material = object3d.material;
+  if (Array.isArray(material)) {
+    for (const entry of material) entry?.dispose?.();
+  } else {
+    material?.dispose?.();
+  }
+}
+function resetSceneLifecycleState() {
   robotPreviewLoadToken += 1;
-  for (const root of state.assemblyRoots || []) scene.remove(root);
-  for (const rendered of state.objects) scene.remove(rendered.object3d);
-  clearLabels();
+  cancelInitialCameraFitRetry();
   state.objects = [];
   state.assemblyRoots = [];
   state.robotAssemblyDiagnostics = [];
@@ -2647,6 +2657,7 @@ function clearSceneObjects() {
   state.physicalAssemblyBounds = null;
   state.finalPhysicalFitBounds = null;
   state.resolvedFramePoses.clear();
+  state.frameLookup = new Map();
   state.lastFrameBounds = null;
   state._sceneBoundsExceededWarned = false;
   state._fitBlockerWarnings = new Set();
@@ -2654,6 +2665,25 @@ function clearSceneObjects() {
   state._supportSurfaceSemanticWarnings = new Set();
   state.robotPreviewResult = null;
   state.initialPosePreview = { active: false, robotId: '', sceneKey: '' };
+  state.web3dReadiness = { state: 'server_ready', emittedSceneReady: false, required: {}, pending: new Set(), failed: false, failure: null };
+}
+function clearSceneObjects() {
+  const scene = state.three.scene;
+  const previousAssemblyRoots = [...(state.assemblyRoots || [])];
+  const previousObjects = [...(state.objects || [])];
+  resetSceneLifecycleState();
+  if (scene) {
+    const disposed = new Set();
+    for (const root of previousAssemblyRoots) {
+      scene.remove(root);
+      disposeOwnedObject3d(root, disposed);
+    }
+    for (const rendered of previousObjects) {
+      scene.remove(rendered.object3d);
+      disposeOwnedObject3d(rendered.object3d, disposed);
+    }
+  }
+  clearLabels();
   if (el.showInitialPose) el.showInitialPose.checked = false;
   setInitialPosePreviewUi(false);
   if (el.resetView) el.resetView.disabled = true;
@@ -2661,6 +2691,8 @@ function clearSceneObjects() {
 }
 function renderScene(items) {
   clearSceneObjects();
+  state.frameLookup = parseSceneFrames(state.sceneJson || {});
+  state.resolvedFramePoses.clear();
   beginWeb3dSceneReadiness(items);
   state.dirtyTransforms.clear();
   state.undoStack = [];


### PR DESCRIPTION
Summary:
- Refactored `clearSceneObjects()` so robot preview token invalidation, camera-fit retry cancellation, preview diagnostics/result cleanup, frame cache cleanup, assembly/object state reset, and Web3D readiness reset always run before any Three.js scene-dependent cleanup.
- Retire previous expanded-URDF/flattened preview ownership by removing prior assembly roots and rendered objects when a Three.js scene exists, disposing viewer-owned geometries/materials, and clearing stale frame/readiness/preview state even when `state.three.scene` is null.
- Added a behavioral Node VM regression harness that executes `viewer.js` lifecycle functions with delayed `loadRobotPreview` callbacks for cross-scene switches instead of relying only on source-string assertions.

Why it matters for Workcell Studio:
- PR #2792 added load tokens and scene-ID guards, but the static regression only proved guard strings existed and did not exercise delayed callback behavior.
- The remaining lifecycle defect was that `clearSceneObjects()` returned before invalidating old callbacks and clearing preview/readiness state when no Three.js scene existed yet.
- This change makes embedded Web3D Product View scene ownership deterministic during rapid scene switching, preventing old robot/gripper callbacks from mutating the active workcell preview.

Affected files/packages:
- `workcell_studio_web/viewer/viewer.js`
- `tests/test_workcell_studio_web_viewer_static.py`

Validation:
- `npm ci` in `workcell_studio_web/viewer` was run to restore Node test dependencies for the local container.
- `node --check workcell_studio_web/viewer/viewer.js` passed.
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py tests/test_scene_preview_widget_refresh_lifecycle.py tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py` passed: 98 tests.
- `git diff --check` passed.
- `git status --short` and `git diff --stat` were reviewed before commit; after validation, the temporary `node_modules/` install was removed and not committed.
- No runtime browser/Product View visual smoke test was performed, so this PR does not claim a visual Product View fix.

Behavioral sequences tested:
- `ur5_2f_test` async expanded-URDF preview load -> switch to `suction_test` -> `clearSceneObjects()` -> delayed old callbacks fire and are rejected.
- `ur5_2f_test` async expanded-URDF preview load -> switch to `ur5_3f_test` -> `clearSceneObjects()` -> delayed old callbacks fire and are rejected.
- `clearSceneObjects()` with `state.three.scene === null` -> delayed old callback fires and is rejected while previous preview/readiness/frame/object state remains cleared.

Safety:
- No ROS launch, controller, MoveIt, hardware, URDF, or scene asset files were changed.
- Fake hardware defaults and guarded real-hardware behavior are untouched.
- Required-mesh scene failure behavior and expanded URDFLoader rendering path are preserved.

Risks / rollback:
- The cleanup now resets frame lookup during scene clearing; `renderScene()` immediately rebuilds frame lookup from the active `sceneJson` before readiness/render work so normal scene loads retain their frame metadata.
- Roll back by reverting this commit if any embedded Web3D lifecycle regression appears; the change is isolated to viewer lifecycle cleanup and its focused test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f20e787088331bf5ade236c5da3a0)