### PR TITLE
Add contextual workcell placement actions

### DIFF
--- a/tests/test_workcell_web3d_contextual_placement_actions.py
+++ b/tests/test_workcell_web3d_contextual_placement_actions.py
@@ -1,0 +1,140 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VIEWER = ROOT / "workcell_studio_web/viewer"
+INDEX = VIEWER / "index.html"
+ACTIONS = VIEWER / "contextual_placement_actions.js"
+CSS = VIEWER / "contextual_placement_actions.css"
+BUNDLE = VIEWER / "dist/viewer.bundle.js"
+
+
+def test_contextual_actions_load_after_collision_validation_and_simple_ui():
+    html = INDEX.read_text(encoding="utf-8")
+    ordered = [
+        "./dist/viewer.bundle.js",
+        "./support_surface_placement.js",
+        "./workcell_task_gizmo.js",
+        "./collision_placement_validation.js",
+        "./simple_product_ui.js",
+        "./contextual_placement_actions.js",
+    ]
+    positions = [html.index(token) for token in ordered]
+    assert positions == sorted(positions)
+    assert 'href="contextual_placement_actions.css"' in html
+    assert html.count("./contextual_placement_actions.js") == 1
+
+
+def test_actions_are_contextual_and_only_available_for_editable_items():
+    source = ACTIONS.read_text(encoding="utf-8")
+    for token in [
+        "state.selectedEditable === true",
+        "state.selectedItemId",
+        "Quick placement",
+        "Place on nearest surface",
+        "Centre on surface",
+        "Align left",
+        "Align right",
+        "Align front",
+        "Align back",
+        "Move to pick area",
+        "Move to place area",
+        "button.disabled = !availability[name]",
+    ]:
+        assert token in source
+
+
+def test_surface_actions_use_rendered_bounds_top_height_and_edge_margin():
+    source = ACTIONS.read_text(encoding="utf-8")
+    for token in [
+        "new Set(['workbench_body', 'table_surface', 'tabletop'])",
+        "new THREE.Box3().setFromObject(root)",
+        "top_surface_z_m",
+        "EDGE_MARGIN_M = 0.01",
+        "support.box.min.x + EDGE_MARGIN_M",
+        "support.box.max.x - EDGE_MARGIN_M",
+        "support.box.min.y + EDGE_MARGIN_M",
+        "support.box.max.y - EDGE_MARGIN_M",
+        "support.top - objectBox.min.z",
+        "clampCenterToSupport",
+        "inner.minX + inner.size.x / 2",
+        "inner.maxX - inner.size.x / 2",
+        "inner.minY + inner.size.y / 2",
+        "inner.maxY - inner.size.y / 2",
+    ]:
+        assert token in source
+
+
+def test_pick_and_place_actions_use_existing_task_zone_metadata():
+    source = ACTIONS.read_text(encoding="utf-8")
+    for token in [
+        "item?.zone_kind",
+        "item?.zone_type",
+        "item?.task_zone",
+        "item?.task_zone_name",
+        "zoneEntries('pick')",
+        "zoneEntries('place')",
+        "zone = zoneEntries(kind)[0]",
+        "containingOrNearestSupport(boxCenter(zone.box))",
+        "target.copy(clampCenterToSupport(boxCenter(zone.box), inner))",
+    ]:
+        assert token in source
+
+
+def test_actions_commit_once_through_existing_transform_editor_and_reject_collisions():
+    source = ACTIONS.read_text(encoding="utf-8")
+    for token in [
+        "fields.x.value = Number(position.x).toFixed(6)",
+        "fields.y.value = Number(position.y).toFixed(6)",
+        "fields.z.value = Number(position.z).toFixed(6)",
+        "fields.x.dispatchEvent(new Event('input', { bubbles: true }))",
+        "__WORKCELL_COLLISION_PLACEMENT_V1__?.validateItem",
+        "editorApi()?.undo?.()",
+        "action reverted",
+        "workcell:contextual-placement-action",
+    ]:
+        assert token in source
+
+
+def test_action_refresh_has_a_stable_signature_instead_of_a_dom_loop():
+    source = ACTIONS.read_text(encoding="utf-8")
+    for token in [
+        "function sectionSignature",
+        "section.dataset.signature = sectionSignature",
+        "if (existing?.dataset.signature === signature) return",
+        "new MutationObserver(() => queueMicrotask(refreshActions))",
+    ]:
+        assert token in source
+
+
+def test_structural_actions_are_explicitly_deferred_until_patch_persistence_exists():
+    source = ACTIONS.read_text(encoding="utf-8")
+    assert "structural_actions: 'deferred_until_persistent_add_remove_patch_support'" in source
+    assert "Duplicate" not in source
+    assert "Delete item" not in source
+
+
+def test_contextual_actions_are_preview_only_and_do_not_rebuild_the_bundle():
+    source = ACTIONS.read_text(encoding="utf-8").lower()
+    for forbidden in [
+        "fetch(",
+        "xmlhttprequest",
+        "websocket",
+        "execute_trajectory",
+        "getmotionplan",
+        "/plan_kinematic_path",
+        "environment.yaml",
+        "object_placement.yaml",
+        "writefile",
+        "unlink(",
+    ]:
+        assert forbidden not in source
+
+    css = CSS.read_text(encoding="utf-8")
+    assert ".contextual-placement-grid" in css
+    assert "grid-template-columns: repeat(2, minmax(0, 1fr))" in css
+    assert "body.embedded-mode .contextual-placement-actions" in css
+    assert len(ACTIONS.read_text(encoding="utf-8").splitlines()) < 500
+    assert len(CSS.read_text(encoding="utf-8").splitlines()) < 140
+    assert BUNDLE.exists()
+    assert "__WORKCELL_CONTEXTUAL_PLACEMENT_ACTIONS_V1__" in ACTIONS.read_text(encoding="utf-8")

--- a/workcell_studio_web/viewer/contextual_placement_actions.css
+++ b/workcell_studio_web/viewer/contextual_placement_actions.css
@@ -1,0 +1,103 @@
+.contextual-placement-actions {
+  margin-top: 0.68rem;
+  padding: 0.68rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: rgba(248, 250, 252, 0.96);
+}
+
+.contextual-placement-actions h3 {
+  margin: 0 0 0.3rem;
+  color: var(--accent);
+  font-size: 0.9rem;
+}
+
+.contextual-placement-note {
+  margin: 0 0 0.58rem;
+  color: var(--muted);
+  font-size: 0.75rem;
+  line-height: 1.35;
+}
+
+.contextual-placement-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.38rem;
+}
+
+.contextual-placement-grid button {
+  min-width: 0;
+  min-height: 2.15rem;
+  padding: 0.4rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 0.4rem;
+  background: var(--panel-2);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 0.75rem;
+  line-height: 1.2;
+  white-space: normal;
+}
+
+.contextual-placement-grid button:not(:disabled):hover,
+.contextual-placement-grid button:focus-visible {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  outline: 2px solid rgba(0, 120, 168, 0.16);
+  outline-offset: 1px;
+}
+
+.contextual-placement-grid button:disabled {
+  cursor: not-allowed;
+  opacity: 0.42;
+}
+
+.contextual-placement-message {
+  margin: 0.58rem 0 0;
+  padding: 0.42rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 0.38rem;
+  font-size: 0.75rem;
+  font-weight: 650;
+  line-height: 1.3;
+}
+
+.contextual-placement-message.success {
+  border-color: rgba(47, 143, 91, 0.45);
+  background: rgba(236, 253, 245, 0.96);
+  color: #14532d;
+}
+
+.contextual-placement-message.warning {
+  border-color: rgba(178, 107, 0, 0.45);
+  background: var(--overlay-surface);
+  color: #7a4600;
+}
+
+.contextual-placement-message.error {
+  border-color: rgba(196, 52, 52, 0.48);
+  background: var(--error-surface);
+  color: #8b1e1e;
+}
+
+@media (max-width: 1100px) {
+  .contextual-placement-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 820px) {
+  .contextual-placement-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 620px) {
+  .contextual-placement-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+body.embedded-mode .contextual-placement-actions {
+  display: none !important;
+}

--- a/workcell_studio_web/viewer/contextual_placement_actions.js
+++ b/workcell_studio_web/viewer/contextual_placement_actions.js
@@ -21,7 +21,6 @@ const runtime = {
   observer: null,
   installed: false,
   frame: 0,
-  selectedId: '',
   message: '',
   severity: 'neutral',
   messageTimer: null,
@@ -66,7 +65,9 @@ function identity(item, node = null) {
     item?.type,
     item?.category,
     item?.zone_kind,
+    item?.zone_type,
     item?.task_zone,
+    item?.task_zone_name,
     item?.source_layer,
     node?.name,
   ].map(value => String(value || '').toLowerCase().replace(/[_-]+/g, ' ')).join(' ');
@@ -125,7 +126,7 @@ function supportEntries() {
 
 function zoneKind(item, node) {
   const text = identity(item, node);
-  const zoneLike = /\b(zone|area|region|task)\b/.test(text) || item?.task_zone || item?.zone_kind;
+  const zoneLike = /\b(zone|area|region|task)\b/.test(text) || item?.task_zone || item?.zone_kind || item?.zone_type;
   if (!zoneLike) return '';
   if (/\bpick(?:ing)?\b/.test(text)) return 'pick';
   if (/\bplace(?:ment)?\b/.test(text)) return 'place';
@@ -147,9 +148,10 @@ function outsideDistance(value, min, max) {
 }
 
 function supportDistanceToPoint(support, point) {
-  const dx = outsideDistance(point.x, support.box.min.x, support.box.max.x);
-  const dy = outsideDistance(point.y, support.box.min.y, support.box.max.y);
-  return Math.hypot(dx, dy);
+  return Math.hypot(
+    outsideDistance(point.x, support.box.min.x, support.box.max.x),
+    outsideDistance(point.y, support.box.min.y, support.box.max.y),
+  );
 }
 
 function nearestSupport(point) {
@@ -167,18 +169,20 @@ function containingOrNearestSupport(point) {
     point.x >= support.box.min.x - EPSILON && point.x <= support.box.max.x + EPSILON &&
     point.y >= support.box.min.y - EPSILON && point.y <= support.box.max.y + EPSILON
   ));
-  if (containing) return { ...containing, distance: 0 };
-  return nearestSupport(point);
+  return containing ? { ...containing, distance: 0 } : nearestSupport(point);
 }
 
 function availableInnerBounds(support, objectBox) {
   const size = objectBox.getSize(new THREE.Vector3());
-  const minX = support.box.min.x + EDGE_MARGIN_M;
-  const maxX = support.box.max.x - EDGE_MARGIN_M;
-  const minY = support.box.min.y + EDGE_MARGIN_M;
-  const maxY = support.box.max.y - EDGE_MARGIN_M;
-  if (size.x > maxX - minX + EPSILON || size.y > maxY - minY + EPSILON) return null;
-  return { minX, maxX, minY, maxY, size };
+  const inner = {
+    minX: support.box.min.x + EDGE_MARGIN_M,
+    maxX: support.box.max.x - EDGE_MARGIN_M,
+    minY: support.box.min.y + EDGE_MARGIN_M,
+    maxY: support.box.max.y - EDGE_MARGIN_M,
+    size,
+  };
+  if (size.x > inner.maxX - inner.minX + EPSILON || size.y > inner.maxY - inner.minY + EPSILON) return null;
+  return inner;
 }
 
 function clampCenterToSupport(center, inner) {
@@ -191,7 +195,7 @@ function clampCenterToSupport(center, inner) {
 
 function targetDelta(action, objectBox, support, zone = null) {
   const inner = availableInnerBounds(support, objectBox);
-  if (!inner) return { error: `${itemLabel(itemOf(support.root), 'Selected item')} is too large for ${itemLabel(support.item, 'the surface')}` };
+  if (!inner) return { error: `Selected item is too large for ${itemLabel(support.item, 'the surface')}` };
 
   const current = boxCenter(objectBox);
   let target = current.clone();
@@ -222,8 +226,6 @@ function targetDelta(action, objectBox, support, zone = null) {
       target.y - current.y,
       support.top - objectBox.min.z,
     ),
-    target,
-    inner,
   };
 }
 
@@ -255,6 +257,12 @@ function collisionResult(id) {
   return window.__WORKCELL_COLLISION_PLACEMENT_V1__?.validateItem?.(id) || null;
 }
 
+function publish(action, state, extra = {}) {
+  const detail = { action, item_id: state?.selectedItemId || '', ...extra };
+  window.dispatchEvent?.(new CustomEvent('workcell:contextual-placement-action', { detail }));
+  window.parent?.postMessage?.({ type: 'workcell_contextual_placement_action', ...detail }, '*');
+}
+
 function showMessage(message, severity = 'neutral', timeoutMs = 1800) {
   runtime.message = message;
   runtime.severity = severity;
@@ -269,12 +277,6 @@ function showMessage(message, severity = 'neutral', timeoutMs = 1800) {
   }
 }
 
-function publish(action, state, extra = {}) {
-  const detail = { action, item_id: state?.selectedItemId || '', ...extra };
-  window.dispatchEvent?.(new CustomEvent('workcell:contextual-placement-action', { detail }));
-  window.parent?.postMessage?.({ type: 'workcell_contextual_placement_action', ...detail }, '*');
-}
-
 function runAction(action) {
   const state = editorState();
   if (!state?.selectedItemId || state.selectedEditable !== true) return false;
@@ -285,7 +287,6 @@ function runAction(action) {
     return false;
   }
 
-  const objectCenter = boxCenter(objectBox);
   let zone = null;
   let support = null;
   if (action === 'move-pick' || action === 'move-place') {
@@ -297,7 +298,7 @@ function runAction(action) {
     }
     support = containingOrNearestSupport(boxCenter(zone.box));
   } else {
-    support = containingOrNearestSupport(objectCenter);
+    support = containingOrNearestSupport(boxCenter(objectBox));
   }
   if (!support) {
     showMessage('No table or workbench is available.', 'error');
@@ -325,7 +326,8 @@ function runAction(action) {
   }
 
   const label = ACTIONS.find(([name]) => name === action)?.[1] || action;
-  showMessage(`${label} · ${itemLabel(support.item, 'surface')}`, collision?.severity === 'warning' ? 'warning' : 'success');
+  const severity = collision?.severity === 'warning' ? 'warning' : 'success';
+  showMessage(`${label} · ${itemLabel(support.item, 'surface')}`, severity);
   publish(action, state, {
     valid: true,
     support_surface_id: itemId(support.item),
@@ -353,10 +355,20 @@ function actionAvailability(state) {
   };
 }
 
-function createActionsSection(state) {
+function sectionSignature(state, availability) {
+  return JSON.stringify({
+    item: state.selectedItemId,
+    availability,
+    message: runtime.message,
+    severity: runtime.severity,
+  });
+}
+
+function createActionsSection(state, availability = actionAvailability(state)) {
   const section = document.createElement('section');
   section.className = 'contextual-placement-actions';
   section.dataset.itemId = state.selectedItemId;
+  section.dataset.signature = sectionSignature(state, availability);
 
   const title = document.createElement('h3');
   title.textContent = 'Quick placement';
@@ -365,7 +377,6 @@ function createActionsSection(state) {
   note.textContent = 'Use the current surface, edge or task area. Collision validation still applies.';
   const grid = document.createElement('div');
   grid.className = 'contextual-placement-grid';
-  const availability = actionAvailability(state);
 
   for (const [name, label] of ACTIONS) {
     const button = document.createElement('button');
@@ -398,12 +409,13 @@ function refreshActions() {
   const editable = Boolean(state?.selectedItemId && state.selectedEditable === true && rootForItemId(state.selectedItemId));
   if (!editable) {
     existing?.remove();
-    runtime.selectedId = '';
     return;
   }
 
-  runtime.selectedId = state.selectedItemId;
-  const replacement = createActionsSection(state);
+  const availability = actionAvailability(state);
+  const signature = sectionSignature(state, availability);
+  if (existing?.dataset.signature === signature) return;
+  const replacement = createActionsSection(state, availability);
   if (existing) existing.replaceWith(replacement);
   else {
     const editor = inspector.querySelector(':scope > .transform-editor');

--- a/workcell_studio_web/viewer/contextual_placement_actions.js
+++ b/workcell_studio_web/viewer/contextual_placement_actions.js
@@ -1,0 +1,448 @@
+import { THREE } from './dist/viewer.bundle.js';
+
+const PATCH_FLAG = Symbol.for('workcell-studio.contextual-placement-actions.v1');
+const SUPPORT_KINDS = new Set(['workbench_body', 'table_surface', 'tabletop']);
+const EDGE_MARGIN_M = 0.01;
+const EPSILON = 1e-6;
+
+const ACTIONS = Object.freeze([
+  ['place-nearest', 'Place on nearest surface'],
+  ['center', 'Centre on surface'],
+  ['align-left', 'Align left'],
+  ['align-right', 'Align right'],
+  ['align-front', 'Align front'],
+  ['align-back', 'Align back'],
+  ['move-pick', 'Move to pick area'],
+  ['move-place', 'Move to place area'],
+]);
+
+const runtime = {
+  scene: null,
+  observer: null,
+  installed: false,
+  frame: 0,
+  selectedId: '',
+  message: '',
+  severity: 'neutral',
+  messageTimer: null,
+};
+
+function editorApi() {
+  return window.__WORKCELL_EDITOR_API_V1__ || null;
+}
+
+function editorState() {
+  try {
+    return editorApi()?.getState?.() || null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function itemOf(node) {
+  return node?.userData?.item || null;
+}
+
+function itemId(item) {
+  return String(item?.id || '').trim();
+}
+
+function itemLabel(item, fallback = 'item') {
+  return item?.label || item?.display_name || item?.object_name || item?.name || item?.id || fallback;
+}
+
+function supportKind(item) {
+  return String(item?.support_surface_kind || item?.supportSurfaceKind || '').trim().toLowerCase();
+}
+
+function identity(item, node = null) {
+  return [
+    item?.id,
+    item?.label,
+    item?.display_name,
+    item?.object_name,
+    item?.name,
+    item?.role,
+    item?.type,
+    item?.category,
+    item?.zone_kind,
+    item?.task_zone,
+    item?.source_layer,
+    node?.name,
+  ].map(value => String(value || '').toLowerCase().replace(/[_-]+/g, ' ')).join(' ');
+}
+
+function rootForItemId(id) {
+  if (!runtime.scene || !id) return null;
+  let found = null;
+  runtime.scene.traverse(node => {
+    if (!found && itemId(itemOf(node)) === String(id)) found = node;
+  });
+  if (!found) return null;
+  while (found.parent && found.parent !== runtime.scene && itemId(itemOf(found.parent)) === String(id)) {
+    found = found.parent;
+  }
+  return found;
+}
+
+function finiteBounds(root) {
+  if (!root) return null;
+  root.updateWorldMatrix?.(true, true);
+  const box = new THREE.Box3().setFromObject(root);
+  const values = [box.min.x, box.min.y, box.min.z, box.max.x, box.max.y, box.max.z];
+  return values.every(Number.isFinite) && !box.isEmpty() ? box : null;
+}
+
+function topSurfaceZ(item, box) {
+  const explicit = Number(item?.top_surface_z_m ?? item?.topSurfaceZM);
+  return Number.isFinite(explicit) ? explicit : box.max.z;
+}
+
+function uniqueSceneEntries(predicate) {
+  if (!runtime.scene) return [];
+  const entries = [];
+  const seen = new Set();
+  runtime.scene.traverse(node => {
+    const item = itemOf(node);
+    if (!item || !predicate(item, node)) return;
+    const id = itemId(item);
+    const root = id ? rootForItemId(id) : node;
+    const key = root?.uuid || id;
+    if (!root || !key || seen.has(key)) return;
+    seen.add(key);
+    const box = finiteBounds(root);
+    if (box) entries.push({ root, item, box });
+  });
+  return entries;
+}
+
+function supportEntries() {
+  return uniqueSceneEntries(item => SUPPORT_KINDS.has(supportKind(item))).map(entry => ({
+    ...entry,
+    top: topSurfaceZ(entry.item, entry.box),
+  }));
+}
+
+function zoneKind(item, node) {
+  const text = identity(item, node);
+  const zoneLike = /\b(zone|area|region|task)\b/.test(text) || item?.task_zone || item?.zone_kind;
+  if (!zoneLike) return '';
+  if (/\bpick(?:ing)?\b/.test(text)) return 'pick';
+  if (/\bplace(?:ment)?\b/.test(text)) return 'place';
+  return '';
+}
+
+function zoneEntries(kind) {
+  return uniqueSceneEntries((item, node) => zoneKind(item, node) === kind);
+}
+
+function boxCenter(box) {
+  return box.getCenter(new THREE.Vector3());
+}
+
+function outsideDistance(value, min, max) {
+  if (value < min) return min - value;
+  if (value > max) return value - max;
+  return 0;
+}
+
+function supportDistanceToPoint(support, point) {
+  const dx = outsideDistance(point.x, support.box.min.x, support.box.max.x);
+  const dy = outsideDistance(point.y, support.box.min.y, support.box.max.y);
+  return Math.hypot(dx, dy);
+}
+
+function nearestSupport(point) {
+  let best = null;
+  for (const support of supportEntries()) {
+    const distance = supportDistanceToPoint(support, point);
+    if (!best || distance < best.distance) best = { ...support, distance };
+  }
+  return best;
+}
+
+function containingOrNearestSupport(point) {
+  const supports = supportEntries();
+  const containing = supports.find(support => (
+    point.x >= support.box.min.x - EPSILON && point.x <= support.box.max.x + EPSILON &&
+    point.y >= support.box.min.y - EPSILON && point.y <= support.box.max.y + EPSILON
+  ));
+  if (containing) return { ...containing, distance: 0 };
+  return nearestSupport(point);
+}
+
+function availableInnerBounds(support, objectBox) {
+  const size = objectBox.getSize(new THREE.Vector3());
+  const minX = support.box.min.x + EDGE_MARGIN_M;
+  const maxX = support.box.max.x - EDGE_MARGIN_M;
+  const minY = support.box.min.y + EDGE_MARGIN_M;
+  const maxY = support.box.max.y - EDGE_MARGIN_M;
+  if (size.x > maxX - minX + EPSILON || size.y > maxY - minY + EPSILON) return null;
+  return { minX, maxX, minY, maxY, size };
+}
+
+function clampCenterToSupport(center, inner) {
+  return new THREE.Vector3(
+    THREE.MathUtils.clamp(center.x, inner.minX + inner.size.x / 2, inner.maxX - inner.size.x / 2),
+    THREE.MathUtils.clamp(center.y, inner.minY + inner.size.y / 2, inner.maxY - inner.size.y / 2),
+    center.z,
+  );
+}
+
+function targetDelta(action, objectBox, support, zone = null) {
+  const inner = availableInnerBounds(support, objectBox);
+  if (!inner) return { error: `${itemLabel(itemOf(support.root), 'Selected item')} is too large for ${itemLabel(support.item, 'the surface')}` };
+
+  const current = boxCenter(objectBox);
+  let target = current.clone();
+  if (action === 'center') {
+    target.x = (inner.minX + inner.maxX) / 2;
+    target.y = (inner.minY + inner.maxY) / 2;
+  } else if (action === 'align-left') {
+    target.x = inner.minX + inner.size.x / 2;
+    target.y = clampCenterToSupport(target, inner).y;
+  } else if (action === 'align-right') {
+    target.x = inner.maxX - inner.size.x / 2;
+    target.y = clampCenterToSupport(target, inner).y;
+  } else if (action === 'align-front') {
+    target.y = inner.minY + inner.size.y / 2;
+    target.x = clampCenterToSupport(target, inner).x;
+  } else if (action === 'align-back') {
+    target.y = inner.maxY - inner.size.y / 2;
+    target.x = clampCenterToSupport(target, inner).x;
+  } else if ((action === 'move-pick' || action === 'move-place') && zone) {
+    target.copy(clampCenterToSupport(boxCenter(zone.box), inner));
+  } else {
+    target.copy(clampCenterToSupport(target, inner));
+  }
+
+  return {
+    delta: new THREE.Vector3(
+      target.x - current.x,
+      target.y - current.y,
+      support.top - objectBox.min.z,
+    ),
+    target,
+    inner,
+  };
+}
+
+function localPositionAfterWorldDelta(root, delta) {
+  const world = root.getWorldPosition(new THREE.Vector3()).add(delta);
+  if (root.parent) root.parent.worldToLocal(world);
+  return world;
+}
+
+function transformInputs() {
+  const inspector = document.getElementById('inspector');
+  if (!inspector) return null;
+  const input = name => inspector.querySelector(`[data-transform-field="${name}"]`);
+  const fields = { x: input('x'), y: input('y'), z: input('z') };
+  return fields.x && fields.y && fields.z ? fields : null;
+}
+
+function commitLocalPosition(position) {
+  const fields = transformInputs();
+  if (!fields) return false;
+  fields.x.value = Number(position.x).toFixed(6);
+  fields.y.value = Number(position.y).toFixed(6);
+  fields.z.value = Number(position.z).toFixed(6);
+  fields.x.dispatchEvent(new Event('input', { bubbles: true }));
+  return true;
+}
+
+function collisionResult(id) {
+  return window.__WORKCELL_COLLISION_PLACEMENT_V1__?.validateItem?.(id) || null;
+}
+
+function showMessage(message, severity = 'neutral', timeoutMs = 1800) {
+  runtime.message = message;
+  runtime.severity = severity;
+  window.clearTimeout(runtime.messageTimer);
+  refreshActions();
+  if (timeoutMs > 0) {
+    runtime.messageTimer = window.setTimeout(() => {
+      runtime.message = '';
+      runtime.severity = 'neutral';
+      refreshActions();
+    }, timeoutMs);
+  }
+}
+
+function publish(action, state, extra = {}) {
+  const detail = { action, item_id: state?.selectedItemId || '', ...extra };
+  window.dispatchEvent?.(new CustomEvent('workcell:contextual-placement-action', { detail }));
+  window.parent?.postMessage?.({ type: 'workcell_contextual_placement_action', ...detail }, '*');
+}
+
+function runAction(action) {
+  const state = editorState();
+  if (!state?.selectedItemId || state.selectedEditable !== true) return false;
+  const root = rootForItemId(state.selectedItemId);
+  const objectBox = finiteBounds(root);
+  if (!root || !objectBox) {
+    showMessage('Selected item has no usable rendered bounds.', 'error');
+    return false;
+  }
+
+  const objectCenter = boxCenter(objectBox);
+  let zone = null;
+  let support = null;
+  if (action === 'move-pick' || action === 'move-place') {
+    const kind = action === 'move-pick' ? 'pick' : 'place';
+    zone = zoneEntries(kind)[0] || null;
+    if (!zone) {
+      showMessage(`No ${kind} area is defined in this scene.`, 'error');
+      return false;
+    }
+    support = containingOrNearestSupport(boxCenter(zone.box));
+  } else {
+    support = containingOrNearestSupport(objectCenter);
+  }
+  if (!support) {
+    showMessage('No table or workbench is available.', 'error');
+    return false;
+  }
+
+  const target = targetDelta(action, objectBox, support, zone);
+  if (target.error) {
+    showMessage(target.error, 'error');
+    return false;
+  }
+
+  const local = localPositionAfterWorldDelta(root, target.delta);
+  if (!commitLocalPosition(local)) {
+    showMessage('Placement controls are unavailable for this item.', 'error');
+    return false;
+  }
+
+  const collision = collisionResult(state.selectedItemId);
+  if (collision && !collision.valid) {
+    editorApi()?.undo?.();
+    showMessage(`${collision.reason || 'Placement overlaps another object'} · action reverted`, 'error', 2400);
+    publish(action, state, { valid: false, reverted: true, reason: collision.reason || 'collision' });
+    return false;
+  }
+
+  const label = ACTIONS.find(([name]) => name === action)?.[1] || action;
+  showMessage(`${label} · ${itemLabel(support.item, 'surface')}`, collision?.severity === 'warning' ? 'warning' : 'success');
+  publish(action, state, {
+    valid: true,
+    support_surface_id: itemId(support.item),
+    zone_id: itemId(zone?.item),
+    collision_severity: collision?.severity || 'valid',
+  });
+  return true;
+}
+
+function actionAvailability(state) {
+  const editable = Boolean(state?.selectedItemId && state.selectedEditable === true);
+  if (!editable) return Object.fromEntries(ACTIONS.map(([name]) => [name, false]));
+  const root = rootForItemId(state.selectedItemId);
+  const bounds = finiteBounds(root);
+  const hasSurface = Boolean(bounds && containingOrNearestSupport(boxCenter(bounds)));
+  return {
+    'place-nearest': hasSurface,
+    center: hasSurface,
+    'align-left': hasSurface,
+    'align-right': hasSurface,
+    'align-front': hasSurface,
+    'align-back': hasSurface,
+    'move-pick': hasSurface && zoneEntries('pick').length > 0,
+    'move-place': hasSurface && zoneEntries('place').length > 0,
+  };
+}
+
+function createActionsSection(state) {
+  const section = document.createElement('section');
+  section.className = 'contextual-placement-actions';
+  section.dataset.itemId = state.selectedItemId;
+
+  const title = document.createElement('h3');
+  title.textContent = 'Quick placement';
+  const note = document.createElement('p');
+  note.className = 'contextual-placement-note';
+  note.textContent = 'Use the current surface, edge or task area. Collision validation still applies.';
+  const grid = document.createElement('div');
+  grid.className = 'contextual-placement-grid';
+  const availability = actionAvailability(state);
+
+  for (const [name, label] of ACTIONS) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.dataset.placementAction = name;
+    button.textContent = label;
+    button.disabled = !availability[name];
+    if ((name === 'move-pick' || name === 'move-place') && !availability[name]) {
+      button.title = `${name === 'move-pick' ? 'Pick' : 'Place'} area is not available in this scene`;
+    }
+    button.addEventListener('click', () => runAction(name));
+    grid.appendChild(button);
+  }
+
+  const status = document.createElement('p');
+  status.className = `contextual-placement-message ${runtime.severity}`;
+  status.setAttribute('role', 'status');
+  status.setAttribute('aria-live', 'polite');
+  status.hidden = !runtime.message;
+  status.textContent = runtime.message;
+  section.append(title, note, grid, status);
+  return section;
+}
+
+function refreshActions() {
+  const inspector = document.getElementById('inspector');
+  if (!inspector) return;
+  const state = editorState();
+  const existing = inspector.querySelector(':scope > .contextual-placement-actions');
+  const editable = Boolean(state?.selectedItemId && state.selectedEditable === true && rootForItemId(state.selectedItemId));
+  if (!editable) {
+    existing?.remove();
+    runtime.selectedId = '';
+    return;
+  }
+
+  runtime.selectedId = state.selectedItemId;
+  const replacement = createActionsSection(state);
+  if (existing) existing.replaceWith(replacement);
+  else {
+    const editor = inspector.querySelector(':scope > .transform-editor');
+    inspector.insertBefore(replacement, editor || null);
+  }
+}
+
+function installObserver() {
+  if (runtime.observer) return;
+  const inspector = document.getElementById('inspector');
+  if (!inspector) return;
+  runtime.observer = new MutationObserver(() => queueMicrotask(refreshActions));
+  runtime.observer.observe(inspector, { childList: true, subtree: true });
+}
+
+function install() {
+  if (runtime.installed) return;
+  runtime.installed = true;
+  installObserver();
+
+  const prototype = THREE.WebGLRenderer?.prototype;
+  if (!prototype || prototype[PATCH_FLAG]) return;
+  const originalRender = prototype.render;
+  prototype.render = function renderWithContextualPlacementActions(scene, camera) {
+    runtime.scene = scene;
+    runtime.frame = (runtime.frame + 1) % 30;
+    if (runtime.frame === 1) refreshActions();
+    return originalRender.call(this, scene, camera);
+  };
+  prototype[PATCH_FLAG] = true;
+
+  window.__WORKCELL_CONTEXTUAL_PLACEMENT_ACTIONS_V1__ = Object.freeze({
+    enabled: true,
+    version: 1,
+    structural_actions: 'deferred_until_persistent_add_remove_patch_support',
+    availableActions: () => actionAvailability(editorState()),
+    run: action => runAction(String(action || '')),
+    refresh: refreshActions,
+  });
+}
+
+install();

--- a/workcell_studio_web/viewer/index.html
+++ b/workcell_studio_web/viewer/index.html
@@ -6,6 +6,7 @@
   <title>Workcell Studio Product View</title>
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="simple_product_ui.css" />
+  <link rel="stylesheet" href="contextual_placement_actions.css" />
 </head>
 <body>
   <header class="topbar">
@@ -104,5 +105,6 @@
   <script type="module" src="./workcell_task_gizmo.js"></script>
   <script type="module" src="./collision_placement_validation.js"></script>
   <script type="module" src="./simple_product_ui.js"></script>
+  <script type="module" src="./contextual_placement_actions.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Problem
Product View now supports safe surface placement, task-focused gizmos and collision validation, but normal layout tasks still require manual dragging or numeric coordinate entry. Common operations such as centring an object, aligning it to a table edge or moving it into a configured pick/place area should be one-click actions.

## Changes
- Add a **Quick placement** section only for the currently selected editable/unlocked item.
- Provide contextual actions:
  - Place on nearest surface
  - Centre on surface
  - Align left/right/front/back
  - Move to pick area
  - Move to place area
- Hide the entire section for generated, locked, robot, gripper, camera and other non-editable items through the existing editor state contract.
- Enable pick/place actions only when matching task-zone metadata exists in the loaded scene.
- Detect support surfaces from the existing `workbench_body`, `table_surface` and `tabletop` metadata.
- Use actual rendered bounds, `top_surface_z_m` and the existing 10 mm support-edge margin.
- Preserve object rotation and scale; actions change only the required XYZ position.
- Commit each action once through the existing numeric transform/editor bridge so Undo/Redo and edit-patch export continue to work.
- Validate the resulting pose through PR #2807 collision validation.
- Automatically Undo and report the reason when a one-click action would overlap another physical object.
- Publish `workcell:contextual-placement-action` events and expose `window.__WORKCELL_CONTEXTUAL_PLACEMENT_ACTIONS_V1__` diagnostics.
- Use a stable section signature so inspector MutationObserver refreshes cannot create a DOM replacement loop.

## Deliberate boundary
Duplicate and Delete are structural scene edits, but the current edit-patch contract only persists transforms. They are explicitly deferred until the planned persistent add/remove patch and Qt save round trip exists; this PR does not offer preview-only structural actions that cannot be saved safely.

## Scope control
- Exactly **4 changed files**.
- **705 additions**, no deletions.
- No generated/minified/binary changes.
- No `viewer.js` refactor and no bundle rewrite.
- No scene generation, YAML writes, asset changes, Qt changes, controller changes, MoveIt changes, hardware changes or motion commands.

## Validation
Focused tests verify:
- load order after collision validation and the simplified inspector;
- editable-selection gating;
- rendered-bounds, support-top and 10 mm edge calculations;
- centre and four-edge alignment calculations;
- pick/place task-zone metadata discovery;
- a single commit through the existing transform inputs;
- collision validation and automatic Undo;
- stable observer signatures rather than refresh loops;
- explicit deferral of unsupported structural edits;
- no network calls, source writes, motion commands or bundle changes.

## Manual acceptance
In canonical `ur5_2f_test`:
1. Select an editable bin, tray, pallet, fixture or pick object and confirm Quick placement appears.
2. Select robot, gripper, camera or generated geometry and confirm Quick placement is absent.
3. Use Place on nearest surface and confirm the object sits on the nearest valid support.
4. Use Centre and each edge alignment action; confirm the full rendered footprint remains inside the table with the existing margin.
5. Confirm rotation and scale do not change.
6. Use Move to pick area and Move to place area where task zones exist.
7. Confirm missing task-zone actions are disabled rather than guessing a destination.
8. Attempt an action that would overlap another object and confirm it is automatically reverted with a clear message.
9. Confirm successful actions create one Undo step, support Redo and appear in Export edits.
10. Confirm no robot motion is commanded.