### PR TITLE
Fix Qt5 build for embedded Product View controllers

### DIFF
--- a/tests/test_workcell_qt5_embedded_controller_compat.py
+++ b/tests/test_workcell_qt5_embedded_controller_compat.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GUI = ROOT / "workcell_builder/workcell_builder/gui"
+EDIT_SAVE = GUI / "embedded_web_edit_save_controller.hpp"
+CURATED_ADD = GUI / "embedded_web_curated_add_controller.hpp"
+
+
+def test_edit_save_controller_resets_qurl_explicitly_for_qt5():
+    source = EDIT_SAVE.read_text(encoding="utf-8")
+    assert "#include <QUrl>" in source
+    assert "last_polled_url_ = QUrl();" in source
+    assert "last_polled_url_ = {};" not in source
+
+
+def test_curated_add_controller_uses_qt5_qjsonarray_api_with_shape_guards():
+    source = CURATED_ADD.read_text(encoding="utf-8")
+
+    assert 'dimensions.size() != 3' in source
+    assert 'xyz.size() != 3' in source
+
+    for token in [
+        "choice.dimensions.at(0).toDouble()",
+        "choice.dimensions.at(1).toDouble()",
+        "choice.dimensions.at(2).toDouble()",
+        "xyz.at(0).toDouble()",
+        "xyz.at(1).toDouble()",
+        "xyz.at(2).toDouble()",
+    ]:
+        assert token in source
+
+    for incompatible in [
+        "choice.dimensions.value(0)",
+        "choice.dimensions.value(1)",
+        "choice.dimensions.value(2)",
+        "xyz.value(0)",
+        "xyz.value(1)",
+        "xyz.value(2)",
+    ]:
+        assert incompatible not in source
+
+
+def test_curated_add_controller_has_unambiguous_process_and_reload_control_flow():
+    source = CURATED_ADD.read_text(encoding="utf-8")
+
+    assert "if (process == process_) {\n          process_ = nullptr;\n        }\n        process->deleteLater();" in source
+    assert "if (view_) {\n      view_->reload();\n    }\n    QTimer::singleShot" in source
+    assert "if (process == process_) process_ = nullptr; process->deleteLater();" not in source
+    assert "if (view_) view_->reload(); QTimer::singleShot" not in source

--- a/workcell_builder/workcell_builder/gui/embedded_web_curated_add_controller.hpp
+++ b/workcell_builder/workcell_builder/gui/embedded_web_curated_add_controller.hpp
@@ -165,10 +165,11 @@ private:
     for (const QJsonValue & value : curated_doc.object().value(QStringLiteral("objects")).toArray()) {
       const QString id = value.toObject().value(QStringLiteral("asset_id")).toString();
       const QJsonObject item = profiles.value(id);
-      if (id.isEmpty() || item.isEmpty()) continue;
+      const QJsonArray dimensions = item.value(QStringLiteral("default_dimensions_m")).toArray();
+      if (id.isEmpty() || item.isEmpty() || dimensions.size() != 3) continue;
       choices.push_back({id, item.value(QStringLiteral("label")).toString(),
         item.value(QStringLiteral("category")).toString(), item.value(QStringLiteral("license")).toString(),
-        item.value(QStringLiteral("source_note")).toString(), item.value(QStringLiteral("default_dimensions_m")).toArray()});
+        item.value(QStringLiteral("source_note")).toString(), dimensions});
     }
     std::sort(choices.begin(), choices.end(), [](const CatalogChoice & a, const CatalogChoice & b) {
       return a.category == b.category ? a.label < b.label : a.category < b.category;
@@ -193,9 +194,9 @@ private:
     QStringList labels; QMap<QString, CatalogChoice> by_label;
     for (const CatalogChoice & choice : choices) {
       const QString dims = QStringLiteral("%1 × %2 × %3 m")
-        .arg(choice.dimensions.value(0).toDouble(), 0, 'f', 2)
-        .arg(choice.dimensions.value(1).toDouble(), 0, 'f', 2)
-        .arg(choice.dimensions.value(2).toDouble(), 0, 'f', 2);
+        .arg(choice.dimensions.at(0).toDouble(), 0, 'f', 2)
+        .arg(choice.dimensions.at(1).toDouble(), 0, 'f', 2)
+        .arg(choice.dimensions.at(2).toDouble(), 0, 'f', 2);
       const QString label = QStringLiteral("%1 — %2 (%3)").arg(choice.category, choice.label, dims);
       labels << label; by_label.insert(label, choice);
     }
@@ -241,7 +242,10 @@ private:
     connect(process, qOverload<int, QProcess::ExitStatus>(&QProcess::finished), this,
       [this, process, phase](int code, QProcess::ExitStatus status) {
         const QByteArray output = process->readAll();
-        if (process == process_) process_ = nullptr; process->deleteLater();
+        if (process == process_) {
+          process_ = nullptr;
+        }
+        process->deleteLater();
         if (!contextCurrent()) { sceneChanged(); return; }
         if (status != QProcess::NormalExit || code != 0) {
           busy_ = false; setStatus(QStringLiteral("Add failed"), QStringLiteral("error"));
@@ -258,19 +262,19 @@ private:
   {
     if (phase == Phase::Plan) {
       const QJsonObject plan = QJsonDocument::fromJson(output.trimmed()).object();
+      const QJsonArray xyz = plan.value(QStringLiteral("pose_xyz")).toArray();
       if (plan.value(QStringLiteral("status")).toString() != QStringLiteral("planned") ||
-          plan.value(QStringLiteral("scene_id")).toString() != scene_id_) {
+          plan.value(QStringLiteral("scene_id")).toString() != scene_id_ || xyz.size() != 3) {
         busy_ = false; setStatus(QStringLiteral("Add failed"), QStringLiteral("error")); return;
       }
       planned_instance_ = plan.value(QStringLiteral("instance_id")).toString();
       planned_sha_ = plan.value(QStringLiteral("layout_sha256")).toString();
-      const QJsonArray xyz = plan.value(QStringLiteral("pose_xyz")).toArray();
       const QString message = QStringLiteral(
         "Add %1 as %2?\n\nSupport: %3\nPose XYZ: %4, %5, %6 m\nLicense: %7\nSource: %8\n\n"
         "Workcell Studio will back up and atomically update only the editable layout, then regenerate, validate and reload Product View. No robot motion is started.")
         .arg(selected_.label, planned_instance_, plan.value(QStringLiteral("support_surface_id")).toString())
-        .arg(xyz.value(0).toDouble(), 0, 'f', 3).arg(xyz.value(1).toDouble(), 0, 'f', 3)
-        .arg(xyz.value(2).toDouble(), 0, 'f', 3).arg(selected_.license, selected_.source_note);
+        .arg(xyz.at(0).toDouble(), 0, 'f', 3).arg(xyz.at(1).toDouble(), 0, 'f', 3)
+        .arg(xyz.at(2).toDouble(), 0, 'f', 3).arg(selected_.license, selected_.source_note);
       if (QMessageBox::question(preview_, QStringLiteral("Confirm Add Curated Object"), message,
           QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes) {
         busy_ = false; setStatus(QStringLiteral("Add cancelled"), QStringLiteral("warning")); pollEditorState(); return;
@@ -280,7 +284,10 @@ private:
     if (phase == Phase::Write) { start(Phase::GenerateValidate); return; }
     if (phase == Phase::GenerateValidate) { start(Phase::Refresh); return; }
     busy_ = false; setStatus(QStringLiteral("Added"), QStringLiteral("success"));
-    if (view_) view_->reload(); QTimer::singleShot(700, this, [this]() { pollEditorState(); });
+    if (view_) {
+      view_->reload();
+    }
+    QTimer::singleShot(700, this, [this]() { pollEditorState(); });
   }
 
   void pollEditorState()

--- a/workcell_builder/workcell_builder/gui/embedded_web_edit_save_controller.hpp
+++ b/workcell_builder/workcell_builder/gui/embedded_web_edit_save_controller.hpp
@@ -22,6 +22,7 @@
 #include <QSaveFile>
 #include <QSizePolicy>
 #include <QTimer>
+#include <QUrl>
 #include <QUrlQuery>
 #include <QVariantMap>
 #include <QWebEnginePage>
@@ -116,7 +117,7 @@ public:
 
     connect(save_button_, &QPushButton::clicked, this, [this]() { requestSave(); });
     connect(view_, &QWebEngineView::loadFinished, this, [this](bool) {
-      last_polled_url_ = {};
+      last_polled_url_ = QUrl();
       QTimer::singleShot(250, this, [this]() { pollEditorState(); });
     });
     poll_timer_.setInterval(350);


### PR DESCRIPTION
## Root cause
The Humble/Ubuntu 22.04 build uses Qt 5.15. The newly merged embedded Product View controllers used two Qt6-friendly forms that do not compile under Qt5:

- assigning `{}` to `QUrl`, which is ambiguous between the Qt5 `QUrl`, `QString` and move assignment overloads;
- calling `QJsonArray::value(index)`, which is not available in the Qt5 API.

The same header is included broadly through the Workcell Builder UI utilities, so these two errors repeated across many translation units and stopped the whole `workcell_builder` target.

## Fix
- Reset the cached URL explicitly with `QUrl()` and include `<QUrl>` directly.
- Replace indexed `QJsonArray::value(...)` calls with Qt5-compatible `at(...)` calls.
- Validate catalog dimensions and planned XYZ arrays have exactly three entries before indexing.
- Add braces around process cleanup and Product View reload paths to remove the reported misleading-indentation warnings without changing their intended control flow.
- Add a focused regression test that rejects the incompatible Qt forms and verifies the array-shape guards.

## Scope
- 3 changed files.
- No generated, minified, binary, asset, scene or bundle changes.
- No viewer behaviour, robot hierarchy, controller, MoveIt, launch, hardware or motion changes.

## Validation
CI should run the existing Humble and Jazzy builds plus the focused Python regression test. The reported local failure should be resolved because both compile errors are removed at their source.

Recommended local confirmation after merge:

```bash
source /opt/ros/humble/setup.bash
colcon build --symlink-install --packages-select workcell_builder
```
