### PR TITLE
Prepare safe environment asset replacement pipeline

### DIFF
--- a/config/workcell_studio_asset_replacements.yaml
+++ b/config/workcell_studio_asset_replacements.yaml
@@ -1,0 +1,131 @@
+schema_version: workcell_studio_asset_replacements/v1
+policy:
+  placeholder_meshes_are_noncanonical: true
+  delete_only_when_unreferenced: true
+  require_source_and_license_before_import: true
+  require_redistribution_confirmation: true
+  preferred_visual_formats: [glb, gltf, dae, obj, stl]
+  collision_policy: simplified_primitive_or_dedicated_collision_mesh
+
+assets:
+  table_small:
+    current_quality: placeholder
+    action: replace_with_canonical
+    replacement_status: canonical_available
+    canonical_visual_uri: package://table_description/meshes/visual/table.stl
+    canonical_collision_uri: package://table_description/meshes/collision/table.stl
+    expected_dimensions_m: [1.2, 0.8, 0.75]
+    notes: Do not download another table for the canonical demo scene.
+
+  table_large:
+    current_quality: placeholder
+    action: replace_with_downloaded_model
+    replacement_status: awaiting_model
+    expected_dimensions_m: [1.8, 0.9, 0.75]
+    preferred_search_terms: [industrial work table CAD, aluminium profile workbench]
+
+  workbench:
+    current_quality: placeholder
+    action: replace_with_canonical
+    replacement_status: canonical_available
+    canonical_visual_uri: package://workbench_description/meshes/visual/table.stl
+    canonical_collision_uri: package://workbench_description/meshes/collision/table.stl
+    expected_dimensions_m: [1.5, 0.75, 0.9]
+    notes: Builder-internal solid-block workbench remains legacy-only until references are migrated.
+
+  bin_small:
+    current_quality: placeholder
+    action: replace_with_downloaded_model
+    replacement_status: awaiting_model
+    expected_dimensions_m: [0.4, 0.3, 0.2]
+    preferred_search_terms: [KLT bin 400x300 CAD, Euro container 400x300]
+
+  bin_large:
+    current_quality: placeholder
+    action: replace_with_downloaded_model
+    replacement_status: awaiting_model
+    expected_dimensions_m: [0.7, 0.5, 0.35]
+    preferred_search_terms: [industrial tote 600x400 CAD, large KLT container]
+
+  tray:
+    current_quality: placeholder
+    action: replace_with_downloaded_model
+    replacement_status: awaiting_model
+    expected_dimensions_m: [0.5, 0.35, 0.06]
+    preferred_search_terms: [industrial parts tray CAD]
+
+  tote_box:
+    current_quality: placeholder
+    action: replace_with_downloaded_model
+    replacement_status: awaiting_model
+    expected_dimensions_m: [0.6, 0.4, 0.28]
+    preferred_search_terms: [Euro tote 600x400 CAD, KLT 600x400]
+
+  conveyor_placeholder:
+    current_quality: placeholder
+    action: replace_with_downloaded_model
+    replacement_status: awaiting_model
+    expected_dimensions_m: [1.2, 0.4, 0.25]
+    preferred_search_terms: [belt conveyor 1200mm CAD, modular conveyor STEP]
+
+  fixture_plate:
+    current_quality: placeholder
+    action: migrate_to_urdf_primitive
+    replacement_status: code_change_required
+    expected_dimensions_m: [0.5, 0.5, 0.03]
+    notes: A dimensioned box primitive is more honest than a generated STL.
+
+  pallet:
+    current_quality: placeholder
+    action: replace_with_downloaded_model
+    replacement_status: awaiting_model
+    expected_dimensions_m: [1.2, 0.8, 0.144]
+    preferred_search_terms: [EUR EPAL pallet CAD 1200x800]
+
+  pedestal:
+    current_quality: placeholder
+    action: replace_with_downloaded_model
+    replacement_status: awaiting_model
+    expected_dimensions_m: [0.4, 0.4, 0.7]
+    preferred_search_terms: [robot pedestal CAD, robot riser stand]
+
+  camera_stand:
+    current_quality: placeholder
+    action: replace_with_downloaded_model
+    replacement_status: awaiting_model
+    expected_dimensions_m: [0.08, 0.08, 1.2]
+    preferred_search_terms: [industrial camera stand CAD, vision sensor mounting frame]
+
+  safety_fence_panel:
+    current_quality: placeholder
+    action: replace_with_downloaded_model
+    replacement_status: awaiting_model
+    expected_dimensions_m: [1.2, 0.05, 1.8]
+    preferred_search_terms: [machine guarding fence panel CAD 1200mm]
+
+  robot_base_plate:
+    current_quality: placeholder
+    action: migrate_to_urdf_primitive
+    replacement_status: code_change_required
+    expected_dimensions_m: [0.6, 0.6, 0.04]
+
+  calibration_cube:
+    current_quality: acceptable_primitive
+    action: migrate_to_urdf_primitive
+    replacement_status: code_change_required
+    expected_dimensions_m: [0.1, 0.1, 0.1]
+    notes: No downloaded mesh is required for a calibration cube.
+
+  pick_box:
+    current_quality: acceptable_primitive
+    action: migrate_to_urdf_primitive
+    replacement_status: code_change_required
+    expected_dimensions_m: [0.08, 0.08, 0.08]
+    notes: No downloaded mesh is required for a simple pick box.
+
+  cylinder_object:
+    current_quality: acceptable_primitive
+    action: migrate_to_urdf_primitive
+    replacement_status: code_change_required
+    expected_dimensions_m: [0.06, 0.06, 0.12]
+    notes: Use a URDF cylinder primitive rather than preserving a generated STL.

--- a/config/workcell_studio_visual_asset_catalog.yaml
+++ b/config/workcell_studio_visual_asset_catalog.yaml
@@ -29,27 +29,39 @@ categories:
     primitive_fallback_dimensions: [1.2,0.8,0.2]
     preview_label: Table
     required_for_new_cell_preview: true
+    quality_tier: canonical
+    replacement_required: false
   workbench:
     package_candidates: [workbench_description]
     preferred_mesh_uris: [package://workbench_description/meshes/visual/table.stl]
     primitive_fallback_dimensions: [1.4,0.8,0.25]
     preview_label: Workbench
     required_for_new_cell_preview: false
+    quality_tier: canonical
+    replacement_required: false
   conveyor_placeholder:
     package_candidates: [conveyor_placeholder_description]
     preferred_mesh_uris: [package://conveyor_placeholder_description/meshes/conveyor_placeholder.stl]
     primitive_fallback_dimensions: [1.2,0.3,0.2]
-    preview_label: Conveyor
+    preview_label: Conveyor (Placeholder)
     required_for_new_cell_preview: false
+    quality_tier: placeholder
+    replacement_required: true
+    support_status: preview_only
   camera_realsense:
     package_candidates: [realsense2_description]
     preferred_mesh_uris: [package://realsense2_description/meshes/d435.dae]
     primitive_fallback_dimensions: [0.08,0.08,0.08]
     preview_label: Camera
     required_for_new_cell_preview: false
+    quality_tier: canonical
+    replacement_required: false
   bin_box_fixture:
     package_candidates: [bin_small_description, bin_large_description, fixture_plate_description]
     preferred_mesh_uris: [package://bin_small_description/meshes/bin_small.stl]
     primitive_fallback_dimensions: [0.3,0.2,0.2]
-    preview_label: Bin/Fixture
+    preview_label: Bin/Fixture (Placeholder)
     required_for_new_cell_preview: false
+    quality_tier: placeholder
+    replacement_required: true
+    support_status: preview_only

--- a/docs/manuals/WORKCELL_ENVIRONMENT_ASSET_REPLACEMENT.md
+++ b/docs/manuals/WORKCELL_ENVIRONMENT_ASSET_REPLACEMENT.md
@@ -1,0 +1,123 @@
+# Workcell Studio environment asset replacement
+
+The generated environment STLs under `workcell_builder/workcell_builder/assets/environment` are legacy layout placeholders. They are not equivalent to proper ROS description-package visuals and must not outrank canonical table, workbench, robot, tool, or camera assets.
+
+## Ownership and safety rules
+
+- Keep UR, Robotiq, suction-tool, and RealSense visuals in their ROS description packages.
+- Do not replace articulated robots or tools with a single downloaded STL.
+- Use downloaded models only when their licence permits modification and redistribution in this public repository.
+- Keep the original source page, creator/manufacturer, licence identifier, and licence text.
+- Use metres, ROS Z-up, and a useful floor or mounting origin.
+- Use a simplified collision mesh or a primitive collision shape; do not reuse a detailed visual mesh as collision by default.
+- Imported assets start as `awaiting_visual_review`. Import does not make an asset canonical.
+
+## Current replacement registry
+
+`config/workcell_studio_asset_replacements.yaml` is the source of truth for legacy placeholder disposition:
+
+- `canonical_available`: a proper repository asset already exists; migrate references instead of downloading another model.
+- `awaiting_model`: a licensed external model is needed.
+- `code_change_required`: replace the generated STL with an honest URDF primitive.
+- `replaced` or `delete_when_unreferenced`: eligible for safe pruning only after all external references are gone.
+
+The first external-model batch is:
+
+1. KLT/industrial bin or tote
+2. EUR/EPAL pallet
+3. short industrial conveyor section
+
+## Audit the repository
+
+```bash
+python3 scripts/manage_workcell_environment_assets.py audit
+```
+
+Write machine-readable output:
+
+```bash
+python3 scripts/manage_workcell_environment_assets.py audit \
+  --format json \
+  --output build/environment_asset_audit.json
+```
+
+The audit reports:
+
+- mesh and URDF existence;
+- SHA-256 and file size;
+- basic STL triangle/normal evidence;
+- replacement status;
+- references outside the asset's own package;
+- whether deletion is currently safe.
+
+A poor-looking mesh is not automatically deleted. It must be explicitly marked `replaced` or `delete_when_unreferenced`, and it must have no remaining repository references.
+
+## Import a licensed model
+
+Keep the downloaded model and licence file unchanged, then run:
+
+```bash
+python3 scripts/manage_workcell_environment_assets.py import \
+  --asset-id klt_tote_600x400 \
+  --display-name "KLT Tote 600 x 400" \
+  --visual-file ~/Downloads/klt_tote.glb \
+  --dimensions 0.6 0.4 0.32 \
+  --source-url "https://supplier.example/model" \
+  --author "Supplier or creator" \
+  --license-id "CC-BY-4.0" \
+  --license-file ~/Downloads/LICENSE.txt \
+  --redistribution-confirmed
+```
+
+Use `--dry-run` first to verify the destination without writing files.
+
+The importer creates:
+
+```text
+assets/environment/<asset_id>_description/
+├── CMakeLists.txt
+├── package.xml
+├── asset_manifest.yaml
+├── SOURCE.md
+├── LICENSE.txt
+├── meshes/visual/<original-file>
+└── urdf/<asset_id>.urdf.xacro
+```
+
+The initial Xacro uses the supplied visual file and a dimensioned box collision. Review the following before catalog approval:
+
+- visible scale against the UR5 and canonical table;
+- rotation and Z-up orientation;
+- origin and mounting point;
+- polygon count and unnecessary internal detail;
+- collision geometry;
+- source and licence completeness;
+- Product View staging and framing.
+
+## Prune obsolete placeholders
+
+Dry-run pruning:
+
+```bash
+python3 scripts/manage_workcell_environment_assets.py prune
+```
+
+Actual deletion:
+
+```bash
+python3 scripts/manage_workcell_environment_assets.py prune --apply
+```
+
+The command refuses to delete meshes that remain referenced. Update the asset profile, catalog, scenes, templates, and URDF wrappers first; then set the registry status to `replaced` or `delete_when_unreferenced`.
+
+## What should remain primitive
+
+Detailed internet models are unnecessary for simple geometry. These should move to URDF primitives and then lose their generated STL files:
+
+- calibration cube;
+- simple pick box;
+- cylinder test object;
+- flat fixture plate;
+- robot base plate.
+
+This gives exact dimensions, smaller repositories, honest collision geometry, and no meaningless low-quality triangles.

--- a/scripts/manage_workcell_environment_assets.py
+++ b/scripts/manage_workcell_environment_assets.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shutil
+import struct
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+PROFILE = ROOT / "workcell_builder/workcell_builder/config/asset_profiles/environment_assets.json"
+REGISTRY = ROOT / "config/workcell_studio_asset_replacements.yaml"
+SUPPORTED_VISUAL_EXTENSIONS = {".stl", ".dae", ".obj", ".glb", ".gltf"}
+TEXT_EXTENSIONS = {
+    ".c", ".cc", ".cpp", ".h", ".hpp", ".json", ".md", ".py", ".txt", ".urdf", ".xacro", ".xml", ".yaml", ".yml"
+}
+SKIP_DIRS = {".git", "build", "install", "log", "node_modules", "__pycache__", ".pytest_cache"}
+SAFE_ID = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+def _relative(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(ROOT).as_posix()
+    except ValueError:
+        return str(path.resolve())
+
+
+def _load_profile() -> list[dict[str, Any]]:
+    data = json.loads(PROFILE.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError(f"{_relative(PROFILE)} must contain a JSON list")
+    return [item for item in data if isinstance(item, dict)]
+
+
+def _load_registry() -> dict[str, Any]:
+    data = yaml.safe_load(REGISTRY.read_text(encoding="utf-8")) or {}
+    if data.get("schema_version") != "workcell_studio_asset_replacements/v1":
+        raise ValueError(f"unsupported replacement registry schema in {_relative(REGISTRY)}")
+    assets = data.get("assets")
+    if not isinstance(assets, dict):
+        raise ValueError("replacement registry must contain an assets mapping")
+    return data
+
+
+def _walk_text_files() -> Iterable[Path]:
+    for path in ROOT.rglob("*"):
+        if not path.is_file() or path.suffix.lower() not in TEXT_EXTENSIONS:
+            continue
+        try:
+            rel_parts = path.relative_to(ROOT).parts
+        except ValueError:
+            continue
+        if any(part in SKIP_DIRS for part in rel_parts):
+            continue
+        yield path
+
+
+def _reference_locations(needle: str, own_package: Path | None = None) -> list[str]:
+    refs: list[str] = []
+    if not needle:
+        return refs
+    for path in _walk_text_files():
+        if own_package is not None:
+            try:
+                path.resolve().relative_to(own_package.resolve())
+                continue
+            except ValueError:
+                pass
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        if needle in text:
+            refs.append(_relative(path))
+    return sorted(set(refs))
+
+
+def _sha256(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _inspect_stl(path: Path) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "format": path.suffix.lower().lstrip("."),
+        "triangle_count": None,
+        "ascii": None,
+        "zero_normal_count": None,
+    }
+    if path.suffix.lower() != ".stl" or not path.is_file():
+        return result
+    data = path.read_bytes()
+    stripped = data.lstrip()
+    looks_ascii = stripped.startswith(b"solid") and b"facet normal" in data[: min(len(data), 1024 * 1024)]
+    result["ascii"] = looks_ascii
+    if looks_ascii:
+        text = data.decode("utf-8", errors="ignore")
+        normals = re.findall(r"facet\s+normal\s+([-+0-9.eE]+)\s+([-+0-9.eE]+)\s+([-+0-9.eE]+)", text)
+        result["triangle_count"] = len(normals)
+        result["zero_normal_count"] = sum(
+            1 for normal in normals if all(abs(float(component)) < 1e-12 for component in normal)
+        )
+    elif len(data) >= 84:
+        result["triangle_count"] = struct.unpack("<I", data[80:84])[0]
+        result["zero_normal_count"] = None
+    return result
+
+
+def build_audit() -> dict[str, Any]:
+    profile = _load_profile()
+    registry = _load_registry()
+    registered = registry["assets"]
+    rows: list[dict[str, Any]] = []
+
+    for item in profile:
+        asset_id = str(item.get("asset_id") or "")
+        replacement = registered.get(asset_id, {})
+        mesh_rel = str(item.get("mesh_path") or "")
+        urdf_rel = str(item.get("urdf_path") or "")
+        mesh = ROOT / mesh_rel if mesh_rel else Path()
+        urdf = ROOT / urdf_rel if urdf_rel else Path()
+        own_package = mesh.parent.parent if mesh_rel and len(mesh.parents) >= 2 else None
+        refs = _reference_locations(mesh_rel, own_package=own_package)
+        filename_refs = _reference_locations(mesh.name, own_package=own_package) if mesh_rel else []
+        references = sorted(set(refs + filename_refs))
+        source_note = str(item.get("source_note") or "").lower()
+        current_quality = str(replacement.get("current_quality") or ("placeholder" if "placeholder" in source_note else "unclassified"))
+        action = str(replacement.get("action") or "review")
+        status = str(replacement.get("replacement_status") or "unregistered")
+        stl = _inspect_stl(mesh)
+        safe_to_delete = bool(
+            mesh_rel
+            and mesh.is_file()
+            and current_quality == "placeholder"
+            and status in {"replaced", "delete_when_unreferenced"}
+            and not references
+        )
+        rows.append(
+            {
+                "asset_id": asset_id,
+                "label": item.get("label"),
+                "category": item.get("category"),
+                "mesh_path": mesh_rel,
+                "mesh_exists": bool(mesh_rel and mesh.is_file()),
+                "mesh_size_bytes": mesh.stat().st_size if mesh_rel and mesh.is_file() else None,
+                "mesh_sha256": _sha256(mesh) if mesh_rel else None,
+                "urdf_path": urdf_rel,
+                "urdf_exists": bool(urdf_rel and urdf.is_file()),
+                "current_quality": current_quality,
+                "action": action,
+                "replacement_status": status,
+                "expected_dimensions_m": replacement.get("expected_dimensions_m") or item.get("default_dimensions_m"),
+                "canonical_visual_uri": replacement.get("canonical_visual_uri"),
+                "references_outside_asset_package": references,
+                "safe_to_delete_now": safe_to_delete,
+                "mesh_inspection": stl,
+            }
+        )
+
+    missing_registry = sorted(
+        str(item.get("asset_id"))
+        for item in profile
+        if "placeholder" in str(item.get("source_note") or "").lower()
+        and str(item.get("asset_id")) not in registered
+    )
+    awaiting_models = sorted(row["asset_id"] for row in rows if row["replacement_status"] == "awaiting_model")
+    safe_deletes = sorted(row["mesh_path"] for row in rows if row["safe_to_delete_now"])
+    return {
+        "schema_version": "workcell_studio_environment_asset_audit/v1",
+        "profile": _relative(PROFILE),
+        "replacement_registry": _relative(REGISTRY),
+        "asset_count": len(rows),
+        "placeholder_count": sum(row["current_quality"] == "placeholder" for row in rows),
+        "awaiting_model_asset_ids": awaiting_models,
+        "missing_replacement_registry_entries": missing_registry,
+        "safe_delete_candidates": safe_deletes,
+        "assets": rows,
+    }
+
+
+def _audit_markdown(audit: dict[str, Any]) -> str:
+    lines = [
+        "# Workcell Studio environment asset audit",
+        "",
+        f"Profile assets: **{audit['asset_count']}**  ",
+        f"Known placeholders: **{audit['placeholder_count']}**  ",
+        f"Awaiting downloaded models: **{len(audit['awaiting_model_asset_ids'])}**  ",
+        f"Safe delete candidates: **{len(audit['safe_delete_candidates'])}**",
+        "",
+        "| Asset | Quality | Action | Status | Mesh | External references | Safe delete |",
+        "|---|---|---|---|---|---:|---|",
+    ]
+    for row in audit["assets"]:
+        lines.append(
+            "| {asset_id} | {current_quality} | {action} | {replacement_status} | `{mesh_path}` | {refs} | {delete} |".format(
+                **row,
+                refs=len(row["references_outside_asset_package"]),
+                delete="yes" if row["safe_to_delete_now"] else "no",
+            )
+        )
+    if audit["missing_replacement_registry_entries"]:
+        lines.extend(["", "## Missing registry entries", ""])
+        lines.extend(f"- `{asset_id}`" for asset_id in audit["missing_replacement_registry_entries"])
+    lines.extend(
+        [
+            "",
+            "## Deletion policy",
+            "",
+            "A generated mesh is never deleted merely because it looks poor. It must be marked replaced or delete_when_unreferenced and have no references outside its own package.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _write_output(text: str, output: str | None) -> None:
+    if output:
+        path = Path(output)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+        print(path)
+    else:
+        print(text)
+
+
+def _safe_asset_id(value: str) -> str:
+    value = value.strip().lower().replace("-", "_").replace(" ", "_")
+    if not SAFE_ID.fullmatch(value):
+        raise ValueError("asset id must match ^[a-z][a-z0-9_]*$")
+    return value
+
+
+def import_asset(args: argparse.Namespace) -> int:
+    asset_id = _safe_asset_id(args.asset_id)
+    visual_source = Path(args.visual_file).expanduser().resolve()
+    license_source = Path(args.license_file).expanduser().resolve()
+    if visual_source.suffix.lower() not in SUPPORTED_VISUAL_EXTENSIONS:
+        raise ValueError(f"unsupported visual format: {visual_source.suffix}")
+    if not visual_source.is_file():
+        raise FileNotFoundError(visual_source)
+    if not license_source.is_file():
+        raise FileNotFoundError(license_source)
+    if not args.redistribution_confirmed:
+        raise ValueError("--redistribution-confirmed is required before copying a third-party model into the repository")
+    dims = [float(value) for value in args.dimensions]
+    if len(dims) != 3 or any(value <= 0 for value in dims):
+        raise ValueError("--dimensions requires three positive metre values")
+
+    package_name = f"{asset_id}_description"
+    package = ROOT / "assets" / "environment" / package_name
+    if package.exists():
+        raise FileExistsError(f"asset package already exists: {_relative(package)}")
+    visual_rel = Path("meshes") / "visual" / visual_source.name
+    destination = package / visual_rel
+    if args.dry_run:
+        print(json.dumps({"package": _relative(package), "visual": str(visual_rel), "status": "dry_run"}, indent=2))
+        return 0
+
+    destination.parent.mkdir(parents=True, exist_ok=False)
+    (package / "urdf").mkdir()
+    shutil.copy2(visual_source, destination)
+    shutil.copy2(license_source, package / "LICENSE.txt")
+
+    x, y, z = dims
+    (package / "package.xml").write_text(
+        f'''<?xml version="1.0"?>\n<package format="3">\n  <name>{package_name}</name>\n  <version>0.1.0</version>\n  <description>Workcell Studio environment asset: {args.display_name}</description>\n  <maintainer email="maintainer@example.com">Workcell Studio</maintainer>\n  <license>{args.license_id}</license>\n  <buildtool_depend>ament_cmake</buildtool_depend>\n  <export><build_type>ament_cmake</build_type></export>\n</package>\n''',
+        encoding="utf-8",
+    )
+    (package / "CMakeLists.txt").write_text(
+        f'''cmake_minimum_required(VERSION 3.8)\nproject({package_name})\nfind_package(ament_cmake REQUIRED)\ninstall(DIRECTORY meshes urdf DESTINATION share/${{PROJECT_NAME}})\ninstall(FILES asset_manifest.yaml SOURCE.md LICENSE.txt DESTINATION share/${{PROJECT_NAME}})\nament_package()\n''',
+        encoding="utf-8",
+    )
+    (package / "asset_manifest.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "workcell_studio_environment_asset/v1",
+                "asset": {
+                    "id": asset_id,
+                    "display_name": args.display_name,
+                    "quality_tier": "candidate",
+                    "approval_status": "awaiting_visual_review",
+                    "visual_mesh": visual_rel.as_posix(),
+                    "collision": {"type": "box", "dimensions_m": dims},
+                    "dimensions_m": dims,
+                    "source_url": args.source_url,
+                    "author_or_manufacturer": args.author,
+                    "license": args.license_id,
+                    "redistribution_confirmed": True,
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    (package / "SOURCE.md").write_text(
+        f'''# Source\n\n- Asset: {args.display_name}\n- Author/manufacturer: {args.author}\n- Source URL: {args.source_url}\n- Licence: {args.license_id}\n- Redistribution permission checked: yes\n- Original file: {visual_source.name}\n- Imported dimensions in metres: {x}, {y}, {z}\n- Import status: awaiting scale, origin, orientation and visual-quality review\n''',
+        encoding="utf-8",
+    )
+    (package / "urdf" / f"{asset_id}.urdf.xacro").write_text(
+        f'''<?xml version="1.0"?>\n<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="{asset_id}">\n  <xacro:macro name="{asset_id}" params="prefix parent *origin">\n    <link name="${{prefix}}{asset_id}">\n      <visual>\n        <origin xyz="0 0 0" rpy="0 0 0"/>\n        <geometry><mesh filename="package://{package_name}/{visual_rel.as_posix()}" scale="1 1 1"/></geometry>\n      </visual>\n      <collision>\n        <origin xyz="0 0 {z / 2:.9g}" rpy="0 0 0"/>\n        <geometry><box size="{x:.9g} {y:.9g} {z:.9g}"/></geometry>\n      </collision>\n    </link>\n    <joint name="${{prefix}}{asset_id}_joint" type="fixed">\n      <parent link="${{parent}}"/>\n      <child link="${{prefix}}{asset_id}"/>\n      <xacro:insert_block name="origin"/>\n    </joint>\n  </xacro:macro>\n</robot>\n''',
+        encoding="utf-8",
+    )
+    print(_relative(package))
+    return 0
+
+
+def prune_assets(apply: bool) -> int:
+    audit = build_audit()
+    candidates = [row for row in audit["assets"] if row["safe_to_delete_now"]]
+    if not candidates:
+        print("No safe placeholder mesh deletions. Referenced placeholders remain quarantined until their references are migrated.")
+        return 0
+    for row in candidates:
+        path = ROOT / row["mesh_path"]
+        if apply:
+            path.unlink()
+            print(f"deleted {_relative(path)}")
+        else:
+            print(f"would delete {_relative(path)}")
+    if not apply:
+        print("Dry run only; pass --apply to delete the listed unreferenced meshes.")
+    return 0
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Audit, safely prune, and import Workcell Studio environment assets.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    audit = sub.add_parser("audit", help="Inspect the current environment asset profile and replacement registry.")
+    audit.add_argument("--format", choices=("json", "markdown"), default="markdown")
+    audit.add_argument("--output")
+
+    prune = sub.add_parser("prune", help="Delete only registry-approved placeholder meshes with no remaining references.")
+    prune.add_argument("--apply", action="store_true")
+
+    imp = sub.add_parser("import", help="Create a reviewable ROS description package from a licensed visual model.")
+    imp.add_argument("--asset-id", required=True)
+    imp.add_argument("--display-name", required=True)
+    imp.add_argument("--visual-file", required=True)
+    imp.add_argument("--dimensions", nargs=3, metavar=("X", "Y", "Z"), required=True)
+    imp.add_argument("--source-url", required=True)
+    imp.add_argument("--author", required=True)
+    imp.add_argument("--license-id", required=True)
+    imp.add_argument("--license-file", required=True)
+    imp.add_argument("--redistribution-confirmed", action="store_true")
+    imp.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        if args.command == "audit":
+            audit = build_audit()
+            text = json.dumps(audit, indent=2, sort_keys=True) + "\n" if args.format == "json" else _audit_markdown(audit)
+            _write_output(text, args.output)
+            return 1 if audit["missing_replacement_registry_entries"] else 0
+        if args.command == "prune":
+            return prune_assets(args.apply)
+        if args.command == "import":
+            return import_asset(args)
+    except (FileNotFoundError, FileExistsError, ValueError, json.JSONDecodeError, yaml.YAMLError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_workcell_environment_asset_replacement_pipeline.py
+++ b/tests/test_workcell_environment_asset_replacement_pipeline.py
@@ -1,0 +1,117 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROFILE = ROOT / "workcell_builder/workcell_builder/config/asset_profiles/environment_assets.json"
+REGISTRY = ROOT / "config/workcell_studio_asset_replacements.yaml"
+CATALOG = ROOT / "config/workcell_studio_visual_asset_catalog.yaml"
+SCRIPT = ROOT / "scripts/manage_workcell_environment_assets.py"
+
+
+def test_every_generated_placeholder_has_an_explicit_replacement_decision():
+    profile = json.loads(PROFILE.read_text(encoding="utf-8"))
+    registry = yaml.safe_load(REGISTRY.read_text(encoding="utf-8"))
+
+    assert registry["schema_version"] == "workcell_studio_asset_replacements/v1"
+    registered = registry["assets"]
+    placeholders = {
+        item["asset_id"]
+        for item in profile
+        if "placeholder" in str(item.get("source_note", "")).lower()
+    }
+
+    assert placeholders
+    assert not placeholders.difference(registered)
+    for asset_id in placeholders:
+        decision = registered[asset_id]
+        assert decision["current_quality"] in {"placeholder", "acceptable_primitive"}
+        assert decision["action"] in {
+            "replace_with_canonical",
+            "replace_with_downloaded_model",
+            "migrate_to_urdf_primitive",
+        }
+        assert len(decision["expected_dimensions_m"]) == 3
+
+
+def test_canonical_assets_and_legacy_placeholders_are_not_presented_as_equal():
+    catalog = yaml.safe_load(CATALOG.read_text(encoding="utf-8"))["categories"]
+
+    assert catalog["table"]["quality_tier"] == "canonical"
+    assert catalog["table"]["replacement_required"] is False
+    assert catalog["table"]["preferred_mesh_uris"] == [
+        "package://table_description/meshes/visual/table.stl"
+    ]
+    assert catalog["workbench"]["quality_tier"] == "canonical"
+    assert catalog["camera_realsense"]["quality_tier"] == "canonical"
+
+    for key in ("conveyor_placeholder", "bin_box_fixture"):
+        assert catalog[key]["quality_tier"] == "placeholder"
+        assert catalog[key]["replacement_required"] is True
+        assert catalog[key]["support_status"] == "preview_only"
+        assert "Placeholder" in catalog[key]["preview_label"]
+
+
+def test_asset_management_script_compiles_and_requires_redistribution_evidence(tmp_path):
+    subprocess.run([sys.executable, "-m", "py_compile", str(SCRIPT)], check=True)
+
+    visual = tmp_path / "candidate.stl"
+    visual.write_text("solid candidate\nendsolid candidate\n", encoding="utf-8")
+    license_file = tmp_path / "LICENSE.txt"
+    license_file.write_text("test licence text", encoding="utf-8")
+
+    base = [
+        sys.executable,
+        str(SCRIPT),
+        "import",
+        "--asset-id",
+        "pipeline_test_candidate",
+        "--display-name",
+        "Pipeline Test Candidate",
+        "--visual-file",
+        str(visual),
+        "--dimensions",
+        "0.4",
+        "0.3",
+        "0.2",
+        "--source-url",
+        "https://example.invalid/model",
+        "--author",
+        "Test Author",
+        "--license-id",
+        "CC0-1.0",
+        "--license-file",
+        str(license_file),
+        "--dry-run",
+    ]
+
+    rejected = subprocess.run(base, text=True, capture_output=True, check=False)
+    assert rejected.returncode == 2
+    assert "--redistribution-confirmed is required" in rejected.stderr
+
+    accepted = subprocess.run(
+        [*base, "--redistribution-confirmed"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert accepted.returncode == 0, accepted.stdout + accepted.stderr
+    payload = json.loads(accepted.stdout)
+    assert payload["status"] == "dry_run"
+    assert payload["package"].endswith(
+        "assets/environment/pipeline_test_candidate_description"
+    )
+
+
+def test_placeholder_deletion_is_reference_and_registry_guarded():
+    source = SCRIPT.read_text(encoding="utf-8")
+
+    assert 'status in {"replaced", "delete_when_unreferenced"}' in source
+    assert "and not references" in source
+    assert "safe_to_delete_now" in source
+    assert "Dry run only; pass --apply" in source
+    assert "Referenced placeholders remain quarantined" in source


### PR DESCRIPTION
## Problem
The repository still contains builder-generated environment STLs that are intentionally crude layout placeholders. Some are solid blocks with poor STL normals, but they remain referenced by the asset profile, URDF wrappers, templates, or catalogs. Deleting them blindly would break existing scenes.

## Changes
- Add `config/workcell_studio_asset_replacements.yaml` as the explicit disposition registry for every profile-managed generated placeholder.
- Distinguish:
  - canonical table/workbench assets already available;
  - assets awaiting licensed external models;
  - simple objects that should become URDF primitives instead of downloaded meshes.
- Mark canonical table/workbench/RealSense entries separately from preview-only bin/conveyor placeholders in the visual catalog.
- Add `scripts/manage_workcell_environment_assets.py` with:
  - repository audit output in Markdown or JSON;
  - file size, SHA-256, STL triangle/normal evidence, and reference reporting;
  - conservative pruning that requires both an approved registry state and zero remaining references;
  - a licensed-model importer that requires source, author, licence file, dimensions, and explicit redistribution confirmation;
  - generated ROS description package metadata, Xacro, source record, and simplified box collision.
- Add the operator workflow manual.
- Add focused regression coverage for replacement-registry completeness, canonical-vs-placeholder classification, importer licence safeguards, and guarded deletion.

## Deletion decision
No binary mesh is deleted in this PR. The audit contract treats all currently referenced placeholder meshes as unsafe to delete. The next cleanup PR can migrate simple cube/cylinder/plate assets to URDF primitives, remove their profile/catalog references, and then delete those generated STLs safely.

## Safety
- No robot motion, controller, MoveIt, launch, or hardware behavior changed.
- Fake-hardware-first defaults are untouched.
- Downloaded files are not accepted without explicit redistribution confirmation and a licence file.
- Imported assets start as `awaiting_visual_review`; import does not make them canonical.

## Validation
CI should run `tests/test_workcell_environment_asset_replacement_pipeline.py`. No third-party binary models are included in this PR.