### PR TITLE
Make the gizmo follow real workcell placement tasks

### DIFF
--- a/tests/test_workcell_web3d_task_gizmo.py
+++ b/tests/test_workcell_web3d_task_gizmo.py
@@ -25,15 +25,13 @@ def test_task_gizmo_defaults_to_xy_move_and_yaw_only_rotation():
     for token in [
         "state.mode === 'move'",
         "state.selectedEditable === true",
-        "gizmo.setMode('translate')",
-        "gizmo.setSpace('world')",
-        "gizmo.showX = true",
-        "gizmo.showY = true",
-        "gizmo.showZ = runtime.freeHeight",
-        "gizmo.setMode('rotate')",
-        "gizmo.showX = false",
-        "gizmo.showY = false",
-        "gizmo.showZ = true",
+        "configureAxes(gizmo, 'translate', true, true, runtime.freeHeight)",
+        "configureAxes(gizmo, 'rotate', false, false, true)",
+        "if (gizmo.mode !== mode) gizmo.setMode(mode)",
+        "if (gizmo.space !== 'world') gizmo.setSpace('world')",
+        "if (gizmo.showX !== showX) gizmo.showX = showX",
+        "if (gizmo.showY !== showY) gizmo.showY = showY",
+        "if (gizmo.showZ !== showZ) gizmo.showZ = showZ",
         "rotation_axes: ['z']",
     ]:
         assert token in source
@@ -70,7 +68,9 @@ def test_shift_temporarily_enables_fine_snap_without_changing_saved_settings():
         "window.addEventListener('blur'",
         "numericInputValue('translation-snap', 0.01)",
         "numericInputValue('rotation-snap', 5)",
-        "THREE.MathUtils.degToRad(rotationDegrees)",
+        "THREE.MathUtils.degToRad",
+        "snapDiffers(gizmo.translationSnap, desiredTranslation)",
+        "snapDiffers(gizmo.rotationSnap, rotation)",
     ]:
         assert token in source
 

--- a/tests/test_workcell_web3d_task_gizmo.py
+++ b/tests/test_workcell_web3d_task_gizmo.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INDEX = ROOT / "workcell_studio_web/viewer/index.html"
+GIZMO = ROOT / "workcell_studio_web/viewer/workcell_task_gizmo.js"
+
+
+def test_task_gizmo_loads_after_viewer_visuals_and_surface_placement():
+    html = INDEX.read_text(encoding="utf-8")
+    ordered = [
+        "./dist/viewer.bundle.js",
+        "./rviz_light_baseline.js",
+        "./support_surface_placement.js",
+        "./workcell_task_gizmo.js",
+    ]
+    positions = [html.index(token) for token in ordered]
+    assert positions == sorted(positions)
+    assert html.count("./workcell_task_gizmo.js") == 1
+
+
+def test_task_gizmo_defaults_to_xy_move_and_yaw_only_rotation():
+    source = GIZMO.read_text(encoding="utf-8")
+
+    for token in [
+        "state.mode === 'move'",
+        "state.selectedEditable === true",
+        "gizmo.setMode('translate')",
+        "gizmo.setSpace('world')",
+        "gizmo.showX = true",
+        "gizmo.showY = true",
+        "gizmo.showZ = runtime.freeHeight",
+        "gizmo.setMode('rotate')",
+        "gizmo.showX = false",
+        "gizmo.showY = false",
+        "gizmo.showZ = true",
+        "rotation_axes: ['z']",
+    ]:
+        assert token in source
+
+    assert "setMode('scale')" not in source
+
+
+def test_free_height_is_explicit_and_pauses_surface_snapping():
+    source = GIZMO.read_text(encoding="utf-8")
+
+    for token in [
+        "free-height-toggle",
+        "Surface move (XY)",
+        "Free height (XYZ)",
+        "support-surface placement controls Z",
+        "window.__WORKCELL_SUPPORT_PLACEMENT_V1__?.clear?.()",
+        "if (runtime.freeHeight) queueMicrotask(clearSupportPlacement)",
+        "runtime.toggle.disabled = !editableMove",
+        "state.mode !== 'move' && runtime.freeHeight",
+        "runtime.selectedItemId !== state.selectedItemId",
+    ]:
+        assert token in source
+
+
+def test_shift_temporarily_enables_fine_snap_without_changing_saved_settings():
+    source = GIZMO.read_text(encoding="utf-8")
+
+    for token in [
+        "FINE_TRANSLATION_M = 0.001",
+        "FINE_ROTATION_DEG = 1",
+        "event.key === 'Shift'",
+        "setFineMode(true)",
+        "setFineMode(false)",
+        "window.addEventListener('blur'",
+        "numericInputValue('translation-snap', 0.01)",
+        "numericInputValue('rotation-snap', 5)",
+        "THREE.MathUtils.degToRad(rotationDegrees)",
+    ]:
+        assert token in source
+
+    assert ".value =" not in source
+
+
+def test_task_gizmo_is_preview_only_and_does_not_add_motion_or_source_writes():
+    source = GIZMO.read_text(encoding="utf-8").lower()
+
+    for forbidden in [
+        "fetch(",
+        "xmlhttprequest",
+        "websocket",
+        "execute_trajectory",
+        "getmotionplan",
+        "/plan_kinematic_path",
+        "environment.yaml",
+        "object_placement.yaml",
+        "writefile",
+        "setmode('scale')",
+    ]:
+        assert forbidden not in source
+
+    assert "__WORKCELL_TASK_GIZMO_V1__" in GIZMO.read_text(encoding="utf-8")
+    assert "workcell:gizmo-task-mode" in GIZMO.read_text(encoding="utf-8")

--- a/tests/test_workcell_web3d_task_gizmo.py
+++ b/tests/test_workcell_web3d_task_gizmo.py
@@ -56,7 +56,7 @@ def test_free_height_is_explicit_and_pauses_surface_snapping():
         assert token in source
 
 
-def test_shift_temporarily_enables_fine_snap_without_changing_saved_settings():
+def test_shift_temporarily_enables_fine_snap_and_restores_user_values():
     source = GIZMO.read_text(encoding="utf-8")
 
     for token in [
@@ -66,15 +66,17 @@ def test_shift_temporarily_enables_fine_snap_without_changing_saved_settings():
         "setFineMode(true)",
         "setFineMode(false)",
         "window.addEventListener('blur'",
-        "numericInputValue('translation-snap', 0.01)",
-        "numericInputValue('rotation-snap', 5)",
+        "runtime.savedTranslationValue = translation.value",
+        "runtime.savedRotationValue = rotation.value",
+        "translation.value = String(FINE_TRANSLATION_M)",
+        "rotation.value = String(FINE_ROTATION_DEG)",
+        "translation.value = runtime.savedTranslationValue",
+        "rotation.value = runtime.savedRotationValue",
         "THREE.MathUtils.degToRad",
         "snapDiffers(gizmo.translationSnap, desiredTranslation)",
         "snapDiffers(gizmo.rotationSnap, rotation)",
     ]:
         assert token in source
-
-    assert ".value =" not in source
 
 
 def test_task_gizmo_is_preview_only_and_does_not_add_motion_or_source_writes():

--- a/workcell_studio_web/viewer/index.html
+++ b/workcell_studio_web/viewer/index.html
@@ -92,5 +92,6 @@
   <script type="module" src="./dist/viewer.bundle.js"></script>
   <script type="module" src="./rviz_light_baseline.js"></script>
   <script type="module" src="./support_surface_placement.js"></script>
+  <script type="module" src="./workcell_task_gizmo.js"></script>
 </body>
 </html>

--- a/workcell_studio_web/viewer/workcell_task_gizmo.js
+++ b/workcell_studio_web/viewer/workcell_task_gizmo.js
@@ -12,6 +12,8 @@ const runtime = {
   toggle: null,
   labelText: null,
   listenersInstalled: false,
+  savedTranslationValue: null,
+  savedRotationValue: null,
 };
 
 function editorState() {
@@ -109,12 +111,8 @@ function snapDiffers(current, desired) {
 
 function applySnap(gizmo, mode) {
   const enabled = snapEnabled();
-  const translation = enabled
-    ? (runtime.fineMode ? FINE_TRANSLATION_M : numericInputValue('translation-snap', 0.01))
-    : null;
-  const rotation = enabled
-    ? THREE.MathUtils.degToRad(runtime.fineMode ? FINE_ROTATION_DEG : numericInputValue('rotation-snap', 5))
-    : null;
+  const translation = enabled ? numericInputValue('translation-snap', 0.01) : null;
+  const rotation = enabled ? THREE.MathUtils.degToRad(numericInputValue('rotation-snap', 5)) : null;
   const desiredTranslation = mode === 'move' ? translation : (enabled ? numericInputValue('translation-snap', 0.01) : null);
 
   if (snapDiffers(gizmo.translationSnap, desiredTranslation)) gizmo.setTranslationSnap(desiredTranslation);
@@ -159,10 +157,27 @@ function applyTaskGizmo() {
   }
 }
 
+function applyFineInputOverride(enabled) {
+  const translation = document.getElementById('translation-snap');
+  const rotation = document.getElementById('rotation-snap');
+  if (enabled) {
+    if (translation && runtime.savedTranslationValue == null) runtime.savedTranslationValue = translation.value;
+    if (rotation && runtime.savedRotationValue == null) runtime.savedRotationValue = rotation.value;
+    if (translation) translation.value = String(FINE_TRANSLATION_M);
+    if (rotation) rotation.value = String(FINE_ROTATION_DEG);
+    return;
+  }
+  if (translation && runtime.savedTranslationValue != null) translation.value = runtime.savedTranslationValue;
+  if (rotation && runtime.savedRotationValue != null) rotation.value = runtime.savedRotationValue;
+  runtime.savedTranslationValue = null;
+  runtime.savedRotationValue = null;
+}
+
 function setFineMode(enabled) {
   const next = Boolean(enabled);
   if (runtime.fineMode === next) return;
   runtime.fineMode = next;
+  applyFineInputOverride(next);
   applyTaskGizmo();
   publishMode();
 }

--- a/workcell_studio_web/viewer/workcell_task_gizmo.js
+++ b/workcell_studio_web/viewer/workcell_task_gizmo.js
@@ -1,0 +1,214 @@
+import { THREE, TransformControls } from './dist/viewer.bundle.js';
+
+const PATCH_FLAG = Symbol.for('workcell-studio.task-gizmo.v1');
+const FINE_TRANSLATION_M = 0.001;
+const FINE_ROTATION_DEG = 1;
+
+const runtime = {
+  gizmo: null,
+  freeHeight: false,
+  fineMode: false,
+  selectedItemId: '',
+  toggle: null,
+  labelText: null,
+  listenersInstalled: false,
+};
+
+function editorState() {
+  try {
+    return window.__WORKCELL_EDITOR_API_V1__?.getState?.() || null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function isTypingTarget(target) {
+  const tag = String(target?.tagName || '').toLowerCase();
+  return tag === 'input' || tag === 'textarea' || tag === 'select' || target?.isContentEditable === true;
+}
+
+function numericInputValue(id, fallback) {
+  const value = Number(document.getElementById(id)?.value);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function snapEnabled() {
+  return Boolean(document.getElementById('snap-toggle')?.checked);
+}
+
+function findGizmo(scene) {
+  let found = null;
+  scene?.traverse?.(node => {
+    if (!found && node instanceof TransformControls) found = node;
+  });
+  return found;
+}
+
+function clearSupportPlacement() {
+  window.__WORKCELL_SUPPORT_PLACEMENT_V1__?.clear?.();
+}
+
+function publishMode() {
+  const detail = {
+    free_height: runtime.freeHeight,
+    fine_mode: runtime.fineMode,
+    move_axes: runtime.freeHeight ? ['x', 'y', 'z'] : ['x', 'y'],
+    rotation_axes: ['z'],
+  };
+  window.dispatchEvent?.(new CustomEvent('workcell:gizmo-task-mode', { detail }));
+  window.parent?.postMessage?.({ type: 'workcell_gizmo_task_mode', ...detail }, '*');
+}
+
+function updateLabel() {
+  if (!runtime.toggle || !runtime.labelText) return;
+  runtime.toggle.checked = runtime.freeHeight;
+  runtime.labelText.textContent = runtime.freeHeight ? 'Free height (XYZ)' : 'Surface move (XY)';
+  runtime.toggle.parentElement.title = runtime.freeHeight
+    ? 'Z translation is enabled and table-surface snapping is paused. Turn this off to return to safe XY placement.'
+    : 'Default workcell placement: move in XY while support-surface placement controls Z. Hold Shift for 1 mm fine snap.';
+}
+
+function setFreeHeight(enabled, announce = true) {
+  runtime.freeHeight = Boolean(enabled);
+  clearSupportPlacement();
+  updateLabel();
+  applyTaskGizmo();
+  if (announce) publishMode();
+}
+
+function ensureToolbarControl() {
+  if (runtime.toggle?.isConnected) return;
+  const toolbar = document.querySelector('.toolbar');
+  if (!toolbar) return;
+
+  const label = document.createElement('label');
+  label.className = 'toolbar-toggle';
+  label.title = 'Default workcell placement: move in XY while support-surface placement controls Z. Hold Shift for 1 mm fine snap.';
+
+  const input = document.createElement('input');
+  input.id = 'free-height-toggle';
+  input.type = 'checkbox';
+  input.disabled = true;
+  input.addEventListener('change', () => setFreeHeight(input.checked));
+
+  const text = document.createElement('span');
+  text.id = 'workcell-gizmo-mode-label';
+  text.textContent = 'Surface move (XY)';
+
+  label.append(input, text);
+  toolbar.appendChild(label);
+  runtime.toggle = input;
+  runtime.labelText = text;
+}
+
+function applySnap(gizmo, mode) {
+  if (!snapEnabled()) {
+    gizmo.setTranslationSnap(null);
+    gizmo.setRotationSnap(null);
+    return;
+  }
+  const translation = runtime.fineMode
+    ? FINE_TRANSLATION_M
+    : numericInputValue('translation-snap', 0.01);
+  const rotationDegrees = runtime.fineMode
+    ? FINE_ROTATION_DEG
+    : numericInputValue('rotation-snap', 5);
+  gizmo.setTranslationSnap(mode === 'move' ? translation : numericInputValue('translation-snap', 0.01));
+  gizmo.setRotationSnap(THREE.MathUtils.degToRad(rotationDegrees));
+}
+
+function applyTaskGizmo() {
+  const state = editorState();
+  const gizmo = runtime.gizmo;
+  if (!state || !gizmo) return;
+
+  const editableMove = state.mode === 'move' && state.selectedEditable === true && Boolean(state.selectedItemId);
+  if (runtime.toggle) runtime.toggle.disabled = !editableMove;
+
+  if (runtime.selectedItemId && runtime.selectedItemId !== state.selectedItemId && runtime.freeHeight) {
+    runtime.freeHeight = false;
+    clearSupportPlacement();
+    updateLabel();
+  }
+  runtime.selectedItemId = state.selectedItemId || '';
+
+  if (state.mode !== 'move' && runtime.freeHeight) {
+    runtime.freeHeight = false;
+    clearSupportPlacement();
+    updateLabel();
+  }
+
+  if (state.mode === 'move') {
+    gizmo.setMode('translate');
+    gizmo.setSpace('world');
+    gizmo.showX = true;
+    gizmo.showY = true;
+    gizmo.showZ = runtime.freeHeight;
+    applySnap(gizmo, 'move');
+  } else if (state.mode === 'rotate') {
+    gizmo.setMode('rotate');
+    gizmo.setSpace('world');
+    gizmo.showX = false;
+    gizmo.showY = false;
+    gizmo.showZ = true;
+    applySnap(gizmo, 'rotate');
+  }
+}
+
+function setFineMode(enabled) {
+  const next = Boolean(enabled);
+  if (runtime.fineMode === next) return;
+  runtime.fineMode = next;
+  applyTaskGizmo();
+  publishMode();
+}
+
+function installInputListeners() {
+  if (runtime.listenersInstalled) return;
+  runtime.listenersInstalled = true;
+
+  window.addEventListener('keydown', event => {
+    if (event.key === 'Shift' && !isTypingTarget(event.target)) setFineMode(true);
+    if (event.key === 'Escape') setFineMode(false);
+  });
+  window.addEventListener('keyup', event => {
+    if (event.key === 'Shift') setFineMode(false);
+  });
+  window.addEventListener('blur', () => setFineMode(false));
+
+  const canvas = document.getElementById('scene-canvas');
+  canvas?.addEventListener('pointerdown', () => {
+    if (runtime.freeHeight) queueMicrotask(clearSupportPlacement);
+  });
+}
+
+function install() {
+  const prototype = THREE.WebGLRenderer?.prototype;
+  if (!prototype || prototype[PATCH_FLAG]) return;
+  const originalRender = prototype.render;
+
+  prototype.render = function renderWithTaskGizmo(scene, camera) {
+    runtime.gizmo = runtime.gizmo && runtime.gizmo.parent ? runtime.gizmo : findGizmo(scene);
+    ensureToolbarControl();
+    applyTaskGizmo();
+    const result = originalRender.call(this, scene, camera);
+    installInputListeners();
+    return result;
+  };
+  prototype[PATCH_FLAG] = true;
+
+  window.__WORKCELL_TASK_GIZMO_V1__ = Object.freeze({
+    enabled: true,
+    version: 1,
+    fine_translation_m: FINE_TRANSLATION_M,
+    fine_rotation_deg: FINE_ROTATION_DEG,
+    getState: () => ({
+      freeHeight: runtime.freeHeight,
+      fineMode: runtime.fineMode,
+      selectedItemId: runtime.selectedItemId,
+    }),
+    setFreeHeight: enabled => setFreeHeight(enabled),
+  });
+}
+
+install();

--- a/workcell_studio_web/viewer/workcell_task_gizmo.js
+++ b/workcell_studio_web/viewer/workcell_task_gizmo.js
@@ -101,20 +101,32 @@ function ensureToolbarControl() {
   runtime.labelText = text;
 }
 
+function snapDiffers(current, desired) {
+  if (current === desired) return false;
+  if (current == null || desired == null) return true;
+  return Math.abs(Number(current) - Number(desired)) > 1e-12;
+}
+
 function applySnap(gizmo, mode) {
-  if (!snapEnabled()) {
-    gizmo.setTranslationSnap(null);
-    gizmo.setRotationSnap(null);
-    return;
-  }
-  const translation = runtime.fineMode
-    ? FINE_TRANSLATION_M
-    : numericInputValue('translation-snap', 0.01);
-  const rotationDegrees = runtime.fineMode
-    ? FINE_ROTATION_DEG
-    : numericInputValue('rotation-snap', 5);
-  gizmo.setTranslationSnap(mode === 'move' ? translation : numericInputValue('translation-snap', 0.01));
-  gizmo.setRotationSnap(THREE.MathUtils.degToRad(rotationDegrees));
+  const enabled = snapEnabled();
+  const translation = enabled
+    ? (runtime.fineMode ? FINE_TRANSLATION_M : numericInputValue('translation-snap', 0.01))
+    : null;
+  const rotation = enabled
+    ? THREE.MathUtils.degToRad(runtime.fineMode ? FINE_ROTATION_DEG : numericInputValue('rotation-snap', 5))
+    : null;
+  const desiredTranslation = mode === 'move' ? translation : (enabled ? numericInputValue('translation-snap', 0.01) : null);
+
+  if (snapDiffers(gizmo.translationSnap, desiredTranslation)) gizmo.setTranslationSnap(desiredTranslation);
+  if (snapDiffers(gizmo.rotationSnap, rotation)) gizmo.setRotationSnap(rotation);
+}
+
+function configureAxes(gizmo, mode, showX, showY, showZ) {
+  if (gizmo.mode !== mode) gizmo.setMode(mode);
+  if (gizmo.space !== 'world') gizmo.setSpace('world');
+  if (gizmo.showX !== showX) gizmo.showX = showX;
+  if (gizmo.showY !== showY) gizmo.showY = showY;
+  if (gizmo.showZ !== showZ) gizmo.showZ = showZ;
 }
 
 function applyTaskGizmo() {
@@ -139,18 +151,10 @@ function applyTaskGizmo() {
   }
 
   if (state.mode === 'move') {
-    gizmo.setMode('translate');
-    gizmo.setSpace('world');
-    gizmo.showX = true;
-    gizmo.showY = true;
-    gizmo.showZ = runtime.freeHeight;
+    configureAxes(gizmo, 'translate', true, true, runtime.freeHeight);
     applySnap(gizmo, 'move');
   } else if (state.mode === 'rotate') {
-    gizmo.setMode('rotate');
-    gizmo.setSpace('world');
-    gizmo.showX = false;
-    gizmo.showY = false;
-    gizmo.showZ = true;
+    configureAxes(gizmo, 'rotate', false, false, true);
     applySnap(gizmo, 'rotate');
   }
 }


### PR DESCRIPTION
## Problem
The generic transform gizmo exposes more freedom than normal workcell layout tasks need. Users can accidentally pull an object away from its support surface, rotate it around inappropriate axes, or struggle to make small precise adjustments.

## Changes
- Add one lightweight post-bundle task-gizmo module; no viewer bundle rebuild.
- Default Move mode to **XY only**, leaving Z controlled by the support-surface placement helper from #2804.
- Keep Rotate mode **yaw/Z only**.
- Do not expose a scale gizmo.
- Add an explicit **Surface move (XY) / Free height (XYZ)** toolbar toggle.
- Keep Free height disabled unless the selected item is editable and Move mode is active.
- Pause support-surface snapping while Free height is enabled, then restore safe surface placement when it is turned off.
- Automatically turn Free height off when changing selection or leaving Move mode.
- Hold **Shift** for temporary fine snapping: **1 mm translation** and **1° rotation**.
- Temporarily override the existing snap inputs while Shift is held so both the gizmo and the viewer's existing snap pipeline use the same fine increments, then restore the user's original values on key-up, Escape or window blur.
- Reuse existing locked/editable rules, Undo/Redo, edit-patch export and support-placement behaviour.
- Guard gizmo setters so unchanged mode, axis and snap values are not rewritten every render frame.
- Expose `window.__WORKCELL_TASK_GIZMO_V1__` and a `workcell:gizmo-task-mode` event for diagnostics.

## Scope control
- Exactly **3 changed files**.
- **334 added lines**, no deletions.
- No generated/minified/binary changes.
- No `viewer.js` refactor or committed bundle rewrite.
- No scene, asset, robot hierarchy, controller, MoveIt, launch, hardware or motion changes.
- No source YAML writes or scene regeneration.

## Validation
Focused tests verify:
- load order after the viewer, light baseline and support-placement modules;
- XY-only translation and yaw-only rotation;
- explicit Free height behaviour and support-placement pause;
- Shift fine-snap activation and restoration of user snap values;
- guarded setters rather than redundant per-frame updates;
- no scale mode, network calls, motion commands or source-file writes.

## Manual acceptance
In canonical `ur5_2f_test`:
1. Select an editable bin, tray, pallet, fixture or pick object.
2. Enter Move mode and confirm only X/Y handles are available while the object remains on its support surface.
3. Drag to the table edges and confirm #2804 still keeps the complete footprint inside the surface.
4. Enable Free height and confirm the Z handle appears and support snapping pauses.
5. Disable Free height and confirm safe XY/surface placement returns.
6. Enter Rotate mode and confirm only yaw/Z rotation is available.
7. Hold Shift while moving or rotating and confirm 1 mm / 1° fine snapping, then release Shift and confirm the original snap values return.
8. Confirm generated robot, gripper, camera and other locked items remain unaffected.
9. Confirm Undo/Redo and Export Edit Patch still contain the final pose.