### PR TITLE
Fix missing embedded gripper meshes and dark Product View canvas

### DIFF
--- a/scripts/check_workcell_web_scene_visual_bounds.py
+++ b/scripts/check_workcell_web_scene_visual_bounds.py
@@ -87,7 +87,10 @@ def _category(section: str, item: Mapping[str, Any]) -> str:
     explicit_category = str(item.get("category") or "").strip().lower()
     if section == "zones" or explicit_category in HELPER_ZONE_CATEGORIES:
         return explicit_category or str(item.get("role") or "zone").lower()
-    text = _text_for(item, "id", "name", "display_name", "role", "category", "source_layer", "active_visual_source")
+    # Infer physical type only from identity fields. Provenance/source-layer values
+    # describe editability and data ownership; for example, "editable" contains
+    # the substring "table" and must never turn an ordinary object into a table.
+    text = _text_for(item, "id", "name", "display_name", "role", "category", "model")
     if section == "robots" or "robot" in text or "ur5" in text or "ur10" in text or "ur3" in text:
         return "robot_link"
     if section == "tools" or "gripper" in text or "tool" in text or "robotiq" in text:

--- a/tests/test_product_view_runtime_preflight.py
+++ b/tests/test_product_view_runtime_preflight.py
@@ -1,0 +1,107 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VIEWER = ROOT / "workcell_studio_web/viewer"
+PREFLIGHT = VIEWER / "product_view_runtime_preflight.js"
+INDEX = VIEWER / "index.html"
+
+
+def test_preflight_loads_before_the_pinned_viewer_bundle():
+    html = INDEX.read_text(encoding="utf-8")
+    preflight = '<script src="./product_view_runtime_preflight.js"></script>'
+    bundle = '<script type="module" src="./dist/viewer.bundle.js"></script>'
+    assert preflight in html
+    assert bundle in html
+    assert html.index(preflight) < html.index(bundle)
+
+
+def test_preflight_rewrites_bare_ros_package_meshes_and_forces_light_clear_color():
+    source = PREFLIGHT.read_text(encoding="utf-8")
+    node_script = f"""
+const vm = require('vm');
+const source = {json.dumps(source)};
+class FakeRequest {{
+  constructor(url, init) {{ this.url = String(url); this.init = init; }}
+}}
+class FakeXhr {{
+  open(method, url) {{ this.method = method; this.url = String(url); }}
+}}
+class FakeGl {{
+  constructor(id = 'scene-canvas') {{ this.canvas = {{ id }}; this.last = null; }}
+  clearColor(r, g, b, a) {{ this.last = [r, g, b, a]; }}
+}}
+const location = new URL(
+  'http://127.0.0.1:8765/index.html?embedded=1&scene=' +
+  encodeURIComponent('build/workcell_studio_web_scene/ur5_2f_test.web_scene.json')
+);
+const styleValues = {{}};
+const calls = [];
+const window = {{
+  location,
+  fetch: async input => {{ calls.push(input instanceof FakeRequest ? input.url : String(input)); return {{ ok: true }}; }},
+  XMLHttpRequest: FakeXhr,
+  WebGLRenderingContext: FakeGl,
+  WebGL2RenderingContext: FakeGl,
+}};
+const context = {{
+  window,
+  document: {{ documentElement: {{ style: {{ setProperty: (key, value) => styleValues[key] = value }} }} }},
+  URL,
+  URLSearchParams,
+  Request: FakeRequest,
+  Symbol,
+  console,
+}};
+vm.runInNewContext(source, context, {{ filename: 'product_view_runtime_preflight.js' }});
+const api = window.__WORKCELL_PRODUCT_VIEW_RUNTIME_PREFLIGHT_V1__;
+if (!api?.enabled || api.getSceneId() !== 'ur5_2f_test') throw new Error('preflight not ready');
+const bare = 'http://127.0.0.1:8765/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae';
+const expected = 'http://127.0.0.1:8765/build/workcell_studio_web_scene/assets/ur5_2f_test/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae';
+if (api.rewritePackageRootUrl(bare) !== expected) throw new Error('package URL not staged');
+const ordinary = 'http://127.0.0.1:8765/workcell_studio_web/viewer/style.css';
+if (api.rewritePackageRootUrl(ordinary) !== ordinary) throw new Error('ordinary URL changed');
+(async () => {{
+  await window.fetch(bare);
+  if (calls[0] !== expected) throw new Error('fetch did not use staged URL');
+  const gl = new FakeGl();
+  gl.clearColor(0.01, 0.02, 0.03, 1);
+  const expectedClear = [0xee / 0xff, 0xf1 / 0xff, 0xf4 / 0xff, 1];
+  if (gl.last.some((value, index) => Math.abs(value - expectedClear[index]) > 1e-12)) {{
+    throw new Error('scene canvas background remained dark');
+  }}
+  const other = new FakeGl('other-canvas');
+  other.clearColor(0.1, 0.2, 0.3, 0.4);
+  if (JSON.stringify(other.last) !== JSON.stringify([0.1, 0.2, 0.3, 0.4])) {{
+    throw new Error('non-viewer canvas was modified');
+  }}
+  if (styleValues['--workcell-product-view-background'] !== '#eef1f4') {{
+    throw new Error('CSS background fallback missing');
+  }}
+}})().catch(error => {{ console.error(error); process.exit(1); }});
+"""
+    result = subprocess.run(
+        ["node", "-e", node_script],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_preflight_stays_scoped_to_visual_asset_fetch_and_rendering_only():
+    source = PREFLIGHT.read_text(encoding="utf-8").lower()
+    for forbidden in (
+        "ros2 launch",
+        "execute_trajectory",
+        "move_group",
+        "real_hardware_enabled",
+        "yaml",
+        "writefile",
+        "localstorage",
+    ):
+        assert forbidden not in source

--- a/tests/test_visual_bounds_editable_source_layer.py
+++ b/tests/test_visual_bounds_editable_source_layer.py
@@ -1,0 +1,50 @@
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/check_workcell_web_scene_visual_bounds.py"
+
+spec = importlib.util.spec_from_file_location(
+    "check_workcell_web_scene_visual_bounds_editable_source_layer", SCRIPT
+)
+checker = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(checker)
+
+
+def test_editable_source_layer_does_not_make_an_object_a_table():
+    payload = {
+        "metadata": {"visual_bounds_contract": {"status": "passed"}},
+        "robots": [],
+        "tools": [],
+        "assets": [
+            {
+                "id": "commissioning_object",
+                "source_layer": "editable_authored_physical",
+                "active_visual_source": "cell_definition.yaml",
+                "dimensions": [0.05, 0.05, 0.05],
+            },
+            {
+                "id": "workbench",
+                "role": "support_surface",
+                "mesh_contract_category": "table",
+                "expected_dimensions_m": [1.2, 0.8, 0.08],
+            },
+        ],
+        "sensors": [
+            {
+                "id": "realsense_camera",
+                "mesh_contract_category": "camera",
+                "expected_dimensions_m": [0.08, 0.08, 0.06],
+            }
+        ],
+        "zones": [],
+    }
+
+    summary, errors = checker.check(payload)
+
+    assert errors == []
+    assert summary["contract_status"] == "passed"
+    assert summary["table_item_count"] == 1
+    assert checker._category("assets", payload["assets"][0]) == "object"

--- a/workcell_studio_web/viewer/index.html
+++ b/workcell_studio_web/viewer/index.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="simple_product_ui.css" />
   <link rel="stylesheet" href="contextual_placement_actions.css" />
+  <script src="./product_view_runtime_preflight.js"></script>
 </head>
 <body>
   <header class="topbar">

--- a/workcell_studio_web/viewer/product_view_runtime_preflight.js
+++ b/workcell_studio_web/viewer/product_view_runtime_preflight.js
@@ -1,0 +1,116 @@
+(() => {
+  'use strict';
+
+  const VERSION = 1;
+  const LIGHT_BACKGROUND = Object.freeze({
+    css: '#eef1f4',
+    red: 0xee / 0xff,
+    green: 0xf1 / 0xff,
+    blue: 0xf4 / 0xff,
+    alpha: 1,
+  });
+  const STAGED_ASSET_PREFIX = 'build/workcell_studio_web_scene/assets';
+  const SAFE_SCENE_ID = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
+  const SAFE_PACKAGE = /^[A-Za-z][A-Za-z0-9_]*$/;
+  const PATCH_FLAG = Symbol.for('workcell-studio.product-view-runtime-preflight.v1');
+
+  function activeSceneId() {
+    const scenePath = new URLSearchParams(window.location.search).get('scene') || '';
+    const normalized = scenePath.replace(/^\/+/, '');
+    const prefix = 'build/workcell_studio_web_scene/';
+    const suffix = '.web_scene.json';
+    if (!normalized.startsWith(prefix) || !normalized.endsWith(suffix)) return '';
+    const filename = normalized.slice(prefix.length).split('/').pop() || '';
+    const sceneId = filename.slice(0, -suffix.length);
+    return SAFE_SCENE_ID.test(sceneId) ? sceneId : '';
+  }
+
+  function isPackageRootCandidate(packageName, rest) {
+    if (!SAFE_PACKAGE.test(packageName) || !rest || rest.includes('..')) return false;
+    if (!rest.startsWith('meshes/')) return false;
+    return packageName === 'workcell_builder' || packageName.endsWith('_description');
+  }
+
+  function rewritePackageRootUrl(value) {
+    const original = String(value || '');
+    if (!original) return original;
+
+    let url;
+    try {
+      url = new URL(original, window.location.href);
+    } catch (_) {
+      return original;
+    }
+    if (url.origin !== window.location.origin) return original;
+
+    const match = url.pathname.match(/^\/([A-Za-z][A-Za-z0-9_]*)\/(.+)$/);
+    if (!match) return original;
+    const [, packageName, rest] = match;
+    if (!isPackageRootCandidate(packageName, rest)) return original;
+
+    const sceneId = activeSceneId();
+    if (!sceneId) return original;
+    url.pathname = `/${STAGED_ASSET_PREFIX}/${sceneId}/${packageName}/${rest}`;
+    return url.href;
+  }
+
+  function installFetchRewrite() {
+    if (typeof window.fetch !== 'function' || window.fetch[PATCH_FLAG]) return;
+    const originalFetch = window.fetch.bind(window);
+    const rewrittenFetch = function workcellProductViewFetch(input, init) {
+      const originalUrl = input instanceof Request ? input.url : input;
+      const rewrittenUrl = rewritePackageRootUrl(originalUrl);
+      if (rewrittenUrl === String(originalUrl || '')) return originalFetch(input, init);
+      if (input instanceof Request) return originalFetch(new Request(rewrittenUrl, input), init);
+      return originalFetch(rewrittenUrl, init);
+    };
+    rewrittenFetch[PATCH_FLAG] = true;
+    rewrittenFetch.originalFetch = originalFetch;
+    window.fetch = rewrittenFetch;
+  }
+
+  function installXhrRewrite() {
+    const prototype = window.XMLHttpRequest?.prototype;
+    if (!prototype?.open || prototype.open[PATCH_FLAG]) return;
+    const originalOpen = prototype.open;
+    const rewrittenOpen = function workcellProductViewXhrOpen(method, url, ...rest) {
+      return originalOpen.call(this, method, rewritePackageRootUrl(url), ...rest);
+    };
+    rewrittenOpen[PATCH_FLAG] = true;
+    prototype.open = rewrittenOpen;
+  }
+
+  function installClearColorOverride(prototype) {
+    if (!prototype?.clearColor || prototype.clearColor[PATCH_FLAG]) return;
+    const originalClearColor = prototype.clearColor;
+    const forcedClearColor = function workcellProductViewClearColor(red, green, blue, alpha) {
+      if (this?.canvas?.id === 'scene-canvas') {
+        return originalClearColor.call(
+          this,
+          LIGHT_BACKGROUND.red,
+          LIGHT_BACKGROUND.green,
+          LIGHT_BACKGROUND.blue,
+          LIGHT_BACKGROUND.alpha,
+        );
+      }
+      return originalClearColor.call(this, red, green, blue, alpha);
+    };
+    forcedClearColor[PATCH_FLAG] = true;
+    prototype.clearColor = forcedClearColor;
+  }
+
+  installFetchRewrite();
+  installXhrRewrite();
+  installClearColorOverride(window.WebGLRenderingContext?.prototype);
+  installClearColorOverride(window.WebGL2RenderingContext?.prototype);
+  document.documentElement.style.setProperty('--workcell-product-view-background', LIGHT_BACKGROUND.css);
+
+  window.__WORKCELL_PRODUCT_VIEW_RUNTIME_PREFLIGHT_V1__ = Object.freeze({
+    enabled: true,
+    version: VERSION,
+    background: LIGHT_BACKGROUND.css,
+    stagedAssetPrefix: STAGED_ASSET_PREFIX,
+    getSceneId: activeSceneId,
+    rewritePackageRootUrl,
+  });
+})();

--- a/workcell_studio_web/viewer/product_view_runtime_preflight.js
+++ b/workcell_studio_web/viewer/product_view_runtime_preflight.js
@@ -56,12 +56,14 @@
 
   function installFetchRewrite() {
     if (typeof window.fetch !== 'function' || window.fetch[PATCH_FLAG]) return;
+    const RequestConstructor = window.Request;
+    const isRequest = input => typeof RequestConstructor === 'function' && input instanceof RequestConstructor;
     const originalFetch = window.fetch.bind(window);
     const rewrittenFetch = function workcellProductViewFetch(input, init) {
-      const originalUrl = input instanceof Request ? input.url : input;
+      const originalUrl = isRequest(input) ? input.url : input;
       const rewrittenUrl = rewritePackageRootUrl(originalUrl);
       if (rewrittenUrl === String(originalUrl || '')) return originalFetch(input, init);
-      if (input instanceof Request) return originalFetch(new Request(rewrittenUrl, input), init);
+      if (isRequest(input)) return originalFetch(new RequestConstructor(rewrittenUrl, input), init);
       return originalFetch(rewrittenUrl, init);
     };
     rewrittenFetch[PATCH_FLAG] = true;
@@ -99,10 +101,26 @@
     prototype.clearColor = forcedClearColor;
   }
 
+  function installCanvasContextHook() {
+    const prototype = window.HTMLCanvasElement?.prototype;
+    if (!prototype?.getContext || prototype.getContext[PATCH_FLAG]) return;
+    const originalGetContext = prototype.getContext;
+    const hookedGetContext = function workcellProductViewGetContext(type, ...rest) {
+      const context = originalGetContext.call(this, type, ...rest);
+      if (context && (type === 'webgl' || type === 'webgl2' || type === 'experimental-webgl')) {
+        installClearColorOverride(Object.getPrototypeOf(context));
+      }
+      return context;
+    };
+    hookedGetContext[PATCH_FLAG] = true;
+    prototype.getContext = hookedGetContext;
+  }
+
   installFetchRewrite();
   installXhrRewrite();
   installClearColorOverride(window.WebGLRenderingContext?.prototype);
   installClearColorOverride(window.WebGL2RenderingContext?.prototype);
+  installCanvasContextHook();
   document.documentElement.style.setProperty('--workcell-product-view-background', LIGHT_BACKGROUND.css);
 
   window.__WORKCELL_PRODUCT_VIEW_RUNTIME_PREFLIGHT_V1__ = Object.freeze({


### PR DESCRIPTION
## Evidence from the reported runtime
The embedded server and freshener complete successfully and stage the scene assets, but Qt WebEngine still requests gripper meshes from bare package-root URLs such as:

`/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae`

Those requests return 404, so the gripper disappears even though the files were staged under the active scene asset directory. The current light-baseline module also executes after the pinned viewer bundle, so it cannot reliably change the clear colour of a WebGL renderer that was already constructed and bound.

## Fix
Add a small pre-bundle Product View runtime preflight that runs before `dist/viewer.bundle.js`:

- rewrites same-origin bare ROS package mesh requests to `build/workcell_studio_web_scene/assets/<scene>/<package>/meshes/...`;
- covers both `fetch` and `XMLHttpRequest`, which are used by Three.js loaders;
- forces the `scene-canvas` WebGL clear colour to the existing light Product View palette before renderer construction;
- leaves non-viewer canvases and ordinary viewer resources unchanged;
- derives and validates the active scene ID from the existing `scene=` URL contract.

This is a focused compatibility bridge for the stale pinned bundle. It does not duplicate assets, change URDF transforms, alter robot hierarchy, or modify source YAML.

## Visual-acceptance correction
The first CI attempt exposed an existing checker false positive before browser startup: the provenance value `editable_authored_physical` was searched with substring matching and the `table` suffix inside `editable` caused `commissioning_object` to be classified as a table. Physical-category inference now uses identity fields only, while explicit mesh contract categories remain authoritative. A regression test covers the exact canonical object record.

## Tests
- verifies the preflight loads before the pinned bundle;
- functionally executes the module under Node VM;
- proves a Robotiq package-root request is rewritten to the active staged scene directory;
- proves the viewer canvas receives the light clear colour while another canvas is untouched;
- proves editable provenance cannot turn an ordinary object into a table;
- checks the module contains no YAML write, ROS launch, controller, MoveIt, or real-hardware behavior.

## Scope
5 files, 296 added lines and 1 deleted line. No bundle, generated, binary, scene, asset or motion changes.

Manual acceptance after merge remains required in the Qt application for `ur5_2f_test` and `ur5_3f_test`: confirm no package-root 404s, the full end effector is visible, and the canvas is light.