### PR TITLE
Save embedded Product View edits through Qt

### DIFF
--- a/scripts/apply_workcell_studio_web_scene_edit_patch.py
+++ b/scripts/apply_workcell_studio_web_scene_edit_patch.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 import argparse
 import datetime as _dt
 import json
+import os
 import shutil
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
@@ -56,8 +58,26 @@ def _load_yaml(path: Path) -> Any:
 
 
 def _write_yaml(path: Path, data: Any) -> None:
+    """Atomically replace one approved YAML file in its original directory."""
     assert yaml is not None
-    path.write_text(yaml.safe_dump(data, sort_keys=False, default_flow_style=False), encoding="utf-8")
+    payload = yaml.safe_dump(data, sort_keys=False, default_flow_style=False)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        if path.exists():
+            os.chmod(temporary, path.stat().st_mode)
+        os.replace(temporary, path)
+    except Exception:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+        raise
 
 
 def _as_list3(value: Any, field: str) -> list[float]:

--- a/scripts/run_workcell_studio_web_edit_workflow.py
+++ b/scripts/run_workcell_studio_web_edit_workflow.py
@@ -111,6 +111,19 @@ def _readiness_cmd(output_dir: Path) -> list[str]:
     ]
 
 
+def _product_view_refresh_cmd(scene: Path, output_dir: Path, scene_id: str) -> list[str]:
+    return [
+        sys.executable,
+        str(SCRIPT_DIR / "ensure_workcell_studio_web_scene_fresh.py"),
+        "--scene",
+        str(scene),
+        "--output",
+        str(output_dir / f"{scene_id}.web_scene.json"),
+        "--stage-assets",
+        "--force",
+    ]
+
+
 def _generated_summary_paths(scene: Path) -> list[Path]:
     return [
         scene / "package.xml",
@@ -207,13 +220,13 @@ def main(argv: list[str] | None = None) -> int:
             _print_next_write_command(args)
             return 0
 
-        write_cmd = [*dry_cmd, "--write"]
+        write_cmd = [*dry_cmd, "--write", "--backup"]
         write_rc = _run_step("write apply", write_cmd)
         if write_rc != 0:
             print("write/apply result: FAIL", file=sys.stderr)
             return write_rc
         patch_applied = True
-        print("write/apply result: PASS")
+        print("write/apply result: PASS (timestamped source backups created)")
 
         try:
             _write_web_scene(scene, after_path)
@@ -251,6 +264,14 @@ def main(argv: list[str] | None = None) -> int:
             return validation_rc
     else:
         print("validation command/result: SKIPPED (pass --validate or --generate-and-validate)")
+
+    if patch_applied:
+        product_view_output = output_dir / f"{scene_id}.web_scene.json"
+        refresh_cmd = _product_view_refresh_cmd(scene, output_dir, scene_id)
+        refresh_rc = _run_step("Product View refresh", refresh_cmd)
+        print(f"Product View refresh result: {'PASS' if refresh_rc == 0 else 'FAIL'} ({product_view_output})")
+        if refresh_rc != 0:
+            return refresh_rc
 
     readiness_output_dir: Path | None = None
     if args.run_readiness:

--- a/tests/test_workcell_builder_embedded_web3d_save_roundtrip.py
+++ b/tests/test_workcell_builder_embedded_web3d_save_roundtrip.py
@@ -1,0 +1,118 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GUI = ROOT / "workcell_builder/workcell_builder/gui"
+CONTROLLER = GUI / "embedded_web_edit_save_controller.hpp"
+UI_UTILS = GUI / "workcell_builder_ui_utils.cpp"
+WORKFLOW = ROOT / "scripts/run_workcell_studio_web_edit_workflow.py"
+APPLICATOR = ROOT / "scripts/apply_workcell_studio_web_scene_edit_patch.py"
+
+
+def test_qt_product_view_installs_one_contextual_save_action():
+    controller = CONTROLLER.read_text(encoding="utf-8")
+    ui_utils = UI_UTILS.read_text(encoding="utf-8")
+
+    assert '#include "embedded_web_edit_save_controller.hpp"' in ui_utils
+    assert "installEmbeddedWebEditSaveControllers(widget);" in ui_utils
+    assert 'objectName() == QStringLiteral("scenePreviewWidget")' in controller
+    assert 'findChild<QWebEngineView *>(QStringLiteral("embeddedWeb3dProductView"))' in controller
+    assert 'setObjectName(QStringLiteral("embeddedSaveLayoutButton"))' in controller
+    assert 'QPushButton(QStringLiteral("Save layout")' in controller
+    assert 'property("workcell_embedded_save_controller")' in controller
+
+
+def test_qt_reads_patch_from_existing_browser_editor_api_and_checks_identity():
+    source = CONTROLLER.read_text(encoding="utf-8")
+    for token in [
+        "window.__WORKCELL_EDITOR_API_V1__",
+        "api.getState()",
+        "api.getEditPatch()",
+        'kPatchSchema = "workcell_studio_web_scene_edit_patch/v1"',
+        'kPatchCreator = "static_web_viewer"',
+        'patch.value(QStringLiteral("scene_id")).toString() != scene_id_',
+        "view_->url() == expected_url_",
+        "sceneIdFromViewerUrl(view_->url()) == scene_id_",
+        "Scene changed—reload required",
+        "No changes",
+        "Validation failed",
+        "Saved",
+    ]:
+        assert token in source
+
+
+def test_qt_writes_patch_atomically_then_runs_dry_run_before_confirmation_and_write():
+    source = CONTROLLER.read_text(encoding="utf-8")
+    assert "QSaveFile output(patch_path_)" in source
+    assert "output.commit()" in source
+    assert 'QStringLiteral("--dry-run-apply")' in source
+    assert 'QStringLiteral("--write") << QStringLiteral("--generate-and-validate")' in source
+    assert "WorkflowPhase::DryRun" in source
+    assert "WorkflowPhase::Write" in source
+    assert "Confirm Save Product View Layout" in source
+    assert source.index("startWorkflow(WorkflowPhase::DryRun)") < source.index("Confirm Save Product View Layout")
+    assert source.index("Confirm Save Product View Layout") < source.index("startWorkflow(WorkflowPhase::Write)")
+    assert "QProcess::MergedChannels" in source
+    assert "waitForFinished" not in source
+
+
+def test_successful_qt_save_reuses_backend_refreshes_and_reloads_product_view():
+    controller = CONTROLLER.read_text(encoding="utf-8")
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "scripts/run_workcell_studio_web_edit_workflow.py" in controller
+    assert "scripts/apply_workcell_studio_web_scene_edit_patch.py" not in controller
+    assert "scripts/validate_workcell_studio_web_scene_edit_patch.py" not in controller
+    assert "if (view_) view_->reload();" in controller
+
+    assert 'write_cmd = [*dry_cmd, "--write", "--backup"]' in workflow
+    assert "persistence verification" in workflow
+    assert "_product_view_refresh_cmd" in workflow
+    assert "ensure_workcell_studio_web_scene_fresh.py" in workflow
+    assert '"--stage-assets"' in workflow
+    assert '"--force"' in workflow
+    assert "Product View refresh result" in workflow
+
+
+def test_source_yaml_write_is_allowlisted_backed_up_and_atomic():
+    source = APPLICATOR.read_text(encoding="utf-8")
+    for token in [
+        '"layout/workcell_studio_layout.yaml"',
+        '"environment.yaml"',
+        'FORBIDDEN_TARGET_PARTS = {"generated"}',
+        'FORBIDDEN_TARGET_NAMES = {"cell_definition.yaml", "scene_manifest.yaml"}',
+        "shutil.copy2(path, path.with_name",
+        "tempfile.mkstemp",
+        "stream.flush()",
+        "os.fsync(stream.fileno())",
+        "os.replace(temporary, path)",
+        "temporary.unlink()",
+    ]:
+        assert token in source
+    assert "path.write_text(yaml.safe_dump" not in source
+
+
+def test_save_roundtrip_has_no_browser_source_writes_or_robot_motion():
+    combined = "\n".join(
+        path.read_text(encoding="utf-8").lower()
+        for path in (CONTROLLER, WORKFLOW, APPLICATOR)
+    )
+    for forbidden in [
+        "execute_trajectory",
+        "getmotionplan",
+        "/plan_kinematic_path",
+        "real_hardware_enabled: true",
+        "move_group.execute",
+        "ros2 launch",
+        "qwebchannel",
+    ]:
+        assert forbidden not in combined
+    assert "no robot motion is started" in combined
+    assert "does not launch controllers" in combined
+    assert "move real hardware" in combined
+
+
+def test_roundtrip_change_stays_focused():
+    assert len(CONTROLLER.read_text(encoding="utf-8").splitlines()) < 520
+    assert len(WORKFLOW.read_text(encoding="utf-8").splitlines()) < 340
+    assert len(APPLICATOR.read_text(encoding="utf-8").splitlines()) < 290

--- a/workcell_builder/workcell_builder/gui/embedded_web_edit_save_controller.hpp
+++ b/workcell_builder/workcell_builder/gui/embedded_web_edit_save_controller.hpp
@@ -1,0 +1,465 @@
+#pragma once
+
+#include <QWidget>
+
+#ifdef WORKCELL_BUILDER_HAS_WEBENGINE
+
+#include <QApplication>
+#include <QBoxLayout>
+#include <QCoreApplication>
+#include <QDir>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QLabel>
+#include <QMessageBox>
+#include <QPointer>
+#include <QProcess>
+#include <QProcessEnvironment>
+#include <QPushButton>
+#include <QRegularExpression>
+#include <QSaveFile>
+#include <QSizePolicy>
+#include <QTimer>
+#include <QUrlQuery>
+#include <QVariantMap>
+#include <QWebEnginePage>
+#include <QWebEngineView>
+
+namespace workcell_builder
+{
+namespace embedded_web_edit_save_detail
+{
+constexpr const char * kPatchSchema = "workcell_studio_web_scene_edit_patch/v1";
+constexpr const char * kPatchCreator = "static_web_viewer";
+constexpr const char * kSceneSuffix = ".web_scene.json";
+
+inline QString canonicalPath(const QString & path)
+{
+  const QFileInfo info(path);
+  const QString canonical = info.canonicalFilePath();
+  return QDir::cleanPath(canonical.isEmpty() ? info.absoluteFilePath() : canonical);
+}
+
+inline bool repoMarkersExist(const QString & root)
+{
+  const QDir dir(root);
+  return QFileInfo::exists(dir.filePath(QStringLiteral("workcell_studio_web/viewer/index.html"))) &&
+    QFileInfo::exists(dir.filePath(QStringLiteral("scripts/run_workcell_studio_web_edit_workflow.py"))) &&
+    QFileInfo(dir.filePath(QStringLiteral("scenes"))).isDir();
+}
+
+inline QString findRepoRoot()
+{
+  const auto walk = [](const QString & start) {
+    QDir dir(canonicalPath(start));
+    for (int depth = 0; depth < 16; ++depth) {
+      if (repoMarkersExist(dir.absolutePath())) return canonicalPath(dir.absolutePath());
+      if (!dir.cdUp()) break;
+    }
+    return QString();
+  };
+
+  const QString configured = QProcessEnvironment::systemEnvironment()
+    .value(QStringLiteral("WORKCELL_STUDIO_REPO_ROOT")).trimmed();
+  if (!configured.isEmpty() && repoMarkersExist(configured)) return canonicalPath(configured);
+
+  for (const QString & candidate : {QDir::currentPath(), QCoreApplication::applicationDirPath()}) {
+    const QString root = walk(candidate);
+    if (!root.isEmpty()) return root;
+  }
+  return {};
+}
+
+inline QString sceneIdFromViewerUrl(const QUrl & url)
+{
+  const QString scene_path = QUrlQuery(url).queryItemValue(QStringLiteral("scene"), QUrl::FullyDecoded);
+  const QString filename = QFileInfo(scene_path).fileName();
+  if (!scene_path.startsWith(QStringLiteral("build/workcell_studio_web_scene/")) ||
+      !filename.endsWith(QString::fromUtf8(kSceneSuffix))) return {};
+  const QString scene_id = filename.left(filename.size() - static_cast<int>(qstrlen(kSceneSuffix)));
+  static const QRegularExpression safe_id(QStringLiteral("^[A-Za-z0-9][A-Za-z0-9_-]*$"));
+  return safe_id.match(scene_id).hasMatch() ? scene_id : QString();
+}
+
+inline QString resolveSceneDir(const QString & repo_root, const QString & scene_id)
+{
+  const QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+  QStringList candidates;
+  for (const QString & key : {QStringLiteral("WORKCELL_STUDIO_SELECTED_SCENE_DIR"),
+      QStringLiteral("WORKCELL_STUDIO_SCENE_DIR")}) {
+    const QString exact = env.value(key).trimmed();
+    if (!exact.isEmpty()) candidates << exact;
+  }
+  const QString scenes_root = env.value(QStringLiteral("WORKCELL_STUDIO_SCENES_PATH")).trimmed();
+  if (!scenes_root.isEmpty()) candidates << QDir(scenes_root).filePath(scene_id);
+  candidates << QDir(repo_root).filePath(QStringLiteral("scenes/%1").arg(scene_id));
+
+  for (const QString & candidate : candidates) {
+    const QFileInfo info(candidate);
+    if (!info.exists() || !info.isDir()) continue;
+    const QString resolved = canonicalPath(candidate);
+    if (QFileInfo(resolved).fileName() == scene_id) return resolved;
+  }
+  return {};
+}
+
+class EmbeddedWebEditSaveController : public QObject
+{
+public:
+  EmbeddedWebEditSaveController(QWidget * preview, QWebEngineView * view)
+  : QObject(preview), preview_(preview), view_(view)
+  {
+    installed_ = createControls();
+    if (!installed_) return;
+
+    connect(save_button_, &QPushButton::clicked, this, [this]() { requestSave(); });
+    connect(view_, &QWebEngineView::loadFinished, this, [this](bool) {
+      last_polled_url_ = {};
+      QTimer::singleShot(250, this, [this]() { pollEditorState(); });
+    });
+    poll_timer_.setInterval(350);
+    connect(&poll_timer_, &QTimer::timeout, this, [this]() { pollEditorState(); });
+    poll_timer_.start();
+    pollEditorState();
+  }
+
+  bool installed() const { return installed_; }
+
+private:
+  enum class WorkflowPhase { DryRun, Write };
+
+  bool createControls()
+  {
+    if (!preview_ || !view_) return false;
+    QPushButton * fit_button = nullptr;
+    for (QPushButton * button : preview_->findChildren<QPushButton *>()) {
+      if (button->text() == QStringLiteral("Fit")) {
+        fit_button = button;
+        break;
+      }
+    }
+    if (!fit_button) return false;
+
+    QBoxLayout * toolbar = nullptr;
+    for (QBoxLayout * layout : preview_->findChildren<QBoxLayout *>()) {
+      if (layout->indexOf(fit_button) >= 0) {
+        toolbar = layout;
+        break;
+      }
+    }
+    if (!toolbar) return false;
+
+    save_button_ = new QPushButton(QStringLiteral("Save layout"), preview_);
+    save_button_->setObjectName(QStringLiteral("embeddedSaveLayoutButton"));
+    save_button_->setProperty("class", "safe_action");
+    save_button_->setToolTip(QStringLiteral(
+      "Validate the current Web3D edit patch, create source-YAML backups, apply it through Qt, regenerate, validate and reload Product View. No robot motion is started."));
+    save_button_->setEnabled(false);
+    save_button_->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
+
+    status_label_ = new QLabel(preview_);
+    status_label_->setObjectName(QStringLiteral("embeddedSaveLayoutStatus"));
+    status_label_->setWordWrap(true);
+    status_label_->setMinimumWidth(0);
+    status_label_->setMaximumWidth(190);
+    status_label_->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
+    status_label_->setVisible(false);
+
+    const int fit_index = toolbar->indexOf(fit_button);
+    toolbar->insertWidget(fit_index + 1, save_button_);
+    toolbar->insertWidget(fit_index + 2, status_label_);
+    return true;
+  }
+
+  void setStatus(const QString & text, const QString & level = QStringLiteral("info"))
+  {
+    if (!status_label_) return;
+    status_label_->setText(text);
+    status_label_->setVisible(!text.isEmpty());
+    QString background = QStringLiteral("#e7f0fb");
+    QString foreground = QStringLiteral("#2769b3");
+    if (level == QStringLiteral("success")) {
+      background = QStringLiteral("#e8f5eb"); foreground = QStringLiteral("#217a34");
+    } else if (level == QStringLiteral("warning")) {
+      background = QStringLiteral("#fff3e0"); foreground = QStringLiteral("#8a5200");
+    } else if (level == QStringLiteral("error")) {
+      background = QStringLiteral("#fdecea"); foreground = QStringLiteral("#b3261e");
+    }
+    status_label_->setStyleSheet(QStringLiteral(
+      "background:%1;color:%2;border:1px solid #c7d3df;border-radius:8px;padding:2px 6px;font-weight:600;")
+      .arg(background, foreground));
+  }
+
+  bool saveContextIsCurrent() const
+  {
+    return view_ && view_->url() == expected_url_ &&
+      sceneIdFromViewerUrl(view_->url()) == scene_id_;
+  }
+
+  void reportSceneChanged()
+  {
+    busy_ = false;
+    if (save_button_) save_button_->setEnabled(false);
+    setStatus(QStringLiteral("Scene changed—reload required"), QStringLiteral("warning"));
+  }
+
+  bool resolveSaveContext(QString * error)
+  {
+    expected_url_ = view_ ? view_->url() : QUrl();
+    scene_id_ = sceneIdFromViewerUrl(expected_url_);
+    if (scene_id_.isEmpty()) {
+      if (error) *error = QStringLiteral("The embedded viewer URL does not identify a safe active scene.");
+      return false;
+    }
+    repo_root_ = findRepoRoot();
+    if (repo_root_.isEmpty()) {
+      if (error) *error = QStringLiteral("Workcell Studio repository root could not be resolved.");
+      return false;
+    }
+    scene_dir_ = resolveSceneDir(repo_root_, scene_id_);
+    if (scene_dir_.isEmpty()) {
+      if (error) *error = QStringLiteral("Selected scene directory could not be resolved for %1.").arg(scene_id_);
+      return false;
+    }
+    patch_path_ = QDir(repo_root_).filePath(
+      QStringLiteral("build/workcell_studio_web_scene/%1.qt_edit_patch.json").arg(scene_id_));
+    return true;
+  }
+
+  bool writePatchAtomically(const QJsonObject & patch, QString * error)
+  {
+    QDir().mkpath(QFileInfo(patch_path_).absolutePath());
+    QSaveFile output(patch_path_);
+    if (!output.open(QIODevice::WriteOnly)) {
+      if (error) *error = QStringLiteral("Could not open patch output: %1").arg(output.errorString());
+      return false;
+    }
+    if (output.write(QJsonDocument(patch).toJson(QJsonDocument::Indented)) < 0 || !output.commit()) {
+      if (error) *error = QStringLiteral("Could not atomically write patch: %1").arg(output.errorString());
+      return false;
+    }
+    return true;
+  }
+
+  void requestSave()
+  {
+    if (busy_ || !view_) return;
+    QString context_error;
+    if (!resolveSaveContext(&context_error)) {
+      setStatus(QStringLiteral("Validation failed"), QStringLiteral("error"));
+      QMessageBox::warning(preview_, QStringLiteral("Save Product View Layout"), context_error);
+      return;
+    }
+
+    busy_ = true;
+    if (save_button_) save_button_->setEnabled(false);
+    setStatus(QStringLiteral("Checking edits…"));
+    static const char kPatchScript[] = R"JS(
+(() => {
+  const api = window.__WORKCELL_EDITOR_API_V1__;
+  if (!api) return {ok:false,error:'Embedded Product View editor is unavailable.'};
+  return {ok:true,state:api.getState(),patch:api.getEditPatch()};
+})()
+)JS";
+    view_->page()->runJavaScript(QString::fromUtf8(kPatchScript), [this](const QVariant & value) {
+      if (!saveContextIsCurrent()) {
+        reportSceneChanged();
+        return;
+      }
+      const QVariantMap payload = value.toMap();
+      if (!payload.value(QStringLiteral("ok")).toBool()) {
+        busy_ = false;
+        setStatus(QStringLiteral("Validation failed"), QStringLiteral("error"));
+        QMessageBox::warning(preview_, QStringLiteral("Save Product View Layout"),
+          payload.value(QStringLiteral("error")).toString());
+        return;
+      }
+
+      const QJsonDocument patch_doc = QJsonDocument::fromVariant(payload.value(QStringLiteral("patch")));
+      if (!patch_doc.isObject()) {
+        busy_ = false;
+        setStatus(QStringLiteral("Validation failed"), QStringLiteral("error"));
+        return;
+      }
+      const QJsonObject patch = patch_doc.object();
+      const QJsonArray edits = patch.value(QStringLiteral("edits")).toArray();
+      if (patch.value(QStringLiteral("schema_version")).toString() != QString::fromUtf8(kPatchSchema) ||
+          patch.value(QStringLiteral("created_by")).toString() != QString::fromUtf8(kPatchCreator) ||
+          patch.value(QStringLiteral("scene_id")).toString() != scene_id_ ||
+          !patch.value(QStringLiteral("edits")).isArray()) {
+        busy_ = false;
+        setStatus(QStringLiteral("Validation failed"), QStringLiteral("error"));
+        QMessageBox::warning(preview_, QStringLiteral("Save Product View Layout"),
+          QStringLiteral("The browser returned an invalid or stale edit-patch contract."));
+        return;
+      }
+      if (edits.isEmpty()) {
+        busy_ = false;
+        setStatus(QStringLiteral("No changes"), QStringLiteral("info"));
+        pollEditorState();
+        return;
+      }
+
+      QString write_error;
+      if (!writePatchAtomically(patch, &write_error)) {
+        busy_ = false;
+        setStatus(QStringLiteral("Validation failed"), QStringLiteral("error"));
+        QMessageBox::critical(preview_, QStringLiteral("Save Product View Layout"), write_error);
+        return;
+      }
+      startWorkflow(WorkflowPhase::DryRun);
+    });
+  }
+
+  void startWorkflow(WorkflowPhase phase)
+  {
+    if (!saveContextIsCurrent()) {
+      reportSceneChanged();
+      return;
+    }
+    if (process_) process_->deleteLater();
+    process_ = new QProcess(this);
+    process_->setProgram(QStringLiteral("python3"));
+    QStringList arguments{
+      QStringLiteral("scripts/run_workcell_studio_web_edit_workflow.py"),
+      QStringLiteral("--scene"), scene_dir_,
+      QStringLiteral("--patch"), patch_path_,
+      QStringLiteral("--output-dir"), QStringLiteral("build/workcell_studio_web_scene")};
+    if (phase == WorkflowPhase::DryRun) {
+      arguments << QStringLiteral("--dry-run-apply");
+      setStatus(QStringLiteral("Validating…"));
+    } else {
+      arguments << QStringLiteral("--write") << QStringLiteral("--generate-and-validate");
+      setStatus(QStringLiteral("Saving…"));
+    }
+    process_->setArguments(arguments);
+    process_->setWorkingDirectory(repo_root_);
+    process_->setProcessChannelMode(QProcess::MergedChannels);
+    QProcess * const process = process_;
+    connect(process, &QProcess::errorOccurred, this, [this, process](QProcess::ProcessError) {
+      if (process != process_) return;
+      busy_ = false;
+      setStatus(QStringLiteral("Validation failed"), QStringLiteral("error"));
+    });
+    connect(process, qOverload<int, QProcess::ExitStatus>(&QProcess::finished), this,
+      [this, process, phase](int exit_code, QProcess::ExitStatus exit_status) {
+        const QString output = QString::fromLocal8Bit(process->readAll());
+        if (process == process_) process_ = nullptr;
+        process->deleteLater();
+        if (!saveContextIsCurrent()) {
+          reportSceneChanged();
+          return;
+        }
+        const bool ok = exit_status == QProcess::NormalExit && exit_code == 0;
+        if (!ok) {
+          busy_ = false;
+          setStatus(phase == WorkflowPhase::DryRun ? QStringLiteral("Validation failed") : QStringLiteral("Save failed"),
+            QStringLiteral("error"));
+          QMessageBox::critical(preview_, QStringLiteral("Save Product View Layout"),
+            QStringLiteral("%1\n\n%2")
+              .arg(phase == WorkflowPhase::DryRun ? QStringLiteral("The edit patch did not pass validation.") :
+                QStringLiteral("The edit patch could not be saved."), output.left(8000)));
+          pollEditorState();
+          return;
+        }
+
+        if (phase == WorkflowPhase::DryRun) {
+          const QString confirmation = QStringLiteral(
+            "Validation passed for %1. Apply these edits now?\n\n"
+            "Qt will create timestamped backups, update only approved editable source YAML, verify persistence, "
+            "regenerate and validate the scene, refresh Product View, and reload it.\n\n"
+            "This does not launch controllers, execute MoveIt plans, or move real hardware.").arg(scene_id_);
+          if (QMessageBox::question(preview_, QStringLiteral("Confirm Save Product View Layout"), confirmation,
+              QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes) {
+            busy_ = false;
+            setStatus(QStringLiteral("Save cancelled"), QStringLiteral("warning"));
+            pollEditorState();
+            return;
+          }
+          startWorkflow(WorkflowPhase::Write);
+          return;
+        }
+
+        busy_ = false;
+        setStatus(QStringLiteral("Saved"), QStringLiteral("success"));
+        if (view_) view_->reload();
+        QTimer::singleShot(600, this, [this]() { pollEditorState(); });
+      });
+    process_->start();
+  }
+
+  void pollEditorState()
+  {
+    if (!installed_ || !view_ || busy_ || state_poll_pending_) return;
+    const QUrl poll_url = view_->url();
+    if (sceneIdFromViewerUrl(poll_url).isEmpty()) {
+      if (save_button_) save_button_->setEnabled(false);
+      return;
+    }
+    state_poll_pending_ = true;
+    static const char kStateScript[] = R"JS(
+(() => {
+  const api = window.__WORKCELL_EDITOR_API_V1__;
+  if (!api) return {ready:false,dirty:false,dirtyCount:0,sceneId:''};
+  const state = api.getState();
+  return {ready:Boolean(state.ready),dirty:Boolean(state.dirty),dirtyCount:Number(state.dirtyCount||0),sceneId:String(state.sceneId||'')};
+})()
+)JS";
+    view_->page()->runJavaScript(QString::fromUtf8(kStateScript), [this, poll_url](const QVariant & value) {
+      state_poll_pending_ = false;
+      if (!view_ || view_->url() != poll_url || busy_) return;
+      const QVariantMap state = value.toMap();
+      const bool ready = state.value(QStringLiteral("ready")).toBool();
+      const bool dirty = state.value(QStringLiteral("dirty")).toBool();
+      const QString reported_scene = state.value(QStringLiteral("sceneId")).toString();
+      const QString url_scene = sceneIdFromViewerUrl(poll_url);
+      if (save_button_) save_button_->setEnabled(ready && dirty && !url_scene.isEmpty() && reported_scene == url_scene);
+      last_polled_url_ = poll_url;
+    });
+  }
+
+  QPointer<QWidget> preview_;
+  QPointer<QWebEngineView> view_;
+  QPointer<QPushButton> save_button_;
+  QPointer<QLabel> status_label_;
+  QPointer<QProcess> process_;
+  QTimer poll_timer_{this};
+  QUrl expected_url_;
+  QUrl last_polled_url_;
+  QString scene_id_;
+  QString repo_root_;
+  QString scene_dir_;
+  QString patch_path_;
+  bool installed_{false};
+  bool busy_{false};
+  bool state_poll_pending_{false};
+};
+}  // namespace embedded_web_edit_save_detail
+
+inline void installEmbeddedWebEditSaveControllers(QWidget * root)
+{
+  if (!root) return;
+  QList<QWidget *> previews;
+  if (root->objectName() == QStringLiteral("scenePreviewWidget")) previews << root;
+  previews.append(root->findChildren<QWidget *>(QStringLiteral("scenePreviewWidget"), Qt::FindChildrenRecursively));
+  for (QWidget * preview : previews) {
+    if (!preview || preview->property("workcell_embedded_save_controller").toBool()) continue;
+    QWebEngineView * view = preview->findChild<QWebEngineView *>(QStringLiteral("embeddedWeb3dProductView"));
+    if (!view) continue;
+    auto * controller = new embedded_web_edit_save_detail::EmbeddedWebEditSaveController(preview, view);
+    if (controller->installed()) preview->setProperty("workcell_embedded_save_controller", true);
+    else controller->deleteLater();
+  }
+}
+}  // namespace workcell_builder
+
+#else
+
+namespace workcell_builder
+{
+inline void installEmbeddedWebEditSaveControllers(QWidget *) {}
+}  // namespace workcell_builder
+
+#endif

--- a/workcell_builder/workcell_builder/gui/workcell_builder_ui_utils.cpp
+++ b/workcell_builder/workcell_builder/gui/workcell_builder_ui_utils.cpp
@@ -1,4 +1,5 @@
 #include "workcell_builder_ui_utils.hpp"
+#include "embedded_web_edit_save_controller.hpp"
 
 #include <QAbstractButton>
 #include <QAbstractItemView>
@@ -320,5 +321,6 @@ void applyCompactDialogDefaults(QWidget * widget)
   configureContainedWidgets(widget);
   applyWorkcellStudioTheme(widget);
   applyPrimarySecondaryButtonStyle(widget);
+  installEmbeddedWebEditSaveControllers(widget);
 }
 }  // namespace workcell_builder


### PR DESCRIPTION
## Problem
Product View edits can now be placed, aligned and collision-validated, but they still require a manual browser export followed by a separate patch-selection workflow. The embedded Qt Product View needs one safe Save action that validates, persists, regenerates and reloads the active scene without allowing the browser to write source files directly.

## Changes
- Add a **Save layout** action beside the existing embedded Product View Undo/Redo/Fit controls.
- Enable it only when the embedded editor reports a ready, dirty scene.
- Read the patch from the existing `window.__WORKCELL_EDITOR_API_V1__.getEditPatch()` contract.
- Validate patch schema, creator, active scene ID and non-empty edits in Qt before invoking the backend.
- Capture the active viewer URL and scene identity; reject delayed callbacks or process results after a scene switch with **Scene changed—reload required**.
- Atomically write the temporary Qt handoff patch with `QSaveFile` under `build/workcell_studio_web_scene/`.
- Run the existing guided workflow asynchronously through `QProcess`; the Qt event loop is never blocked.
- Run a complete dry-run first, then request explicit confirmation before `--write`.
- On confirmed save, run persistence verification plus scene generation and validation.
- Create timestamped backups for every approved source YAML file before replacement.
- Replace each approved YAML file atomically using a same-directory temporary file, `fsync` and `os.replace`.
- Refresh the canonical staged Product View web scene after persistence and validation, then reload the embedded browser.
- Show clear states: **No changes**, **Validation failed**, **Scene changed—reload required**, **Save failed**, and **Saved**.

## Safety and trust boundaries
- The browser never writes YAML or generated files.
- The existing backend validator and allowlisted applicator remain authoritative.
- Only `layout/workcell_studio_layout.yaml` and `environment.yaml` can be updated.
- Generated directories, `cell_definition.yaml` and `scene_manifest.yaml` remain forbidden.
- No controllers, MoveIt execution, ROS launch, hardware access or robot motion is introduced.

## Scope control
- Exactly **5 changed files**.
- **629 additions and 3 deletions**.
- No generated/minified/binary changes.
- No `viewer.js` or bundle refactor.
- No asset, scene geometry, robot hierarchy, controller, MoveIt or launch changes.

## Validation
Focused tests verify:
- one Qt Save action is attached to the embedded Product View;
- patch retrieval uses the existing editor API;
- scene identity and stale-callback guards;
- atomic Qt patch handoff;
- asynchronous dry-run before confirmation and write;
- reuse of the existing backend workflow rather than duplicated validation logic;
- source allowlists, timestamped backups and atomic YAML replacement;
- canonical Product View refresh and browser reload;
- absence of browser writes and robot-motion commands.

## Manual acceptance
In canonical `ur5_2f_test`:
1. Move or align an editable item and confirm Save layout becomes enabled.
2. Click Save layout and confirm dry-run validation completes before the confirmation dialog.
3. Cancel once and confirm source YAML is unchanged.
4. Confirm save and verify the status changes to Saved.
5. Confirm a timestamped `.bak` exists beside each changed source YAML.
6. Confirm Product View reloads automatically and the edited position remains unchanged.
7. Reopen the scene and confirm the position still persists.
8. Switch scenes during a save attempt and confirm the stale result is rejected with Scene changed—reload required.
9. Create an invalid or locked edit and confirm Validation failed without source mutation.
10. Confirm no ROS launch, controller activation or robot motion occurs.