### PR TITLE
Consolidate post-bundle Product View modules

### DIFF
--- a/tests/test_workcell_web3d_post_bundle_consolidation.py
+++ b/tests/test_workcell_web3d_post_bundle_consolidation.py
@@ -1,0 +1,99 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VIEWER = ROOT / "workcell_studio_web/viewer"
+INDEX = VIEWER / "index.html"
+CONSOLIDATOR = VIEWER / "post_bundle_viewer_modules.js"
+
+MODULES = [
+    ("rviz_light_baseline.js", "__WORKCELL_RVIZ_LIGHT_BASELINE__"),
+    ("support_surface_placement.js", "__WORKCELL_SUPPORT_PLACEMENT_V1__"),
+    ("workcell_task_gizmo.js", "__WORKCELL_TASK_GIZMO_V1__"),
+    ("collision_placement_validation.js", "__WORKCELL_COLLISION_PLACEMENT_V1__"),
+    ("simple_product_ui.js", "__WORKCELL_SIMPLE_PRODUCT_UI_V1__"),
+    ("contextual_placement_actions.js", "__WORKCELL_CONTEXTUAL_PLACEMENT_ACTIONS_V1__"),
+]
+
+
+def test_post_bundle_consolidator_loads_once_after_every_existing_extension():
+    html = INDEX.read_text(encoding="utf-8")
+    ordered = ["./dist/viewer.bundle.js", *[f"./{name}" for name, _ in MODULES], "./post_bundle_viewer_modules.js"]
+    positions = [html.index(token) for token in ordered]
+    assert positions == sorted(positions)
+    assert html.count("./post_bundle_viewer_modules.js") == 1
+    for token in ordered:
+        assert html.count(token) == 1
+
+
+def test_consolidator_has_one_explicit_inventory_for_all_post_bundle_modules():
+    source = CONSOLIDATOR.read_text(encoding="utf-8")
+    for filename, global_name in MODULES:
+        assert f"file: '{filename}'" in source
+        assert f"global: '{global_name}'" in source
+        assert (VIEWER / filename).exists()
+    assert "const MODULES = Object.freeze([" in source
+    assert "modules: MODULES" in source
+    assert "missing.length === 0" in source
+
+
+def test_consolidated_api_preserves_existing_module_contracts():
+    source = CONSOLIDATOR.read_text(encoding="utf-8")
+    for token in [
+        "window.__WORKCELL_POST_BUNDLE_VIEWER_V1__ = api",
+        "getStatus",
+        "getEditorState: editorState",
+        "clearTransientFeedback",
+        "refreshUi",
+        "validateSelected",
+        "setFreeHeight",
+        "runPlacementAction",
+        "syncSceneIdentity",
+        "__WORKCELL_SUPPORT_PLACEMENT_V1__?.clear?.()",
+        "__WORKCELL_COLLISION_PLACEMENT_V1__?.clear?.()",
+        "__WORKCELL_SIMPLE_PRODUCT_UI_V1__?.refresh?.()",
+        "__WORKCELL_CONTEXTUAL_PLACEMENT_ACTIONS_V1__?.refresh?.()",
+        "__WORKCELL_COLLISION_PLACEMENT_V1__?.validateItem?.(id)",
+        "__WORKCELL_TASK_GIZMO_V1__?.setFreeHeight?.(Boolean(enabled))",
+        "__WORKCELL_CONTEXTUAL_PLACEMENT_ACTIONS_V1__?.run?.(String(action || ''))",
+    ]:
+        assert token in source
+
+
+def test_scene_switch_cleanup_and_status_publication_are_bounded_and_event_driven():
+    source = CONSOLIDATOR.read_text(encoding="utf-8")
+    for token in [
+        "sceneId !== lastSceneId",
+        "clearTransientFeedback()",
+        "workcell:post-bundle-viewer-status",
+        "workcell_post_bundle_viewer_status",
+        "signature === lastAnnouncement",
+        "beforeunload",
+        "visibilitychange",
+        "queueMicrotask(() =>",
+    ]:
+        assert token in source
+    assert "setInterval(" not in source
+    assert "requestAnimationFrame(" not in source
+    assert "new MutationObserver" not in source
+
+
+def test_consolidation_does_not_add_an_eighth_renderer_patch_or_side_effectful_io():
+    source = CONSOLIDATOR.read_text(encoding="utf-8").lower()
+    for forbidden in [
+        "webglrenderer",
+        "prototype.render",
+        "fetch(",
+        "xmlhttprequest",
+        "websocket",
+        "environment.yaml",
+        "workcell_studio_layout.yaml",
+        "writefile",
+        "unlink(",
+        "execute_trajectory",
+        "getmotionplan",
+        "/plan_kinematic_path",
+        "ros2 launch",
+    ]:
+        assert forbidden not in source
+    assert len(CONSOLIDATOR.read_text(encoding="utf-8").splitlines()) < 220

--- a/workcell_studio_web/viewer/index.html
+++ b/workcell_studio_web/viewer/index.html
@@ -106,5 +106,6 @@
   <script type="module" src="./collision_placement_validation.js"></script>
   <script type="module" src="./simple_product_ui.js"></script>
   <script type="module" src="./contextual_placement_actions.js"></script>
+  <script type="module" src="./post_bundle_viewer_modules.js"></script>
 </body>
 </html>

--- a/workcell_studio_web/viewer/post_bundle_viewer_modules.js
+++ b/workcell_studio_web/viewer/post_bundle_viewer_modules.js
@@ -1,0 +1,177 @@
+const VERSION = 1;
+
+const MODULES = Object.freeze([
+  Object.freeze({
+    id: 'rviz-light-baseline',
+    file: 'rviz_light_baseline.js',
+    global: '__WORKCELL_RVIZ_LIGHT_BASELINE__',
+    purpose: 'rendering baseline',
+  }),
+  Object.freeze({
+    id: 'support-surface-placement',
+    file: 'support_surface_placement.js',
+    global: '__WORKCELL_SUPPORT_PLACEMENT_V1__',
+    purpose: 'support-aware dragging',
+  }),
+  Object.freeze({
+    id: 'task-gizmo',
+    file: 'workcell_task_gizmo.js',
+    global: '__WORKCELL_TASK_GIZMO_V1__',
+    purpose: 'task-focused transform controls',
+  }),
+  Object.freeze({
+    id: 'collision-placement-validation',
+    file: 'collision_placement_validation.js',
+    global: '__WORKCELL_COLLISION_PLACEMENT_V1__',
+    purpose: 'layout collision feedback',
+  }),
+  Object.freeze({
+    id: 'simple-product-ui',
+    file: 'simple_product_ui.js',
+    global: '__WORKCELL_SIMPLE_PRODUCT_UI_V1__',
+    purpose: 'progressive disclosure',
+  }),
+  Object.freeze({
+    id: 'contextual-placement-actions',
+    file: 'contextual_placement_actions.js',
+    global: '__WORKCELL_CONTEXTUAL_PLACEMENT_ACTIONS_V1__',
+    purpose: 'one-click placement actions',
+  }),
+]);
+
+let lastSceneId = '';
+let lastAnnouncement = '';
+
+function editorApi() {
+  return window.__WORKCELL_EDITOR_API_V1__ || null;
+}
+
+function editorState() {
+  try {
+    return editorApi()?.getState?.() || null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function moduleApi(module) {
+  return window[module.global] || null;
+}
+
+function moduleStatus(module) {
+  const api = moduleApi(module);
+  return Object.freeze({
+    id: module.id,
+    file: module.file,
+    purpose: module.purpose,
+    global: module.global,
+    ready: Boolean(api?.enabled),
+    version: Number(api?.version || 0),
+  });
+}
+
+function getStatus() {
+  const modules = MODULES.map(moduleStatus);
+  const missing = modules.filter(module => !module.ready).map(module => module.id);
+  const state = editorState();
+  return Object.freeze({
+    enabled: true,
+    version: VERSION,
+    ready: missing.length === 0,
+    sceneId: String(state?.sceneId || ''),
+    selectedItemId: String(state?.selectedItemId || ''),
+    dirty: Boolean(state?.dirty),
+    modules: Object.freeze(modules),
+    missing: Object.freeze(missing),
+  });
+}
+
+function clearTransientFeedback() {
+  window.__WORKCELL_SUPPORT_PLACEMENT_V1__?.clear?.();
+  window.__WORKCELL_COLLISION_PLACEMENT_V1__?.clear?.();
+}
+
+function refreshUi() {
+  window.__WORKCELL_SIMPLE_PRODUCT_UI_V1__?.refresh?.();
+  window.__WORKCELL_CONTEXTUAL_PLACEMENT_ACTIONS_V1__?.refresh?.();
+  return getStatus();
+}
+
+function validateSelected() {
+  const id = String(editorState()?.selectedItemId || '');
+  if (!id) return null;
+  return window.__WORKCELL_COLLISION_PLACEMENT_V1__?.validateItem?.(id) || null;
+}
+
+function setFreeHeight(enabled) {
+  window.__WORKCELL_TASK_GIZMO_V1__?.setFreeHeight?.(Boolean(enabled));
+  return window.__WORKCELL_TASK_GIZMO_V1__?.getState?.() || null;
+}
+
+function runPlacementAction(action) {
+  return Boolean(window.__WORKCELL_CONTEXTUAL_PLACEMENT_ACTIONS_V1__?.run?.(String(action || '')));
+}
+
+function syncSceneIdentity() {
+  const sceneId = String(editorState()?.sceneId || '');
+  if (lastSceneId && sceneId && sceneId !== lastSceneId) clearTransientFeedback();
+  if (sceneId) lastSceneId = sceneId;
+  return sceneId;
+}
+
+function announceStatus() {
+  syncSceneIdentity();
+  const status = getStatus();
+  const signature = JSON.stringify({
+    ready: status.ready,
+    sceneId: status.sceneId,
+    missing: status.missing,
+  });
+  if (signature === lastAnnouncement) return status;
+  lastAnnouncement = signature;
+  window.dispatchEvent?.(new CustomEvent('workcell:post-bundle-viewer-status', { detail: status }));
+  window.parent?.postMessage?.({
+    type: 'workcell_post_bundle_viewer_status',
+    ready: status.ready,
+    scene_id: status.sceneId,
+    missing: [...status.missing],
+  }, '*');
+  return status;
+}
+
+const api = Object.freeze({
+  enabled: true,
+  version: VERSION,
+  modules: MODULES,
+  getStatus,
+  getEditorState: editorState,
+  clearTransientFeedback,
+  refreshUi,
+  validateSelected,
+  setFreeHeight,
+  runPlacementAction,
+  syncSceneIdentity,
+});
+
+window.__WORKCELL_POST_BUNDLE_VIEWER_V1__ = api;
+
+for (const eventName of [
+  'workcell:support-placement',
+  'workcell:gizmo-task-mode',
+  'workcell:collision-placement',
+  'workcell:contextual-placement-action',
+  'workcell:editor-state',
+  'workcell:scene-loaded',
+]) {
+  window.addEventListener(eventName, announceStatus);
+}
+window.addEventListener('pageshow', announceStatus);
+window.addEventListener('beforeunload', clearTransientFeedback, { once: true });
+document.addEventListener('visibilitychange', () => {
+  if (!document.hidden) announceStatus();
+});
+
+queueMicrotask(() => {
+  refreshUi();
+  announceStatus();
+});


### PR DESCRIPTION
## Problem
The Product View enhancement sequence intentionally added several small post-bundle modules without rebuilding the pinned viewer bundle. Their behaviour is now stable, but their public contracts remain scattered across six separate window globals, which makes Qt integration, diagnostics and future maintenance harder than necessary.

## Changes
- Add one final post-bundle consolidation layer loaded after all existing viewer extensions.
- Keep the proven module files and their exact load order unchanged:
  - RViz light baseline
  - support-surface placement
  - task-focused gizmo
  - collision placement validation
  - simplified Product View UI
  - contextual placement actions
- Define one explicit frozen module inventory containing each file, purpose and public global contract.
- Expose `window.__WORKCELL_POST_BUNDLE_VIEWER_V1__` as the stable integration surface for:
  - consolidated readiness and missing-module diagnostics;
  - editor-state access;
  - transient placement/collision helper cleanup;
  - UI refresh;
  - selected-item collision validation;
  - Free height control;
  - contextual placement actions;
  - scene-identity synchronization.
- Publish one deduplicated `workcell:post-bundle-viewer-status` event and parent-window status message.
- Clear transient support/collision feedback when the active scene identity changes or the page unloads.
- Keep synchronization event-driven; no polling interval, animation loop or MutationObserver is added.

## Deliberate compatibility boundary
This cleanup does not rewrite, merge or delete the proven extension modules. It does not alter their renderer hooks, placement calculations, UI observers or existing public APIs. The consolidator is a stable facade above them, so current tests and embedded Qt integrations remain compatible while new integrations have one supported entry point.

## Scope control
- Exactly **3 changed files**.
- **277 additions**, no deletions.
- No generated, minified or binary changes.
- No viewer bundle rebuild.
- No `viewer.js` refactor.
- No scene, asset, robot hierarchy, Qt, controller, MoveIt, launch, hardware or motion changes.
- No source YAML writes, network calls or additional renderer patch.

## Validation
Focused tests verify:
- the consolidator loads exactly once after the bundle and all six existing modules;
- the existing module load order remains unchanged;
- the module inventory matches every existing global contract;
- the consolidated API delegates to existing placement, collision, gizmo, UI and contextual-action APIs;
- scene-switch cleanup and status publication are bounded and event-driven;
- no interval, animation loop, MutationObserver, renderer patch, network call, source write or motion command is introduced.

## Manual acceptance
In canonical `ur5_2f_test`:
1. Confirm Product View loads and behaves exactly as before.
2. Confirm `window.__WORKCELL_POST_BUNDLE_VIEWER_V1__.getStatus()` reports all six modules ready.
3. Select an editable object and confirm `validateSelected()` returns the existing collision result.
4. Toggle Free height through the consolidated API and confirm the existing toolbar state follows.
5. Run a contextual placement action through the consolidated API and confirm Undo/Redo and collision rejection remain intact.
6. Switch scenes and confirm temporary support/collision outlines are cleared.
7. Confirm no robot motion, ROS launch or controller activation occurs.