### PR TITLE
Fix workcell_builder PreviewItem test compilation

### DIFF
--- a/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
@@ -458,7 +458,6 @@ TEST(IndependentPickZoneAuthoring, ModelYamlAndOverlayContract)
   EXPECT_EQ(message, "Pick Zone dimensions must be positive");
 
   auto item = make_item("pick_zone_1");
-  item.type = "pick";
   item.role = "pick";
   item.category = "Task Zones";
   EXPECT_FALSE(Scene3DViewportWidget::should_include_in_default_fit_for_test(item));
@@ -507,7 +506,6 @@ TEST(IndependentPlaceZoneAuthoring, ModelYamlAndOverlayContract)
   EXPECT_EQ(message, "Place Zone dimensions must be positive");
 
   auto item = make_item("place_zone_1");
-  item.type = "place";
   item.role = "place";
   item.category = "Task Zones";
   EXPECT_FALSE(Scene3DViewportWidget::should_include_in_default_fit_for_test(item));


### PR DESCRIPTION
## Failure reproduced from the user build
`workcell_builder` fails while compiling `scene3d_render_role_classifier_test.cpp` because two tests assign `item.type`, but `ScenePreviewWidget::PreviewItem` has no `type` member. The real task-zone model (`TaskZone`) still has and tests its `type` field; the render-preview model uses `role` and `category` for zone classification.

## Fix
Remove only the two stale `PreviewItem::type` assignments from the pick-zone and place-zone render tests. The tests retain the authoritative preview metadata:

- `role = pick/place`
- `category = Task Zones`
- default-fit exclusion assertions
- place-zone material-colour assertion
- all `TaskZone::type` YAML/save/reload assertions

## Scope
1 file, 2 deleted lines. No production code, Product View, scene, asset, URDF, controller, launch, MoveIt, hardware, source YAML or motion changes.

## Validation target
Rebuild `workcell_builder` or the full workspace. The fatal errors at test lines 461 and 510 should be gone. The other messages in the supplied log are warnings rather than the cause of this build failure.