### PR TITLE
Add universal supported-scene reproducibility gate

### DIFF
--- a/.github/workflows/web3d-visual-acceptance.yml
+++ b/.github/workflows/web3d-visual-acceptance.yml
@@ -14,6 +14,7 @@ on:
       - tests/test_workcell_web3d_visual_acceptance.py
       - tests/test_workcell_studio_web_viewer_static.py
       - scenes/ur5_2f_test/**
+      - scenes/supported_scenes.yaml
 
 jobs:
   browser-proof:
@@ -60,6 +61,12 @@ jobs:
 
       - name: Install Playwright Chromium
         run: python3 -m playwright install --with-deps chromium
+
+      - name: Run supported scene reproducibility registry gate
+        run: |
+          python3 scripts/run_workcell_web3d_visual_acceptance.py \
+            --all-supported-scenes \
+            --output build/workcell_studio_web_scene/supported_scene_reproducibility.json
 
       - name: Prove real ur5_2f_test xacro expansion
         run: |
@@ -145,5 +152,6 @@ jobs:
             build/workcell_studio_web_scene/ur5_2f_test.visual_acceptance.json
             build/workcell_studio_web_scene/ur5_2f_test.rviz_parity.png
             build/workcell_studio_web_scene/ur5_2f_test.web_scene.json
+            build/workcell_studio_web_scene/supported_scene_reproducibility.json
             scenes/ur5_2f_test/generated/scene_visual_mesh_index.json
             scenes/ur5_2f_test/generated/expanded_scene_preview.urdf

--- a/scenes/supported_scenes.yaml
+++ b/scenes/supported_scenes.yaml
@@ -21,6 +21,14 @@ update_policy: >-
   When adding, renaming, disabling, or removing a supported scene, update this
   catalog in the same PR as the scene change and re-run the catalog-backed
   all-scenes validators. Use known_blocker: "" when there is no known blocker.
+
+common_required_capabilities:
+  ur_arm: &cap_ur_arm ur_arm
+  robotiq_2f: &cap_robotiq_2f robotiq_2f_gripper
+  robotiq_3f: &cap_robotiq_3f robotiq_3f_gripper
+  suction: &cap_suction suction_gripper
+  fake_hardware: &cap_fake_hardware fake_hardware_launch
+  web3d: &cap_web3d web3d_visual_acceptance
 common_authoring_files: &common_authoring_files
   - environment.yaml
   - layout/workcell_studio_layout.yaml
@@ -33,6 +41,9 @@ common_generated_files: &common_generated_files
   - generated/scene3d_gui_smoke.json
 scenes:
   - scene_name: suction_test
+    robot: cartesian_placeholder
+    tool: suction
+    required_capabilities: [*cap_suction, *cap_fake_hardware, *cap_web3d]
     package_name: suction_test
     scene_path: scenes/suction_test
     support_level: supported
@@ -45,6 +56,9 @@ scenes:
     build_command: colcon build --symlink-install --packages-select suction_test
     fake_hardware_launch_command: ros2 launch suction_test demo.launch.py use_fake_hardware:=true launch_rviz:=true
   - scene_name: ur10_2f_test
+    robot: ur10
+    tool: robotiq_2f
+    required_capabilities: [*cap_ur_arm, *cap_robotiq_2f, *cap_fake_hardware, *cap_web3d]
     package_name: ur10_2f_test
     scene_path: scenes/ur10_2f_test
     support_level: supported
@@ -57,6 +71,9 @@ scenes:
     build_command: colcon build --symlink-install --packages-select ur10_2f_test
     fake_hardware_launch_command: ros2 launch ur10_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true
   - scene_name: ur3_suction_test
+    robot: ur3
+    tool: suction
+    required_capabilities: [*cap_ur_arm, *cap_suction, *cap_fake_hardware, *cap_web3d]
     package_name: ur3_suction_test
     scene_path: scenes/ur3_suction_test
     support_level: supported
@@ -69,6 +86,9 @@ scenes:
     build_command: colcon build --symlink-install --packages-select ur3_suction_test
     fake_hardware_launch_command: ros2 launch ur3_suction_test demo.launch.py use_fake_hardware:=true launch_rviz:=true
   - scene_name: ur5_2f_builder_pick_place_demo
+    robot: ur5
+    tool: robotiq_2f
+    required_capabilities: [*cap_ur_arm, *cap_robotiq_2f, *cap_fake_hardware, *cap_web3d]
     package_name: ur5_2f_builder_pick_place_demo
     scene_path: scenes/ur5_2f_builder_pick_place_demo
     support_level: supported
@@ -81,6 +101,9 @@ scenes:
     build_command: colcon build --symlink-install --packages-select ur5_2f_builder_pick_place_demo
     fake_hardware_launch_command: ros2 launch ur5_2f_builder_pick_place_demo demo.launch.py use_fake_hardware:=true launch_rviz:=true
   - scene_name: ur5_2f_sorting_test
+    robot: ur5
+    tool: robotiq_2f
+    required_capabilities: [*cap_ur_arm, *cap_robotiq_2f, *cap_fake_hardware, *cap_web3d]
     package_name: ur5_2f_sorting_test
     scene_path: scenes/ur5_2f_sorting_test
     support_level: supported
@@ -93,6 +116,9 @@ scenes:
     build_command: colcon build --symlink-install --packages-select ur5_2f_sorting_test
     fake_hardware_launch_command: ros2 launch ur5_2f_sorting_test demo.launch.py use_fake_hardware:=true launch_rviz:=true
   - scene_name: ur5_2f_test
+    robot: ur5
+    tool: robotiq_2f
+    required_capabilities: [*cap_ur_arm, *cap_robotiq_2f, *cap_fake_hardware, *cap_web3d]
     package_name: ur5_2f_test
     scene_path: scenes/ur5_2f_test
     support_level: supported
@@ -105,6 +131,9 @@ scenes:
     build_command: colcon build --symlink-install --packages-select ur5_2f_test
     fake_hardware_launch_command: ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true
   - scene_name: ur5_3f_test
+    robot: ur5
+    tool: robotiq_3f
+    required_capabilities: [*cap_ur_arm, *cap_robotiq_3f, *cap_fake_hardware, *cap_web3d]
     package_name: ur5_3f_test
     scene_path: scenes/ur5_3f_test
     support_level: supported
@@ -117,6 +146,9 @@ scenes:
     build_command: colcon build --symlink-install --packages-select ur5_3f_test
     fake_hardware_launch_command: ros2 launch ur5_3f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true
   - scene_name: ur5_airpick4_test
+    robot: ur5
+    tool: airpick4_suction
+    required_capabilities: [*cap_ur_arm, *cap_suction, *cap_fake_hardware, *cap_web3d]
     package_name: ur5_airpick4_test
     scene_path: scenes/ur5_airpick4_test
     support_level: supported

--- a/scripts/run_workcell_web3d_visual_acceptance.py
+++ b/scripts/run_workcell_web3d_visual_acceptance.py
@@ -1048,15 +1048,131 @@ def run_browser(url: str, status_path: Path, screenshot_path: Path, require: boo
     return {"available": False, "method": "skipped", "status": None, "reason": f"No Playwright/chromium/google-chrome browser available. Playwright error: {playwright_error}"}
 
 
+SCENE_REPRODUCIBILITY_SCHEMA = "workcell_studio_supported_scene_reproducibility/v1"
+
+
+def _load_supported_entries(catalog_path: Path | None = None) -> tuple[list[Any], list[str]]:
+    if str(REPO_ROOT / "scripts") not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT / "scripts"))
+    from supported_scene_catalog import default_catalog_path, load_supported_scene_catalog
+    path = catalog_path or default_catalog_path(REPO_ROOT)
+    _catalog, entries, errors = load_supported_scene_catalog(path)
+    return entries, errors
+
+
+def _step_status(ok: bool, reason: str = "") -> dict[str, Any]:
+    return {"status": "PASS" if ok else "FAIL", "reason": reason}
+
+
+def _check_render_ownership(web_scene_path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(web_scene_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return _step_status(False, f"could not read staged web scene JSON {repo_relative(web_scene_path)}: {exc}")
+    summary = payload.get("render_ownership_summary") if isinstance(payload, Mapping) else None
+    if not isinstance(summary, Mapping):
+        return _step_status(False, "staged web scene missing render_ownership_summary")
+    unknown = int(summary.get("unknown_physical_owners") or 0)
+    duplicate = int(summary.get("duplicate_primary_identities") or 0)
+    if unknown or duplicate:
+        return _step_status(False, f"render ownership has unknown={unknown} duplicate_primary={duplicate}")
+    return {"status": "PASS", "summary": dict(summary)}
+
+
+def _check_readiness_metadata(scene_dir: Path, entry: Any) -> dict[str, Any]:
+    paths = [scene_dir / "generated/generated_workcell_summary.json", scene_dir / "generated/scene_package_readiness.json"]
+    missing = [repo_relative(p) for p in paths if not p.is_file()]
+    if missing:
+        return _step_status(False, "missing robot/tool readiness metadata: " + ", ".join(missing))
+    try:
+        summary = json.loads(paths[0].read_text(encoding="utf-8"))
+    except Exception as exc:
+        return _step_status(False, f"could not parse {repo_relative(paths[0])}: {exc}")
+    missing_fields = [key for key in ("robot", "end_effector", "grasp_strategy") if not summary.get(key)]
+    missing_caps = [cap for cap in getattr(entry, "required_capabilities", ()) if cap not in json.dumps(summary).lower() and cap not in json.dumps(getattr(entry, "raw", {})).lower()]
+    if missing_fields:
+        return _step_status(False, "generated readiness metadata missing fields: " + ", ".join(missing_fields))
+    return {"status": "PASS", "robot": getattr(entry, "robot", ""), "tool": getattr(entry, "tool", ""), "required_capabilities": list(getattr(entry, "required_capabilities", ())), "unmatched_registry_capabilities": missing_caps}
+
+
+def evaluate_supported_scene_reproducibility(entry: Any, *, output_root: Path, require_browser: bool = False, port: int = 8765) -> dict[str, Any]:
+    scene_dir = (REPO_ROOT / entry.scene_path).resolve()
+    row: dict[str, Any] = {"scene_id": entry.scene_name, "robot": entry.robot, "tool": entry.tool, "required_capabilities": list(entry.required_capabilities), "status": "PASS", "blocker_reason": "", "checks": {}}
+    if entry.status == "blocked" or not entry.enabled:
+        reason = entry.known_blocker or "catalog marks scene blocked/disabled without an explicit blocker reason"
+        row.update(status="BLOCKED", blocker_reason=reason)
+        row["checks"]["catalog_status"] = {"status": "BLOCKED", "reason": reason}
+        return row
+    missing_source = [rel for rel in entry.authoring_files if not (scene_dir / rel).is_file()]
+    row["checks"]["required_source_files"] = _step_status(not missing_source, "missing: " + ", ".join(missing_source) if missing_source else "")
+    gen_root = (output_root / entry.scene_name).resolve()
+    cmd = [sys.executable, "scripts/generate_workcell_from_cell_definition.py", repo_relative(scene_dir / "cell_definition.yaml"), "--output-dir", repo_relative(gen_root.parent), "--package-name", entry.package_name, "--force"]
+    row["checks"]["scene_generation"] = run_step(cmd)
+    generated_scene = gen_root.parent / entry.package_name
+    if row["checks"]["scene_generation"]["returncode"] == 0:
+        val_cmd = [sys.executable, "scripts/validate_builder_generated_scene.py", repo_relative(generated_scene), "--json"]
+        row["checks"]["schema_validation"] = run_step(val_cmd)
+        web_json = BUILD_ROOT / f"{entry.scene_name}.web_scene.json"
+        row["checks"]["web3d_acceptance_tooling"] = run_step([sys.executable, "scripts/ensure_workcell_studio_web_scene_fresh.py", "--scene", repo_relative(generated_scene), "--output", repo_relative(web_json), "--stage-assets"])
+        if row["checks"]["web3d_acceptance_tooling"]["returncode"] == 0:
+            row["checks"]["staged_urdf_meshes"] = run_step([sys.executable, "scripts/check_workcell_web_scene_mesh_contract.py", repo_relative(web_json)])
+            row["checks"]["visual_bounds"] = run_step([sys.executable, "scripts/check_workcell_web_scene_visual_bounds.py", repo_relative(web_json), "--json"])
+            row["checks"]["render_ownership"] = _check_render_ownership(web_json)
+        row["checks"]["robot_tool_readiness_metadata"] = _check_readiness_metadata(generated_scene, entry)
+        missing_launch = [rel for rel in ("launch/demo.launch.py", "urdf/scene.urdf.xacro") if not (generated_scene / rel).is_file()]
+        row["checks"]["fake_hardware_launch_files"] = _step_status(not missing_launch and "use_fake_hardware:=true" in entry.fake_hardware_launch_command, "missing/unguarded launch contract: " + ", ".join(missing_launch) if missing_launch else "")
+    failed = []
+    for name, check in row["checks"].items():
+        if check.get("status") == "FAIL" or check.get("returncode", 0) != 0:
+            failed.append(name)
+    if failed:
+        row["status"] = "FAIL"
+        row["failure_reason"] = "failed checks: " + ", ".join(failed)
+    return row
+
+
+def run_supported_scene_reproducibility_gate(*, output: Path | None = None, catalog: Path | None = None, scene_ids: Sequence[str] | None = None, require_browser: bool = False, port: int = 8765) -> dict[str, Any]:
+    entries, catalog_errors = _load_supported_entries(catalog)
+    if scene_ids:
+        wanted = set(scene_ids)
+        entries = [e for e in entries if e.scene_name in wanted]
+    out_root = REPO_ROOT / "build" / "workcell_studio_supported_scene_reproducibility"
+    out_root.mkdir(parents=True, exist_ok=True)
+    rows = [evaluate_supported_scene_reproducibility(e, output_root=out_root, require_browser=require_browser, port=port) for e in entries]
+    counts = {"PASS": 0, "FAIL": 0, "BLOCKED": 0}
+    for row in rows:
+        counts[row["status"]] += 1
+    report = {"schema": SCENE_REPRODUCIBILITY_SCHEMA, "status": "FAIL" if counts["FAIL"] or catalog_errors else "PASS", "counts": counts, "catalog_errors": catalog_errors, "scenes": rows}
+    if output:
+        out = output if output.is_absolute() else (REPO_ROOT / output)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print("Supported scene reproducibility gate")
+    for row in rows:
+        reason = row.get("blocker_reason") or row.get("failure_reason") or ""
+        print(f"{row['status']}: {row['scene_id']} robot={row['robot']} tool={row['tool']} {reason}")
+    print(json.dumps({"status": report["status"], "counts": counts}, sort_keys=True))
+    return report
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Run browser visual acceptance for a Workcell Studio Web 3D scene.")
-    parser.add_argument("--scene", required=True, help="Scene directory to export and validate.")
+    parser.add_argument("--scene", help="Scene directory to export and validate.")
     parser.add_argument("--output", help="Optional staged web_scene.json output path.")
     parser.add_argument("--scene-id", help="Override derived scene id used for default output/report names.")
     parser.add_argument("--require-browser", action="store_true", help="Fail if Playwright/chromium/google-chrome is unavailable or cannot run.")
     parser.add_argument("--port", type=int, default=8765, help="Repo-root HTTP server port (default: 8765).")
+    parser.add_argument("--all-supported-scenes", action="store_true", help="Run the supported-scene reproducibility gate instead of one browser scene.")
+    parser.add_argument("--catalog", type=Path, help="Supported-scene catalog path for --all-supported-scenes.")
+    parser.add_argument("--only-scene", action="append", default=[], help="Limit --all-supported-scenes to one scene id; repeatable.")
     args = parser.parse_args(argv)
 
+    if args.all_supported_scenes:
+        report = run_supported_scene_reproducibility_gate(output=Path(args.output) if args.output else BUILD_ROOT / "supported_scene_reproducibility.json", catalog=args.catalog, scene_ids=args.only_scene, require_browser=args.require_browser, port=args.port)
+        return 1 if report["status"] == "FAIL" else 0
+
+    if not args.scene:
+        print("error: --scene is required unless --all-supported-scenes is used", file=sys.stderr)
+        return 2
     scene_dir = Path(args.scene).expanduser()
     if not scene_dir.is_absolute():
         scene_dir = (REPO_ROOT / scene_dir).resolve()

--- a/scripts/supported_scene_catalog.py
+++ b/scripts/supported_scene_catalog.py
@@ -32,6 +32,9 @@ class SupportedSceneEntry:
     support_level: str
     status: str
     known_blocker: str
+    robot: str
+    tool: str
+    required_capabilities: tuple[str, ...]
     authoring_files: tuple[str, ...]
     generated_files: tuple[str, ...]
     validation_command: str
@@ -98,6 +101,9 @@ def load_supported_scene_catalog(path: Path) -> tuple[dict[str, Any], list[Suppo
         support_level = str(raw.get("support_level", "supported")).strip() or "supported"
         status = str(raw.get("status", "supported")).strip() or "supported"
         known_blocker = str(raw.get("known_blocker", "")).strip()
+        robot = str(raw.get("robot", "")).strip() or scene_name.split("_", 1)[0]
+        tool = str(raw.get("tool", "")).strip() or "unspecified_tool"
+        required_capabilities = _string_list(raw.get("required_capabilities")) or ("fake_hardware_launch",)
         authoring_files = _string_list(raw.get("authoring_files"))
         generated_files = _string_list(raw.get("generated_files"))
         validation_command = str(raw.get("validation_command", "")).strip()
@@ -134,6 +140,9 @@ def load_supported_scene_catalog(path: Path) -> tuple[dict[str, Any], list[Suppo
                 support_level=support_level,
                 status=status,
                 known_blocker=known_blocker,
+                robot=robot,
+                tool=tool,
+                required_capabilities=required_capabilities,
                 authoring_files=authoring_files,
                 generated_files=generated_files,
                 validation_command=validation_command,

--- a/tests/test_workcell_web3d_visual_acceptance.py
+++ b/tests/test_workcell_web3d_visual_acceptance.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 from pathlib import Path
 
 import yaml
@@ -769,3 +770,79 @@ def test_acceptance_requires_all_robotiq_collada_diagnostics():
 
 def test_acceptance_no_longer_rewrites_physical_fit_bounds():
     assert not hasattr(module, 'normalize_physical_fit_bounds')
+
+
+def test_supported_scene_registry_includes_robot_tool_and_required_capabilities():
+    catalog = yaml.safe_load((ROOT / "scenes/supported_scenes.yaml").read_text(encoding="utf-8"))
+    registered = {row["scene_name"]: row for row in catalog["scenes"]}
+    for scene_id in ["ur5_2f_test", "ur5_3f_test", "suction_test", "ur10_2f_test", "ur3_suction_test"]:
+        row = registered[scene_id]
+        assert row["robot"]
+        assert row["tool"]
+        assert row["required_capabilities"]
+        assert "fake_hardware_launch" in row["required_capabilities"]
+
+
+def test_supported_scene_reproducibility_gate_reports_blocked_with_reason(monkeypatch, tmp_path):
+    entry = type("Entry", (), {
+        "scene_name": "blocked_scene", "scene_path": "scenes/blocked_scene", "package_name": "blocked_scene",
+        "robot": "ur5", "tool": "robotiq_2f", "required_capabilities": ("fake_hardware_launch",),
+        "status": "blocked", "enabled": True, "known_blocker": "explicit ROS workspace blocker",
+        "authoring_files": ("environment.yaml",), "fake_hardware_launch_command": "ros2 launch blocked_scene demo.launch.py use_fake_hardware:=true",
+    })()
+    monkeypatch.setattr(module, "_load_supported_entries", lambda catalog=None: ([entry], []))
+    report = module.run_supported_scene_reproducibility_gate(output=tmp_path / "report.json")
+    assert report["counts"] == {"PASS": 0, "FAIL": 0, "BLOCKED": 1}
+    assert report["status"] == "PASS"
+    assert report["scenes"][0]["blocker_reason"] == "explicit ROS workspace blocker"
+
+
+def test_supported_scene_reproducibility_gate_reports_fail_and_nonzero_reason(monkeypatch, tmp_path):
+    scene = ROOT / "scenes/fail_fixture"
+    entry = type("Entry", (), {
+        "scene_name": "fail_fixture", "scene_path": "scenes/fail_fixture", "package_name": "fail_fixture",
+        "robot": "ur5", "tool": "robotiq_2f", "required_capabilities": ("fake_hardware_launch",),
+        "status": "supported", "enabled": True, "known_blocker": "",
+        "authoring_files": ("environment.yaml", "cell_definition.yaml"),
+        "fake_hardware_launch_command": "ros2 launch fail_fixture demo.launch.py use_fake_hardware:=true",
+    })()
+    monkeypatch.setattr(module, "_load_supported_entries", lambda catalog=None: ([entry], []))
+    report = module.run_supported_scene_reproducibility_gate(output=tmp_path / "report.json")
+    row = report["scenes"][0]
+    assert row["status"] == "FAIL"
+    assert report["status"] == "FAIL"
+    assert "required_source_files" in row["failure_reason"]
+
+
+def test_supported_scene_reproducibility_gate_reports_pass(monkeypatch, tmp_path):
+    scene = tmp_path / "repo" / "scenes" / "pass_scene"
+    (scene / "generated").mkdir(parents=True)
+    for rel in ["environment.yaml", "cell_definition.yaml", "layout/workcell_studio_layout.yaml", "launch/demo.launch.py", "urdf/scene.urdf.xacro"]:
+        (scene / rel).parent.mkdir(parents=True, exist_ok=True)
+        (scene / rel).write_text("ok\n", encoding="utf-8")
+    (scene / "generated/generated_workcell_summary.json").write_text(json.dumps({"robot": {"capability": "ur5"}, "end_effector": {"capability": "robotiq_2f"}, "grasp_strategy": {"id": "finger"}}), encoding="utf-8")
+    (scene / "generated/scene_package_readiness.json").write_text("{}", encoding="utf-8")
+    generated = tmp_path / "repo" / "build/workcell_studio_supported_scene_reproducibility/pass_scene"
+    (generated / "generated").mkdir(parents=True)
+    for rel in ["launch/demo.launch.py", "urdf/scene.urdf.xacro"]:
+        (generated / rel).parent.mkdir(parents=True, exist_ok=True)
+        (generated / rel).write_text("ok\n", encoding="utf-8")
+    (generated / "generated/generated_workcell_summary.json").write_text(json.dumps({"robot": {"capability": "ur5"}, "end_effector": {"capability": "robotiq_2f"}, "grasp_strategy": {"id": "finger"}}), encoding="utf-8")
+    (generated / "generated/scene_package_readiness.json").write_text("{}", encoding="utf-8")
+    web = tmp_path / "web.json"
+    web.write_text(json.dumps({"render_ownership_summary": {"unknown_physical_owners": 0, "duplicate_primary_identities": 0}}), encoding="utf-8")
+    entry = type("Entry", (), {
+        "scene_name": "pass_scene", "scene_path": "scenes/pass_scene", "package_name": "pass_scene",
+        "robot": "ur5", "tool": "robotiq_2f", "required_capabilities": ("fake_hardware_launch",),
+        "status": "supported", "enabled": True, "known_blocker": "",
+        "authoring_files": ("environment.yaml", "cell_definition.yaml"),
+        "fake_hardware_launch_command": "ros2 launch pass_scene demo.launch.py use_fake_hardware:=true",
+    })()
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path / "repo")
+    monkeypatch.setattr(module, "BUILD_ROOT", tmp_path)
+    monkeypatch.setattr(module, "run_step", lambda cmd: {"command": cmd, "returncode": 0, "stdout": "", "stderr": ""})
+    monkeypatch.setattr(module, "_load_supported_entries", lambda catalog=None: ([entry], []))
+    monkeypatch.setattr(module, "_check_render_ownership", lambda path: {"status": "PASS", "summary": {}})
+    report = module.run_supported_scene_reproducibility_gate(output=tmp_path / "report.json")
+    assert report["counts"]["PASS"] == 1
+    assert report["status"] == "PASS"


### PR DESCRIPTION
### Motivation
- Provide a single reproducibility gate that reports PASS / FAIL / BLOCKED for every supported scene so scene-level regressions are caught consistently. 
- Reuse the existing Web3D visual-acceptance pipeline rather than duplicating validation logic, and make the registry the single source-of-truth for supported scenes. 
- Ensure checks cover authoring inputs, generation, schema validation, staged URDF/mesh resolution, render ownership, robot/tool readiness metadata, and presence of guarded fake-hardware launches.

### Description
- Add machine-readable supported-scene registry fields and entries: `robot`, `tool`, and `required_capabilities` in `scenes/supported_scenes.yaml`. 
- Extend the catalog loader in `scripts/supported_scene_catalog.py` to expose `robot`, `tool`, and `required_capabilities` on `SupportedSceneEntry` and preserve existing validation rules. 
- Extend `scripts/run_workcell_web3d_visual_acceptance.py` with an `--all-supported-scenes` mode that runs `run_supported_scene_reproducibility_gate` and `evaluate_supported_scene_reproducibility`, producing per-scene checks and a single JSON report; the gate writes machine-readable JSON and exits non-zero when any scene is `FAIL`. 
- Implement per-scene checks that verify required source files, attempt scene generation, run generated-scene schema validation, stage a Web3D export and run mesh/bounds contract checks, validate `render_ownership_summary`, check generated readiness metadata (`generated_workcell_summary.json`, `scene_package_readiness.json`) for robot/tool fields, and ensure a fake-hardware guarded launch contract exists. 
- Add focused unit tests covering registry fields and PASS/FAIL/BLOCKED outcomes in `tests/test_workcell_web3d_visual_acceptance.py` and wire the gate into CI by running it in `.github/workflows/web3d-visual-acceptance.yml` and uploading its JSON artifact.

Files changed (key): `scripts/run_workcell_web3d_visual_acceptance.py`, `scripts/supported_scene_catalog.py`, `scenes/supported_scenes.yaml`, `tests/test_workcell_web3d_visual_acceptance.py`, `.github/workflows/web3d-visual-acceptance.yml`.

### Testing
- Ran unit test suite for the Web3D acceptance and supported-scene readiness validators: `python3 -m pytest tests/test_workcell_web3d_visual_acceptance.py tests/test_validate_supported_scenes_readiness.py` and observed all tests pass (combined run: 76 passed). 
- Exercised the gate end-to-end: `python3 scripts/run_workcell_web3d_visual_acceptance.py --all-supported-scenes --output build/workcell_studio_web_scene/supported_scene_reproducibility.json`, which produced a machine-readable report at `build/workcell_studio_web_scene/supported_scene_reproducibility.json` and printed per-scene statuses; current catalog scenes were reported as `BLOCKED` with explicit blocker reasons (no FAIL rows). 
- Compiled Python sources for basic sanity: `python3 -m py_compile scripts/run_workcell_web3d_visual_acceptance.py scripts/supported_scene_catalog.py` — OK. 
- Confirmed the gate obeys safety constraints: fake-hardware remains required and no real-hardware defaults or runtime motion paths were enabled by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60b1fb03a083318a9fec5cdec58ac3)