### PR TITLE
Synchronize hierarchy, Product View and inspector selection

### DIFF
--- a/tests/test_embedded_web3d_editor_bridge_static.py
+++ b/tests/test_embedded_web3d_editor_bridge_static.py
@@ -68,3 +68,32 @@ def test_qt_compact_toolbar_for_embedded_web3d():
     assert "set_visible(snap_mode_selector_, embedded_web_active)" in CPP
     assert "Unsaved preview edits: %1" in CPP
     assert "Locked item — select an editable object or area" in CPP
+
+
+def test_product_view_selection_uses_stable_identity_and_filters_helpers():
+    assert "function isNormalSelectableRendered(rendered)" in VIEWER
+    assert "item.selectable !== false" in VIEWER
+    assert "!isDiagnosticOnlyItem(item) && !isOverlayPolicyItem(item)" in VIEWER
+    assert "renderedById(requestedId)" in VIEWER
+    assert "missing_render_identity" in VIEWER
+    assert "diagnostic_helper_or_non_selectable" in VIEWER
+    assert "selectObject(item.id);" in VIEWER
+    assert "itemLabel(item)" not in VIEWER.split("function pickObject", 1)[1].split("function beginDirectMoveDrag", 1)[0]
+
+
+def test_qt_selection_clears_stale_scene_and_missing_id_callbacks():
+    assert "selected_preview_item_id_.clear();" in CPP
+    assert "scene_context_changed" in CPP
+    assert "selection_missing_after_refresh" in CPP
+    assert "Preview selection cleared after refresh (id missing):" in CPP
+    assert "if (!embedded_web_identity_is_current(identity)) return;" in CPP
+    assert "if (id != selected_preview_item_id_)" in CPP
+    assert "selection_update_guard_" in (ROOT / "workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text(encoding="utf-8")
+
+
+def test_selection_diagnostics_are_exposed_to_qt_bridge():
+    assert "function currentSelectionDiagnostics()" in VIEWER
+    assert "selectionDiagnostics: currentSelectionDiagnostics()" in VIEWER
+    assert "selectionDiagnostics: () => currentSelectionDiagnostics()" in VIEWER
+    for field in ["renderIdentity", "sourceLayer", "activeVisualSource", "diagnosticOnly", "helperOrOverlay", "objectPresent"]:
+        assert field in VIEWER

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -1787,6 +1787,14 @@ void ScenePreviewWidget::set_preview_context(const PreviewContext & context)
     cancel_embedded_web_lifecycle(false);
   }
   root_resolution_summary_keys_.clear();
+  selected_preview_item_id_.clear();
+  if (auto * viewport = active_native_viewport()) {
+    viewport->selected_id.clear();
+    viewport->update();
+  }
+  run_embedded_editor_command(QStringLiteral("window.__WORKCELL_EDITOR_API_V1__&&window.__WORKCELL_EDITOR_API_V1__.clearSelection()"));
+  emit preview_item_selected(QString(), QStringLiteral("scene_context_changed"));
+
   if (!normalized.scene_id.isEmpty()) {
     set_preview_scene_name(normalized.scene_id);
     if (!scene_name_changed) refresh_embedded_web_product_view();
@@ -1943,7 +1951,19 @@ bool ScenePreviewWidget::native_compatibility_viewport_has_usable_content() cons
 }
 
 void ScenePreviewWidget::set_fallback_2d_view(QGraphicsView * view){ fallback_2d_view_ = view; if (!view2d_container_->layout()) view2d_container_->setLayout(new QVBoxLayout()); view2d_container_->layout()->addWidget(view); if (fallback_2d_view_ && fallback_2d_view_->scene() && info_chip_label_ && !fallback_info_chip_proxy_) { fallback_info_chip_proxy_ = fallback_2d_view_->scene()->addWidget(info_chip_label_); fallback_info_chip_proxy_->setZValue(10000.0); fallback_info_chip_proxy_->setPos(12.0, 12.0); } refresh_info_chip(); }
-void ScenePreviewWidget::set_scene_selected(bool selected){ scene_selected_ = selected; refresh_mode_and_state(); }
+void ScenePreviewWidget::set_scene_selected(bool selected){
+  scene_selected_ = selected;
+  if (!selected && !selected_preview_item_id_.isEmpty()) {
+    selected_preview_item_id_.clear();
+    if (auto * viewport = active_native_viewport()) {
+      viewport->selected_id.clear();
+      viewport->update();
+    }
+    run_embedded_editor_command(QStringLiteral("window.__WORKCELL_EDITOR_API_V1__&&window.__WORKCELL_EDITOR_API_V1__.clearSelection()"));
+    emit preview_item_selected(QString(), QStringLiteral("scene_cleared"));
+  }
+  refresh_mode_and_state();
+}
 void ScenePreviewWidget::set_3d_available(bool available, const QString & reason){
   preview3d_available_ = available;
   unavailable_reason_ = reason;
@@ -1998,9 +2018,18 @@ void ScenePreviewWidget::set_preview_items(const QVector<PreviewItem> & items)
   auto * viewport = active_native_viewport();
   if (viewport) viewport->ingest_preview_items(preview_items_);
   const bool has_selected = std::any_of(preview_items_.cbegin(), preview_items_.cend(), [this](const PreviewItem & it){ return it.id == selected_preview_item_id_; });
-  if (viewport) viewport->selected_id = selected_preview_item_id_;
+  if (!selected_preview_item_id_.isEmpty() && !has_selected) {
+    const QString missing_id = selected_preview_item_id_;
+    selected_preview_item_id_.clear();
+    if (viewport) viewport->selected_id.clear();
+    run_embedded_editor_command(QStringLiteral("window.__WORKCELL_EDITOR_API_V1__&&window.__WORKCELL_EDITOR_API_V1__.clearSelection()"));
+    emit studio_log_requested(QString("Preview selection cleared after refresh (id missing): %1").arg(missing_id));
+    emit preview_item_selected(QString(), QStringLiteral("selection_missing_after_refresh"));
+  } else if (viewport) {
+    viewport->selected_id = selected_preview_item_id_;
+  }
   if (diagnostic_debug_logging_enabled() && !selected_preview_item_id_.isEmpty()) {
-    emit studio_log_requested(has_selected ? QString("Preview selection restored after refresh: %1").arg(selected_preview_item_id_) : QString("Preview selection retained after refresh; id is hidden by filters or absent from the visible preview payload: %1").arg(selected_preview_item_id_));
+    emit studio_log_requested(QString("Preview selection restored after refresh: %1").arg(selected_preview_item_id_));
   }
   if (viewport) viewport->fit_include_overlays = false;
   apply_product_view_defaults();
@@ -2116,7 +2145,23 @@ void ScenePreviewWidget::set_task_overlay_visibility(bool task_route, bool pick_
   // else if (v->label_mode == LabelMode::All) v->label_mode = LabelMode::SelectedOnly;
   v->update();
 }
-void ScenePreviewWidget::select_preview_item(const QString & id){ selected_preview_item_id_ = id; if (auto * v = active_native_viewport()) { v->selected_id = id; v->update(); } else run_embedded_editor_command(QStringLiteral("window.__WORKCELL_EDITOR_API_V1__&&window.__WORKCELL_EDITOR_API_V1__.selectItem(%1)").arg(QString::fromUtf8(QJsonDocument(QJsonArray{id}).toJson(QJsonDocument::Compact)).mid(1).chopped(1))); if (simple_3d_view_) simple_3d_view_->update(); }
+void ScenePreviewWidget::select_preview_item(const QString & id){
+  const QString stable_id = id.trimmed();
+  if (!stable_id.isEmpty() && !preview_item_by_id(stable_id)) {
+    if (diagnostic_debug_logging_enabled()) emit studio_log_requested(QString("Preview selection ignored because id is absent from current payload: %1").arg(stable_id));
+    return;
+  }
+  selected_preview_item_id_ = stable_id;
+  if (auto * v = active_native_viewport()) {
+    v->selected_id = stable_id;
+    v->update();
+  } else if (stable_id.isEmpty()) {
+    run_embedded_editor_command(QStringLiteral("window.__WORKCELL_EDITOR_API_V1__&&window.__WORKCELL_EDITOR_API_V1__.clearSelection()"));
+  } else {
+    run_embedded_editor_command(QStringLiteral("window.__WORKCELL_EDITOR_API_V1__&&window.__WORKCELL_EDITOR_API_V1__.selectItem(%1)").arg(QString::fromUtf8(QJsonDocument(QJsonArray{stable_id}).toJson(QJsonDocument::Compact)).mid(1).chopped(1)));
+  }
+  if (simple_3d_view_) simple_3d_view_->update();
+}
 QString ScenePreviewWidget::selected_preview_item_id() const { return selected_preview_item_id_; }
 const ScenePreviewWidget::PreviewItem * ScenePreviewWidget::preview_item_by_id(const QString & id) const
 {

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -809,9 +809,28 @@ function pushEditorEvent(type, payload = {}) {
   state.editorEvents.push({ type, timestamp: new Date().toISOString(), ...payload });
   if (state.editorEvents.length > 100) state.editorEvents.splice(0, state.editorEvents.length - 100);
 }
+function currentSelectionDiagnostics() {
+  const id = String(state.selected || '');
+  const rendered = renderedById(id);
+  const item = rendered?.item || null;
+  return {
+    sceneId: sceneId(),
+    selectedItemId: id,
+    renderIdentity: id,
+    selectedItemType: rendered ? itemType(item) : '',
+    selectable: Boolean(item && item.selectable !== false && !isDiagnosticOnlyItem(item) && !isOverlayPolicyItem(item)),
+    editable: Boolean(item && canEditItem(item)),
+    locked: Boolean(item?.locked),
+    sourceLayer: String(item?.source_layer || ''),
+    activeVisualSource: String(item?.active_visual_source || ''),
+    diagnosticOnly: Boolean(item && isDiagnosticOnlyItem(item)),
+    helperOrOverlay: Boolean(item && isOverlayPolicyItem(item)),
+    objectPresent: Boolean(rendered),
+  };
+}
 function editorState() {
   const rendered = renderedById(state.selected);
-  return { ready: Boolean(state.sceneJson && state.three?.scene), sceneId: sceneId(), selectedItemId: state.selected || '', selectedItemType: rendered ? itemType(rendered.item) : '', selectedEditable: Boolean(rendered && rendered.item && canEditItem(rendered['item'])), dirty: state.dirtyTransforms.size > 0, dirtyCount: state.dirtyTransforms.size, canUndo: state.undoStack.length > 0, canRedo: state.redoStack.length > 0, mode: state.editorMode, error: state.editorError || '' };
+  return { ready: Boolean(state.sceneJson && state.three?.scene), sceneId: sceneId(), selectedItemId: state.selected || '', selectedItemType: rendered ? itemType(rendered.item) : '', selectedEditable: Boolean(rendered && rendered.item && canEditItem(rendered['item'])), selectionDiagnostics: currentSelectionDiagnostics(), dirty: state.dirtyTransforms.size > 0, dirtyCount: state.dirtyTransforms.size, canUndo: state.undoStack.length > 0, canRedo: state.redoStack.length > 0, mode: state.editorMode, error: state.editorError || '' };
 }
 function emitDirtyChanged() { pushEditorEvent('dirty_changed', { dirty: state.dirtyTransforms.size > 0, dirtyCount: state.dirtyTransforms.size, canUndo: state.undoStack.length > 0, canRedo: state.redoStack.length > 0 }); }
 function showError(message) {
@@ -3349,10 +3368,21 @@ function refreshSelectionHighlight(rendered) {
   state.three.scene.add(helper);
 }
 
+function isNormalSelectableRendered(rendered) {
+  const item = rendered?.item;
+  return Boolean(item?.id) && item.selectable !== false && !isDiagnosticOnlyItem(item) && !isOverlayPolicyItem(item);
+}
 function selectObject(id) {
   const wasInitialPreviewActive = state.initialPosePreview.active;
   if (state.directMoveDrag && state.directMoveDrag.itemId !== (id || '')) cancelDirectMoveDrag('Move cancelled');
   if (state.directRotateDrag && state.directRotateDrag.itemId !== (id || '')) cancelDirectRotateDrag('Rotation cancelled');
+  const requestedId = String(id || '');
+  const requested = requestedId ? renderedById(requestedId) : null;
+  if (requestedId && !isNormalSelectableRendered(requested)) {
+    pushEditorEvent('selection_ignored', { itemId: requestedId, reason: requested ? 'diagnostic_helper_or_non_selectable' : 'missing_render_identity', sceneId: sceneId() });
+    return '';
+  }
+  id = requestedId;
   const previous = state.selected || '';
   state.selected = id;
   document.querySelectorAll('.object-list li').forEach(li => li.classList.toggle('selected', li.dataset.id === id));
@@ -3372,10 +3402,14 @@ function pickObject(event) {
   state.three.pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
   state.three.raycaster.setFromCamera(state.three.pointer, state.three.camera);
   const hits = state.three.raycaster.intersectObjects(state.objects.map(o => o.object3d), true);
-  const hit = hits.find(h => h.object?.parent || h.object);
-  const item = hit?.object?.userData?.item || hit?.object?.parent?.userData?.item;
-  if (item?.id) selectObject(item.id);
-  return item?.id || '';
+  for (const hit of hits) {
+    const item = hit?.object?.userData?.item || hit?.object?.parent?.userData?.item;
+    const rendered = item?.id ? renderedById(item.id) : null;
+    if (!isNormalSelectableRendered(rendered)) continue;
+    selectObject(item.id);
+    return item.id;
+  }
+  return '';
 }
 
 
@@ -3793,6 +3827,7 @@ function setEditorSnap(enabled, translationMeters, rotationDegrees) {
 window.__WORKCELL_EDITOR_API_V1__ = {
   getState: () => editorState(),
   selectItem: id => { selectObject(String(id || '')); return editorState(); },
+  selectionDiagnostics: () => currentSelectionDiagnostics(),
   clearSelection: () => { clearSelection(); return editorState(); },
   setMode: mode => { setEditorMode(mode); return editorState(); },
   setSnap: (enabled, translationMeters, rotationDegrees) => { setEditorSnap(enabled, translationMeters, rotationDegrees); return editorState(); },


### PR DESCRIPTION
### Motivation
- Provide one authoritative current-scene selection across the Qt hierarchy, embedded Web3D Product View and inspector using stable item IDs rather than labels or mesh names.
- Prevent selection feedback loops and stale callbacks when scenes change, while allowing persistent selection across normal payload refreshes when the identity remains present.

### Description
- Qt: clear preview selection on scene context changes and scene clears, ignore stale selection callbacks, and reject selection requests for IDs that are not present in the current payload by validating in `ScenePreviewWidget::select_preview_item`, `set_preview_items`, and `set_preview_context` (changes in `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp`).
- Browser viewer: filter out diagnostic/helper/overlay rows and non-selectable objects from normal selections, resolve picks and programmatic selection by stable render `id`, expose concise selection diagnostics through a new `currentSelectionDiagnostics()` helper and add `selectionDiagnostics` to the embedded editor API, and emit bounded `selection_ignored` events when selection is invalid (changes in `workcell_studio_web/viewer/viewer.js`).
- Guarding: added explicit embedded-editor bridge calls to clear selection in the embedded viewer when Qt clears or changes scene context to avoid cross-backend feedback loops.
- Tests: added static tests to assert identity-based selection, helper filtering, stale/missing selection clearing, and diagnostics exposure (updates in `tests/test_embedded_web3d_editor_bridge_static.py`).

### Testing
- Ran focused pytest suites `python3 -m pytest tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py tests/test_embedded_web3d_editor_bridge_static.py::test_product_view_selection_uses_stable_identity_and_filters_helpers tests/test_embedded_web3d_editor_bridge_static.py::test_qt_selection_clears_stale_scene_and_missing_id_callbacks tests/test_embedded_web3d_editor_bridge_static.py::test_selection_diagnostics_are_exposed_to_qt_bridge` and all targeted tests passed.
- Verified JavaScript syntax with `node -c workcell_studio_web/viewer/viewer.js` and ran `git diff --check`, both of which passed.
- `colcon build --packages-select workcell_builder` was not run because `/opt/ros/humble/setup.bash` is not present in this environment, and `git push` failed because no `origin` remote is configured; local branch `codex/synchronize-product-view-selection` was committed as `Synchronize product view selection by identity`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60b5048f608331adaf4d571377ea84)