### PR TITLE
Simplify Product View around the placement workflow

### DIFF
--- a/tests/test_workcell_web3d_simple_product_ui.py
+++ b/tests/test_workcell_web3d_simple_product_ui.py
@@ -28,7 +28,7 @@ def test_common_actions_stay_visible_and_advanced_controls_move_under_more():
     html = INDEX.read_text(encoding="utf-8")
     assert "Workcell Studio Product View" in html
     assert "Arrange, review and validate the workcell scene." in html
-    assert ">Open scene" in html
+    assert "Open scene" in html
     assert ">Fit</button>" in html
     assert ">Undo</button>" in html
     assert ">Redo</button>" in html

--- a/tests/test_workcell_web3d_simple_product_ui.py
+++ b/tests/test_workcell_web3d_simple_product_ui.py
@@ -1,0 +1,129 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VIEWER = ROOT / "workcell_studio_web/viewer"
+INDEX = VIEWER / "index.html"
+CSS = VIEWER / "simple_product_ui.css"
+UI = VIEWER / "simple_product_ui.js"
+BUNDLE = VIEWER / "dist/viewer.bundle.js"
+
+
+def test_simple_ui_loads_after_viewer_placement_and_task_gizmo():
+    html = INDEX.read_text(encoding="utf-8")
+    ordered = [
+        "./dist/viewer.bundle.js",
+        "./rviz_light_baseline.js",
+        "./support_surface_placement.js",
+        "./workcell_task_gizmo.js",
+        "./simple_product_ui.js",
+    ]
+    positions = [html.index(token) for token in ordered]
+    assert positions == sorted(positions)
+    assert 'href="simple_product_ui.css"' in html
+    assert html.count("./simple_product_ui.js") == 1
+
+
+def test_common_actions_stay_visible_and_advanced_controls_move_under_more():
+    html = INDEX.read_text(encoding="utf-8")
+    assert "Workcell Studio Product View" in html
+    assert "Arrange, review and validate the workcell scene." in html
+    assert ">Open scene" in html
+    assert ">Fit</button>" in html
+    assert ">Undo</button>" in html
+    assert ">Redo</button>" in html
+    assert ">Export edits</button>" in html
+    assert 'id="task-gizmo-slot"' in html
+    assert 'id="more-tools"' in html
+
+    more = html.split('id="more-tools"', 1)[1].split("</details>", 1)[0]
+    for control in [
+        'id="clear-edits"',
+        'id="snap-toggle"',
+        'id="translation-snap"',
+        'id="rotation-snap"',
+        'id="labels-toggle"',
+        'id="debug-overlays-toggle"',
+        'id="show-initial-pose"',
+    ]:
+        assert control in more
+
+
+def test_side_panels_use_progressive_disclosure_instead_of_permanent_clutter():
+    html = INDEX.read_text(encoding="utf-8")
+    for token in [
+        "Scene items",
+        'id="scene-details"',
+        ">Scene details</summary>",
+        "Selected item",
+        'id="warnings-details"',
+        'id="warning-count"',
+    ]:
+        assert token in html
+
+    source = UI.read_text(encoding="utf-8")
+    for token in [
+        "PRIMARY_INSPECTOR_ROWS",
+        "Technical details (",
+        "details.hidden = count === 0",
+        "if (count > 0) details.open = true",
+        "moveTaskGizmoControl",
+        "more.open = false",
+    ]:
+        assert token in source
+
+
+def test_inspector_exposes_only_normal_workcell_pose_fields_by_default():
+    source = UI.read_text(encoding="utf-8")
+    for token in [
+        "Place item",
+        "Left / right (X)",
+        "Forward / back (Y)",
+        "Height (Z)",
+        "Turn (Yaw)",
+        "hold Shift for fine adjustment",
+        "setTransformFieldVisible('z', freeHeight)",
+        "setTransformFieldVisible('roll', false)",
+        "setTransformFieldVisible('pitch', false)",
+        "setTransformFieldVisible('scale_x', false)",
+        "setTransformFieldVisible('scale_y', false)",
+        "setTransformFieldVisible('scale_z', false)",
+    ]:
+        assert token in source
+
+
+def test_more_menu_and_side_disclosures_remain_bounded_without_page_scrolling():
+    css = CSS.read_text(encoding="utf-8")
+    for token in [
+        ".toolbar-more-panel",
+        "max-height: min(70vh, 30rem)",
+        "overflow-x: hidden",
+        "overflow-y: auto",
+        "overscroll-behavior: contain",
+        ".panel-disclosure",
+        ".technical-details",
+        ".simple-ui-hidden-field",
+        "body.embedded-mode .toolbar-more",
+    ]:
+        assert token in css
+
+
+def test_simple_ui_is_small_preview_only_and_does_not_rebuild_the_bundle():
+    source = UI.read_text(encoding="utf-8").lower()
+    for forbidden in [
+        "fetch(",
+        "xmlhttprequest",
+        "websocket",
+        "execute_trajectory",
+        "getmotionplan",
+        "/plan_kinematic_path",
+        "environment.yaml",
+        "object_placement.yaml",
+        "writefile",
+    ]:
+        assert forbidden not in source
+
+    assert len(UI.read_text(encoding="utf-8").splitlines()) < 260
+    assert len(CSS.read_text(encoding="utf-8").splitlines()) < 320
+    assert BUNDLE.exists()
+    assert "__WORKCELL_SIMPLE_PRODUCT_UI_V1__" in UI.read_text(encoding="utf-8")

--- a/workcell_studio_web/viewer/index.html
+++ b/workcell_studio_web/viewer/index.html
@@ -3,73 +3,82 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Workcell Studio Web 3D Viewer</title>
+  <title>Workcell Studio Product View</title>
   <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="simple_product_ui.css" />
 </head>
 <body>
   <header class="topbar">
-    <div>
-      <h1>Workcell Studio Web 3D Viewer</h1>
-      <p>Fast browser-based 3D visual review for Workcell Studio <code>web_scene.json</code> exports.</p>
+    <div class="product-title">
+      <h1>Product View</h1>
+      <p>Arrange, review and validate the workcell scene.</p>
     </div>
-    <div class="toolbar">
-      <label class="file-picker">
-        Load web_scene.json
+    <div class="toolbar" aria-label="Product View actions">
+      <label class="file-picker primary-action">
+        Open scene
         <input id="scene-file" type="file" accept="application/json,.json" />
       </label>
-      <button id="reset-view" class="toolbar-button" type="button" disabled title="Fit Scene / Reset View: recomputes and reapplies the fitted workcell overview from renderable bounds." aria-label="Fit Scene / Reset View">Fit Scene / Reset View</button>
+      <button id="reset-view" class="toolbar-button" type="button" disabled title="Fit Scene / Reset View: recomputes and reapplies the fitted workcell overview from renderable bounds." aria-label="Fit Scene / Reset View">Fit</button>
       <button id="undo-edit" class="toolbar-button" type="button" disabled>Undo</button>
       <button id="redo-edit" class="toolbar-button" type="button" disabled>Redo</button>
-      <button id="clear-edits" class="toolbar-button" type="button" disabled>Clear Preview Edits</button>
-      <button id="export-edit-patch" class="toolbar-button" type="button" disabled>Export Edit Patch</button>
-      <label class="toolbar-toggle" title="Snap editable preview transforms to grid increments">
-        <input id="snap-toggle" type="checkbox" checked />
-        Snap
-      </label>
-      <label class="toolbar-number" title="Translation snap increment in meters">
-        Move snap (m)
-        <input id="translation-snap" type="number" min="0" step="0.005" value="0.01" />
-      </label>
-      <label class="toolbar-number" title="Rotation snap increment in degrees">
-        Rot snap (deg)
-        <input id="rotation-snap" type="number" min="0" step="1" value="5" />
-      </label>
-      <label class="toolbar-toggle" title="Show read-only object labels in the viewer">
-        <input id="labels-toggle" type="checkbox" />
-        Labels
-      </label>
-      <label class="toolbar-toggle" title="Show zones and helper/debug overlay geometry in the viewer">
-        <input id="debug-overlays-toggle" type="checkbox" />
-        Show zones/debug overlays
-      </label>
-      <label class="toolbar-toggle" title="Preview the selected robot at its configured initial joint pose. This does not command the robot.">
-        <input id="show-initial-pose" type="checkbox" disabled />
-        Show Initial Pose
-      </label>
+      <button id="export-edit-patch" class="toolbar-button primary-action" type="button" disabled title="Export preview changes as an edit patch">Export edits</button>
+      <span id="task-gizmo-slot" class="task-gizmo-slot" aria-live="polite"></span>
+      <details id="more-tools" class="toolbar-more">
+        <summary>More</summary>
+        <div class="toolbar-more-panel">
+          <button id="clear-edits" class="toolbar-button" type="button" disabled>Clear edits</button>
+          <label class="toolbar-toggle" title="Snap editable preview transforms to grid increments">
+            <input id="snap-toggle" type="checkbox" checked />
+            Snap
+          </label>
+          <label class="toolbar-number" title="Translation snap increment in meters">
+            Move snap (m)
+            <input id="translation-snap" type="number" min="0" step="0.005" value="0.01" />
+          </label>
+          <label class="toolbar-number" title="Rotation snap increment in degrees">
+            Turn snap (deg)
+            <input id="rotation-snap" type="number" min="0" step="1" value="5" />
+          </label>
+          <label class="toolbar-toggle" title="Show read-only object labels in the viewer">
+            <input id="labels-toggle" type="checkbox" />
+            Object labels
+          </label>
+          <label class="toolbar-toggle" title="Show zones and helper/debug overlay geometry in the viewer">
+            <input id="debug-overlays-toggle" type="checkbox" />
+            Zones and helpers
+          </label>
+          <label class="toolbar-toggle" title="Preview the selected robot at its configured initial joint pose. This does not command the robot.">
+            <input id="show-initial-pose" type="checkbox" disabled />
+            Robot initial pose
+          </label>
+        </div>
+      </details>
     </div>
   </header>
 
   <main class="app-shell">
-    <aside class="object-panel" aria-label="Object list panel">
-      <h2>Objects</h2>
-      <section id="scene-summary" class="scene-summary state empty" aria-live="polite">
-        <h3>Scene summary</h3>
-        <div class="summary-grid">
-          <span>Scene</span><strong data-summary-field="scene-name">No scene loaded</strong>
-          <span>Renderable</span><strong data-summary-field="renderable-count">0</strong>
-          <span>Meshes loaded</span><strong data-summary-field="mesh-loaded-count">0</strong>
-          <span>Fallbacks</span><strong data-summary-field="fallback-count">0</strong>
-          <span>Missing/failed meshes</span><strong data-summary-field="mesh-failed-count">0</strong>
-          <span>Generated/locked</span><strong data-summary-field="generated-locked-count">0</strong>
-          <span>Editable layout/env</span><strong data-summary-field="editable-count">0</strong>
-          <span>Robot preview</span><strong data-summary-field="robot-preview-mode">mesh rows</strong>
-        </div>
-      </section>
-      <div id="empty-state" class="state empty">Choose an exported <code>web_scene.json</code> file to begin.</div>
+    <aside class="object-panel" aria-label="Scene items panel">
+      <h2>Scene items</h2>
+      <details id="scene-details" class="panel-disclosure">
+        <summary>Scene details</summary>
+        <section id="scene-summary" class="scene-summary state empty" aria-live="polite">
+          <div class="summary-grid">
+            <span>Scene</span><strong data-summary-field="scene-name">No scene loaded</strong>
+            <span>Renderable</span><strong data-summary-field="renderable-count">0</strong>
+            <span>Meshes loaded</span><strong data-summary-field="mesh-loaded-count">0</strong>
+            <span>Fallbacks</span><strong data-summary-field="fallback-count">0</strong>
+            <span>Missing/failed</span><strong data-summary-field="mesh-failed-count">0</strong>
+            <span>Generated/locked</span><strong data-summary-field="generated-locked-count">0</strong>
+            <span>Editable</span><strong data-summary-field="editable-count">0</strong>
+            <span>Robot preview</span><strong data-summary-field="robot-preview-mode">mesh rows</strong>
+          </div>
+        </section>
+      </details>
+      <div id="empty-state" class="state empty">Open a scene to start.</div>
       <ul id="object-list" class="object-list"></ul>
     </aside>
 
-    <section class="viewport-panel" aria-label="3D canvas area">
+    <section class="viewport-panel" aria-label="3D product view">
       <div id="error-state" class="state error" hidden></div>
       <div id="dirty-state" class="state dirty" hidden>Unsaved preview edits</div>
       <div id="initial-pose-status" class="state preview-status" hidden>Initial pose preview</div>
@@ -77,15 +86,15 @@
       <div id="label-layer" class="label-layer" aria-hidden="true"></div>
     </section>
 
-    <aside class="details-panel" aria-label="Inspector and warnings panel">
-      <section>
-        <h2>Inspector</h2>
-        <div id="inspector" class="state empty">Select an object from the list or canvas.</div>
+    <aside class="details-panel" aria-label="Selected item and warnings panel">
+      <section class="selected-item-section">
+        <h2>Selected item</h2>
+        <div id="inspector" class="state empty">Select an item from the list or the scene.</div>
       </section>
-      <section>
-        <h2>Warnings</h2>
+      <details id="warnings-details" class="panel-disclosure warning-disclosure" hidden>
+        <summary>Warnings <span id="warning-count" class="disclosure-count">0</span></summary>
         <div id="warnings" class="warnings state empty">No scene loaded.</div>
-      </section>
+      </details>
     </aside>
   </main>
 
@@ -93,5 +102,6 @@
   <script type="module" src="./rviz_light_baseline.js"></script>
   <script type="module" src="./support_surface_placement.js"></script>
   <script type="module" src="./workcell_task_gizmo.js"></script>
+  <script type="module" src="./simple_product_ui.js"></script>
 </body>
 </html>

--- a/workcell_studio_web/viewer/simple_product_ui.css
+++ b/workcell_studio_web/viewer/simple_product_ui.css
@@ -1,0 +1,288 @@
+/* Focused Product View layer: keep common actions visible and technical controls optional. */
+.product-title {
+  flex: 0 0 auto;
+  min-width: 9rem;
+}
+
+.product-title h1 {
+  font-size: 1rem;
+}
+
+.product-title p {
+  max-width: 22rem;
+  margin-top: 0.08rem;
+  font-size: 0.75rem;
+}
+
+.topbar {
+  align-items: center;
+  padding: 0.5rem 0.7rem;
+}
+
+.toolbar {
+  flex-basis: auto;
+  gap: 0.38rem;
+}
+
+.toolbar .primary-action {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: #083f55;
+  font-weight: 650;
+}
+
+.toolbar .primary-action:not(:disabled):hover,
+.toolbar .primary-action:focus-visible {
+  background: #c4e5f3;
+}
+
+.task-gizmo-slot {
+  display: contents;
+}
+
+.toolbar-more {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.toolbar-more > summary {
+  min-height: 2.25rem;
+  padding: 0.48rem 0.7rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--panel-2);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: 650;
+  line-height: 1.15;
+  list-style: none;
+  user-select: none;
+}
+
+.toolbar-more > summary::-webkit-details-marker {
+  display: none;
+}
+
+.toolbar-more > summary::after {
+  content: "▾";
+  margin-left: 0.42rem;
+  color: var(--muted);
+}
+
+.toolbar-more[open] > summary,
+.toolbar-more > summary:hover,
+.toolbar-more > summary:focus-visible {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  outline: none;
+}
+
+.toolbar-more-panel {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 0.42rem);
+  right: 0;
+  display: grid;
+  grid-template-columns: minmax(10rem, 1fr);
+  gap: 0.42rem;
+  width: min(18rem, calc(100vw - 1.4rem));
+  max-height: min(70vh, 30rem);
+  padding: 0.62rem;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border: 1px solid var(--border);
+  border-radius: 0.65rem;
+  background: rgba(248, 250, 252, 0.99);
+  box-shadow: 0 0.65rem 1.8rem rgba(23, 32, 42, 0.2);
+}
+
+.toolbar-more-panel > * {
+  width: 100%;
+  justify-content: space-between;
+}
+
+.toolbar-more-panel .toolbar-button {
+  text-align: left;
+}
+
+.panel-disclosure {
+  width: 100%;
+  margin: 0 0 0.65rem;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: rgba(238, 242, 246, 0.72);
+}
+
+.panel-disclosure > summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.5rem 0.58rem;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 0.76rem;
+  font-weight: 700;
+  line-height: 1.2;
+  list-style: none;
+}
+
+.panel-disclosure > summary::-webkit-details-marker {
+  display: none;
+}
+
+.panel-disclosure > summary::after {
+  content: "+";
+  color: var(--accent);
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.panel-disclosure[open] > summary::after {
+  content: "−";
+}
+
+.panel-disclosure > summary:hover,
+.panel-disclosure > summary:focus-visible {
+  background: var(--accent-soft);
+  color: var(--text);
+  outline: none;
+}
+
+#scene-summary {
+  margin: 0;
+  border: 0;
+  border-top: 1px solid var(--border);
+  border-radius: 0;
+  background: var(--panel);
+}
+
+.disclosure-count {
+  min-width: 1.35rem;
+  padding: 0.06rem 0.35rem;
+  border-radius: 999px;
+  background: var(--error-surface);
+  color: var(--error);
+  text-align: center;
+}
+
+.warning-disclosure {
+  margin-top: 0.8rem;
+  border-color: rgba(178, 107, 0, 0.45);
+}
+
+.warning-disclosure #warnings {
+  margin: 0;
+  border: 0;
+  border-top: 1px solid rgba(178, 107, 0, 0.35);
+  border-radius: 0;
+}
+
+.selected-item-section {
+  min-width: 0;
+}
+
+.technical-details {
+  margin-top: 0.68rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--panel-2);
+}
+
+.technical-details > summary {
+  padding: 0.46rem 0.56rem;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 650;
+}
+
+.technical-details .inspector-table {
+  border-top: 1px solid var(--border);
+  background: var(--panel);
+}
+
+.simple-ui-hidden-field {
+  display: none !important;
+}
+
+.transform-editor h3 {
+  font-size: 0.9rem;
+}
+
+.transform-editor .edit-note {
+  line-height: 1.4;
+}
+
+body.simple-product-ui .details-panel {
+  gap: 0.65rem;
+}
+
+@media (max-width: 1100px) {
+  .topbar {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .topbar > div:first-child {
+    width: auto;
+  }
+
+  .toolbar {
+    width: auto;
+    justify-content: flex-end;
+  }
+}
+
+@media (max-width: 900px) {
+  .topbar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .product-title p {
+    display: none;
+  }
+
+  .toolbar {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .toolbar-more-panel {
+    right: auto;
+    left: 0;
+  }
+}
+
+@media (max-width: 620px) {
+  .toolbar {
+    display: flex;
+  }
+
+  .toolbar .file-picker,
+  .toolbar .toolbar-button,
+  .toolbar .toolbar-toggle,
+  .toolbar .toolbar-number {
+    width: auto;
+    justify-content: center;
+  }
+
+  .toolbar-more-panel {
+    position: fixed;
+    top: auto;
+    right: 0.55rem;
+    bottom: 0.55rem;
+    left: 0.55rem;
+    width: auto;
+    max-height: 65vh;
+  }
+}
+
+body.embedded-mode .toolbar-more,
+body.embedded-mode .panel-disclosure {
+  display: none !important;
+}

--- a/workcell_studio_web/viewer/simple_product_ui.js
+++ b/workcell_studio_web/viewer/simple_product_ui.js
@@ -1,0 +1,184 @@
+const SIMPLE_UI_VERSION = 1;
+const PRIMARY_INSPECTOR_ROWS = new Map([
+  ['label', 'Name'],
+  ['type', 'Type'],
+  ['details', 'Surface'],
+  ['pose xyz', 'Position'],
+  ['pose rpy', 'Rotation'],
+  ['editable', 'Editable'],
+  ['locked', 'Locked'],
+  ['support_surface_kind', 'Support'],
+  ['top_surface_z_m', 'Surface height'],
+  ['render_status', 'Visual'],
+]);
+
+const runtime = {
+  inspectorObserver: null,
+  warningObserver: null,
+  toolbarObserver: null,
+  installed: false,
+};
+
+function moveTaskGizmoControl() {
+  const slot = document.getElementById('task-gizmo-slot');
+  const input = document.getElementById('free-height-toggle');
+  const label = input?.closest('label');
+  if (slot && label && label.parentElement !== slot) slot.appendChild(label);
+}
+
+function firstTextNode(label) {
+  return Array.from(label?.childNodes || []).find(node => node.nodeType === Node.TEXT_NODE) || null;
+}
+
+function renameTransformField(name, labelText) {
+  const input = document.querySelector(`#inspector [data-transform-field="${name}"]`);
+  const label = input?.closest('label');
+  const text = firstTextNode(label);
+  if (text) text.textContent = labelText;
+}
+
+function setTransformFieldVisible(name, visible) {
+  const input = document.querySelector(`#inspector [data-transform-field="${name}"]`);
+  input?.closest('label')?.classList.toggle('simple-ui-hidden-field', !visible);
+}
+
+function syncTaskTransformFields() {
+  const freeHeight = Boolean(document.getElementById('free-height-toggle')?.checked);
+  setTransformFieldVisible('x', true);
+  setTransformFieldVisible('y', true);
+  setTransformFieldVisible('z', freeHeight);
+  setTransformFieldVisible('roll', false);
+  setTransformFieldVisible('pitch', false);
+  setTransformFieldVisible('yaw', true);
+  setTransformFieldVisible('scale_x', false);
+  setTransformFieldVisible('scale_y', false);
+  setTransformFieldVisible('scale_z', false);
+}
+
+function simplifyTransformEditor(editor) {
+  if (!editor) return;
+  const title = editor.querySelector('h3');
+  if (title) title.textContent = 'Place item';
+
+  const note = editor.querySelector('.edit-note');
+  if (note) {
+    note.textContent = 'Move on the surface, turn around Z and hold Shift for fine adjustment. Export edits when finished.';
+  }
+
+  renameTransformField('x', 'Left / right (X)');
+  renameTransformField('y', 'Forward / back (Y)');
+  renameTransformField('z', 'Height (Z)');
+  renameTransformField('yaw', 'Turn (Yaw)');
+  syncTaskTransformFields();
+}
+
+function buildTechnicalDetails(rows) {
+  if (!rows.length) return null;
+  const details = document.createElement('details');
+  details.className = 'technical-details';
+  const summary = document.createElement('summary');
+  summary.textContent = `Technical details (${rows.length})`;
+  const table = document.createElement('table');
+  table.className = 'inspector-table';
+  const body = document.createElement('tbody');
+  rows.forEach(row => body.appendChild(row));
+  table.appendChild(body);
+  details.append(summary, table);
+  return details;
+}
+
+function simplifyInspector() {
+  const inspector = document.getElementById('inspector');
+  if (!inspector) return;
+  const table = inspector.querySelector(':scope > .inspector-table');
+  if (!table || table.dataset.simpleProductUi === String(SIMPLE_UI_VERSION)) {
+    simplifyTransformEditor(inspector.querySelector('.transform-editor'));
+    return;
+  }
+
+  const technicalRows = [];
+  table.querySelectorAll('tbody > tr').forEach(row => {
+    const heading = row.querySelector('th');
+    const key = String(heading?.textContent || '').trim().toLowerCase();
+    const friendly = PRIMARY_INSPECTOR_ROWS.get(key);
+    if (friendly) heading.textContent = friendly;
+    else technicalRows.push(row);
+  });
+  table.dataset.simpleProductUi = String(SIMPLE_UI_VERSION);
+
+  const transformEditor = inspector.querySelector('.transform-editor');
+  const technical = buildTechnicalDetails(technicalRows);
+  if (technical) inspector.insertBefore(technical, transformEditor || null);
+  simplifyTransformEditor(transformEditor);
+}
+
+function updateWarningDisclosure() {
+  const details = document.getElementById('warnings-details');
+  const warnings = document.getElementById('warnings');
+  const countNode = document.getElementById('warning-count');
+  if (!details || !warnings || !countNode) return;
+
+  const items = warnings.querySelectorAll('.warning-item').length;
+  const count = items || (warnings.classList.contains('empty') ? 0 : 1);
+  countNode.textContent = String(count);
+  details.hidden = count === 0;
+  if (count > 0) details.open = true;
+}
+
+function closeMoreTools(event) {
+  const more = document.getElementById('more-tools');
+  if (!more?.open) return;
+  if (event.type === 'keydown' && event.key === 'Escape') {
+    more.open = false;
+    return;
+  }
+  if (event.type === 'pointerdown' && !more.contains(event.target)) more.open = false;
+}
+
+function installObservers() {
+  const inspector = document.getElementById('inspector');
+  if (inspector && !runtime.inspectorObserver) {
+    runtime.inspectorObserver = new MutationObserver(simplifyInspector);
+    runtime.inspectorObserver.observe(inspector, { childList: true, subtree: true });
+  }
+
+  const warnings = document.getElementById('warnings');
+  if (warnings && !runtime.warningObserver) {
+    runtime.warningObserver = new MutationObserver(updateWarningDisclosure);
+    runtime.warningObserver.observe(warnings, { childList: true, subtree: true, attributes: true, attributeFilter: ['class'] });
+  }
+
+  const toolbar = document.querySelector('.toolbar');
+  if (toolbar && !runtime.toolbarObserver) {
+    runtime.toolbarObserver = new MutationObserver(moveTaskGizmoControl);
+    runtime.toolbarObserver.observe(toolbar, { childList: true, subtree: true });
+  }
+}
+
+function install() {
+  if (runtime.installed) return;
+  runtime.installed = true;
+  document.body.classList.add('simple-product-ui');
+  installObservers();
+  moveTaskGizmoControl();
+  simplifyInspector();
+  updateWarningDisclosure();
+
+  document.addEventListener('change', event => {
+    if (event.target?.id === 'free-height-toggle') syncTaskTransformFields();
+  });
+  document.addEventListener('pointerdown', closeMoreTools);
+  document.addEventListener('keydown', closeMoreTools);
+
+  window.__WORKCELL_SIMPLE_PRODUCT_UI_V1__ = Object.freeze({
+    enabled: true,
+    version: SIMPLE_UI_VERSION,
+    refresh: () => {
+      moveTaskGizmoControl();
+      simplifyInspector();
+      updateWarningDisclosure();
+    },
+  });
+}
+
+install();


### PR DESCRIPTION
## Problem
Product View now has correct surface placement and a task-focused gizmo, but the interface still presents every technical control, scene metric and raw inspector field at once. The result is visually busy and makes the normal workflow harder to understand.

## Changes
- Rename the page to **Workcell Studio Product View** with a short task-oriented description.
- Keep only the common actions visible: **Open scene, Fit, Undo, Redo, Export edits** and the current surface/free-height placement mode.
- Move Clear edits, snap settings, labels, zones/helpers and robot initial-pose preview into one bounded **More** menu.
- Keep the More menu vertically contained with no page-level or horizontal scrolling.
- Rename the side panels to **Scene items** and **Selected item**.
- Collapse scene diagnostics under **Scene details** instead of showing them permanently.
- Hide the warnings section when there are no warnings and automatically reveal it when actionable warnings appear.
- Keep the normal inspector focused on name, type, pose, support and visual state; move raw paths, provenance and rendering metadata under **Technical details**.
- Rename transform fields for normal workcell use: Left/right, Forward/back, Height and Turn.
- Hide roll, pitch and scale fields from the normal workflow.
- Show Height only when PR #2805 Free height mode is enabled.
- Relocate the dynamically created Surface move / Free height control into the primary action row without duplicating it.
- Close the More menu on outside click or Escape.
- Preserve embedded Product View containment and the existing viewer, placement, gizmo, Undo/Redo and edit-patch behaviour.

## Scope control
- Exactly **4 changed files**.
- **669 additions and 58 deletions** (727 changed lines total), below the focused PR limit.
- No generated/minified/binary changes.
- No `viewer.js` refactor and no bundle rewrite.
- No Qt application changes in this PR.
- No scene, asset, transform, robot hierarchy, controller, MoveIt, launch, hardware or motion changes.
- No source YAML writes or scene regeneration.

## Validation
Focused tests verify:
- module and stylesheet load order after the viewer, light baseline, placement helper and task gizmo;
- common actions remain visible while advanced controls live under More;
- scene diagnostics, warnings and technical metadata use progressive disclosure;
- only task-relevant pose fields appear by default;
- the More menu remains bounded with internal vertical scrolling only;
- no bundle modifications, network calls, motion commands or source-file writes are introduced.

## Manual acceptance
In canonical `ur5_2f_test`:
1. Confirm the top row immediately exposes Open scene, Fit, Undo, Redo, Export edits and Surface move / Free height.
2. Confirm snap settings, labels, helpers, Clear edits and robot initial pose are available under More and do not overflow the window.
3. Select an editable item and confirm the normal inspector shows only useful placement information and X/Y/Yaw controls.
4. Enable Free height and confirm Height appears; disable it and confirm Height is hidden again.
5. Expand Technical details and confirm the original raw metadata remains available.
6. Confirm Scene details stays collapsed by default.
7. Confirm Warnings is hidden when empty and opens automatically when a real warning exists.
8. Confirm Move, Rotate, support-surface placement, Shift fine snap, Undo/Redo and Export edits continue to work.
9. Confirm embedded Product View still fills its Qt panel without browser scrollbars.