### PR TITLE
Make Product View startup diagnostics actionable

### DIFF
--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -7,11 +7,27 @@
 #include <fstream>
 #include <initializer_list>
 #include <set>
+#include <mutex>
 #include <vector>
 #include <yaml-cpp/yaml.h>
+#include <boost/system/error_code.hpp>
 
 namespace fs = boost::filesystem;
 namespace workcell_builder {
+
+
+static bool log_task_metadata_loader_path_once(const fs::path & p, const std::string & reason)
+{
+  static std::mutex mutex;
+  static std::set<std::string> seen_paths;
+  boost::system::error_code ec;
+  const fs::path normalized = fs::weakly_canonical(p, ec);
+  const std::string key = (ec ? p.lexically_normal() : normalized).string();
+  std::lock_guard<std::mutex> lock(mutex);
+  if (!seen_paths.insert(key).second) return false;
+  return workcell_builder::log_warning_once_per_context_path_reason(
+    "task_metadata_summary_loader", p, reason);
+}
 
 struct YamlLoadStatus
 {
@@ -40,8 +56,7 @@ static YamlLoadStatus read_yaml(const fs::path & p, YAML::Node * out)
     status.parse_warning = true;
     status.reason = "unknown exception";
   }
-  workcell_builder::log_warning_once_per_context_path_reason(
-    "task_metadata_summary_loader", p, "scene YAML parse warning: " + status.reason);
+  log_task_metadata_loader_path_once(p, "scene YAML parse warning: " + status.reason);
   return status;
 }
 
@@ -360,7 +375,7 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
     if (deterministic_fallback_layout) return;
     deterministic_fallback_layout = true;
     deterministic_fallback_reason = reason;
-    workcell_builder::log_warning_once_per_context_path_reason("task_metadata_summary_loader", scene_dir / "layout" / "workcell_studio_layout.yaml", "downgraded to legacy mode");
+    log_task_metadata_loader_path_once(scene_dir / "layout" / "workcell_studio_layout.yaml", "downgraded to legacy mode");
   };
   const auto add_warning = [&m](const std::string & context, const std::string & detail) {
     m.warnings.push_back("layout/workcell_studio_layout.yaml [" + context + "]: " + detail);
@@ -853,9 +868,9 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
   else { m.status = "READY"; }
   return m;
   } catch (const YAML::Exception & e) {
-    workcell_builder::log_warning_once_per_context_path_reason("task_metadata_summary_loader", scene_dir / "layout" / "workcell_studio_layout.yaml", std::string("YAML parse exception in preview loader: ") + e.what());
+    log_task_metadata_loader_path_once(scene_dir / "layout" / "workcell_studio_layout.yaml", std::string("YAML parse exception in preview loader: ") + e.what());
   } catch (const std::exception & e) {
-    workcell_builder::log_warning_once_per_context_path_reason("task_metadata_summary_loader", scene_dir / "layout" / "workcell_studio_layout.yaml", std::string("std exception in preview loader: ") + e.what());
+    log_task_metadata_loader_path_once(scene_dir / "layout" / "workcell_studio_layout.yaml", std::string("std exception in preview loader: ") + e.what());
   }
   WorkcellStudioCanvasModel fallback;
   fallback.scene_name = scene_name;

--- a/workcell_builder/workcell_builder/src_workcell_yaml_utils.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_yaml_utils.cpp
@@ -171,27 +171,33 @@ PerceptionContractSummary parse_perception_contract_summary(const YAML::Node & t
   const YAML::Node task = (task_or_root && task_or_root.IsMap() && task_or_root["task"]) ?
     task_or_root["task"] : task_or_root;
   if (!task || !task.IsMap()) {
-    out.warning = "perception is not a map; downgraded to legacy disabled mode";
     return out;
   }
   const YAML::Node perception = task["perception"];
   if (!perception) {
-    out.warning = "perception missing; downgraded to legacy disabled mode";
     return out;
   }
   if (!perception.IsMap()) {
-    out.warning = "perception is not a map; downgraded to legacy disabled mode";
+    std::string scalar = yaml_scalar_or_empty(perception);
+    std::string legacy;
+    const std::string mode = canonicalize_scene3d_camera_mode(scalar, &legacy);
+    if (mode == "none") {
+      out.mode = "legacy_disabled";
+      out.legacy_source_mode = legacy.empty() ? scalar : legacy;
+      return out;
+    }
+    out.enabled = true;
+    out.mode = mode;
+    out.legacy_source_mode = legacy;
     return out;
   }
   if (perception.size() == 0) {
-    out.warning = "perception map is empty; downgraded to legacy disabled mode";
     return out;
   }
   out.enabled = true;
   const std::string raw_mode = yaml_map_value_or_empty(perception, "mode");
   if (raw_mode.empty()) {
     out.mode = "epd_optional";
-    out.warning = "perception map present but mode missing; defaulted to epd_optional";
     return out;
   }
   out.mode = canonicalize_scene3d_camera_mode(raw_mode, &out.legacy_source_mode);

--- a/workcell_builder/workcell_builder/test/workcell_yaml_utils_test.cpp
+++ b/workcell_builder/workcell_builder/test/workcell_yaml_utils_test.cpp
@@ -65,9 +65,9 @@ TEST(WorkcellYamlUtils, PerceptionContractSummaryHandlesScalarAndMissing)
   const auto d = workcell_builder::parse_perception_contract_summary(empty_map);
   const auto e = workcell_builder::parse_perception_contract_summary(missing);
 
-  EXPECT_FALSE(a.enabled); EXPECT_EQ(a.mode, "legacy_disabled"); EXPECT_FALSE(a.warning.empty());
-  EXPECT_FALSE(b.enabled); EXPECT_EQ(b.mode, "legacy_disabled"); EXPECT_FALSE(b.warning.empty());
-  EXPECT_FALSE(c.enabled); EXPECT_EQ(c.mode, "legacy_disabled"); EXPECT_FALSE(c.warning.empty());
-  EXPECT_FALSE(d.enabled); EXPECT_EQ(d.mode, "legacy_disabled"); EXPECT_FALSE(d.warning.empty());
-  EXPECT_FALSE(e.enabled); EXPECT_EQ(e.mode, "legacy_disabled"); EXPECT_FALSE(e.warning.empty());
+  EXPECT_FALSE(a.enabled); EXPECT_EQ(a.mode, "legacy_disabled"); EXPECT_TRUE(a.warning.empty());
+  EXPECT_FALSE(b.enabled); EXPECT_EQ(b.mode, "legacy_disabled"); EXPECT_TRUE(b.warning.empty());
+  EXPECT_FALSE(c.enabled); EXPECT_EQ(c.mode, "legacy_disabled"); EXPECT_TRUE(c.warning.empty());
+  EXPECT_FALSE(d.enabled); EXPECT_EQ(d.mode, "legacy_disabled"); EXPECT_TRUE(d.warning.empty());
+  EXPECT_FALSE(e.enabled); EXPECT_EQ(e.mode, "legacy_disabled"); EXPECT_TRUE(e.warning.empty());
 }

--- a/workcell_studio_web/viewer/urdf_robot_renderer.js
+++ b/workcell_studio_web/viewer/urdf_robot_renderer.js
@@ -146,6 +146,16 @@ function countDescendantMeshes(object) {
   return count;
 }
 
+function summarizeColladaDiagnostic(diagnostics, detail) {
+  const key = [detail.up_axis || '', detail.unit_meter ?? '', detail.root_transform_normalized ? 'normalized' : 'unchanged'].join('|');
+  diagnostics.robot_collada_summary_keys = diagnostics.robot_collada_summary_keys || [];
+  if (!diagnostics.robot_collada_summary_keys.includes(key)) diagnostics.robot_collada_summary_keys.push(key);
+  diagnostics.robot_collada_summary = diagnostics.robot_collada_summary || [];
+  const row = diagnostics.robot_collada_summary.find(entry => entry.key === key);
+  if (row) { row.count += 1; return; }
+  diagnostics.robot_collada_summary.push({ key, count: 1, severity: 'debug', ...detail });
+}
+
 function normalizeRosColladaScene(dae, uri, diagnostics) {
   const scene = dae?.scene;
   if (!scene) return scene;
@@ -167,14 +177,16 @@ function normalizeRosColladaScene(dae, uri, diagnostics) {
     && !isIdentityTransform(scene)
     && (upAxis === 'Z_UP' || (Number.isFinite(unitMeter) && Math.abs(unitMeter - 1) > 1e-9));
   if (!hasLoaderRootConversion) {
-    diagnostics.robot_collada_mesh_diagnostics.push({
+    const detail = {
       uri,
       up_axis: upAxis || null,
       unit_meter: Number.isFinite(unitMeter) ? unitMeter : null,
       descendant_mesh_count: meshCount,
       root_transform_normalized: false,
       root_transform_before: before,
-    });
+    };
+    diagnostics.robot_collada_mesh_diagnostics.push(detail);
+    summarizeColladaDiagnostic(diagnostics, detail);
     return scene;
   }
 
@@ -186,7 +198,7 @@ function normalizeRosColladaScene(dae, uri, diagnostics) {
   scene.updateMatrixWorld(true);
   diagnostics.robot_collada_root_normalization_count += 1;
   diagnostics.robotColladaRootNormalizationCount = diagnostics.robot_collada_root_normalization_count;
-  diagnostics.robot_collada_mesh_diagnostics.push({
+  const detail = {
     uri,
     up_axis: upAxis || null,
     unit_meter: Number.isFinite(unitMeter) ? unitMeter : null,
@@ -194,7 +206,9 @@ function normalizeRosColladaScene(dae, uri, diagnostics) {
     root_transform_normalized: true,
     root_transform_before: before,
     root_transform_after: objectLocalTransformDiagnostics(scene),
-  });
+  };
+  diagnostics.robot_collada_mesh_diagnostics.push(detail);
+  summarizeColladaDiagnostic(diagnostics, detail);
   return scene;
 }
 
@@ -581,6 +595,8 @@ export function loadRobotPreview(previewConfig, rendererContext = {}) {
     robotColladaRootNormalizationCount: 0,
     robot_collada_mesh_diagnostics: [],
     robotColladaMeshDiagnostics: [],
+    robot_collada_summary: [],
+    robotColladaSummary: [],
     robot_package_mesh_resolutions: [],
     robot_descendant_render_mesh_diagnostics: [],
     robotDescendantRenderMeshDiagnostics: [],
@@ -633,6 +649,8 @@ export function loadRobotPreview(previewConfig, rendererContext = {}) {
     collectMatrixParityDiagnostics(previewConfig, diagnostics);
     diagnostics.robot_collada_mesh_diagnostics = diagnostics.robot_collada_mesh_diagnostics || [];
     diagnostics.robotColladaMeshDiagnostics = diagnostics.robot_collada_mesh_diagnostics;
+    diagnostics.robot_collada_summary = diagnostics.robot_collada_summary || [];
+    diagnostics.robotColladaSummary = diagnostics.robot_collada_summary;
     const rootDiagnostics = linkRootDiagnostics(robot, robot.links);
     diagnostics.robot_root_links = rootDiagnostics.roots;
     diagnostics.robotRootLinks = rootDiagnostics.roots;

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -28,7 +28,7 @@ const LOCKED_EDIT_REASON = 'Locked/generated preview item; edit source layout/en
 const MIN_FRAME_RADIUS = 1.2;
 const EMPTY_SCENE_MESSAGE = 'Scene contains no renderable robots, tools, assets, sensors, zones, items, or objects.';
 const FRAME_DISTANCE_MULTIPLIER = 2.7;
-const state = { sceneJson: null, sourceWebSceneFile: '', frameLookup: new Map(), resolvedFramePoses: new Map(), objects: [], assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, robotUrdfPreviewDiagnostics: {}, physicalAssemblyBounds: null, finalPhysicalFitBounds: null, selected: null, three: {}, animationId: null, lastFrameBounds: null, initialCameraFit: { sceneKey: '', done: false, attempts: 0, pendingRetry: null, userControlled: false }, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: new Map(), undoStack: [], redoStack: [], gizmoDragStart: null, directMoveDrag: null, directRotateDrag: null, editorMode: 'select', editorEvents: [], editorError: '', robotPreviewResult: null, initialPosePreview: { active: false, robotId: '', sceneKey: '' }, web3dReadiness: { state: 'booting', terminal: false, terminalState: '', terminalNavigationKey: '', terminalEmissionCount: 0, statusSequence: 0, required: {}, pending: new Set(), failed: false, failure: null }, builderRevision: '', sceneJsonLoaded: false, activeNavigationKey: '' };
+const state = { sceneJson: null, sourceWebSceneFile: '', diagnosticKeys: new Set(), frameLookup: new Map(), resolvedFramePoses: new Map(), objects: [], assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, robotUrdfPreviewDiagnostics: {}, physicalAssemblyBounds: null, finalPhysicalFitBounds: null, selected: null, three: {}, animationId: null, lastFrameBounds: null, initialCameraFit: { sceneKey: '', done: false, attempts: 0, pendingRetry: null, userControlled: false }, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: new Map(), undoStack: [], redoStack: [], gizmoDragStart: null, directMoveDrag: null, directRotateDrag: null, editorMode: 'select', editorEvents: [], editorError: '', robotPreviewResult: null, initialPosePreview: { active: false, robotId: '', sceneKey: '' }, web3dReadiness: { state: 'booting', terminal: false, terminalState: '', terminalNavigationKey: '', terminalEmissionCount: 0, statusSequence: 0, required: {}, pending: new Set(), failed: false, failure: null }, builderRevision: '', sceneJsonLoaded: false, activeNavigationKey: '' };
 let robotPreviewLoadToken = 0;
 const RESET_VIEW_TITLE = 'Fit Scene / Reset View: recomputes and reapplies the fitted workcell overview from renderable bounds.';
 const STAGED_MESH_ROOTS = [
@@ -1101,6 +1101,17 @@ function warnMissingGeneratedUrdfFramePose(item) {
     legacy_fallback_pose: item?.final_transform || item?.world_from_visual || item?.baked_world_visual_pose || item?.pose || item?.world_pose || null,
   });
 }
+function diagnosticResourceKey(item, meshUri = '') {
+  return String(meshUri || item?.mesh_uri || item?.original_mesh_uri || item?.package_uri || item?.source_path || item?.mesh_path || item?.id || itemLabel(item || {}) || '').trim();
+}
+function appendDedupedRuntimeDiagnostic(warning) {
+  const key = [sceneId(), warning?.code || warning?.source || 'diagnostic', diagnosticResourceKey(warning, warning?.mesh_uri || warning?.original_mesh_uri)].join('\n');
+  if (state.diagnosticKeys.has(key)) return null;
+  state.diagnosticKeys.add(key);
+  state.runtimeWarnings.push(warning);
+  refreshWarnings();
+  return warning;
+}
 function appendViewerDiagnosticWarning(item, code, reason, extra = {}) {
   const warning = {
     source: 'runtime_viewer',
@@ -1121,9 +1132,7 @@ function appendViewerDiagnosticWarning(item, code, reason, extra = {}) {
     message: `${code}: ${item?.id || itemLabel(item || {})} (${item?.link || item?.object_name || itemLabel(item || {})}): ${reason || 'viewer diagnostic warning'}`,
     ...extra,
   };
-  state.runtimeWarnings.push(warning);
-  refreshWarnings();
-  return warning;
+  return appendDedupedRuntimeDiagnostic(warning);
 }
 function validateRenderableTransform(item) {
   const pose = poseOf(item);
@@ -1254,7 +1263,7 @@ function meshStatusLabel(rendered) {
   return String(status || 'unknown').replace(/_/g, ' ');
 }
 function appendRuntimeWarning(item, meshUri, reason, code = 'mesh_primitive_fallback', extra = {}) {
-  state.runtimeWarnings.push({
+  return appendDedupedRuntimeDiagnostic({
     source: 'runtime_mesh',
     code,
     object_id: item?.id || itemLabel(item || {}),
@@ -1277,7 +1286,6 @@ function appendRuntimeWarning(item, meshUri, reason, code = 'mesh_primitive_fall
     message: `${code}: Primitive fallback for ${item?.id || itemLabel(item || {})} (${item?.link || item?.object_name || itemLabel(item || {})}): ${reason || 'mesh loading skipped'}`,
     ...extra,
   });
-  refreshWarnings();
 }
 
 function meshUriDiagnostic(item) {
@@ -2697,6 +2705,7 @@ function resetSceneLifecycleState() {
   state.frameLookup = new Map();
   state.lastFrameBounds = null;
   state._sceneBoundsExceededWarned = false;
+  state.diagnosticKeys = new Set();
   state._fitBlockerWarnings = new Set();
   state._generatedUrdfFramePoseWarnings = new Set();
   state._supportSurfaceSemanticWarnings = new Set();
@@ -2806,7 +2815,7 @@ function loadExpandedUrdfRobotPreview(preview) {
   const callbackIsCurrent = () => loadToken === robotPreviewLoadToken && loadSceneId === sceneId();
   const ignoreStaleCallback = () => {
     if (!staleCallbackLogged) {
-      console.warn(`Ignored stale robot preview callback: callback_scene=${loadSceneId} active_scene=${sceneId()}`);
+      console.debug?.(`Ignored stale robot preview callback: callback_scene=${loadSceneId} active_scene=${sceneId()}`);
       staleCallbackLogged = true;
     }
     return true;


### PR DESCRIPTION
### Motivation
- Reduce noisy, repeated, and non-actionable diagnostics during Product View startup so operator error/warning counters reflect only actionable failures.
- Ensure Collada loader normalization, metadata loader path messages, perception defaults, and stale callbacks produce bounded, informative diagnostics rather than spamming logs.

### Description
- Deduplicate runtime diagnostics in the web viewer by scene + diagnostic code + relevant resource using a `diagnosticKeys` set and `appendDedupedRuntimeDiagnostic` helper so identical warnings appear only once per active scene (`workcell_studio_web/viewer/viewer.js`).
- Suppress repeated task-metadata loader path logs by adding `log_task_metadata_loader_path_once` (mutex + path set) so `task_metadata_summary_loader` path messages are emitted once per scene/path (`workcell_builder/.../src_workcell_studio_canvas_model.cpp`).
- Treat ColladaLoader Z_UP/unit normalizations as a bounded debug/summary diagnostic instead of repeated warnings by adding `summarizeColladaDiagnostic` and a `robot_collada_summary` summary array while preserving per-mesh diagnostics (`workcell_studio_web/viewer/urdf_robot_renderer.js`).
- Downgrade stale robot-preview callback console output to debug-only (no operator-facing console.warn) to avoid inflating warning counts during rapid scene switching (`workcell_studio_web/viewer/viewer.js`).
- Normalize perception parsing so disabled/missing/legacy/empty perception is informational (no startup warning) while still parsing and warning for enabled/required modes; updated tests to reflect the new non-warning defaults (`workcell_builder/.../src_workcell_yaml_utils.cpp` and `workcell_builder/.../test/workcell_yaml_utils_test.cpp`).

### Testing
- Ran focused Python tests: `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py tests/test_workcell_studio_web_viewer_static.py` — all tests passed (90 passed).
- Verified bundled viewer JS syntax with `node --check workcell_studio_web/viewer/viewer.js` and `node --check workcell_studio_web/viewer/urdf_robot_renderer.js` — both checks passed.
- Ran `git diff --check` to ensure no whitespace/patch issues — passed.
- `colcon build --symlink-install --packages-select workcell_builder` was not run in this environment because `colcon` and ROS Humble setup were not available in the container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a609ad9db048331885c084c59b8c99d)