### PR TITLE
Prefer canonical environment visuals over placeholder STLs

### DIFF
--- a/assets/environment/table_description/table.yaml
+++ b/assets/environment/table_description/table.yaml
@@ -13,7 +13,7 @@ table:
       collision:
         name: None
         geometry:
-          filepath: package://table_description/meshes/visual/table.stl
+          filepath: package://table_description/meshes/collision/table.stl
           scale:
             scale_x: 0.001
             scale_y: 0.001

--- a/assets/environment/table_description/urdf/table.urdf.xacro
+++ b/assets/environment/table_description/urdf/table.urdf.xacro
@@ -9,7 +9,7 @@
 	  </visual>
 	  <collision name="None_${prefix}">
 	    <geometry>
-	      <mesh filename="package://table_description/meshes/visual/table.stl" scale="0.001000 0.001000 0.001000"/>
+	      <mesh filename="package://table_description/meshes/collision/table.stl" scale="0.001000 0.001000 0.001000"/>
 	    </geometry>
 	  </collision>
 	</link>
@@ -19,4 +19,4 @@
 	  <child link="table_${prefix}"/>
 	</joint>
 </xacro:macro>
-</robot> 
+</robot>

--- a/config/workcell_studio_visual_asset_catalog.yaml
+++ b/config/workcell_studio_visual_asset_catalog.yaml
@@ -25,13 +25,13 @@ categories:
     required_for_new_cell_preview: false
   table:
     package_candidates: [table_description]
-    preferred_mesh_uris: [package://table_description/meshes/table.stl]
+    preferred_mesh_uris: [package://table_description/meshes/visual/table.stl]
     primitive_fallback_dimensions: [1.2,0.8,0.2]
     preview_label: Table
     required_for_new_cell_preview: true
   workbench:
     package_candidates: [workbench_description]
-    preferred_mesh_uris: [package://workbench_description/meshes/workbench.stl]
+    preferred_mesh_uris: [package://workbench_description/meshes/visual/table.stl]
     primitive_fallback_dimensions: [1.4,0.8,0.25]
     preview_label: Workbench
     required_for_new_cell_preview: false

--- a/tests/test_canonical_environment_asset_selection.py
+++ b/tests/test_canonical_environment_asset_selection.py
@@ -1,0 +1,143 @@
+import importlib.util
+import shutil
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPORTER_PATH = ROOT / "scripts" / "export_workcell_studio_web_scene.py"
+SPEC = importlib.util.spec_from_file_location("canonical_asset_exporter", EXPORTER_PATH)
+EXPORTER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(EXPORTER)
+
+
+def test_visual_catalog_points_to_real_package_mesh_locations():
+    catalog = yaml.safe_load(
+        (ROOT / "config" / "workcell_studio_visual_asset_catalog.yaml").read_text(encoding="utf-8")
+    )["categories"]
+
+    assert catalog["table"]["preferred_mesh_uris"] == [
+        "package://table_description/meshes/visual/table.stl"
+    ]
+    assert catalog["workbench"]["preferred_mesh_uris"] == [
+        "package://workbench_description/meshes/visual/table.stl"
+    ]
+    assert catalog["camera_realsense"]["preferred_mesh_uris"] == [
+        "package://realsense2_description/meshes/d435.dae"
+    ]
+
+    assert (ROOT / "assets/environment/table_description/meshes/visual/table.stl").is_file()
+    assert (ROOT / "assets/environment/workbench_description/meshes/visual/table.stl").is_file()
+    assert (ROOT / "assets/environment/realsense2_description/meshes/d435.dae").is_file()
+
+
+def test_table_description_uses_separate_visual_and_collision_meshes():
+    xacro = (ROOT / "assets/environment/table_description/urdf/table.urdf.xacro").read_text(
+        encoding="utf-8"
+    )
+    table = yaml.safe_load(
+        (ROOT / "assets/environment/table_description/table.yaml").read_text(encoding="utf-8")
+    )["table"]["links"]["table"]
+
+    assert 'filename="package://table_description/meshes/visual/table.stl"' in xacro
+    assert 'filename="package://table_description/meshes/collision/table.stl"' in xacro
+    assert table["visual"]["geometry"]["filepath"] == (
+        "package://table_description/meshes/visual/table.stl"
+    )
+    assert table["collision"]["geometry"]["filepath"] == (
+        "package://table_description/meshes/collision/table.stl"
+    )
+
+
+def test_builder_catalog_prefers_package_visuals_and_demotes_placeholders():
+    source = (
+        ROOT / "workcell_builder/workcell_builder/gui/asset_catalog_model.cpp"
+    ).read_text(encoding="utf-8")
+
+    for token in [
+        'ext == ".dae"',
+        'ext == ".obj"',
+        "path_is_collision(path)",
+        "package_directory_for(path, root)",
+        'filename == "d435.dae"',
+        'entry.source = placeholder ? "generated_placeholder"',
+        '"canonical_asset"',
+        "emitted_packages",
+    ]:
+        assert token in source
+
+    assert source.index('roots.emplace_back(repo_root + "/assets")') < source.index(
+        'roots.emplace_back(repo_root + "/workcell_builder/workcell_builder/assets")'
+    )
+
+
+def test_canonical_table_and_camera_stage_as_mesh_backed_web_assets(tmp_path):
+    scene_id = "canonical_environment_asset_test"
+    scene = tmp_path / scene_id
+    scene.mkdir()
+    (scene / "environment.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "scene": {"id": scene_id, "name": scene_id},
+                "environment": {
+                    "support_surfaces": [
+                        {
+                            "id": "workbench_support_surface",
+                            "type": "table",
+                            "role": "support_surface",
+                            "category": "work_surface",
+                            "frame": "world",
+                            "pose_xyz": [0.0, 0.0, 0.0],
+                            "pose_rpy": [0.0, 0.0, 0.0],
+                            "mesh_uri": "package://workbench_description/meshes/visual/table.stl",
+                            "mesh_scale": [0.001, 0.001, 0.001],
+                        }
+                    ],
+                    "sensors": [
+                        {
+                            "id": "configured_camera",
+                            "type": "realsense",
+                            "role": "camera",
+                            "category": "camera",
+                            "frame": "world",
+                            "pose_xyz": [0.35, 0.0, 0.85],
+                            "pose_rpy": [0.0, 1.5708, 0.0],
+                            "mesh_uri": "package://realsense2_description/meshes/d435.dae",
+                        }
+                    ],
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    staged_dir = ROOT / "build/workcell_studio_web_scene/assets" / scene_id
+    try:
+        payload = EXPORTER.build_web_scene(
+            scene,
+            stage_assets=True,
+            output_path=tmp_path / "build" / f"{scene_id}.web_scene.json",
+        )
+
+        table = next(item for item in payload["assets"] if item["id"] == "workbench_support_surface")
+        camera = next(item for item in payload["sensors"] if item["id"] == "configured_camera")
+
+        assert table["mesh_staging_status"] == "staged"
+        assert camera["mesh_staging_status"] == "staged"
+        assert table["original_package_uri"] == (
+            "package://workbench_description/meshes/visual/table.stl"
+        )
+        assert camera["original_package_uri"] == (
+            "package://realsense2_description/meshes/d435.dae"
+        )
+        assert table["mesh_uri"].endswith("workbench_description/meshes/visual/table.stl")
+        assert camera["mesh_uri"].endswith("realsense2_description/meshes/d435.dae")
+
+        required = payload["viewer_summary"]["required_item_status"]
+        assert required["table"]["status"] == "mesh_backed"
+        assert required["camera"]["status"] == "mesh_backed"
+        assert payload["metadata"]["mesh_contract"]["core_mesh_failures"] == []
+    finally:
+        shutil.rmtree(staged_dir, ignore_errors=True)

--- a/workcell_builder/workcell_builder/gui/asset_catalog_model.cpp
+++ b/workcell_builder/workcell_builder/gui/asset_catalog_model.cpp
@@ -1,124 +1,363 @@
 #include "include/asset_catalog_model.h"
 
 #include <boost/filesystem.hpp>
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
 #include <fstream>
-#include <map>
-#include <ctime>
+#include <set>
+#include <string>
+#include <tuple>
+#include <vector>
 
 namespace fs = boost::filesystem;
 
 namespace {
 
-std::vector<std::string> candidate_roots(const std::string & workspace_root, const std::string & repo_root)
+struct RankedAsset
 {
-  std::vector<std::string> roots;
-  const char * env_root = std::getenv("WORKCELL_BUILDER_ASSET_ROOT");
-  if (env_root && *env_root) roots.emplace_back(env_root);
-  roots.emplace_back(workspace_root + "/src/easy_manipulation_deployment/assets");
-  roots.emplace_back(workspace_root + "/src/assets");
-  roots.emplace_back(repo_root + "/assets");
-  roots.emplace_back(repo_root + "/workcell_builder/workcell_builder/assets");
-  return roots;
+  AssetCatalogEntry entry;
+  int rank{0};
+  std::string package_key;
+};
+
+std::string lower_copy(std::string value)
+{
+  std::transform(
+    value.begin(), value.end(), value.begin(),
+    [](unsigned char c) {return static_cast<char>(std::tolower(c));});
+  return value;
 }
 
-AssetCatalogEntry make_seed(const std::string & name, const std::string & category, const std::string & readiness, const std::string & icon)
+bool has_path_component(const fs::path & path, const std::string & component)
 {
-  AssetCatalogEntry e;
-  e.id = name;
-  e.display_name = name;
-  e.category = category;
-  e.source = "fallback_seed";
-  e.readiness = readiness;
-  e.icon_key = icon;
-  e.suggested_action = "Preview and replace with workspace asset when available.";
-  e.warnings.push_back("fallback_seed");
-  return e;
+  const std::string expected = lower_copy(component);
+  for (const auto & part : path) {
+    if (lower_copy(part.string()) == expected) return true;
+  }
+  return false;
 }
+
+bool is_supported_visual_mesh(const fs::path & path)
+{
+  const std::string ext = lower_copy(path.extension().string());
+  return ext == ".stl" || ext == ".dae" || ext == ".obj" || ext == ".glb" || ext == ".gltf";
 }
+
+bool is_description_file(const fs::path & path)
+{
+  const std::string ext = lower_copy(path.extension().string());
+  return ext == ".urdf" || ext == ".xacro";
+}
+
+bool path_is_collision(const fs::path & path)
+{
+  return has_path_component(path, "collision");
+}
+
+bool path_is_non_product_support_file(const fs::path & path)
+{
+  return has_path_component(path, "tests") ||
+         has_path_component(path, "test") ||
+         has_path_component(path, "rviz") ||
+         has_path_component(path, "launch");
+}
+
+bool path_is_internal_placeholder(const fs::path & path)
+{
+  const std::string normalized = lower_copy(path.generic_string());
+  return normalized.find("/workcell_builder/workcell_builder/assets/environment/") != std::string::npos ||
+         normalized.find("placeholder") != std::string::npos;
+}
+
+bool path_is_canonical_asset(const fs::path & path)
+{
+  const std::string normalized = lower_copy(path.generic_string());
+  return normalized.find("/assets/environment/") != std::string::npos ||
+         normalized.find("/assets/robots/") != std::string::npos ||
+         normalized.find("/assets/end_effectors/") != std::string::npos;
+}
+
+bool path_is_visual_mesh(const fs::path & path)
+{
+  return is_supported_visual_mesh(path) && has_path_component(path, "visual");
+}
+
+fs::path package_directory_for(const fs::path & file, const fs::path & root)
+{
+  fs::path current = file.parent_path();
+  const std::string root_text = root.generic_string();
+  while (!current.empty()) {
+    if (fs::exists(current / "package.xml")) return current;
+    if (current == root || current.generic_string().size() < root_text.size()) break;
+    const fs::path parent = current.parent_path();
+    if (parent == current) break;
+    current = parent;
+  }
+  return fs::path();
+}
+
+std::string display_name_from_id(std::string id)
+{
+  const std::string suffix = "_description";
+  if (id.size() > suffix.size() && id.compare(id.size() - suffix.size(), suffix.size(), suffix) == 0) {
+    id.erase(id.size() - suffix.size());
+  }
+  std::replace(id.begin(), id.end(), '_', ' ');
+  bool upper_next = true;
+  for (char & c : id) {
+    if (c == ' ') {
+      upper_next = true;
+    } else if (upper_next) {
+      c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+      upper_next = false;
+    }
+  }
+  return id;
+}
+
+int root_rank(const fs::path & root, const std::string & workspace_root, const std::string & repo_root)
+{
+  const std::string normalized = lower_copy(root.generic_string());
+  if (normalized.find("/workcell_builder/workcell_builder/assets") != std::string::npos) return 80;
+  if (!repo_root.empty() && normalized.find(lower_copy(repo_root + "/assets")) == 0) return 0;
+  if (!workspace_root.empty() && normalized.find(lower_copy(workspace_root)) == 0) return 10;
+  return 20;
+}
+
+int file_rank(
+  const fs::path & path,
+  const fs::path & root,
+  const std::string & workspace_root,
+  const std::string & repo_root)
+{
+  int rank = root_rank(root, workspace_root, repo_root);
+  const std::string ext = lower_copy(path.extension().string());
+  const std::string filename = lower_copy(path.filename().string());
+
+  if (path_is_internal_placeholder(path)) rank += 200;
+  if (is_description_file(path)) rank += 60;
+  if (is_supported_visual_mesh(path)) rank += 20;
+  if (path_is_visual_mesh(path)) rank -= 15;
+  if (ext == ".dae") rank -= 5;
+  if (filename == "d435.dae") rank -= 20;
+  return rank;
+}
+
+std::vector<fs::path> candidate_roots(const std::string & workspace_root, const std::string & repo_root)
+{
+  std::vector<fs::path> roots;
+  const char * env_root = std::getenv("WORKCELL_BUILDER_ASSET_ROOT");
+  if (env_root && *env_root) roots.emplace_back(env_root);
+
+  // Canonical repository/workspace packages must be considered before the
+  // lightweight builder-internal primitive placeholders.
+  roots.emplace_back(workspace_root + "/src/easy_manipulation_deployment/assets");
+  roots.emplace_back(repo_root + "/assets");
+  roots.emplace_back(workspace_root + "/src/assets");
+  roots.emplace_back(repo_root + "/workcell_builder/workcell_builder/assets");
+
+  std::vector<fs::path> deduped;
+  std::set<std::string> seen;
+  for (const auto & root : roots) {
+    boost::system::error_code ec;
+    const fs::path normalized = fs::exists(root, ec) && !ec ? fs::canonical(root, ec) : root.lexically_normal();
+    const std::string key = normalized.generic_string();
+    if (seen.insert(key).second) deduped.push_back(normalized);
+  }
+  return deduped;
+}
+
+void classify_entry(AssetCatalogEntry & entry, const fs::path & path, bool placeholder, bool canonical)
+{
+  const std::string identity = lower_copy(entry.id + " " + entry.display_name + " " + path.generic_string());
+  const std::string ext = lower_copy(path.extension().string());
+
+  entry.source = placeholder ? "generated_placeholder" : (canonical ? "canonical_asset" : "discovered_asset");
+  entry.compatible_templates = {"Pick and Place Cell: UR5 + Robotiq 2F + table + cube + bin"};
+
+  if (identity.find("robotiq") != std::string::npos ||
+      identity.find("gripper") != std::string::npos ||
+      identity.find("suction") != std::string::npos ||
+      identity.find("airpick") != std::string::npos)
+  {
+    entry.category = "end_effector";
+    entry.role_hints = {
+      identity.find("suction") != std::string::npos || identity.find("airpick") != std::string::npos ?
+      "suction_tool" : "gripper"};
+    entry.icon_key = identity.find("suction") != std::string::npos ? "🧲" : "🦾";
+    entry.readiness = placeholder ? "PREVIEW_ONLY" : "READY_WITH_WARNINGS";
+    if (!placeholder) entry.warnings.push_back("Verify mount frame and RPY against the selected robot description.");
+    entry.suggested_action = "Set as End Effector";
+  } else if (identity.find("camera") != std::string::npos ||
+             identity.find("realsense") != std::string::npos ||
+             identity.find("d435") != std::string::npos)
+  {
+    entry.category = "camera_sensor";
+    entry.role_hints = {"camera"};
+    entry.icon_key = "📷";
+    entry.readiness = placeholder ? "PREVIEW_ONLY" : "READY";
+    entry.suggested_action = "Add as camera";
+  } else if (identity.find("ur_description") != std::string::npos ||
+             identity.find("universal_robot") != std::string::npos ||
+             identity.find("fanuc") != std::string::npos ||
+             identity.find("panda") != std::string::npos)
+  {
+    entry.category = "robot";
+    entry.role_hints = {"robot_base"};
+    entry.icon_key = "🤖";
+    entry.readiness = identity.find("moveit") != std::string::npos ? "READY" : "MISSING_MOVEIT_CONFIG";
+    if (entry.readiness != "READY") entry.blockers.push_back("MoveIt config not detected");
+    entry.suggested_action = "Set as Robot";
+  } else {
+    entry.category = "environment_object";
+    const bool support_surface =
+      identity.find("table") != std::string::npos || identity.find("workbench") != std::string::npos;
+    entry.role_hints = {support_surface ? "support_surface" : "environment_object"};
+    entry.icon_key = "🧱";
+    entry.readiness = placeholder ? "PREVIEW_ONLY" : "READY";
+    entry.suggested_action = support_surface ? "Add as support surface" : "Add as environment object";
+  }
+
+  if (placeholder) {
+    entry.warnings.push_back(
+      "Generated primitive placeholder; prefer the canonical ROS description package visual when available.");
+  } else if (canonical && ext == ".dae") {
+    entry.warnings.push_back("Canonical COLLADA visual selected to preserve authored materials and appearance.");
+  }
+  entry.can_add_to_scene =
+    entry.readiness == "READY" ||
+    entry.readiness == "PREVIEW_ONLY" ||
+    entry.readiness == "READY_WITH_WARNINGS";
+}
+
+AssetCatalogEntry make_seed(
+  const std::string & name,
+  const std::string & category,
+  const std::string & readiness,
+  const std::string & icon)
+{
+  AssetCatalogEntry entry;
+  entry.id = name;
+  entry.display_name = name;
+  entry.category = category;
+  entry.source = "fallback_seed";
+  entry.readiness = readiness;
+  entry.icon_key = icon;
+  entry.suggested_action = "Preview and replace with workspace asset when available.";
+  entry.warnings.push_back("fallback_seed");
+  entry.can_add_to_scene = readiness == "PREVIEW_ONLY";
+  return entry;
+}
+
+}  // namespace
 
 AssetCatalogModel discover_asset_catalog(const std::string & workspace_root, const std::string & repo_root)
 {
-  AssetCatalogModel m;
+  AssetCatalogModel model;
+  std::vector<RankedAsset> candidates;
+  std::set<std::string> seen_files;
+
   for (const auto & root : candidate_roots(workspace_root, repo_root)) {
-    m.discovered_roots.push_back(root);
+    model.discovered_roots.push_back(root.string());
     boost::system::error_code ec;
     if (!fs::exists(root, ec) || ec) continue;
 
     for (fs::recursive_directory_iterator it(root, ec), end; it != end && !ec; it.increment(ec)) {
-      if (!fs::is_regular_file(it->path(), ec)) continue;
-      const std::string ext = it->path().extension().string();
-      if (ext != ".urdf" && ext != ".xacro" && ext != ".stl") continue;
-
-      AssetCatalogEntry e;
-      e.id = it->path().stem().string();
-      e.display_name = it->path().stem().string();
-      e.path = it->path().string();
-      e.discovered_files.push_back(e.path);
-      e.source = (root.find(repo_root) == 0) ? "repo" : "workspace";
-      e.compatible_templates = {"Pick and Place Cell: UR5 + Robotiq 2F + table + cube + bin"};
-
-      const auto lower = e.id;
-      if (lower.find("ur") != std::string::npos || lower.find("fanuc") != std::string::npos || lower.find("panda") != std::string::npos) {
-        e.category = "robot";
-        e.role_hints = {"robot_base"};
-        e.icon_key = "🤖";
-        e.readiness = (e.path.find("moveit") != std::string::npos) ? "READY" : "MISSING_MOVEIT_CONFIG";
-        if (e.readiness != "READY") e.blockers.push_back("MoveIt config not detected");
-        e.suggested_action = "Set as Robot";
-      } else if (lower.find("robotiq") != std::string::npos || lower.find("gripper") != std::string::npos || lower.find("suction") != std::string::npos) {
-        e.category = "end_effector";
-        e.role_hints = {lower.find("suction") != std::string::npos ? "suction_tool" : "gripper"};
-        e.icon_key = (lower.find("suction") != std::string::npos) ? "🧲" : "🦾";
-        e.readiness = "READY_WITH_WARNINGS";
-        e.warnings.push_back("Mount RPY default: -1.5708 -1.5708 0");
-        e.suggested_action = "Set as End Effector";
-      } else if (lower.find("camera") != std::string::npos || lower.find("realsense") != std::string::npos) {
-        e.category = "camera_sensor";
-        e.role_hints = {"camera"};
-        e.icon_key = "📷";
-        e.readiness = "PREVIEW_ONLY";
-        e.warnings.push_back("metadata/preview asset");
-        e.suggested_action = "Add as camera metadata";
-      } else {
-        e.category = "environment_object";
-        e.role_hints = {"support_surface"};
-        e.icon_key = "🧱";
-        e.readiness = ext == ".stl" ? "PREVIEW_ONLY" : "READY";
-        e.suggested_action = "Add as support surface/object";
+      if (!fs::is_regular_file(it->path(), ec) || ec) continue;
+      const fs::path path = it->path();
+      if ((!is_supported_visual_mesh(path) && !is_description_file(path)) ||
+          path_is_collision(path) ||
+          path_is_non_product_support_file(path))
+      {
+        continue;
       }
-      e.can_add_to_scene = (e.readiness == "READY" || e.readiness == "PREVIEW_ONLY" || e.readiness == "READY_WITH_WARNINGS");
-      m.assets.push_back(e);
+
+      boost::system::error_code canonical_ec;
+      const fs::path resolved = fs::canonical(path, canonical_ec);
+      const std::string file_key = (canonical_ec ? path : resolved).generic_string();
+      if (!seen_files.insert(file_key).second) continue;
+
+      const fs::path package_dir = package_directory_for(path, root);
+      const std::string package_name = package_dir.empty() ? std::string() : package_dir.filename().string();
+      if (lower_copy(package_name).find("_moveit_config") != std::string::npos) continue;
+
+      RankedAsset candidate;
+      candidate.package_key = package_dir.empty() ? std::string() : package_dir.generic_string();
+      candidate.rank = file_rank(path, root, workspace_root, repo_root);
+      candidate.entry.id = package_name.empty() ? path.stem().string() : package_name;
+      candidate.entry.display_name = display_name_from_id(candidate.entry.id);
+      candidate.entry.path = path.string();
+      candidate.entry.discovered_files = {candidate.entry.path};
+      classify_entry(
+        candidate.entry,
+        path,
+        path_is_internal_placeholder(path),
+        path_is_canonical_asset(path) && !path_is_internal_placeholder(path));
+      candidates.push_back(candidate);
     }
   }
 
-  if (m.assets.empty()) {
-    m.assets.push_back(make_seed("UR5", "robot", "PREVIEW_ONLY", "🤖"));
-    m.assets.push_back(make_seed("Robotiq 2F", "end_effector", "PREVIEW_ONLY", "🦾"));
-    m.assets.push_back(make_seed("simple_conveyor", "conveyor", "PREVIEW_ONLY", "➡️"));
-    m.assets.push_back(make_seed("RealSense D435i", "camera_sensor", "PREVIEW_ONLY", "📷"));
+  std::sort(
+    candidates.begin(), candidates.end(),
+    [](const RankedAsset & lhs, const RankedAsset & rhs) {
+      return std::tie(lhs.rank, lhs.entry.category, lhs.entry.display_name, lhs.entry.path) <
+             std::tie(rhs.rank, rhs.entry.category, rhs.entry.display_name, rhs.entry.path);
+    });
+
+  std::set<std::string> emitted_packages;
+  for (const auto & candidate : candidates) {
+    if (!candidate.package_key.empty() && !emitted_packages.insert(candidate.package_key).second) continue;
+    model.assets.push_back(candidate.entry);
   }
-  return m;
+
+  if (model.assets.empty()) {
+    model.assets.push_back(make_seed("UR5", "robot", "PREVIEW_ONLY", "🤖"));
+    model.assets.push_back(make_seed("Robotiq 2F", "end_effector", "PREVIEW_ONLY", "🦾"));
+    model.assets.push_back(make_seed("simple_conveyor", "conveyor", "PREVIEW_ONLY", "➡️"));
+    model.assets.push_back(make_seed("RealSense D435i", "camera_sensor", "PREVIEW_ONLY", "📷"));
+  }
+  return model;
 }
 
-bool export_asset_catalog_report(const AssetCatalogModel & model, const std::string & output_dir, std::string * json_path, std::string * html_path, std::string * error)
+bool export_asset_catalog_report(
+  const AssetCatalogModel & model,
+  const std::string & output_dir,
+  std::string * json_path,
+  std::string * html_path,
+  std::string * error)
 {
   boost::system::error_code ec;
   fs::create_directories(output_dir, ec);
-  if (ec) { if (error) *error = ec.message(); return false; }
-  const fs::path j = fs::path(output_dir) / "asset_catalog.json";
-  const fs::path h = fs::path(output_dir) / "asset_catalog.html";
-  std::ofstream jout(j.string());
-  if (!jout) return false;
-  jout << "{\n  \"discovered_roots\": [";
-  for (size_t i = 0; i < model.discovered_roots.size(); ++i) { if (i) jout << ","; jout << "\"" << model.discovered_roots[i] << "\""; }
-  jout << "],\n  \"assets\": [";
-  for (size_t i = 0; i < model.assets.size(); ++i) { if (i) jout << ","; jout << "{\"name\":\"" << model.assets[i].display_name << "\",\"readiness\":\"" << model.assets[i].readiness << "\"}"; }
-  jout << "],\n  \"note\": \"fake_hardware_first=true,no_runtime_motion=true\"\n}\n";
-  std::ofstream hout(h.string());
-  hout << "<html><body><h1>Asset Catalog Report</h1><p>fake_hardware_first / no-runtime-motion preserved</p><ul>";
-  for (const auto & r : model.discovered_roots) hout << "<li>" << r << "</li>";
-  hout << "</ul></body></html>";
-  if (json_path) *json_path = j.string();
-  if (html_path) *html_path = h.string();
+  if (ec) {
+    if (error) *error = ec.message();
+    return false;
+  }
+  const fs::path json_file = fs::path(output_dir) / "asset_catalog.json";
+  const fs::path html_file = fs::path(output_dir) / "asset_catalog.html";
+  std::ofstream json(json_file.string());
+  if (!json) return false;
+  json << "{\n  \"discovered_roots\": [";
+  for (size_t i = 0; i < model.discovered_roots.size(); ++i) {
+    if (i) json << ",";
+    json << "\"" << model.discovered_roots[i] << "\"";
+  }
+  json << "],\n  \"assets\": [";
+  for (size_t i = 0; i < model.assets.size(); ++i) {
+    if (i) json << ",";
+    json << "{\"name\":\"" << model.assets[i].display_name
+         << "\",\"readiness\":\"" << model.assets[i].readiness
+         << "\",\"source\":\"" << model.assets[i].source << "\"}";
+  }
+  json << "],\n  \"note\": \"fake_hardware_first=true,no_runtime_motion=true\"\n}\n";
+
+  std::ofstream html(html_file.string());
+  html << "<html><body><h1>Asset Catalog Report</h1>"
+       << "<p>fake_hardware_first / no-runtime-motion preserved</p><ul>";
+  for (const auto & root : model.discovered_roots) html << "<li>" << root << "</li>";
+  html << "</ul></body></html>";
+  if (json_path) *json_path = json_file.string();
+  if (html_path) *html_path = html_file.string();
   return true;
 }


### PR DESCRIPTION
## Problem
The Product View and Asset Library could select lightweight builder-generated placeholder STLs (solid boxes for tables, bins, stands, etc.) even though proper ROS description packages already exist for the workbench/table and RealSense camera. Two preferred catalog URIs also pointed to files that do not exist, and the canonical table description reused the visual mesh as its collision mesh.

## Changes
- Correct the table and workbench preferred mesh URIs to their real `meshes/visual/table.stl` locations.
- Keep the RealSense D435 visual on the canonical `d435.dae` asset.
- Fix `table_description` so collision metadata and Xacro use `meshes/collision/table.stl`.
- Rework the compiled Asset Library discovery to:
  - prefer canonical top-level ROS asset packages before builder-internal placeholders;
  - include DAE/OBJ/GLB/GLTF visuals, not only STL;
  - reject collision/test/RViz/launch files from visual selection;
  - choose one best visual per ROS package;
  - prioritize `meshes/visual` and the D435 COLLADA model;
  - mark generated internal environment meshes as `generated_placeholder` / `PREVIEW_ONLY` instead of presenting them as equivalent product assets.
- Add regression coverage proving canonical table/workbench/camera paths exist and stage as mesh-backed Web3D assets.

## Safety
No motion, launch, controller, MoveIt, hardware, or real-hardware defaults were changed. Fake-hardware-first behavior is unchanged.

## Validation
- `asset_catalog_model.cpp` was syntax-checked with `g++ -std=c++17 -Wall -Wextra -Wpedantic -fsyntax-only` against the project header contract.
- Added `tests/test_canonical_environment_asset_selection.py` for path, collision-source, catalog-priority, and real exporter staging behavior.

The PR does not replace all placeholder geometry. It prevents those placeholders from outranking the correct packaged visuals and fixes the canonical assets used by the current Product View.