### PR TITLE
Give Product View an RViz-like light visual baseline

### DIFF
--- a/tests/test_workcell_web3d_rviz_light_baseline.py
+++ b/tests/test_workcell_web3d_rviz_light_baseline.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VIEWER = ROOT / "workcell_studio_web/viewer"
+INDEX = VIEWER / "index.html"
+BASELINE = VIEWER / "rviz_light_baseline.js"
+
+
+def test_rviz_light_baseline_loads_after_the_pinned_viewer_bundle():
+    index = INDEX.read_text(encoding="utf-8")
+    bundle_script = 'src="./dist/viewer.bundle.js"'
+    baseline_script = 'src="./rviz_light_baseline.js"'
+    assert bundle_script in index
+    assert baseline_script in index
+    assert index.index(bundle_script) < index.index(baseline_script)
+
+
+def test_rviz_light_baseline_is_light_clear_and_shadow_enabled():
+    source = BASELINE.read_text(encoding="utf-8")
+    for token in [
+        "background: 0xf2f4f6",
+        "renderer.outputColorSpace = THREE.SRGBColorSpace",
+        "renderer.toneMapping = THREE.ACESFilmicToneMapping",
+        "renderer.shadowMap.enabled = true",
+        "renderer.shadowMap.type = THREE.PCFSoftShadowMap",
+        "rviz_light_hemisphere",
+        "rviz_light_key",
+        "gridMajor: 0x8996a3",
+        "gridMinor: 0xc8d0d8",
+        "node.castShadow = shadows",
+        "node.receiveShadow = shadows",
+        "workcell-studio.rviz-light-baseline.v1",
+        "__WORKCELL_RVIZ_LIGHT_BASELINE__",
+    ]:
+        assert token in source
+
+
+def test_rviz_light_baseline_reuses_existing_scene_geometry():
+    source = BASELINE.read_text(encoding="utf-8")
+    for unwanted in [
+        "new THREE.PlaneGeometry",
+        "new THREE.MeshStandardMaterial",
+        "new THREE.DirectionalLight",
+        "new THREE.HemisphereLight",
+    ]:
+        assert unwanted not in source

--- a/workcell_studio_web/viewer/index.html
+++ b/workcell_studio_web/viewer/index.html
@@ -90,5 +90,6 @@
   </main>
 
   <script type="module" src="./dist/viewer.bundle.js"></script>
+  <script type="module" src="./rviz_light_baseline.js"></script>
 </body>
 </html>

--- a/workcell_studio_web/viewer/rviz_light_baseline.js
+++ b/workcell_studio_web/viewer/rviz_light_baseline.js
@@ -1,0 +1,129 @@
+import { THREE } from './dist/viewer.bundle.js';
+
+const BASELINE = Object.freeze({
+  background: 0xf2f4f6,
+  sky: 0xffffff,
+  groundBounce: 0xcbd3dc,
+  gridMajor: 0x8996a3,
+  gridMinor: 0xc8d0d8,
+  exposure: 1.08,
+});
+const PATCH_FLAG = Symbol.for('workcell-studio.rviz-light-baseline.v1');
+const configuredRenderers = new WeakSet();
+const configuredScenes = new WeakSet();
+const configuredMeshes = new WeakSet();
+
+function isHelper(node) {
+  const data = node?.userData || {};
+  const identity = [
+    node?.name,
+    data?.source_layer,
+    data?.role,
+    data?.category,
+    data?.item?.source_layer,
+    data?.item?.role,
+    data?.item?.category,
+  ].map(value => String(value || '').toLowerCase().replace(/[_-]+/g, ' ')).join(' ');
+  return Boolean(
+    node?.isGridHelper ||
+    node?.isAxesHelper ||
+    data?.exclude_from_fit_bounds === true ||
+    /\b(debug|diagnostic|overlay|helper|zone|reach|fov|warning)\b/.test(identity)
+  );
+}
+
+function isTranslucent(material) {
+  const materials = Array.isArray(material) ? material : [material];
+  return materials.some(entry => entry?.transparent && Number(entry.opacity ?? 1) < 0.9);
+}
+
+function configureRenderer(renderer) {
+  if (configuredRenderers.has(renderer)) return;
+  configuredRenderers.add(renderer);
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+  renderer.toneMapping = THREE.ACESFilmicToneMapping;
+  renderer.toneMappingExposure = BASELINE.exposure;
+  renderer.shadowMap.enabled = true;
+  renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+  renderer.setClearColor(BASELINE.background, 1);
+}
+
+function configureScene(scene) {
+  if (configuredScenes.has(scene)) return;
+  configuredScenes.add(scene);
+  if (!scene.background?.isColor) scene.background = new THREE.Color();
+  scene.background.setHex(BASELINE.background);
+  scene.fog = null;
+
+  for (const child of scene.children) {
+    if (child?.isHemisphereLight) {
+      child.name = 'rviz_light_hemisphere';
+      child.color.setHex(BASELINE.sky);
+      child.groundColor.setHex(BASELINE.groundBounce);
+      child.intensity = 1.45;
+    } else if (child?.isDirectionalLight) {
+      child.name = 'rviz_light_key';
+      child.color.setHex(0xffffff);
+      child.intensity = 1.6;
+      child.position.set(3.5, -4.5, 6.5);
+      child.castShadow = true;
+      child.shadow.mapSize.set(2048, 2048);
+      Object.assign(child.shadow.camera, {
+        near: 0.1,
+        far: 20,
+        left: -5,
+        right: 5,
+        top: 5,
+        bottom: -5,
+      });
+      child.shadow.camera.updateProjectionMatrix();
+      child.shadow.bias = -0.00025;
+      child.shadow.normalBias = 0.018;
+    } else if (child?.isGridHelper) {
+      child.position.z = 0.002;
+      child.renderOrder = -5;
+      const materials = Array.isArray(child.material) ? child.material : [child.material];
+      materials.forEach((material, index) => {
+        if (!material) return;
+        material.color?.setHex(index === 0 ? BASELINE.gridMajor : BASELINE.gridMinor);
+        material.transparent = true;
+        material.opacity = index === 0 ? 0.82 : 0.62;
+        material.depthWrite = false;
+      });
+    }
+  }
+}
+
+function configureNewMeshShadows(scene) {
+  scene.traverse(node => {
+    if (!node?.isMesh || configuredMeshes.has(node)) return;
+    configuredMeshes.add(node);
+    const shadows = !isHelper(node) && !isTranslucent(node.material);
+    node.castShadow = shadows;
+    node.receiveShadow = shadows;
+  });
+}
+
+function install() {
+  const prototype = THREE.WebGLRenderer?.prototype;
+  if (!prototype || prototype[PATCH_FLAG]) return;
+  const originalRender = prototype.render;
+  prototype.render = function renderWithRvizLightBaseline(scene, camera) {
+    configureRenderer(this);
+    configureScene(scene);
+    const frame = (scene.userData.rvizLightMeshScanFrame || 0) + 1;
+    scene.userData.rvizLightMeshScanFrame = frame % 20;
+    if (frame === 1 || frame % 20 === 0) configureNewMeshShadows(scene);
+    return originalRender.call(this, scene, camera);
+  };
+  prototype[PATCH_FLAG] = true;
+  window.__WORKCELL_RVIZ_LIGHT_BASELINE__ = Object.freeze({
+    enabled: true,
+    version: 1,
+    background: '#f2f4f6',
+    shadows: 'pcf_soft',
+    tone_mapping: 'aces_filmic',
+  });
+}
+
+install();


### PR DESCRIPTION
## Problem
Product View can still feel dark and visually flat even though its UI shell is light. The grid, robot, tool, table and small environment objects need a clearer RViz-like presentation before support-surface placement work begins.

## Changes
- Load a lightweight Product View visual-baseline module after the pinned viewer bundle.
- Force a neutral light grey background (`#f2f4f6`).
- Use sRGB output, ACES filmic tone mapping and restrained exposure.
- Rebalance the existing hemisphere and directional lights instead of adding duplicate lights.
- Improve major/minor grid contrast while keeping the grid unobtrusive.
- Enable PCF soft shadows and configure physical opaque meshes to cast and receive shadows.
- Exclude zones, overlays, axes, grid helpers and translucent debug geometry from shadow casting.
- Re-scan asynchronously loaded meshes periodically so robot, tool and asset meshes receive the same visual treatment.
- Expose `window.__WORKCELL_RVIZ_LIGHT_BASELINE__` for browser diagnostics.

## Deliberate scope
- Three changed files and 177 changed lines.
- No generated bundle rewrite, asset changes or external downloads.
- No scene poses, transforms, gizmo behaviour, controllers, MoveIt, launch, hardware or robot motion changes.
- Existing Web3D readiness and fake-hardware-first behaviour remain unchanged.

## Validation
Focused tests confirm:
- the baseline loads after the pinned bundle;
- light background, tone mapping, grid, lighting and shadows are configured;
- no duplicate ground plane, materials or lights are created.

## Manual acceptance
Open canonical `ur5_2f_test` in standalone and embedded Product View and verify:
1. The background is clearly light grey rather than dark.
2. UR5, Robotiq, table and camera remain easy to distinguish.
3. Major and minor grid lines are visible without dominating the scene.
4. Opaque objects cast soft shadows onto physical receiving meshes.
5. Zones/debug overlays remain lightweight and do not create heavy shadows.
6. Camera fit, selection, edit patch, gizmo and scene readiness behaviour remain unchanged.