### PR TITLE
Add curated objects from embedded Product View

### DIFF
--- a/scripts/add_workcell_studio_curated_object.py
+++ b/scripts/add_workcell_studio_curated_object.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
-"""Plan or persist one curated catalog object in an editable Workcell Studio layout.
+"""Safely plan or persist one curated object in a Workcell Studio layout.
 
-Dry-run is the default.  The command writes only
-layout/workcell_studio_layout.yaml, and only after the caller explicitly passes
---write.  It never edits generated files, environment.yaml, manifests, robot
-configuration, controllers, or motion settings.
+Dry-run is the default. Only layout/workcell_studio_layout.yaml may be written,
+and only with --write. Generated files, environment metadata, robot settings,
+controllers, launch files and motion configuration are outside this command.
 """
 from __future__ import annotations
 
@@ -16,7 +15,6 @@ import math
 import os
 import re
 import shutil
-import sys
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -26,63 +24,56 @@ try:
 except ImportError:  # pragma: no cover
     yaml = None  # type: ignore
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-PROFILE = REPO_ROOT / "workcell_builder/workcell_builder/config/asset_profiles/environment_assets.json"
+ROOT = Path(__file__).resolve().parents[1]
+PROFILE = ROOT / "workcell_builder/workcell_builder/config/asset_profiles/environment_assets.json"
+CURATION = ROOT / "workcell_builder/workcell_builder/config/asset_profiles/curated_add_objects.json"
 LAYOUT_REL = Path("layout/workcell_studio_layout.yaml")
 ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
 MESH_SUFFIXES = {".stl", ".dae", ".obj"}
-EDGE_MARGIN = 0.01
-CLEARANCE = 0.01
-HELPER_TOKENS = ("zone", "keepout", "home_pose", "camera", "reach", "overlay", "helper", "warning")
-SUPPORT_TOKENS = ("support_surface", "table_surface", "tabletop", "workbench")
+EDGE_MARGIN = CLEARANCE = 0.01
+HELPERS = ("zone", "keepout", "home_pose", "camera", "reach", "overlay", "helper", "warning")
+SUPPORTS = ("support_surface", "table_surface", "tabletop", "workbench")
 COLORS = {
-    "bin": [0.95, 0.68, 0.20, 0.88],
-    "tray": [0.22, 0.58, 0.82, 0.88],
-    "tote": [0.28, 0.65, 0.48, 0.88],
-    "fixture": [0.48, 0.52, 0.58, 1.0],
+    "bin": [0.95, 0.68, 0.20, 0.88], "tray": [0.22, 0.58, 0.82, 0.88],
+    "tote": [0.28, 0.65, 0.48, 0.88], "fixture": [0.48, 0.52, 0.58, 1.0],
     "object": [0.91, 0.36, 0.24, 1.0],
 }
 
 
-def _fail(message: str, *, json_output: bool) -> int:
-    payload = {"status": "error", "error": message}
-    if json_output:
-        print(json.dumps(payload, sort_keys=True))
+def _emit_error(message: str, as_json: bool) -> int:
+    if as_json:
+        print(json.dumps({"status": "error", "error": message}, sort_keys=True))
     else:
-        print(f"ERROR: {message}", file=sys.stderr)
+        print(f"ERROR: {message}")
     return 1
 
 
-def _sha256(path: Path) -> str:
+def _sha(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def _num3(value: Any, field: str) -> list[float]:
+def _num3(value: Any, name: str, *, positive: bool = False) -> list[float]:
     if not isinstance(value, list) or len(value) < 3:
-        raise ValueError(f"{field} must contain three numbers")
+        raise ValueError(f"{name} must contain three numbers")
     out = [float(value[i]) for i in range(3)]
-    if not all(math.isfinite(v) and v > 0.0 for v in out):
-        raise ValueError(f"{field} must contain three finite positive numbers")
+    if not all(math.isfinite(v) and (not positive or v > 0.0) for v in out):
+        raise ValueError(f"{name} must contain three finite{' positive' if positive else ''} numbers")
     return out
 
 
 def _pose(item: dict[str, Any]) -> list[float] | None:
     pose = item.get("pose")
-    xyz = pose.get("xyz") if isinstance(pose, dict) else item.get("pose_xyz")
-    if not isinstance(xyz, list) or len(xyz) < 3:
-        return None
+    value = pose.get("xyz") if isinstance(pose, dict) else item.get("pose_xyz")
     try:
-        out = [float(xyz[i]) for i in range(3)]
+        return _num3(value, "pose")
     except (TypeError, ValueError):
         return None
-    return out if all(math.isfinite(v) for v in out) else None
 
 
-def _dimensions(item: dict[str, Any]) -> list[float] | None:
-    raw = item.get("dimensions") or item.get("size")
+def _dims(item: dict[str, Any]) -> list[float] | None:
     try:
-        return _num3(raw, "dimensions")
-    except ValueError:
+        return _num3(item.get("dimensions") or item.get("size"), "dimensions", positive=True)
+    except (TypeError, ValueError):
         return None
 
 
@@ -91,17 +82,16 @@ def _identity(item: dict[str, Any]) -> str:
 
 
 def _is_support(item: dict[str, Any]) -> bool:
+    return any(token in _identity(item) for token in SUPPORTS)
+
+
+def _is_obstacle(item: dict[str, Any]) -> bool:
     text = _identity(item)
-    return any(token in text for token in SUPPORT_TOKENS)
+    return not _is_support(item) and not any(token in text for token in HELPERS) and _pose(item) is not None and _dims(item) is not None
 
 
-def _is_physical_obstacle(item: dict[str, Any]) -> bool:
-    text = _identity(item)
-    return not _is_support(item) and not any(token in text for token in HELPER_TOKENS) and _pose(item) is not None and _dimensions(item) is not None
-
-
-def _aabb(center: list[float], dims: list[float], clearance: float = 0.0) -> tuple[list[float], list[float]]:
-    half = [dims[i] / 2.0 + clearance for i in range(3)]
+def _aabb(center: list[float], size: list[float], clearance: float = 0.0) -> tuple[list[float], list[float]]:
+    half = [size[i] / 2.0 + clearance for i in range(3)]
     return ([center[i] - half[i] for i in range(3)], [center[i] + half[i] for i in range(3)])
 
 
@@ -109,74 +99,68 @@ def _overlap(a: tuple[list[float], list[float]], b: tuple[list[float], list[floa
     return all(min(a[1][i], b[1][i]) - max(a[0][i], b[0][i]) > 1e-9 for i in range(3))
 
 
-def _candidate_offsets(max_x: float, max_y: float) -> list[tuple[float, float]]:
+def _offsets(max_x: float, max_y: float) -> list[tuple[float, float]]:
     step = 0.05
-    nx = max(0, int(math.floor(max_x / step)))
-    ny = max(0, int(math.floor(max_y / step)))
-    values = [(ix * step, iy * step) for ix in range(-nx, nx + 1) for iy in range(-ny, ny + 1)]
-    return sorted(values, key=lambda p: (p[0] * p[0] + p[1] * p[1], abs(p[1]), abs(p[0]), p[1], p[0]))
+    xs = range(-max(0, int(max_x // step)), max(0, int(max_x // step)) + 1)
+    ys = range(-max(0, int(max_y // step)), max(0, int(max_y // step)) + 1)
+    return sorted(((x * step, y * step) for x in xs for y in ys), key=lambda p: (p[0] ** 2 + p[1] ** 2, abs(p[1]), abs(p[0]), p[1], p[0]))
 
 
-def _find_placement(items: list[dict[str, Any]], dims: list[float]) -> tuple[dict[str, Any], list[float]]:
-    supports = [item for item in items if _is_support(item) and _pose(item) is not None and _dimensions(item) is not None]
-    supports.sort(key=lambda item: str(item.get("id", "")))
-    obstacles = [item for item in items if _is_physical_obstacle(item)]
+def _placement(items: list[dict[str, Any]], size: list[float]) -> tuple[str, list[float]]:
+    supports = sorted((i for i in items if _is_support(i) and _pose(i) and _dims(i)), key=lambda i: str(i.get("id", "")))
+    obstacles = [i for i in items if _is_obstacle(i)]
     for support in supports:
-        support_pose = _pose(support)
-        support_dims = _dimensions(support)
-        assert support_pose is not None and support_dims is not None
-        max_x = support_dims[0] / 2.0 - dims[0] / 2.0 - EDGE_MARGIN
-        max_y = support_dims[1] / 2.0 - dims[1] / 2.0 - EDGE_MARGIN
-        if max_x < 0.0 or max_y < 0.0:
+        sp, sd = _pose(support), _dims(support)
+        assert sp is not None and sd is not None
+        mx, my = sd[0] / 2 - size[0] / 2 - EDGE_MARGIN, sd[1] / 2 - size[1] / 2 - EDGE_MARGIN
+        if mx < 0 or my < 0:
             continue
-        z = support_pose[2] + support_dims[2] / 2.0 + dims[2] / 2.0
-        for dx, dy in _candidate_offsets(max_x, max_y):
-            candidate = [support_pose[0] + dx, support_pose[1] + dy, z]
-            candidate_box = _aabb(candidate, dims, CLEARANCE)
-            blocked = False
-            for obstacle in obstacles:
-                obstacle_pose = _pose(obstacle)
-                obstacle_dims = _dimensions(obstacle)
-                assert obstacle_pose is not None and obstacle_dims is not None
-                if _overlap(candidate_box, _aabb(obstacle_pose, obstacle_dims)):
-                    blocked = True
-                    break
-            if not blocked:
-                return support, candidate
+        z = sp[2] + sd[2] / 2 + size[2] / 2
+        for dx, dy in _offsets(mx, my):
+            candidate = [sp[0] + dx, sp[1] + dy, z]
+            box = _aabb(candidate, size, CLEARANCE)
+            if not any(_overlap(box, _aabb(_pose(o), _dims(o))) for o in obstacles):  # type: ignore[arg-type]
+                return str(support.get("id")), candidate
     raise ValueError("no collision-free support-surface slot is available for this object")
 
 
 def _catalog() -> dict[str, dict[str, Any]]:
-    data = json.loads(PROFILE.read_text(encoding="utf-8"))
-    return {str(item.get("asset_id")): item for item in data if isinstance(item, dict) and item.get("asset_id")}
+    profiles = json.loads(PROFILE.read_text(encoding="utf-8"))
+    curation = json.loads(CURATION.read_text(encoding="utf-8"))
+    if curation.get("schema_version") != "workcell_studio_curated_add_objects/v1":
+        raise ValueError("curated add-object manifest schema is invalid")
+    by_id = {str(v.get("asset_id")): dict(v) for v in profiles if isinstance(v, dict) and v.get("asset_id")}
+    approved: dict[str, dict[str, Any]] = {}
+    for rule in curation.get("objects", []):
+        if not isinstance(rule, dict) or rule.get("placement_policy") != "support_surface":
+            continue
+        asset_id = str(rule.get("asset_id") or "")
+        if asset_id not in by_id:
+            raise ValueError(f"curated asset is missing from environment profile: {asset_id}")
+        approved[asset_id] = {**by_id[asset_id], **rule, "curated_add_enabled": True}
+    return approved
 
 
 def _validate_asset(asset: dict[str, Any]) -> tuple[list[float], str, str | None]:
-    if asset.get("curated_add_enabled") is not True or asset.get("placement_policy") != "support_surface":
-        raise ValueError("asset is not approved for the curated add-object workflow")
-    dims = _num3(asset.get("default_dimensions_m"), "default_dimensions_m")
+    size = _num3(asset.get("default_dimensions_m"), "default_dimensions_m", positive=True)
     geometry = str(asset.get("geometry_type") or "mesh")
     primitive = None
     if geometry == "urdf_primitive":
         primitive = str(asset.get("primitive_geometry_type") or "")
         if primitive not in {"box", "cylinder", "sphere", "capsule"}:
-            raise ValueError("curated primitive asset has no supported primitive_geometry_type")
+            raise ValueError("curated primitive has no supported primitive_geometry_type")
     else:
-        mesh_path = Path(str(asset.get("mesh_path") or ""))
-        if mesh_path.is_absolute() or ".." in mesh_path.parts or mesh_path.suffix.lower() not in MESH_SUFFIXES:
-            raise ValueError("curated mesh path is unsafe or unsupported")
-        if not (REPO_ROOT / mesh_path).is_file():
-            raise ValueError(f"curated mesh file is missing: {mesh_path}")
-    return dims, geometry, primitive
+        mesh = Path(str(asset.get("mesh_path") or ""))
+        if mesh.is_absolute() or ".." in mesh.parts or mesh.suffix.lower() not in MESH_SUFFIXES or not (ROOT / mesh).is_file():
+            raise ValueError("curated mesh path is missing, unsafe or unsupported")
+    return size, geometry, primitive
 
 
 def _instance_id(asset_id: str, items: list[dict[str, Any]], requested: str | None) -> str:
     used = {str(item.get("id")) for item in items}
     if requested:
-        if not ID_RE.fullmatch(requested):
-            raise ValueError("instance ID must match [A-Za-z0-9][A-Za-z0-9_-]*")
-        if requested in used:
-            raise ValueError(f"instance ID already exists: {requested}")
+        if not ID_RE.fullmatch(requested) or requested in used:
+            raise ValueError("instance ID is invalid or already exists")
         return requested
     for index in range(1, 1000):
         candidate = f"{asset_id}_{index:02d}"
@@ -185,112 +169,80 @@ def _instance_id(asset_id: str, items: list[dict[str, Any]], requested: str | No
     raise ValueError(f"could not allocate a unique instance ID for {asset_id}")
 
 
-def _layout_item(asset: dict[str, Any], instance_id: str, support_id: str, pose_xyz: list[float], dims: list[float], geometry: str, primitive: str | None) -> dict[str, Any]:
-    asset_type = str(asset.get("asset_type") or "object")
+def _new_item(asset: dict[str, Any], item_id: str, support_id: str, xyz: list[float], size: list[float], geometry: str, primitive: str | None) -> dict[str, Any]:
+    kind = str(asset.get("asset_type") or "object")
     item: dict[str, Any] = {
-        "id": instance_id,
-        "type": asset_type,
-        "role": "pick_object" if asset_type == "object" else asset_type,
+        "id": item_id, "type": kind, "role": "pick_object" if kind == "object" else kind,
         "category": str(asset.get("category") or "Curated Objects"),
-        "display_name": f"{asset.get('label', asset.get('asset_id'))} {instance_id.rsplit('_', 1)[-1]}",
-        "editable": True,
-        "locked": False,
-        "source_layer": "editable_layout",
-        "source": str(LAYOUT_REL).replace(os.sep, "/"),
-        "pose": {"xyz": pose_xyz, "rpy": [0.0, 0.0, 0.0]},
-        "dimensions": dims,
-        "support_surface_ref": support_id,
-        "catalog_asset_id": str(asset["asset_id"]),
-        "placement_source": "curated_asset_catalog",
-        "material": {"color": COLORS.get(asset_type, COLORS["object"])},
+        "display_name": f"{asset.get('label', asset.get('asset_id'))} {item_id.rsplit('_', 1)[-1]}",
+        "editable": True, "locked": False, "source_layer": "editable_layout",
+        "source": "layout/workcell_studio_layout.yaml",
+        "pose": {"xyz": xyz, "rpy": [0.0, 0.0, 0.0]}, "dimensions": size,
+        "support_surface_ref": support_id, "catalog_asset_id": str(asset["asset_id"]),
+        "placement_source": "curated_asset_catalog", "material": {"color": COLORS.get(kind, COLORS["object"])},
     }
     if geometry == "urdf_primitive":
-        item["geometry_type"] = primitive
-        item["primitive_geometry_type"] = primitive
+        item.update({"geometry_type": primitive, "primitive_geometry_type": primitive})
     else:
-        item["geometry_type"] = "mesh"
-        item["mesh_path"] = str(asset["mesh_path"])
+        item.update({"geometry_type": "mesh", "mesh_path": str(asset["mesh_path"])})
     return item
 
 
-def _atomic_yaml(path: Path, data: dict[str, Any]) -> None:
+def _atomic_write(path: Path, data: dict[str, Any]) -> None:
     assert yaml is not None
-    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    fd, temp = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as stream:
             yaml.safe_dump(data, stream, sort_keys=False, default_flow_style=False)
-            stream.flush()
-            os.fsync(stream.fileno())
-        os.replace(tmp_name, path)
-        directory_fd = os.open(path.parent, os.O_RDONLY)
-        try:
-            os.fsync(directory_fd)
-        finally:
-            os.close(directory_fd)
+            stream.flush(); os.fsync(stream.fileno())
+        os.replace(temp, path)
+        directory = os.open(path.parent, os.O_RDONLY)
+        try: os.fsync(directory)
+        finally: os.close(directory)
     finally:
-        if os.path.exists(tmp_name):
-            os.unlink(tmp_name)
+        if os.path.exists(temp): os.unlink(temp)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Safely add one approved curated object to an editable Workcell Studio layout.")
-    parser.add_argument("--scene", required=True, type=Path)
-    parser.add_argument("--asset-id", required=True)
-    parser.add_argument("--instance-id")
-    parser.add_argument("--expected-layout-sha256")
-    parser.add_argument("--write", action="store_true")
-    parser.add_argument("--backup", action="store_true")
-    parser.add_argument("--json", action="store_true")
-    args = parser.parse_args(argv)
+    parser = argparse.ArgumentParser(description="Add one approved catalog object to an editable layout.")
+    parser.add_argument("--scene", required=True, type=Path); parser.add_argument("--asset-id", required=True)
+    parser.add_argument("--instance-id"); parser.add_argument("--expected-layout-sha256")
+    parser.add_argument("--write", action="store_true"); parser.add_argument("--backup", action="store_true")
+    parser.add_argument("--json", action="store_true"); args = parser.parse_args(argv)
     try:
-        if yaml is None:
-            raise ValueError("PyYAML is required")
-        scene = args.scene.resolve()
-        layout_path = scene / LAYOUT_REL
-        if not scene.is_dir() or not layout_path.is_file():
-            raise ValueError(f"editable layout is missing: {layout_path}")
-        layout_sha = _sha256(layout_path)
-        if args.expected_layout_sha256 and args.expected_layout_sha256 != layout_sha:
+        if yaml is None: raise ValueError("PyYAML is required")
+        scene = args.scene.resolve(); layout_path = scene / LAYOUT_REL
+        if not scene.is_dir() or not layout_path.is_file(): raise ValueError(f"editable layout is missing: {layout_path}")
+        before_sha = _sha(layout_path)
+        if args.expected_layout_sha256 and args.expected_layout_sha256 != before_sha:
             raise ValueError("layout changed after preview; reload and plan the add again")
         layout = yaml.safe_load(layout_path.read_text(encoding="utf-8")) or {}
         if layout.get("schema_version") != "workcell_studio_layout/v1" or not isinstance(layout.get("items"), list):
             raise ValueError("layout must use workcell_studio_layout/v1 with an items list")
-        catalog = _catalog()
-        asset = catalog.get(args.asset_id)
-        if asset is None:
-            raise ValueError(f"unknown curated asset: {args.asset_id}")
-        dims, geometry, primitive = _validate_asset(asset)
+        asset = _catalog().get(args.asset_id)
+        if asset is None: raise ValueError(f"asset is not approved for curated add: {args.asset_id}")
+        size, geometry, primitive = _validate_asset(asset)
         items = [item for item in layout["items"] if isinstance(item, dict)]
-        instance_id = _instance_id(args.asset_id, items, args.instance_id)
-        support, pose_xyz = _find_placement(items, dims)
-        support_id = str(support.get("id"))
-        new_item = _layout_item(asset, instance_id, support_id, pose_xyz, dims, geometry, primitive)
-        result = {
-            "status": "written" if args.write else "planned",
-            "scene_id": scene.name,
-            "asset_id": args.asset_id,
-            "instance_id": instance_id,
-            "support_surface_id": support_id,
-            "pose_xyz": pose_xyz,
-            "dimensions_m": dims,
-            "layout_sha256": layout_sha,
-            "layout_path": str(layout_path),
-            "license": str(asset.get("license") or "unknown"),
+        item_id = _instance_id(args.asset_id, items, args.instance_id)
+        support_id, xyz = _placement(items, size)
+        result: dict[str, Any] = {
+            "status": "written" if args.write else "planned", "scene_id": scene.name,
+            "asset_id": args.asset_id, "instance_id": item_id, "support_surface_id": support_id,
+            "pose_xyz": xyz, "dimensions_m": size, "layout_sha256": before_sha,
+            "layout_path": str(layout_path), "license": str(asset.get("license") or "unknown"),
             "source_note": str(asset.get("source_note") or ""),
         }
         if args.write:
             if args.backup:
                 stamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
                 backup = layout_path.with_name(f"{layout_path.name}.{stamp}.bak")
-                shutil.copy2(layout_path, backup)
-                result["backup_path"] = str(backup)
-            layout["items"].append(new_item)
-            _atomic_yaml(layout_path, layout)
-            result["layout_sha256_after"] = _sha256(layout_path)
+                shutil.copy2(layout_path, backup); result["backup_path"] = str(backup)
+            layout["items"].append(_new_item(asset, item_id, support_id, xyz, size, geometry, primitive))
+            _atomic_write(layout_path, layout); result["layout_sha256_after"] = _sha(layout_path)
         print(json.dumps(result, sort_keys=True) if args.json else json.dumps(result, indent=2, sort_keys=True))
         return 0
     except (OSError, ValueError, json.JSONDecodeError) as exc:
-        return _fail(str(exc), json_output=args.json)
+        return _emit_error(str(exc), args.json)
 
 
 if __name__ == "__main__":

--- a/scripts/add_workcell_studio_curated_object.py
+++ b/scripts/add_workcell_studio_curated_object.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Plan or persist one curated catalog object in an editable Workcell Studio layout.
+
+Dry-run is the default.  The command writes only
+layout/workcell_studio_layout.yaml, and only after the caller explicitly passes
+--write.  It never edits generated files, environment.yaml, manifests, robot
+configuration, controllers, or motion settings.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import math
+import os
+import re
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml  # type: ignore
+except ImportError:  # pragma: no cover
+    yaml = None  # type: ignore
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROFILE = REPO_ROOT / "workcell_builder/workcell_builder/config/asset_profiles/environment_assets.json"
+LAYOUT_REL = Path("layout/workcell_studio_layout.yaml")
+ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+MESH_SUFFIXES = {".stl", ".dae", ".obj"}
+EDGE_MARGIN = 0.01
+CLEARANCE = 0.01
+HELPER_TOKENS = ("zone", "keepout", "home_pose", "camera", "reach", "overlay", "helper", "warning")
+SUPPORT_TOKENS = ("support_surface", "table_surface", "tabletop", "workbench")
+COLORS = {
+    "bin": [0.95, 0.68, 0.20, 0.88],
+    "tray": [0.22, 0.58, 0.82, 0.88],
+    "tote": [0.28, 0.65, 0.48, 0.88],
+    "fixture": [0.48, 0.52, 0.58, 1.0],
+    "object": [0.91, 0.36, 0.24, 1.0],
+}
+
+
+def _fail(message: str, *, json_output: bool) -> int:
+    payload = {"status": "error", "error": message}
+    if json_output:
+        print(json.dumps(payload, sort_keys=True))
+    else:
+        print(f"ERROR: {message}", file=sys.stderr)
+    return 1
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _num3(value: Any, field: str) -> list[float]:
+    if not isinstance(value, list) or len(value) < 3:
+        raise ValueError(f"{field} must contain three numbers")
+    out = [float(value[i]) for i in range(3)]
+    if not all(math.isfinite(v) and v > 0.0 for v in out):
+        raise ValueError(f"{field} must contain three finite positive numbers")
+    return out
+
+
+def _pose(item: dict[str, Any]) -> list[float] | None:
+    pose = item.get("pose")
+    xyz = pose.get("xyz") if isinstance(pose, dict) else item.get("pose_xyz")
+    if not isinstance(xyz, list) or len(xyz) < 3:
+        return None
+    try:
+        out = [float(xyz[i]) for i in range(3)]
+    except (TypeError, ValueError):
+        return None
+    return out if all(math.isfinite(v) for v in out) else None
+
+
+def _dimensions(item: dict[str, Any]) -> list[float] | None:
+    raw = item.get("dimensions") or item.get("size")
+    try:
+        return _num3(raw, "dimensions")
+    except ValueError:
+        return None
+
+
+def _identity(item: dict[str, Any]) -> str:
+    return " ".join(str(item.get(k, "")).lower().replace("-", "_") for k in ("id", "type", "role", "category"))
+
+
+def _is_support(item: dict[str, Any]) -> bool:
+    text = _identity(item)
+    return any(token in text for token in SUPPORT_TOKENS)
+
+
+def _is_physical_obstacle(item: dict[str, Any]) -> bool:
+    text = _identity(item)
+    return not _is_support(item) and not any(token in text for token in HELPER_TOKENS) and _pose(item) is not None and _dimensions(item) is not None
+
+
+def _aabb(center: list[float], dims: list[float], clearance: float = 0.0) -> tuple[list[float], list[float]]:
+    half = [dims[i] / 2.0 + clearance for i in range(3)]
+    return ([center[i] - half[i] for i in range(3)], [center[i] + half[i] for i in range(3)])
+
+
+def _overlap(a: tuple[list[float], list[float]], b: tuple[list[float], list[float]]) -> bool:
+    return all(min(a[1][i], b[1][i]) - max(a[0][i], b[0][i]) > 1e-9 for i in range(3))
+
+
+def _candidate_offsets(max_x: float, max_y: float) -> list[tuple[float, float]]:
+    step = 0.05
+    nx = max(0, int(math.floor(max_x / step)))
+    ny = max(0, int(math.floor(max_y / step)))
+    values = [(ix * step, iy * step) for ix in range(-nx, nx + 1) for iy in range(-ny, ny + 1)]
+    return sorted(values, key=lambda p: (p[0] * p[0] + p[1] * p[1], abs(p[1]), abs(p[0]), p[1], p[0]))
+
+
+def _find_placement(items: list[dict[str, Any]], dims: list[float]) -> tuple[dict[str, Any], list[float]]:
+    supports = [item for item in items if _is_support(item) and _pose(item) is not None and _dimensions(item) is not None]
+    supports.sort(key=lambda item: str(item.get("id", "")))
+    obstacles = [item for item in items if _is_physical_obstacle(item)]
+    for support in supports:
+        support_pose = _pose(support)
+        support_dims = _dimensions(support)
+        assert support_pose is not None and support_dims is not None
+        max_x = support_dims[0] / 2.0 - dims[0] / 2.0 - EDGE_MARGIN
+        max_y = support_dims[1] / 2.0 - dims[1] / 2.0 - EDGE_MARGIN
+        if max_x < 0.0 or max_y < 0.0:
+            continue
+        z = support_pose[2] + support_dims[2] / 2.0 + dims[2] / 2.0
+        for dx, dy in _candidate_offsets(max_x, max_y):
+            candidate = [support_pose[0] + dx, support_pose[1] + dy, z]
+            candidate_box = _aabb(candidate, dims, CLEARANCE)
+            blocked = False
+            for obstacle in obstacles:
+                obstacle_pose = _pose(obstacle)
+                obstacle_dims = _dimensions(obstacle)
+                assert obstacle_pose is not None and obstacle_dims is not None
+                if _overlap(candidate_box, _aabb(obstacle_pose, obstacle_dims)):
+                    blocked = True
+                    break
+            if not blocked:
+                return support, candidate
+    raise ValueError("no collision-free support-surface slot is available for this object")
+
+
+def _catalog() -> dict[str, dict[str, Any]]:
+    data = json.loads(PROFILE.read_text(encoding="utf-8"))
+    return {str(item.get("asset_id")): item for item in data if isinstance(item, dict) and item.get("asset_id")}
+
+
+def _validate_asset(asset: dict[str, Any]) -> tuple[list[float], str, str | None]:
+    if asset.get("curated_add_enabled") is not True or asset.get("placement_policy") != "support_surface":
+        raise ValueError("asset is not approved for the curated add-object workflow")
+    dims = _num3(asset.get("default_dimensions_m"), "default_dimensions_m")
+    geometry = str(asset.get("geometry_type") or "mesh")
+    primitive = None
+    if geometry == "urdf_primitive":
+        primitive = str(asset.get("primitive_geometry_type") or "")
+        if primitive not in {"box", "cylinder", "sphere", "capsule"}:
+            raise ValueError("curated primitive asset has no supported primitive_geometry_type")
+    else:
+        mesh_path = Path(str(asset.get("mesh_path") or ""))
+        if mesh_path.is_absolute() or ".." in mesh_path.parts or mesh_path.suffix.lower() not in MESH_SUFFIXES:
+            raise ValueError("curated mesh path is unsafe or unsupported")
+        if not (REPO_ROOT / mesh_path).is_file():
+            raise ValueError(f"curated mesh file is missing: {mesh_path}")
+    return dims, geometry, primitive
+
+
+def _instance_id(asset_id: str, items: list[dict[str, Any]], requested: str | None) -> str:
+    used = {str(item.get("id")) for item in items}
+    if requested:
+        if not ID_RE.fullmatch(requested):
+            raise ValueError("instance ID must match [A-Za-z0-9][A-Za-z0-9_-]*")
+        if requested in used:
+            raise ValueError(f"instance ID already exists: {requested}")
+        return requested
+    for index in range(1, 1000):
+        candidate = f"{asset_id}_{index:02d}"
+        if candidate not in used:
+            return candidate
+    raise ValueError(f"could not allocate a unique instance ID for {asset_id}")
+
+
+def _layout_item(asset: dict[str, Any], instance_id: str, support_id: str, pose_xyz: list[float], dims: list[float], geometry: str, primitive: str | None) -> dict[str, Any]:
+    asset_type = str(asset.get("asset_type") or "object")
+    item: dict[str, Any] = {
+        "id": instance_id,
+        "type": asset_type,
+        "role": "pick_object" if asset_type == "object" else asset_type,
+        "category": str(asset.get("category") or "Curated Objects"),
+        "display_name": f"{asset.get('label', asset.get('asset_id'))} {instance_id.rsplit('_', 1)[-1]}",
+        "editable": True,
+        "locked": False,
+        "source_layer": "editable_layout",
+        "source": str(LAYOUT_REL).replace(os.sep, "/"),
+        "pose": {"xyz": pose_xyz, "rpy": [0.0, 0.0, 0.0]},
+        "dimensions": dims,
+        "support_surface_ref": support_id,
+        "catalog_asset_id": str(asset["asset_id"]),
+        "placement_source": "curated_asset_catalog",
+        "material": {"color": COLORS.get(asset_type, COLORS["object"])},
+    }
+    if geometry == "urdf_primitive":
+        item["geometry_type"] = primitive
+        item["primitive_geometry_type"] = primitive
+    else:
+        item["geometry_type"] = "mesh"
+        item["mesh_path"] = str(asset["mesh_path"])
+    return item
+
+
+def _atomic_yaml(path: Path, data: dict[str, Any]) -> None:
+    assert yaml is not None
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            yaml.safe_dump(data, stream, sort_keys=False, default_flow_style=False)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(tmp_name, path)
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Safely add one approved curated object to an editable Workcell Studio layout.")
+    parser.add_argument("--scene", required=True, type=Path)
+    parser.add_argument("--asset-id", required=True)
+    parser.add_argument("--instance-id")
+    parser.add_argument("--expected-layout-sha256")
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--backup", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    try:
+        if yaml is None:
+            raise ValueError("PyYAML is required")
+        scene = args.scene.resolve()
+        layout_path = scene / LAYOUT_REL
+        if not scene.is_dir() or not layout_path.is_file():
+            raise ValueError(f"editable layout is missing: {layout_path}")
+        layout_sha = _sha256(layout_path)
+        if args.expected_layout_sha256 and args.expected_layout_sha256 != layout_sha:
+            raise ValueError("layout changed after preview; reload and plan the add again")
+        layout = yaml.safe_load(layout_path.read_text(encoding="utf-8")) or {}
+        if layout.get("schema_version") != "workcell_studio_layout/v1" or not isinstance(layout.get("items"), list):
+            raise ValueError("layout must use workcell_studio_layout/v1 with an items list")
+        catalog = _catalog()
+        asset = catalog.get(args.asset_id)
+        if asset is None:
+            raise ValueError(f"unknown curated asset: {args.asset_id}")
+        dims, geometry, primitive = _validate_asset(asset)
+        items = [item for item in layout["items"] if isinstance(item, dict)]
+        instance_id = _instance_id(args.asset_id, items, args.instance_id)
+        support, pose_xyz = _find_placement(items, dims)
+        support_id = str(support.get("id"))
+        new_item = _layout_item(asset, instance_id, support_id, pose_xyz, dims, geometry, primitive)
+        result = {
+            "status": "written" if args.write else "planned",
+            "scene_id": scene.name,
+            "asset_id": args.asset_id,
+            "instance_id": instance_id,
+            "support_surface_id": support_id,
+            "pose_xyz": pose_xyz,
+            "dimensions_m": dims,
+            "layout_sha256": layout_sha,
+            "layout_path": str(layout_path),
+            "license": str(asset.get("license") or "unknown"),
+            "source_note": str(asset.get("source_note") or ""),
+        }
+        if args.write:
+            if args.backup:
+                stamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+                backup = layout_path.with_name(f"{layout_path.name}.{stamp}.bak")
+                shutil.copy2(layout_path, backup)
+                result["backup_path"] = str(backup)
+            layout["items"].append(new_item)
+            _atomic_yaml(layout_path, layout)
+            result["layout_sha256_after"] = _sha256(layout_path)
+        print(json.dumps(result, sort_keys=True) if args.json else json.dumps(result, indent=2, sort_keys=True))
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        return _fail(str(exc), json_output=args.json)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_workcell_curated_add_object_workflow.py
+++ b/tests/test_workcell_curated_add_object_workflow.py
@@ -1,0 +1,151 @@
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/add_workcell_studio_curated_object.py"
+CURATION = ROOT / "workcell_builder/workcell_builder/config/asset_profiles/curated_add_objects.json"
+CONTROLLER = ROOT / "workcell_builder/workcell_builder/gui/embedded_web_curated_add_controller.hpp"
+BOOTSTRAP = ROOT / "workcell_builder/workcell_builder/gui/embedded_web_curated_add_bootstrap.hpp"
+UI_HEADER = ROOT / "workcell_builder/workcell_builder/include/workcell_builder_ui_utils.hpp"
+
+
+def _scene(tmp_path: Path) -> Path:
+    scene = tmp_path / "scenes/tiny_scene"
+    (scene / "layout").mkdir(parents=True)
+    (scene / "generated").mkdir()
+    layout = {
+        "schema_version": "workcell_studio_layout/v1",
+        "items": [
+            {
+                "id": "table", "type": "support_surface", "role": "support_surface",
+                "category": "work_surface", "pose": {"xyz": [0.0, 0.0, 0.05], "rpy": [0, 0, 0]},
+                "dimensions": [1.2, 0.8, 0.1], "geometry_type": "box", "editable": True, "locked": False,
+            },
+            {
+                "id": "existing_box", "type": "object", "role": "pick_object",
+                "pose": {"xyz": [0.0, 0.0, 0.15], "rpy": [0, 0, 0]},
+                "dimensions": [0.2, 0.2, 0.1], "geometry_type": "box", "editable": True, "locked": False,
+            },
+            {
+                "id": "pick_zone", "type": "pick_zone", "role": "pick_zone",
+                "pose": {"xyz": [0.0, 0.0, 0.105], "rpy": [0, 0, 0]}, "dimensions": [0.8, 0.6, 0.01],
+            },
+        ],
+    }
+    (scene / "layout/workcell_studio_layout.yaml").write_text(yaml.safe_dump(layout, sort_keys=False), encoding="utf-8")
+    (scene / "environment.yaml").write_text("sentinel: unchanged\n", encoding="utf-8")
+    (scene / "generated/sentinel.txt").write_text("unchanged\n", encoding="utf-8")
+    return scene
+
+
+def _run(scene: Path, asset_id: str, *extra: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--scene", str(scene), "--asset-id", asset_id, "--json", *extra],
+        cwd=ROOT, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False,
+    )
+
+
+def test_curated_manifest_is_small_support_surface_only_and_excludes_structural_assets():
+    manifest = json.loads(CURATION.read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == "workcell_studio_curated_add_objects/v1"
+    ids = {item["asset_id"] for item in manifest["objects"]}
+    assert ids == {"bin_small", "bin_large", "tray", "tote_box", "fixture_plate", "calibration_cube", "pick_box", "cylinder_object"}
+    assert all(item["placement_policy"] == "support_surface" for item in manifest["objects"])
+    assert not ids.intersection({"table_small", "workbench", "pallet", "robot_base_plate", "camera_stand", "safety_fence_panel"})
+
+
+def test_dry_run_plans_collision_free_support_placement_without_mutation(tmp_path: Path):
+    scene = _scene(tmp_path)
+    layout = scene / "layout/workcell_studio_layout.yaml"
+    before = layout.read_bytes()
+    result = _run(scene, "pick_box")
+    assert result.returncode == 0, result.stdout + result.stderr
+    plan = json.loads(result.stdout)
+    assert plan["status"] == "planned"
+    assert plan["support_surface_id"] == "table"
+    assert plan["instance_id"] == "pick_box_01"
+    assert plan["pose_xyz"] != [0.0, 0.0, 0.14]
+    assert layout.read_bytes() == before
+
+
+def test_confirmed_write_is_atomic_backed_up_and_bottom_aligned(tmp_path: Path):
+    scene = _scene(tmp_path)
+    layout_path = scene / "layout/workcell_studio_layout.yaml"
+    before_environment = (scene / "environment.yaml").read_bytes()
+    before_generated = (scene / "generated/sentinel.txt").read_bytes()
+    plan = json.loads(_run(scene, "pick_box").stdout)
+    result = _run(
+        scene, "pick_box", "--instance-id", plan["instance_id"],
+        "--expected-layout-sha256", plan["layout_sha256"], "--write", "--backup",
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    written = json.loads(result.stdout)
+    assert written["status"] == "written"
+    assert Path(written["backup_path"]).is_file()
+    layout = yaml.safe_load(layout_path.read_text(encoding="utf-8"))
+    item = next(value for value in layout["items"] if value["id"] == "pick_box_01")
+    assert item["source"] == "layout/workcell_studio_layout.yaml"
+    assert item["source_layer"] == "editable_layout"
+    assert item["editable"] is True and item["locked"] is False
+    assert item["catalog_asset_id"] == "pick_box"
+    assert item["support_surface_ref"] == "table"
+    assert item["primitive_geometry_type"] == "box"
+    assert abs((item["pose"]["xyz"][2] - item["dimensions"][2] / 2.0) - 0.1) < 1e-9
+    assert (scene / "environment.yaml").read_bytes() == before_environment
+    assert (scene / "generated/sentinel.txt").read_bytes() == before_generated
+
+
+def test_stale_layout_and_non_curated_asset_are_rejected(tmp_path: Path):
+    scene = _scene(tmp_path)
+    stale = hashlib.sha256(b"older layout").hexdigest()
+    stale_result = _run(scene, "pick_box", "--expected-layout-sha256", stale, "--write")
+    assert stale_result.returncode != 0
+    assert "layout changed after preview" in json.loads(stale_result.stdout)["error"]
+    structural = _run(scene, "table_small")
+    assert structural.returncode != 0
+    assert "not approved" in json.loads(structural.stdout)["error"]
+
+
+def test_curated_mesh_asset_keeps_repo_relative_mesh_reference(tmp_path: Path):
+    scene = _scene(tmp_path)
+    plan = json.loads(_run(scene, "bin_small").stdout)
+    result = _run(scene, "bin_small", "--instance-id", plan["instance_id"],
+                  "--expected-layout-sha256", plan["layout_sha256"], "--write")
+    assert result.returncode == 0, result.stdout + result.stderr
+    layout = yaml.safe_load((scene / "layout/workcell_studio_layout.yaml").read_text(encoding="utf-8"))
+    item = next(value for value in layout["items"] if value["id"] == "bin_small_01")
+    assert item["geometry_type"] == "mesh"
+    assert item["mesh_path"].startswith("workcell_builder/workcell_builder/assets/environment/")
+    assert not Path(item["mesh_path"]).is_absolute()
+
+
+def test_qt_workflow_is_curated_async_scene_guarded_and_requires_clean_editor():
+    source = CONTROLLER.read_text(encoding="utf-8")
+    for token in [
+        "Add object", "QInputDialog::getItem", "curated_add_objects.json", "environment_assets.json",
+        "add_workcell_studio_curated_object.py", "--expected-layout-sha256", "--backup",
+        "run_workcell_studio_web_edit_workflow.py", "--generate-and-validate",
+        "ensure_workcell_studio_web_scene_fresh.py", "--stage-assets", "--force",
+        "Scene changed—reload required", "Planning…", "Adding…", "Generating…", "Refreshing…", "Added",
+        "!state.value(QStringLiteral(\"dirty\")).toBool()", "view_->url() == expected_url_", "QProcess",
+    ]:
+        assert token in source
+    assert "QFileDialog" not in source
+    assert "waitForFinished" not in source
+    assert "window.__WORKCELL_EDITOR_API_V1__" in source
+    assert "embedded_web_curated_add_bootstrap.hpp" in UI_HEADER.read_text(encoding="utf-8")
+    assert "Q_COREAPP_STARTUP_FUNCTION" in BOOTSTRAP.read_text(encoding="utf-8")
+
+
+def test_no_browser_yaml_write_or_robot_motion_commands_are_added():
+    combined = "\n".join(path.read_text(encoding="utf-8") for path in (SCRIPT, CONTROLLER, BOOTSTRAP))
+    for forbidden in (
+        "ros2 launch", "execute_trajectory", "move_group", "GetMotionPlan", "real_hardware_enabled: true",
+        "fetch(\"file://", "environment.yaml\").write", "scene_manifest.yaml\").write",
+    ):
+        assert forbidden not in combined

--- a/workcell_builder/workcell_builder/config/asset_profiles/curated_add_objects.json
+++ b/workcell_builder/workcell_builder/config/asset_profiles/curated_add_objects.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "workcell_studio_curated_add_objects/v1",
+  "objects": [
+    {"asset_id": "bin_small", "placement_policy": "support_surface"},
+    {"asset_id": "bin_large", "placement_policy": "support_surface"},
+    {"asset_id": "tray", "placement_policy": "support_surface"},
+    {"asset_id": "tote_box", "placement_policy": "support_surface"},
+    {"asset_id": "fixture_plate", "placement_policy": "support_surface", "primitive_geometry_type": "box"},
+    {"asset_id": "calibration_cube", "placement_policy": "support_surface", "primitive_geometry_type": "box"},
+    {"asset_id": "pick_box", "placement_policy": "support_surface", "primitive_geometry_type": "box"},
+    {"asset_id": "cylinder_object", "placement_policy": "support_surface", "primitive_geometry_type": "cylinder"}
+  ]
+}

--- a/workcell_builder/workcell_builder/gui/embedded_web_curated_add_bootstrap.hpp
+++ b/workcell_builder/workcell_builder/gui/embedded_web_curated_add_bootstrap.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <algorithm>
+#include "embedded_web_curated_add_controller.hpp"
+
+#ifdef WORKCELL_BUILDER_HAS_WEBENGINE
+
+#include <QApplication>
+#include <QTimer>
+
+namespace workcell_builder
+{
+inline void bootstrapEmbeddedWebCuratedAddControllers()
+{
+  if (!qApp || qApp->property("workcell_embedded_curated_add_bootstrap").toBool()) return;
+  qApp->setProperty("workcell_embedded_curated_add_bootstrap", true);
+  auto * timer = new QTimer(qApp);
+  timer->setInterval(500);
+  QObject::connect(timer, &QTimer::timeout, qApp, []() {
+    for (QWidget * window : QApplication::topLevelWidgets()) {
+      installEmbeddedWebCuratedAddControllers(window);
+    }
+  });
+  timer->start();
+  QTimer::singleShot(0, qApp, []() {
+    for (QWidget * window : QApplication::topLevelWidgets()) {
+      installEmbeddedWebCuratedAddControllers(window);
+    }
+  });
+}
+}  // namespace workcell_builder
+
+Q_COREAPP_STARTUP_FUNCTION(workcell_builder::bootstrapEmbeddedWebCuratedAddControllers)
+
+#endif

--- a/workcell_builder/workcell_builder/gui/embedded_web_curated_add_bootstrap.hpp
+++ b/workcell_builder/workcell_builder/gui/embedded_web_curated_add_bootstrap.hpp
@@ -30,6 +30,10 @@ inline void bootstrapEmbeddedWebCuratedAddControllers()
 }
 }  // namespace workcell_builder
 
-Q_COREAPP_STARTUP_FUNCTION(workcell_builder::bootstrapEmbeddedWebCuratedAddControllers)
+inline void workcellBuilderBootstrapCuratedAddControllers()
+{
+  workcell_builder::bootstrapEmbeddedWebCuratedAddControllers();
+}
+Q_COREAPP_STARTUP_FUNCTION(workcellBuilderBootstrapCuratedAddControllers)
 
 #endif

--- a/workcell_builder/workcell_builder/gui/embedded_web_curated_add_controller.hpp
+++ b/workcell_builder/workcell_builder/gui/embedded_web_curated_add_controller.hpp
@@ -1,0 +1,330 @@
+#pragma once
+
+#include <QWidget>
+
+#ifdef WORKCELL_BUILDER_HAS_WEBENGINE
+
+#include "embedded_web_edit_save_controller.hpp"
+
+#include <QBoxLayout>
+#include <QFile>
+#include <QInputDialog>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QLabel>
+#include <QMap>
+#include <QMessageBox>
+#include <QPointer>
+#include <QProcess>
+#include <QPushButton>
+#include <QSizePolicy>
+#include <QTimer>
+#include <QVariantMap>
+#include <QWebEnginePage>
+#include <QWebEngineView>
+
+namespace workcell_builder
+{
+namespace embedded_web_curated_add_detail
+{
+using embedded_web_edit_save_detail::findRepoRoot;
+using embedded_web_edit_save_detail::resolveSceneDir;
+using embedded_web_edit_save_detail::sceneIdFromViewerUrl;
+
+struct CatalogChoice
+{
+  QString asset_id;
+  QString label;
+  QString category;
+  QString license;
+  QString source_note;
+  QJsonArray dimensions;
+};
+
+class EmbeddedWebCuratedAddController : public QObject
+{
+public:
+  EmbeddedWebCuratedAddController(QWidget * preview, QWebEngineView * view)
+  : QObject(preview), preview_(preview), view_(view)
+  {
+    installed_ = createControls();
+    if (!installed_) return;
+    connect(add_button_, &QPushButton::clicked, this, [this]() { requestAdd(); });
+    connect(view_, &QWebEngineView::loadFinished, this, [this](bool) {
+      QTimer::singleShot(250, this, [this]() { pollEditorState(); });
+    });
+    poll_timer_.setInterval(400);
+    connect(&poll_timer_, &QTimer::timeout, this, [this]() { pollEditorState(); });
+    poll_timer_.start();
+    pollEditorState();
+  }
+
+  bool installed() const { return installed_; }
+
+private:
+  enum class Phase { Plan, Write, GenerateValidate, Refresh };
+
+  bool createControls()
+  {
+    if (!preview_ || !view_) return false;
+    QPushButton * fit = nullptr;
+    for (QPushButton * button : preview_->findChildren<QPushButton *>()) {
+      if (button->text() == QStringLiteral("Fit")) { fit = button; break; }
+    }
+    if (!fit) return false;
+    QBoxLayout * toolbar = nullptr;
+    for (QBoxLayout * layout : preview_->findChildren<QBoxLayout *>()) {
+      if (layout->indexOf(fit) >= 0) { toolbar = layout; break; }
+    }
+    if (!toolbar) return false;
+
+    add_button_ = new QPushButton(QStringLiteral("Add object"), preview_);
+    add_button_->setObjectName(QStringLiteral("embeddedCuratedAddObjectButton"));
+    add_button_->setProperty("class", "primary_action");
+    add_button_->setEnabled(false);
+    add_button_->setToolTip(QStringLiteral(
+      "Choose an approved bin, tray, fixture or pick object. Workcell Studio finds a collision-free table position, backs up the editable layout, validates, regenerates and reloads Product View. No robot motion is started."));
+    add_button_->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
+
+    status_label_ = new QLabel(preview_);
+    status_label_->setObjectName(QStringLiteral("embeddedCuratedAddObjectStatus"));
+    status_label_->setWordWrap(true);
+    status_label_->setMaximumWidth(150);
+    status_label_->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
+    status_label_->setVisible(false);
+
+    const int fit_index = toolbar->indexOf(fit);
+    toolbar->insertWidget(fit_index + 1, add_button_);
+    toolbar->insertWidget(fit_index + 2, status_label_);
+    return true;
+  }
+
+  void setStatus(const QString & text, const QString & level = QStringLiteral("info"))
+  {
+    if (!status_label_) return;
+    status_label_->setText(text); status_label_->setVisible(!text.isEmpty());
+    QString bg = QStringLiteral("#e7f0fb"), fg = QStringLiteral("#2769b3");
+    if (level == QStringLiteral("success")) { bg = QStringLiteral("#e8f5eb"); fg = QStringLiteral("#217a34"); }
+    else if (level == QStringLiteral("warning")) { bg = QStringLiteral("#fff3e0"); fg = QStringLiteral("#8a5200"); }
+    else if (level == QStringLiteral("error")) { bg = QStringLiteral("#fdecea"); fg = QStringLiteral("#b3261e"); }
+    status_label_->setStyleSheet(QStringLiteral(
+      "background:%1;color:%2;border:1px solid #c7d3df;border-radius:8px;padding:2px 6px;font-weight:600;").arg(bg, fg));
+  }
+
+  bool contextCurrent() const
+  {
+    return view_ && view_->url() == expected_url_ && sceneIdFromViewerUrl(view_->url()) == scene_id_;
+  }
+
+  void sceneChanged()
+  {
+    busy_ = false;
+    if (add_button_) add_button_->setEnabled(false);
+    setStatus(QStringLiteral("Scene changed—reload required"), QStringLiteral("warning"));
+  }
+
+  bool resolveContext(QString * error)
+  {
+    expected_url_ = view_ ? view_->url() : QUrl();
+    scene_id_ = sceneIdFromViewerUrl(expected_url_);
+    repo_root_ = findRepoRoot();
+    scene_dir_ = resolveSceneDir(repo_root_, scene_id_);
+    if (scene_id_.isEmpty() || repo_root_.isEmpty() || scene_dir_.isEmpty()) {
+      if (error) *error = QStringLiteral("The active Product View scene or repository could not be resolved safely.");
+      return false;
+    }
+    return true;
+  }
+
+  QList<CatalogChoice> catalog(QString * error) const
+  {
+    const QDir root(repo_root_);
+    QFile profile(root.filePath(QStringLiteral(
+      "workcell_builder/workcell_builder/config/asset_profiles/environment_assets.json")));
+    QFile curated(root.filePath(QStringLiteral(
+      "workcell_builder/workcell_builder/config/asset_profiles/curated_add_objects.json")));
+    if (!profile.open(QIODevice::ReadOnly) || !curated.open(QIODevice::ReadOnly)) {
+      if (error) *error = QStringLiteral("The curated object catalog could not be read.");
+      return {};
+    }
+    const QJsonDocument profile_doc = QJsonDocument::fromJson(profile.readAll());
+    const QJsonDocument curated_doc = QJsonDocument::fromJson(curated.readAll());
+    if (!profile_doc.isArray() || !curated_doc.isObject() ||
+        curated_doc.object().value(QStringLiteral("schema_version")).toString() !=
+          QStringLiteral("workcell_studio_curated_add_objects/v1")) {
+      if (error) *error = QStringLiteral("The curated object catalog contract is invalid.");
+      return {};
+    }
+    QMap<QString, QJsonObject> profiles;
+    for (const QJsonValue & value : profile_doc.array()) {
+      const QJsonObject item = value.toObject();
+      profiles.insert(item.value(QStringLiteral("asset_id")).toString(), item);
+    }
+    QList<CatalogChoice> choices;
+    for (const QJsonValue & value : curated_doc.object().value(QStringLiteral("objects")).toArray()) {
+      const QString id = value.toObject().value(QStringLiteral("asset_id")).toString();
+      const QJsonObject item = profiles.value(id);
+      if (id.isEmpty() || item.isEmpty()) continue;
+      choices.push_back({id, item.value(QStringLiteral("label")).toString(),
+        item.value(QStringLiteral("category")).toString(), item.value(QStringLiteral("license")).toString(),
+        item.value(QStringLiteral("source_note")).toString(), item.value(QStringLiteral("default_dimensions_m")).toArray()});
+    }
+    std::sort(choices.begin(), choices.end(), [](const CatalogChoice & a, const CatalogChoice & b) {
+      return a.category == b.category ? a.label < b.label : a.category < b.category;
+    });
+    if (choices.isEmpty() && error) *error = QStringLiteral("No approved curated objects are available.");
+    return choices;
+  }
+
+  void requestAdd()
+  {
+    if (busy_ || !view_) return;
+    QString error;
+    if (!resolveContext(&error)) {
+      setStatus(QStringLiteral("Add failed"), QStringLiteral("error"));
+      QMessageBox::warning(preview_, QStringLiteral("Add Curated Object"), error); return;
+    }
+    const QList<CatalogChoice> choices = catalog(&error);
+    if (choices.isEmpty()) {
+      setStatus(QStringLiteral("Add failed"), QStringLiteral("error"));
+      QMessageBox::warning(preview_, QStringLiteral("Add Curated Object"), error); return;
+    }
+    QStringList labels; QMap<QString, CatalogChoice> by_label;
+    for (const CatalogChoice & choice : choices) {
+      const QString dims = QStringLiteral("%1 × %2 × %3 m")
+        .arg(choice.dimensions.value(0).toDouble(), 0, 'f', 2)
+        .arg(choice.dimensions.value(1).toDouble(), 0, 'f', 2)
+        .arg(choice.dimensions.value(2).toDouble(), 0, 'f', 2);
+      const QString label = QStringLiteral("%1 — %2 (%3)").arg(choice.category, choice.label, dims);
+      labels << label; by_label.insert(label, choice);
+    }
+    bool accepted = false;
+    const QString selected = QInputDialog::getItem(preview_, QStringLiteral("Add Curated Object"),
+      QStringLiteral("Choose an approved object:"), labels, 0, false, &accepted);
+    if (!accepted || selected.isEmpty()) return;
+    selected_ = by_label.value(selected);
+    busy_ = true; if (add_button_) add_button_->setEnabled(false);
+    start(Phase::Plan);
+  }
+
+  void start(Phase phase)
+  {
+    if (!contextCurrent()) { sceneChanged(); return; }
+    if (process_) process_->deleteLater();
+    process_ = new QProcess(this); process_->setProgram(QStringLiteral("python3"));
+    QStringList args;
+    if (phase == Phase::Plan || phase == Phase::Write) {
+      args << QStringLiteral("scripts/add_workcell_studio_curated_object.py")
+           << QStringLiteral("--scene") << scene_dir_ << QStringLiteral("--asset-id") << selected_.asset_id
+           << QStringLiteral("--json");
+      if (phase == Phase::Write) {
+        args << QStringLiteral("--instance-id") << planned_instance_
+             << QStringLiteral("--expected-layout-sha256") << planned_sha_
+             << QStringLiteral("--write") << QStringLiteral("--backup");
+      }
+      setStatus(phase == Phase::Plan ? QStringLiteral("Planning…") : QStringLiteral("Adding…"));
+    } else if (phase == Phase::GenerateValidate) {
+      args << QStringLiteral("scripts/run_workcell_studio_web_edit_workflow.py")
+           << QStringLiteral("--scene") << scene_dir_ << QStringLiteral("--generate-and-validate");
+      setStatus(QStringLiteral("Generating…"));
+    } else {
+      args << QStringLiteral("scripts/ensure_workcell_studio_web_scene_fresh.py")
+           << QStringLiteral("--scene") << scene_dir_ << QStringLiteral("--output")
+           << QStringLiteral("build/workcell_studio_web_scene/%1.web_scene.json").arg(scene_id_)
+           << QStringLiteral("--stage-assets") << QStringLiteral("--force");
+      setStatus(QStringLiteral("Refreshing…"));
+    }
+    process_->setArguments(args); process_->setWorkingDirectory(repo_root_);
+    process_->setProcessChannelMode(QProcess::MergedChannels);
+    QProcess * const process = process_;
+    connect(process, qOverload<int, QProcess::ExitStatus>(&QProcess::finished), this,
+      [this, process, phase](int code, QProcess::ExitStatus status) {
+        const QByteArray output = process->readAll();
+        if (process == process_) process_ = nullptr; process->deleteLater();
+        if (!contextCurrent()) { sceneChanged(); return; }
+        if (status != QProcess::NormalExit || code != 0) {
+          busy_ = false; setStatus(QStringLiteral("Add failed"), QStringLiteral("error"));
+          QMessageBox::critical(preview_, QStringLiteral("Add Curated Object"),
+            QStringLiteral("The curated object workflow failed.\n\n%1").arg(QString::fromLocal8Bit(output).left(8000)));
+          pollEditorState(); return;
+        }
+        phaseFinished(phase, output);
+      });
+    process_->start();
+  }
+
+  void phaseFinished(Phase phase, const QByteArray & output)
+  {
+    if (phase == Phase::Plan) {
+      const QJsonObject plan = QJsonDocument::fromJson(output.trimmed()).object();
+      if (plan.value(QStringLiteral("status")).toString() != QStringLiteral("planned") ||
+          plan.value(QStringLiteral("scene_id")).toString() != scene_id_) {
+        busy_ = false; setStatus(QStringLiteral("Add failed"), QStringLiteral("error")); return;
+      }
+      planned_instance_ = plan.value(QStringLiteral("instance_id")).toString();
+      planned_sha_ = plan.value(QStringLiteral("layout_sha256")).toString();
+      const QJsonArray xyz = plan.value(QStringLiteral("pose_xyz")).toArray();
+      const QString message = QStringLiteral(
+        "Add %1 as %2?\n\nSupport: %3\nPose XYZ: %4, %5, %6 m\nLicense: %7\nSource: %8\n\n"
+        "Workcell Studio will back up and atomically update only the editable layout, then regenerate, validate and reload Product View. No robot motion is started.")
+        .arg(selected_.label, planned_instance_, plan.value(QStringLiteral("support_surface_id")).toString())
+        .arg(xyz.value(0).toDouble(), 0, 'f', 3).arg(xyz.value(1).toDouble(), 0, 'f', 3)
+        .arg(xyz.value(2).toDouble(), 0, 'f', 3).arg(selected_.license, selected_.source_note);
+      if (QMessageBox::question(preview_, QStringLiteral("Confirm Add Curated Object"), message,
+          QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes) {
+        busy_ = false; setStatus(QStringLiteral("Add cancelled"), QStringLiteral("warning")); pollEditorState(); return;
+      }
+      start(Phase::Write); return;
+    }
+    if (phase == Phase::Write) { start(Phase::GenerateValidate); return; }
+    if (phase == Phase::GenerateValidate) { start(Phase::Refresh); return; }
+    busy_ = false; setStatus(QStringLiteral("Added"), QStringLiteral("success"));
+    if (view_) view_->reload(); QTimer::singleShot(700, this, [this]() { pollEditorState(); });
+  }
+
+  void pollEditorState()
+  {
+    if (!installed_ || !view_ || busy_ || poll_pending_) return;
+    const QUrl url = view_->url(); const QString url_scene = sceneIdFromViewerUrl(url);
+    if (url_scene.isEmpty()) { if (add_button_) add_button_->setEnabled(false); return; }
+    poll_pending_ = true;
+    static const char kState[] = R"JS((() => { const a=window.__WORKCELL_EDITOR_API_V1__; if(!a)return {ready:false,dirty:true,sceneId:''}; const s=a.getState(); return {ready:Boolean(s.ready),dirty:Boolean(s.dirty),sceneId:String(s.sceneId||'')}; })())JS";
+    view_->page()->runJavaScript(QString::fromUtf8(kState), [this, url, url_scene](const QVariant & value) {
+      poll_pending_ = false; if (!view_ || view_->url() != url || busy_) return;
+      const QVariantMap state = value.toMap();
+      if (add_button_) add_button_->setEnabled(state.value(QStringLiteral("ready")).toBool() &&
+        !state.value(QStringLiteral("dirty")).toBool() && state.value(QStringLiteral("sceneId")).toString() == url_scene);
+      add_button_->setToolTip(state.value(QStringLiteral("dirty")).toBool() ?
+        QStringLiteral("Save or undo current Product View edits before adding an object.") :
+        QStringLiteral("Add an approved catalog object to a collision-free support-surface position."));
+    });
+  }
+
+  QPointer<QWidget> preview_; QPointer<QWebEngineView> view_; QPointer<QPushButton> add_button_;
+  QPointer<QLabel> status_label_; QPointer<QProcess> process_; QTimer poll_timer_{this};
+  QUrl expected_url_; QString scene_id_, repo_root_, scene_dir_, planned_instance_, planned_sha_;
+  CatalogChoice selected_; bool installed_{false}, busy_{false}, poll_pending_{false};
+};
+}  // namespace embedded_web_curated_add_detail
+
+inline void installEmbeddedWebCuratedAddControllers(QWidget * root)
+{
+  if (!root) return;
+  QList<QWidget *> previews;
+  if (root->objectName() == QStringLiteral("scenePreviewWidget")) previews << root;
+  previews.append(root->findChildren<QWidget *>(QStringLiteral("scenePreviewWidget"), Qt::FindChildrenRecursively));
+  for (QWidget * preview : previews) {
+    if (!preview || preview->property("workcell_embedded_curated_add_controller").toBool()) continue;
+    auto * view = preview->findChild<QWebEngineView *>(QStringLiteral("embeddedWeb3dProductView"));
+    if (!view) continue;
+    auto * controller = new embedded_web_curated_add_detail::EmbeddedWebCuratedAddController(preview, view);
+    if (controller->installed()) preview->setProperty("workcell_embedded_curated_add_controller", true);
+    else controller->deleteLater();
+  }
+}
+}  // namespace workcell_builder
+
+#else
+namespace workcell_builder { inline void installEmbeddedWebCuratedAddControllers(QWidget *) {} }
+#endif

--- a/workcell_builder/workcell_builder/include/workcell_builder_ui_utils.hpp
+++ b/workcell_builder/workcell_builder/include/workcell_builder_ui_utils.hpp
@@ -5,6 +5,8 @@
 #include <QPushButton>
 #include <QString>
 
+#include "embedded_web_curated_add_bootstrap.hpp"
+
 namespace workcell_builder
 {
 enum class StatusType


### PR DESCRIPTION
## Problem
The embedded Product View can now safely save transform edits, but users still have to leave the preview and use older asset-management dialogs to introduce new objects. A novice-friendly workcell workflow needs one bounded **Add object** action that offers only approved objects, places them on a real support surface, persists the addition safely, regenerates, validates and reloads the same scene.

## Changes
- Add an **Add object** action to the embedded Qt Product View toolbar.
- Present a deliberately small curated catalog through `QInputDialog`: small/large bins, tray, tote, fixture plate, calibration cube, pick box and cylinder.
- Keep structural or higher-risk assets out of this first workflow: tables, workbenches, conveyors, pallet, robot bases, camera stands and safety fencing are not selectable.
- Disable Add object while Product View has unsaved transform edits; users must save or undo those edits first.
- Plan placement before mutation using actual support-surface pose and dimensions.
- Place the object bottom exactly on the support top, retain a 10 mm edge margin, and search deterministic 50 mm candidate positions until a collision-free slot is found.
- Ignore zones/helpers as physical obstacles while respecting existing tangible layout objects.
- Allocate deterministic unique IDs such as `pick_box_01`.
- Write only `layout/workcell_studio_layout.yaml`; added records are editable, unlocked, source-labelled, catalog-linked and support-surface-linked.
- Preserve mesh assets through repo-relative mesh paths and use exact primitive metadata for the approved primitive objects.
- Run dry-run planning first and show the exact instance ID, support, pose, licence and source note before confirmation.
- Reject stale writes through an expected layout SHA-256 guard.
- Create a timestamped backup and replace the layout atomically using a same-directory temporary file, `fsync` and `os.replace`.
- Reuse the existing scene generation/validation workflow, refresh the staged Product View scene, and reload the embedded browser.
- Guard every asynchronous phase against scene/URL switching.

## Safety and trust boundaries
- No arbitrary file picker, URL, download or asset import path is exposed.
- The curated manifest is the allowlist; the existing environment asset profile remains the source of labels, dimensions, paths and licence metadata.
- `environment.yaml`, generated files, manifests and cell definitions are not written by the add backend.
- No ROS launch, controller activation, MoveIt execution, hardware access or robot motion is introduced.

## Scope
- 6 changed files.
- 784 additions and no deletions.
- No generated, minified, binary or scene-specific asset changes.
- No `viewer.js`, robot hierarchy, controller, MoveIt or launch changes.

## Validation
Focused tests cover:
- exact curated allowlist and structural-asset exclusions;
- dry-run non-mutation;
- deterministic collision-free support placement;
- bottom-to-table alignment;
- unique instance IDs;
- stale-layout rejection;
- timestamped backup and atomic layout write;
- primitive and mesh-backed object records;
- no mutation of environment/generated sentinels;
- clean-editor gating, asynchronous Qt workflow and stale-scene guards;
- reuse of generation/validation and Product View refresh;
- absence of browser YAML writes and robot-motion commands.

## Manual acceptance
Using embedded `ur5_2f_test`:
1. Confirm **Add object** is enabled only when Product View is ready and clean.
2. Create an unsaved move and confirm Add object is disabled until Save layout or Undo.
3. Open Add object and confirm only the eight approved entries are listed with category and dimensions.
4. Select Pick Box, review the planned ID/support/pose/licence, then cancel; confirm no file changes.
5. Repeat and confirm; verify a layout `.bak` is created and the object appears after automatic reload.
6. Confirm the object rests exactly on the work surface and does not overlap the existing bin/object.
7. Add a second Pick Box and confirm it receives `_02` and a different valid position.
8. Add Bin Small and confirm its mesh-backed appearance remains intact.
9. Fill or shrink the support surface and confirm an impossible placement fails without mutation.
10. Switch scenes during planning/generation and confirm the stale result is rejected with **Scene changed—reload required**.
11. Reopen the scene and confirm added objects persist.
12. Confirm no controller, ROS launch or robot motion occurs.