### PR TITLE
Keep Workcell Studio windows and side panels inside screen bounds

### DIFF
--- a/tests/test_workcell_interface_containment.py
+++ b/tests/test_workcell_interface_containment.py
@@ -1,67 +1,33 @@
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
-QT_UTILS = ROOT / "workcell_builder/workcell_builder/gui/workcell_builder_ui_utils.cpp"
-WEB_CSS = ROOT / "workcell_studio_web/viewer/style.css"
+QT = (ROOT / "workcell_builder/workcell_builder/gui/workcell_builder_ui_utils.cpp").read_text(encoding="utf-8")
+CSS = (ROOT / "workcell_studio_web/viewer/style.css").read_text(encoding="utf-8")
 
 
-def test_qt_windows_are_screen_bounded_and_controls_shrink_inside_layouts():
-    text = QT_UTILS.read_text(encoding="utf-8")
-
-    for token in [
-        "class ResponsiveWindowGuard",
-        "availableGeometry()",
-        "frameGeometry()",
-        "QEvent::Show",
-        "QEvent::Resize",
-        "bounded_window_size",
-        "setMinimumWidth(0)",
-        "QSizePolicy::Expanding",
-    ]:
-        assert token in text
+def test_qt_windows_and_side_content_remain_contained():
+    for token in (
+        "class ResponsiveWindowGuard", "availableGeometry()", "frameGeometry()",
+        "QEvent::Show", "QEvent::Resize", "bounded_window_size",
+        "setWidgetResizable(true)", "setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff)",
+        "QAbstractScrollArea::AdjustIgnored", "setTextElideMode(Qt::ElideRight)",
+        "setUsesScrollButtons(true)", "setExpanding(false)",
+        "QTextEdit::WidgetWidth", "QPlainTextEdit::WidgetWidth",
+        "setMinimumWidth(0)", "QSizePolicy::Expanding",
+    ):
+        assert token in QT
 
 
-def test_qt_side_content_avoids_nested_horizontal_scrolling():
-    text = QT_UTILS.read_text(encoding="utf-8")
-
-    for token in [
-        "setWidgetResizable(true)",
-        "setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff)",
-        "QAbstractScrollArea::AdjustIgnored",
-        "setTextElideMode(Qt::ElideRight)",
-        "setUsesScrollButtons(true)",
-        "setExpanding(false)",
-        "QTextEdit::WidgetWidth",
-        "QPlainTextEdit::WidgetWidth",
-    ]:
-        assert token in text
-
-
-def test_web_viewer_owns_the_viewport_without_page_level_scrollbars():
-    css = WEB_CSS.read_text(encoding="utf-8")
-
-    for token in [
-        "grid-template-rows: auto minmax(0, 1fr)",
-        "overflow: hidden",
-        "overflow-x: hidden",
-        "overflow-y: auto",
-        "scrollbar-gutter: stable",
+def test_web_viewer_uses_bounded_internal_scrolling_only():
+    for token in (
+        "grid-template-rows: auto minmax(0, 1fr)", "overflow: hidden",
+        "overflow-x: hidden", "overflow-y: auto", "scrollbar-gutter: stable",
         "overscroll-behavior: contain",
         "grid-template-columns: clamp(12rem, 18vw, 18rem) minmax(0, 1fr) clamp(15rem, 22vw, 22rem)",
-    ]:
-        assert token in css
-
-    assert "height: calc(100vh - 74px)" not in css
-    assert "min-height: 34rem" not in css
-
-
-def test_web_viewer_narrow_layout_keeps_both_side_panels_bounded():
-    css = WEB_CSS.read_text(encoding="utf-8")
-
-    assert "@media (max-width: 820px)" in css
-    assert "grid-template-columns: minmax(11rem, 15rem) minmax(0, 1fr)" in css
-    assert "grid-column: 1 / -1" in css
-    assert "max-height: none" in css
-    assert "body.embedded-mode" in css
-    assert "height: 100%" in css
+        "@media (max-width: 820px)",
+        "grid-template-columns: minmax(11rem, 15rem) minmax(0, 1fr)",
+        "grid-column: 1 / -1", "max-height: none", "body.embedded-mode",
+    ):
+        assert token in CSS
+    assert "height: calc(100vh - 74px)" not in CSS
+    assert "min-height: 34rem" not in CSS

--- a/tests/test_workcell_interface_containment.py
+++ b/tests/test_workcell_interface_containment.py
@@ -1,33 +1,24 @@
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-QT = (ROOT / "workcell_builder/workcell_builder/gui/workcell_builder_ui_utils.cpp").read_text(encoding="utf-8")
-CSS = (ROOT / "workcell_studio_web/viewer/style.css").read_text(encoding="utf-8")
+QT = (ROOT / "workcell_builder/workcell_builder/gui/workcell_builder_ui_utils.cpp").read_text()
+CSS = (ROOT / "workcell_studio_web/viewer/style.css").read_text()
 
 
-def test_qt_windows_and_side_content_remain_contained():
-    for token in (
-        "class ResponsiveWindowGuard", "availableGeometry()", "frameGeometry()",
-        "QEvent::Show", "QEvent::Resize", "bounded_window_size",
-        "setWidgetResizable(true)", "setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff)",
-        "QAbstractScrollArea::AdjustIgnored", "setTextElideMode(Qt::ElideRight)",
-        "setUsesScrollButtons(true)", "setExpanding(false)",
-        "QTextEdit::WidgetWidth", "QPlainTextEdit::WidgetWidth",
-        "setMinimumWidth(0)", "QSizePolicy::Expanding",
-    ):
+def test_qt_interface_is_screen_bounded_without_horizontal_side_scrolling():
+    for token in ("ResponsiveWindowGuard", "availableGeometry()", "frameGeometry()",
+                  "bounded_window_size", "setWidgetResizable(true)",
+                  "setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff)",
+                  "QAbstractScrollArea::AdjustIgnored", "setTextElideMode(Qt::ElideRight)",
+                  "setUsesScrollButtons(true)", "QTextEdit::WidgetWidth"):
         assert token in QT
 
 
-def test_web_viewer_uses_bounded_internal_scrolling_only():
-    for token in (
-        "grid-template-rows: auto minmax(0, 1fr)", "overflow: hidden",
-        "overflow-x: hidden", "overflow-y: auto", "scrollbar-gutter: stable",
-        "overscroll-behavior: contain",
-        "grid-template-columns: clamp(12rem, 18vw, 18rem) minmax(0, 1fr) clamp(15rem, 22vw, 22rem)",
-        "@media (max-width: 820px)",
-        "grid-template-columns: minmax(11rem, 15rem) minmax(0, 1fr)",
-        "grid-column: 1 / -1", "max-height: none", "body.embedded-mode",
-    ):
+def test_web_viewer_contains_all_scrolling_inside_bounded_panels():
+    for token in ("grid-template-rows: auto minmax(0, 1fr)", "overflow-x: hidden",
+                  "overflow-y: auto", "scrollbar-gutter: stable", "overscroll-behavior: contain",
+                  "grid-template-columns: clamp(12rem, 18vw, 18rem) minmax(0, 1fr) clamp(15rem, 22vw, 22rem)",
+                  "@media (max-width: 820px)", "grid-column: 1 / -1", "body.embedded-mode"):
         assert token in CSS
     assert "height: calc(100vh - 74px)" not in CSS
     assert "min-height: 34rem" not in CSS

--- a/tests/test_workcell_interface_containment.py
+++ b/tests/test_workcell_interface_containment.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+QT_UTILS = ROOT / "workcell_builder/workcell_builder/gui/workcell_builder_ui_utils.cpp"
+WEB_CSS = ROOT / "workcell_studio_web/viewer/style.css"
+
+
+def test_qt_windows_are_screen_bounded_and_controls_shrink_inside_layouts():
+    text = QT_UTILS.read_text(encoding="utf-8")
+
+    for token in [
+        "class ResponsiveWindowGuard",
+        "availableGeometry()",
+        "frameGeometry()",
+        "QEvent::Show",
+        "QEvent::Resize",
+        "bounded_window_size",
+        "setMinimumWidth(0)",
+        "QSizePolicy::Expanding",
+    ]:
+        assert token in text
+
+
+def test_qt_side_content_avoids_nested_horizontal_scrolling():
+    text = QT_UTILS.read_text(encoding="utf-8")
+
+    for token in [
+        "setWidgetResizable(true)",
+        "setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff)",
+        "QAbstractScrollArea::AdjustIgnored",
+        "setTextElideMode(Qt::ElideRight)",
+        "setUsesScrollButtons(true)",
+        "setExpanding(false)",
+        "QTextEdit::WidgetWidth",
+        "QPlainTextEdit::WidgetWidth",
+    ]:
+        assert token in text
+
+
+def test_web_viewer_owns_the_viewport_without_page_level_scrollbars():
+    css = WEB_CSS.read_text(encoding="utf-8")
+
+    for token in [
+        "grid-template-rows: auto minmax(0, 1fr)",
+        "overflow: hidden",
+        "overflow-x: hidden",
+        "overflow-y: auto",
+        "scrollbar-gutter: stable",
+        "overscroll-behavior: contain",
+        "grid-template-columns: clamp(12rem, 18vw, 18rem) minmax(0, 1fr) clamp(15rem, 22vw, 22rem)",
+    ]:
+        assert token in css
+
+    assert "height: calc(100vh - 74px)" not in css
+    assert "min-height: 34rem" not in css
+
+
+def test_web_viewer_narrow_layout_keeps_both_side_panels_bounded():
+    css = WEB_CSS.read_text(encoding="utf-8")
+
+    assert "@media (max-width: 820px)" in css
+    assert "grid-template-columns: minmax(11rem, 15rem) minmax(0, 1fr)" in css
+    assert "grid-column: 1 / -1" in css
+    assert "max-height: none" in css
+    assert "body.embedded-mode" in css
+    assert "height: 100%" in css

--- a/workcell_builder/workcell_builder/gui/workcell_builder_ui_utils.cpp
+++ b/workcell_builder/workcell_builder/gui/workcell_builder_ui_utils.cpp
@@ -1,38 +1,241 @@
 #include "workcell_builder_ui_utils.hpp"
 
 #include <QAbstractButton>
+#include <QAbstractItemView>
+#include <QAbstractScrollArea>
+#include <QAbstractSpinBox>
+#include <QApplication>
+#include <QComboBox>
 #include <QDialogButtonBox>
+#include <QEvent>
+#include <QFrame>
+#include <QGroupBox>
+#include <QGuiApplication>
+#include <QHeaderView>
 #include <QLabel>
+#include <QLayout>
+#include <QLineEdit>
+#include <QListView>
+#include <QPlainTextEdit>
 #include <QPushButton>
+#include <QScreen>
+#include <QScrollArea>
 #include <QSizePolicy>
+#include <QTabBar>
+#include <QTabWidget>
+#include <QTableView>
+#include <QTextEdit>
+#include <QTreeView>
 #include <QVariant>
+#include <QWindow>
+
+#include <algorithm>
 
 namespace workcell_builder
 {
+namespace
+{
+QScreen * screenForWidget(QWidget * widget)
+{
+  if (widget && widget->windowHandle() && widget->windowHandle()->screen()) {
+    return widget->windowHandle()->screen();
+  }
+  return QGuiApplication::primaryScreen();
+}
+
+QRect usableScreenGeometry(QWidget * widget)
+{
+  QScreen * screen = screenForWidget(widget);
+  if (!screen) return QRect(0, 0, 1280, 720);
+
+  QRect available = screen->availableGeometry();
+  const int inset = std::min(16, std::min(available.width(), available.height()) / 20);
+  return available.adjusted(inset, inset, -inset, -inset);
+}
+
+void keepWindowInsideScreen(QWidget * widget)
+{
+  if (!widget || widget->isFullScreen() || widget->isMaximized()) return;
+
+  const QRect available = usableScreenGeometry(widget);
+  if (!available.isValid()) return;
+
+  const QSize bounded_window_size(
+    std::min(widget->width(), available.width()),
+    std::min(widget->height(), available.height()));
+
+  const QSize current_minimum = widget->minimumSize();
+  widget->setMinimumSize(
+    std::min(current_minimum.width(), available.width()),
+    std::min(current_minimum.height(), available.height()));
+
+  if (bounded_window_size != widget->size()) {
+    widget->resize(bounded_window_size);
+  }
+
+  const QRect frame = widget->frameGeometry();
+  const int max_x = std::max(available.left(), available.right() - frame.width() + 1);
+  const int max_y = std::max(available.top(), available.bottom() - frame.height() + 1);
+  const int bounded_x = std::max(available.left(), std::min(frame.left(), max_x));
+  const int bounded_y = std::max(available.top(), std::min(frame.top(), max_y));
+  if (bounded_x != frame.left() || bounded_y != frame.top()) {
+    widget->move(bounded_x, bounded_y);
+  }
+}
+
+class ResponsiveWindowGuard : public QObject
+{
+public:
+  explicit ResponsiveWindowGuard(QWidget * window)
+  : QObject(window), window_(window)
+  {
+  }
+
+protected:
+  bool eventFilter(QObject * watched, QEvent * event) override
+  {
+    if (watched == window_ && !adjusting_ &&
+      (event->type() == QEvent::Show || event->type() == QEvent::Resize ||
+      event->type() == QEvent::WindowStateChange))
+    {
+      adjusting_ = true;
+      keepWindowInsideScreen(window_);
+      adjusting_ = false;
+    }
+    return QObject::eventFilter(watched, event);
+  }
+
+private:
+  QWidget * window_ = nullptr;
+  bool adjusting_ = false;
+};
+
+void installResponsiveWindowGuard(QWidget * widget)
+{
+  if (!widget || widget->property("workcell_responsive_window_guard").toBool()) return;
+  widget->installEventFilter(new ResponsiveWindowGuard(widget));
+  widget->setProperty("workcell_responsive_window_guard", true);
+}
+
+void configureContainedWidgets(QWidget * widget)
+{
+  if (!widget) return;
+
+  for (QLayout * layout : widget->findChildren<QLayout *>()) {
+    const QMargins margins = layout->contentsMargins();
+    layout->setContentsMargins(
+      std::min(margins.left(), 12),
+      std::min(margins.top(), 12),
+      std::min(margins.right(), 12),
+      std::min(margins.bottom(), 12));
+    if (layout->spacing() > 10) layout->setSpacing(8);
+  }
+
+  for (QScrollArea * area : widget->findChildren<QScrollArea *>()) {
+    area->setWidgetResizable(true);
+    area->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    area->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    area->setSizeAdjustPolicy(QAbstractScrollArea::AdjustIgnored);
+    area->setFrameShape(QFrame::NoFrame);
+    area->setMinimumWidth(0);
+    area->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+  }
+
+  for (QAbstractItemView * view : widget->findChildren<QAbstractItemView *>()) {
+    view->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    view->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    view->setSizeAdjustPolicy(QAbstractScrollArea::AdjustIgnored);
+    view->setTextElideMode(Qt::ElideRight);
+    view->setMinimumWidth(0);
+    view->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+  }
+
+  for (QTableView * table : widget->findChildren<QTableView *>()) {
+    if (table->horizontalHeader()) {
+      table->horizontalHeader()->setStretchLastSection(true);
+      table->horizontalHeader()->setMinimumSectionSize(44);
+    }
+    table->setWordWrap(true);
+  }
+
+  for (QTextEdit * editor : widget->findChildren<QTextEdit *>()) {
+    editor->setLineWrapMode(QTextEdit::WidgetWidth);
+    editor->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    editor->setSizeAdjustPolicy(QAbstractScrollArea::AdjustIgnored);
+    editor->setMinimumWidth(0);
+  }
+
+  for (QPlainTextEdit * editor : widget->findChildren<QPlainTextEdit *>()) {
+    editor->setLineWrapMode(QPlainTextEdit::WidgetWidth);
+    editor->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    editor->setSizeAdjustPolicy(QAbstractScrollArea::AdjustIgnored);
+    editor->setMinimumWidth(0);
+  }
+
+  for (QTabWidget * tabs : widget->findChildren<QTabWidget *>()) {
+    tabs->setUsesScrollButtons(true);
+    tabs->setElideMode(Qt::ElideRight);
+    tabs->setDocumentMode(true);
+    tabs->setMinimumWidth(0);
+    tabs->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    if (tabs->tabBar()) tabs->tabBar()->setExpanding(false);
+  }
+
+  for (QLineEdit * edit : widget->findChildren<QLineEdit *>()) {
+    edit->setMinimumWidth(0);
+    edit->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+  }
+  for (QComboBox * combo : widget->findChildren<QComboBox *>()) {
+    combo->setMinimumWidth(0);
+    combo->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
+    combo->setMinimumContentsLength(8);
+    combo->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+  }
+  for (QAbstractSpinBox * spin : widget->findChildren<QAbstractSpinBox *>()) {
+    spin->setMinimumWidth(0);
+    spin->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+  }
+  for (QPushButton * button : widget->findChildren<QPushButton *>()) {
+    button->setMinimumWidth(0);
+    button->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+  }
+  for (QGroupBox * group : widget->findChildren<QGroupBox *>()) {
+    group->setMinimumWidth(0);
+    group->setSizePolicy(QSizePolicy::Expanding, group->sizePolicy().verticalPolicy());
+  }
+}
+}  // namespace
+
 QString workcellStudioStyleSheet()
 {
   return QStringLiteral(
     "QWidget { font-size: 13px; color: #17202a; }"
     "QMainWindow, QDialog { background-color: #f4f7fb; }"
-    "QGroupBox { background-color: #ffffff; border: 1px solid #c7d3df; border-radius: 8px; margin-top: 10px; }"
+    "QGroupBox { background-color: #ffffff; border: 1px solid #c7d3df; border-radius: 8px; margin-top: 10px; padding-top: 5px; }"
     "QGroupBox::title { subcontrol-origin: margin; left: 10px; padding: 0 4px; color: #4d5b6a; font-weight: 600; }"
-    "QTabWidget::pane { border: 1px solid #c7d3df; background: #ffffff; }"
-    "QTabBar::tab { background: #eef3f8; color: #4d5b6a; border: 1px solid #c7d3df; padding: 6px 12px; }"
-    "QTabBar::tab:selected { background: #ffffff; color: #17202a; }"
-    "QLineEdit, QComboBox, QSpinBox, QTextBrowser, QPlainTextEdit, QListWidget, QTreeWidget, QTableWidget { background-color: #ffffff; border: 1px solid #c7d3df; border-radius: 4px; }"
-    "QLineEdit:focus, QComboBox:focus, QSpinBox:focus { border: 1px solid #1d5da8; }"
-    "QHeaderView::section { background: #eef3f8; color: #17202a; border: 1px solid #c7d3df; padding: 4px; font-weight: 600; }"
-    "QPushButton { background-color: #60758a; color: #ffffff; border: 1px solid #4d5b6a; border-radius: 5px; padding: 6px 12px; }"
-    "QPushButton:hover { background-color: #4d647a; }"
-    "QPushButton:pressed { background-color: #3f5366; }"
-    "QPushButton:disabled { background-color: #d8e0e8; color: #6c7884; border: 1px solid #c7d3df; }"
+    "QTabWidget::pane { border: 1px solid #c7d3df; background: #ffffff; border-radius: 6px; }"
+    "QTabBar::tab { background: #eef3f8; color: #4d5b6a; border: 1px solid #c7d3df; padding: 7px 10px; }"
+    "QTabBar::tab:selected { background: #ffffff; color: #17202a; border-bottom-color: #ffffff; }"
+    "QTabBar::tab:hover { background: #e1eaf3; }"
+    "QLineEdit, QComboBox, QSpinBox, QDoubleSpinBox, QTextBrowser, QTextEdit, QPlainTextEdit, QListWidget, QTreeWidget, QTableWidget { background-color: #ffffff; border: 1px solid #c7d3df; border-radius: 4px; selection-background-color: #d7edf7; selection-color: #17202a; }"
+    "QLineEdit:focus, QComboBox:focus, QSpinBox:focus, QDoubleSpinBox:focus, QListWidget:focus, QTreeWidget:focus, QTableWidget:focus { border: 2px solid #1d5da8; }"
+    "QHeaderView::section { background: #eef3f8; color: #17202a; border: 0; border-right: 1px solid #c7d3df; border-bottom: 1px solid #c7d3df; padding: 5px; font-weight: 600; }"
+    "QPushButton, QToolButton { min-height: 30px; background-color: #60758a; color: #ffffff; border: 1px solid #4d5b6a; border-radius: 5px; padding: 5px 10px; }"
+    "QPushButton:hover, QToolButton:hover { background-color: #4d647a; }"
+    "QPushButton:pressed, QToolButton:pressed { background-color: #3f5366; }"
+    "QPushButton:disabled, QToolButton:disabled { background-color: #d8e0e8; color: #6c7884; border: 1px solid #c7d3df; }"
     "QPushButton[class='primary_action'] { background-color: #1d5da8; border-color: #174a86; color: #ffffff; font-weight: 600; }"
     "QPushButton[class='secondary_action'] { background-color: #60758a; border-color: #4d647a; }"
     "QPushButton[class='safe_action'] { background-color: #217a34; border-color: #1a622a; }"
     "QPushButton[class='preview_action'] { background-color: #6f42c1; border-color: #57329a; }"
     "QPushButton[class='destructive_action'] { background-color: #fce8e7; color: #b3261e; border: 1px solid #b3261e; }"
     "QPushButton[class='disabled_placeholder'] { background-color: #d8e0e8; color: #6c7884; border: 1px dashed #6c7884; }"
-    "QScrollArea, QAbstractScrollArea { background: #f4f7fb; border: 1px solid #c7d3df; }");
+    "QScrollArea { background: transparent; border: 0; }"
+    "QAbstractScrollArea { background: #ffffff; border: 1px solid #c7d3df; }"
+    "QScrollBar:vertical { width: 10px; margin: 0; background: transparent; }"
+    "QScrollBar::handle:vertical { min-height: 28px; background: #b7c4d1; border-radius: 5px; }"
+    "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical { height: 0; }"
+    "QToolTip { background: #17202a; color: #ffffff; border: 0; padding: 5px; }");
 }
 
 void applyWorkcellStudioTheme(QWidget * widget)
@@ -66,25 +269,55 @@ void applyStatusBadgeStyle(QLabel * label, StatusType status)
   label->setStyleSheet(QString("background:%1; color:%2; border:1px solid #c7d3df; border-radius:10px; padding:2px 8px; font-weight:600;").arg(bg, fg));
 }
 
-void capDialogSize(QWidget * widget, int, int){ if(!widget) return; widget->setMinimumSize(640,420); widget->setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX); }
-void makeTextWidgetsWrap(QWidget * widget){ if(!widget) return; for (QLabel * label : widget->findChildren<QLabel *>()) { label->setWordWrap(true); label->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);} }
+void capDialogSize(QWidget * widget, int, int)
+{
+  if (!widget) return;
+
+  const QRect available = usableScreenGeometry(widget);
+  widget->setMinimumSize(
+    std::min(640, available.width()),
+    std::min(420, available.height()));
+  widget->setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
+  installResponsiveWindowGuard(widget);
+  keepWindowInsideScreen(widget);
+}
+
+void makeTextWidgetsWrap(QWidget * widget)
+{
+  if (!widget) return;
+  for (QLabel * label : widget->findChildren<QLabel *>()) {
+    label->setWordWrap(true);
+    label->setMinimumWidth(0);
+    label->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+  }
+}
 
 void applyPrimarySecondaryButtonStyle(QWidget * widget)
 {
   if (!widget) return;
   for (QDialogButtonBox * box : widget->findChildren<QDialogButtonBox *>()) {
-    if (auto * ok = box->button(QDialogButtonBox::Ok)) { applyButtonRoleStyle(ok, ButtonRole::primary_action); ok->setDefault(true);}    
-    if (auto * save = box->button(QDialogButtonBox::Save)) { applyButtonRoleStyle(save, ButtonRole::primary_action); save->setDefault(true);}    
+    if (auto * ok = box->button(QDialogButtonBox::Ok)) {
+      applyButtonRoleStyle(ok, ButtonRole::primary_action);
+      ok->setDefault(true);
+    }
+    if (auto * save = box->button(QDialogButtonBox::Save)) {
+      applyButtonRoleStyle(save, ButtonRole::primary_action);
+      save->setDefault(true);
+    }
   }
 }
 
-void applyStatusLabelStyle(QLabel * label, StatusType status){ applyStatusBadgeStyle(label, status); }
+void applyStatusLabelStyle(QLabel * label, StatusType status)
+{
+  applyStatusBadgeStyle(label, status);
+}
 
 void applyCompactDialogDefaults(QWidget * widget)
 {
   if (!widget) return;
   capDialogSize(widget);
   makeTextWidgetsWrap(widget);
+  configureContainedWidgets(widget);
   applyWorkcellStudioTheme(widget);
   applyPrimarySecondaryButtonStyle(widget);
 }

--- a/workcell_studio_web/viewer/style.css
+++ b/workcell_studio_web/viewer/style.css
@@ -7,120 +7,244 @@
   --text: #17202a;
   --muted: #526173;
   --accent: #0078a8;
+  --accent-soft: #d7edf7;
   --warn: #b26b00;
   --error: #c43434;
   --error-surface: #ffeef0;
   --overlay-surface: #fff6dd;
   --border: #c5ced8;
+  --radius: 0.55rem;
 }
 
-* { box-sizing: border-box; }
+* {
+  box-sizing: border-box;
+  min-width: 0;
+}
+
+html,
 body {
+  width: 100%;
+  height: 100%;
   margin: 0;
-  min-height: 100vh;
+  overflow: hidden;
+}
+
+body {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
   background: var(--bg);
   color: var(--text);
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
+button,
+input,
+label,
+section,
+aside,
+main,
+div {
+  max-width: 100%;
+}
+
+button,
+input {
+  font: inherit;
+}
+
 .topbar {
+  z-index: 3;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: 1rem;
-  padding: 0.85rem 1rem;
+  gap: 0.75rem 1rem;
+  min-width: 0;
+  padding: 0.7rem 0.85rem;
   border-bottom: 1px solid var(--border);
   background: var(--panel);
+  box-shadow: 0 0.12rem 0.45rem rgba(23, 32, 42, 0.08);
 }
-.topbar h1 { margin: 0; font-size: 1.1rem; }
-.topbar p { margin: 0.2rem 0 0; color: var(--muted); font-size: 0.85rem; }
+
+.topbar > div:first-child {
+  flex: 0 1 24rem;
+}
+
+.topbar h1 {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.25;
+}
+
+.topbar p {
+  margin: 0.18rem 0 0;
+  color: var(--muted);
+  font-size: 0.8rem;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
 .toolbar {
-  display: inline-flex;
+  display: flex;
+  flex: 1 1 42rem;
   align-items: center;
-  gap: 0.6rem;
-  flex-wrap: wrap;
   justify-content: flex-end;
+  gap: 0.45rem;
+  min-width: 0;
+  max-width: 100%;
+  flex-wrap: wrap;
 }
+
+.file-picker,
+.toolbar-button,
+.toolbar-number,
+.toolbar-toggle {
+  min-height: 2.25rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
 .file-picker {
   display: inline-flex;
   align-items: center;
-  gap: 0.6rem;
-  padding: 0.55rem 0.8rem;
-  border: 1px solid var(--accent);
-  border-radius: 0.5rem;
-  background: #d7edf7;
+  gap: 0.45rem;
+  min-width: 11rem;
+  padding: 0.45rem 0.65rem;
+  border-color: var(--accent);
+  background: var(--accent-soft);
   color: var(--text);
   cursor: pointer;
-  white-space: nowrap;
+  font-weight: 600;
 }
-.file-picker input { max-width: 15rem; }
+
+.file-picker input {
+  width: clamp(7rem, 12vw, 13rem);
+  min-width: 0;
+}
+
 .toolbar-button {
-  border: 1px solid var(--border);
-  border-radius: 0.5rem;
+  padding: 0.45rem 0.65rem;
   background: var(--panel-2);
   color: var(--text);
   cursor: pointer;
-  padding: 0.55rem 0.8rem;
-  white-space: nowrap;
+  white-space: normal;
+  line-height: 1.2;
 }
-.toolbar-button:not(:disabled):hover { border-color: var(--accent); background: #d7edf7; }
-.toolbar-button:disabled { cursor: not-allowed; opacity: 0.45; }
 
-.toolbar-number {
+.toolbar-button:not(:disabled):hover,
+.toolbar-button:focus-visible {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  outline: 2px solid rgba(0, 120, 168, 0.18);
+  outline-offset: 1px;
+}
+
+.toolbar-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.toolbar-number,
+.toolbar-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.38rem 0.55rem;
-  border: 1px solid var(--border);
-  border-radius: 0.5rem;
-  background: rgba(248, 250, 252, 0.86);
+  gap: 0.32rem;
+  padding: 0.35rem 0.5rem;
+  background: rgba(248, 250, 252, 0.92);
   color: var(--muted);
-  font-size: 0.78rem;
-  white-space: nowrap;
+  font-size: 0.76rem;
+  line-height: 1.2;
 }
+
 .toolbar-number input {
-  width: 4.5rem;
-  padding: 0.25rem 0.3rem;
+  width: 4.25rem;
+  min-width: 3.4rem;
+  padding: 0.24rem 0.3rem;
   border: 1px solid var(--border);
   border-radius: 0.3rem;
   background: #ffffff;
   color: var(--text);
 }
+
 .toolbar-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.45rem 0.65rem;
-  border: 1px solid var(--border);
-  border-radius: 0.5rem;
-  background: rgba(248, 250, 252, 0.86);
-  color: var(--muted);
   cursor: pointer;
-  font-size: 0.86rem;
-  white-space: nowrap;
 }
-.toolbar-toggle:hover { border-color: var(--accent); color: var(--text); }
-.toolbar-toggle input { accent-color: var(--accent); }
+
+.toolbar-toggle:hover,
+.toolbar-toggle:focus-within {
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+.toolbar-toggle input {
+  accent-color: var(--accent);
+}
 
 .app-shell {
   display: grid;
-  grid-template-columns: minmax(13rem, 18rem) 1fr minmax(16rem, 22rem);
-  height: calc(100vh - 74px);
-  min-height: 34rem;
+  grid-template-columns: clamp(12rem, 18vw, 18rem) minmax(0, 1fr) clamp(15rem, 22vw, 22rem);
+  grid-template-rows: minmax(0, 1fr);
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
   background: var(--workspace-bg);
 }
-.object-panel, .details-panel {
-  overflow: auto;
-  padding: 1rem;
+
+.object-panel,
+.details-panel {
+  min-width: 0;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  padding: 0.8rem;
   background: var(--panel);
   border-color: var(--border);
 }
-.object-panel { border-right: 1px solid var(--border); }
-.details-panel { border-left: 1px solid var(--border); }
-h2 { margin: 0 0 0.75rem; font-size: 0.95rem; color: var(--accent); }
 
-.viewport-panel { position: relative; min-width: 0; background: var(--workspace-bg); }
-#scene-canvas { width: 100%; height: 100%; display: block; background: var(--workspace-bg); }
+.object-panel {
+  border-right: 1px solid var(--border);
+}
+
+.details-panel {
+  border-left: 1px solid var(--border);
+}
+
+.object-panel > *,
+.details-panel > *,
+.details-panel section,
+.details-panel section > * {
+  min-width: 0;
+  max-width: 100%;
+}
+
+h2 {
+  margin: 0 0 0.65rem;
+  color: var(--accent);
+  font-size: 0.92rem;
+  line-height: 1.25;
+}
+
+.viewport-panel {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--workspace-bg);
+  isolation: isolate;
+}
+
+#scene-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  background: var(--workspace-bg);
+  touch-action: none;
+}
 
 .label-layer {
   position: absolute;
@@ -129,42 +253,62 @@ h2 { margin: 0 0 0.75rem; font-size: 0.95rem; color: var(--accent); }
   overflow: hidden;
   pointer-events: none;
 }
-.label-layer.labels-hidden { display: none; }
+
+.label-layer.labels-hidden {
+  display: none;
+}
+
 .object-label {
   position: absolute;
   left: 0;
   top: 0;
-  max-width: 10rem;
+  max-width: min(10rem, 35vw);
   padding: 0.16rem 0.42rem;
+  overflow: hidden;
   border: 1px solid rgba(0, 120, 168, 0.45);
   border-radius: 999px;
-  background: rgba(248, 250, 252, 0.86);
-  box-shadow: 0 0.2rem 0.8rem rgba(0, 0, 0, 0.22);
+  background: rgba(248, 250, 252, 0.9);
+  box-shadow: 0 0.2rem 0.8rem rgba(0, 0, 0, 0.18);
   color: #123040;
   font-size: 0.72rem;
   font-weight: 600;
   line-height: 1.25;
-  overflow: hidden;
   text-overflow: ellipsis;
   text-shadow: 0 1px 0 rgba(255, 255, 255, 0.75);
   white-space: nowrap;
 }
+
 .object-label.selected {
   border-color: var(--accent);
   background: rgba(0, 120, 168, 0.16);
   color: #0b3345;
 }
+
 .state {
-  padding: 0.75rem;
-  border-radius: 0.5rem;
+  max-width: 100%;
+  padding: 0.68rem;
+  overflow-wrap: anywhere;
   border: 1px solid var(--border);
+  border-radius: var(--radius);
   background: var(--panel-2);
   color: var(--muted);
+  line-height: 1.35;
 }
-.empty { border-style: dashed; }
-.error {
+
+.empty {
+  border-style: dashed;
+}
+
+.error,
+.dirty,
+.preview-status {
   position: absolute;
   z-index: 2;
+  max-width: calc(100% - 2rem);
+  box-shadow: 0 0.2rem 0.8rem rgba(23, 32, 42, 0.14);
+}
+
+.error {
   top: 1rem;
   left: 1rem;
   right: 1rem;
@@ -172,151 +316,437 @@ h2 { margin: 0 0 0.75rem; font-size: 0.95rem; color: var(--accent); }
   border-color: var(--error);
   background: var(--error-surface);
 }
+
+.dirty {
+  top: 1rem;
+  right: 1rem;
+  border-color: var(--warn);
+  background: var(--overlay-surface);
+  color: #5f3a00;
+}
+
+.preview-status {
+  left: 1rem;
+  bottom: 1rem;
+  border-color: var(--accent);
+  background: rgba(215, 237, 247, 0.94);
+  color: #0b5f80;
+}
+
 .warning-item {
   margin: 0 0 0.5rem;
-  padding: 0.55rem;
+  padding: 0.52rem;
+  overflow-wrap: anywhere;
   border-left: 3px solid var(--warn);
   background: var(--overlay-surface);
   color: #5f3a00;
 }
 
 .scene-summary {
-  margin-bottom: 0.75rem;
-  padding: 0.65rem;
+  margin-bottom: 0.7rem;
+  padding: 0.62rem;
 }
+
 .scene-summary h3 {
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.45rem;
   color: var(--accent);
-  font-size: 0.82rem;
+  font-size: 0.78rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
+
 .summary-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 0.32rem 0.65rem;
+  grid-template-columns: minmax(0, 1fr) minmax(3.4rem, auto);
+  gap: 0.3rem 0.55rem;
   align-items: baseline;
-  font-size: 0.78rem;
+  font-size: 0.76rem;
 }
-.summary-grid span { color: var(--muted); }
+
+.summary-grid span {
+  min-width: 0;
+  color: var(--muted);
+  overflow-wrap: anywhere;
+}
+
 .summary-grid strong {
-  max-width: 8rem;
-  color: #0b5f80;
-  font-size: 0.82rem;
+  min-width: 0;
+  max-width: 100%;
   overflow: hidden;
+  color: #0b5f80;
+  font-size: 0.79rem;
   text-align: right;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.object-list { list-style: none; margin: 0; padding: 0; }
+.object-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
 .object-list li {
-  margin-bottom: 0.4rem;
-  padding: 0.55rem;
+  position: relative;
+  margin-bottom: 0.38rem;
+  padding: 0.52rem;
+  overflow: hidden;
   border: 1px solid var(--border);
   border-radius: 0.45rem;
   background: var(--panel-2);
   cursor: pointer;
 }
-.object-list li:hover, .object-list li.selected { border-color: var(--accent); background: #d7edf7; }
+
+.object-list li:hover,
+.object-list li.selected,
+.object-list li:focus-visible {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  outline: none;
+}
+
 .object-list .object-group-heading {
-  margin: 0.75rem 0 0.35rem;
-  padding: 0.2rem 0.1rem;
+  margin: 0.72rem 0 0.32rem;
+  padding: 0.18rem 0.08rem;
   border: 0;
   background: transparent;
   color: var(--accent);
   cursor: default;
-  font-size: 0.72rem;
+  font-size: 0.7rem;
   font-weight: 700;
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
-.object-list .object-group-heading:hover { border-color: transparent; background: transparent; }
-.object-list .object-name { display: block; padding-right: 4.5rem; }
-.object-list .meta { display: block; color: var(--muted); font-size: 0.78rem; margin-top: 0.2rem; }
-.object-list .type-tag {
-  float: right;
-  max-width: 4.25rem;
+
+.object-list .object-group-heading:hover {
+  border-color: transparent;
+  background: transparent;
+}
+
+.object-list .object-name {
+  display: block;
+  padding-right: 4.5rem;
   overflow: hidden;
-  padding: 0.12rem 0.35rem;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  color: #0b5f80;
-  font-size: 0.68rem;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+.object-list .meta {
+  display: block;
+  margin-top: 0.18rem;
+  color: var(--muted);
+  font-size: 0.76rem;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.object-list .type-tag {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  max-width: 4.1rem;
+  overflow: hidden;
+  padding: 0.1rem 0.32rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: #0b5f80;
+  font-size: 0.66rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .object-list .status-chip {
   display: inline-block;
-  margin-top: 0.35rem;
-  padding: 0.12rem 0.35rem;
+  max-width: 100%;
+  margin-top: 0.32rem;
+  padding: 0.1rem 0.32rem;
+  overflow: hidden;
   border: 1px solid var(--border);
   border-radius: 999px;
   color: #176734;
-  font-size: 0.68rem;
+  font-size: 0.66rem;
   line-height: 1.1;
-}
-.object-list .status-loaded, .object-list .status-mesh_loaded { color: #8df5a8; }
-.object-list .status-load_error, .object-list .status-missing_file, .object-list .status-unsafe_path, .object-list .status-unsupported_format, .object-list .status-unresolved_package_uri, .object-list .status-loader_failure, .object-list .status-url_not_served, .object-list .status-file_access_blocked, .object-list .status-required_mesh_failed_debug_fallback { color: #9d2633; border-color: rgba(196, 52, 52, 0.45); background: rgba(196, 52, 52, 0.08); }
-.inspector-table { width: 100%; border-collapse: collapse; font-size: 0.86rem; }
-.inspector-table th, .inspector-table td { padding: 0.35rem 0.2rem; border-bottom: 1px solid var(--border); vertical-align: top; }
-.inspector-table th { width: 38%; text-align: left; color: var(--muted); font-weight: 600; }
-code { color: #0b5f80; }
-
-@media (max-width: 900px) {
-  .app-shell { grid-template-columns: 1fr; grid-template-rows: auto minmax(24rem, 1fr) auto; height: auto; }
-  .object-panel, .details-panel { border: 0; border-bottom: 1px solid var(--border); max-height: 18rem; }
-  .viewport-panel { height: 55vh; }
-  .topbar { align-items: flex-start; flex-direction: column; }
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.dirty {
-  position: absolute;
-  z-index: 2;
-  right: 1rem;
-  top: 1rem;
-  border-color: var(--warn);
-  background: var(--overlay-surface);
+.object-list .status-loaded,
+.object-list .status-mesh_loaded {
+  color: #176734;
+  border-color: rgba(23, 103, 52, 0.35);
+  background: rgba(23, 103, 52, 0.07);
+}
+
+.object-list .status-load_error,
+.object-list .status-missing_file,
+.object-list .status-unsafe_path,
+.object-list .status-unsupported_format,
+.object-list .status-unresolved_package_uri,
+.object-list .status-loader_failure,
+.object-list .status-url_not_served,
+.object-list .status-file_access_blocked,
+.object-list .status-required_mesh_failed_debug_fallback {
+  color: #9d2633;
+  border-color: rgba(196, 52, 52, 0.45);
+  background: rgba(196, 52, 52, 0.08);
+}
+
+.inspector-table {
+  width: 100%;
+  max-width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
+  font-size: 0.8rem;
+}
+
+.inspector-table th,
+.inspector-table td {
+  min-width: 0;
+  padding: 0.34rem 0.2rem;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+
+.inspector-table th {
+  width: 36%;
+  color: var(--muted);
+  font-weight: 600;
+  text-align: left;
+}
+
+code {
+  color: #0b5f80;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.transform-editor {
+  margin-top: 0.8rem;
+  padding: 0.68rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: rgba(248, 250, 252, 0.92);
+}
+
+.transform-editor h3 {
+  margin: 0 0 0.42rem;
+  color: var(--accent);
+  font-size: 0.86rem;
+}
+
+.edit-mode-active {
+  padding-left: 0.5rem;
+  border-left: 3px solid var(--accent);
+}
+
+.edit-note,
+.edit-lock-reason {
+  margin: 0 0 0.6rem;
+  color: var(--muted);
+  font-size: 0.78rem;
+  overflow-wrap: anywhere;
+}
+
+.edit-lock-reason {
   color: #5f3a00;
 }
-.transform-editor {
-  margin-top: 0.85rem;
-  padding: 0.75rem;
-  border: 1px solid var(--border);
-  border-radius: 0.5rem;
-  background: rgba(248, 250, 252, 0.86);
+
+.transform-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.42rem;
 }
-.transform-editor h3 { margin: 0 0 0.45rem; font-size: 0.9rem; color: var(--accent); }
-.edit-mode-active { border-left: 3px solid var(--accent); padding-left: 0.5rem; }
-.edit-note, .edit-lock-reason { margin: 0 0 0.65rem; color: var(--muted); font-size: 0.8rem; }
-.edit-lock-reason { color: #5f3a00; }
-.transform-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.45rem; }
-.transform-grid label { color: var(--muted); font-size: 0.75rem; }
+
+.transform-grid label {
+  min-width: 0;
+  color: var(--muted);
+  font-size: 0.72rem;
+}
+
 .transform-grid input {
   display: block;
   width: 100%;
-  margin-top: 0.18rem;
-  padding: 0.35rem;
+  min-width: 0;
+  margin-top: 0.16rem;
+  padding: 0.34rem;
   border: 1px solid var(--border);
   border-radius: 0.35rem;
   background: #ffffff;
   color: var(--text);
 }
-.transform-grid input:disabled { cursor: not-allowed; opacity: 0.55; }
-.editor-actions { margin-top: 0.65rem; }
+
+.transform-grid input:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.editor-actions {
+  display: flex;
+  gap: 0.42rem;
+  margin-top: 0.62rem;
+  flex-wrap: wrap;
+}
+
 .editor-actions button {
+  flex: 1 1 7rem;
+  min-width: 0;
+  padding: 0.42rem 0.58rem;
   border: 1px solid var(--border);
   border-radius: 0.4rem;
   background: var(--panel-2);
   color: var(--text);
   cursor: pointer;
-  padding: 0.45rem 0.65rem;
+  white-space: normal;
 }
-.editor-actions button:disabled { cursor: not-allowed; opacity: 0.45; }
+
+.editor-actions button:not(:disabled):hover,
+.editor-actions button:focus-visible {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  outline: none;
+}
+
+.editor-actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.object-panel::-webkit-scrollbar,
+.details-panel::-webkit-scrollbar {
+  width: 0.65rem;
+}
+
+.object-panel::-webkit-scrollbar-thumb,
+.details-panel::-webkit-scrollbar-thumb {
+  border: 0.16rem solid transparent;
+  border-radius: 999px;
+  background: #aebbc8;
+  background-clip: padding-box;
+}
+
+@media (max-width: 1100px) {
+  .topbar {
+    flex-direction: column;
+  }
+
+  .topbar > div:first-child,
+  .toolbar {
+    width: 100%;
+    flex-basis: auto;
+  }
+
+  .toolbar {
+    justify-content: flex-start;
+  }
+
+  .app-shell {
+    grid-template-columns: minmax(11rem, 15rem) minmax(0, 1fr) minmax(14rem, 18rem);
+  }
+}
+
+@media (max-width: 820px) {
+  .topbar {
+    padding: 0.55rem 0.65rem;
+  }
+
+  .topbar p {
+    display: none;
+  }
+
+  .toolbar {
+    gap: 0.35rem;
+  }
+
+  .toolbar-button,
+  .file-picker,
+  .toolbar-number,
+  .toolbar-toggle {
+    min-height: 2rem;
+    padding-top: 0.35rem;
+    padding-bottom: 0.35rem;
+  }
+
+  .app-shell {
+    grid-template-columns: minmax(11rem, 15rem) minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr) minmax(9rem, 28vh);
+  }
+
+  .object-panel {
+    grid-column: 1;
+    grid-row: 1;
+    border-right: 1px solid var(--border);
+    border-bottom: 0;
+    max-height: none;
+  }
+
+  .viewport-panel {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .details-panel {
+    display: grid;
+    grid-column: 1 / -1;
+    grid-row: 2;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.8rem;
+    max-height: none;
+    border-top: 1px solid var(--border);
+    border-left: 0;
+  }
+
+  .details-panel section {
+    min-width: 0;
+    overflow: hidden;
+  }
+}
+
+@media (max-width: 620px) {
+  .toolbar {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .file-picker {
+    grid-column: 1 / -1;
+    width: 100%;
+  }
+
+  .toolbar-button,
+  .toolbar-number,
+  .toolbar-toggle {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .app-shell {
+    grid-template-columns: minmax(9rem, 40vw) minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr) minmax(8rem, 26vh);
+  }
+
+  .object-panel,
+  .details-panel {
+    padding: 0.55rem;
+  }
+
+  .details-panel {
+    gap: 0.5rem;
+  }
+
+  .transform-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
 
 body.embedded-mode {
+  display: block;
+  width: 100%;
+  height: 100%;
   overflow: hidden;
 }
+
 body.embedded-mode .topbar,
 body.embedded-mode .object-panel,
 body.embedded-mode .details-panel,
@@ -325,19 +755,31 @@ body.embedded-mode #warnings,
 body.embedded-mode .toolbar {
   display: none !important;
 }
+
 body.embedded-mode .app-shell {
-  grid-template-columns: 1fr;
-  height: 100vh;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr);
+  width: 100%;
+  height: 100%;
+  min-height: 0;
   padding: 0;
+  overflow: hidden;
 }
+
 body.embedded-mode .viewport-panel {
-  min-height: 100vh;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
   border-radius: 0;
+  overflow: hidden;
 }
+
 body.embedded-mode #scene-canvas {
   width: 100%;
   height: 100%;
 }
+
 body.embedded-mode #dirty-state::after {
   content: " Preview edits are not saved yet.";
 }


### PR DESCRIPTION
## Problem
The desktop builder still uses fixed window sizes and several scrollable widgets can force horizontal or page-level scrolling. The Web3D viewer also calculates its workspace height from a fixed top-bar height, so a wrapped toolbar can push the application outside the viewport. These behaviours make smaller screens and embedded side panels awkward to use.

## Changes
### Qt application and dialogs
- Add a reusable `ResponsiveWindowGuard` through the existing `applyCompactDialogDefaults()` path.
- Clamp normal windows to the active screen's available geometry on show, resize and window-state changes.
- Reduce oversized minimum dimensions when the available screen is smaller.
- Keep maximized and full-screen behaviour unchanged.
- Make scroll areas widget-resizable and disable nested horizontal scrollbars.
- Use vertical scrolling only where content genuinely needs it.
- Allow labels to wrap and form controls to shrink inside their layouts.
- Elide long list/tree entries instead of growing side panels.
- Keep tab labels compact with controlled tab buttons rather than widening the window.
- Improve focus, button, tab, tooltip and scrollbar styling consistently across dialogs.

### Web3D/Product View
- Make the page a fixed two-row application shell: dynamic top bar plus a bounded workspace.
- Remove the fixed `calc(100vh - 74px)` and `min-height: 34rem` assumptions.
- Prevent page-level horizontal and vertical scrolling.
- Keep scrolling local to the object and inspector panels.
- Ensure the canvas always receives the remaining bounded area.
- Wrap long inspector paths, warnings, metadata and toolbar labels.
- Add responsive layouts for medium and narrow windows while retaining both side panels.
- Keep embedded Product View at exactly 100% of its Qt container with no browser scrollbars.

## Validation
A focused regression test checks the screen-bound Qt guard, contained widget policies, internal-only Web3D scrolling, narrow-window layout and embedded-mode containment.

## Scope
- Three changed files.
- 999 changed lines, within the focused PR limit.
- No scene data, robot geometry, assets, transforms, controller, MoveIt, launch, hardware or motion behaviour is changed.
- Fake-hardware-first safety remains unchanged.

## Manual acceptance after CI
Open Workcell Studio at common desktop sizes, including approximately 1366x768, then verify:
1. The main window opens fully inside the usable screen.
2. Tabs, buttons and status text remain inside their groups.
3. Side lists do not show horizontal scrollbars.
4. Only content-heavy panels scroll vertically.
5. Embedded Product View fills its panel without browser scrollbars.
6. Standalone Web3D keeps the canvas visible while object and inspector panels scroll independently.