### PR TITLE
Formalize the Workcell Studio EPD bridge contract

### DIFF
--- a/docs/manuals/DETECTED_OBJECTS_V1.md
+++ b/docs/manuals/DETECTED_OBJECTS_V1.md
@@ -55,3 +55,12 @@ python3 scripts/run_task_recipe_adapter.py \
   --objects tests/fixtures/detected_objects/valid_epd_colour_sorting.yaml \
   --json
 ```
+
+
+## Workcell Studio normalized snapshot contract
+
+Workcell Studio now validates EPD payloads through the machine-readable `workcell_perception_snapshot/v1` contract before task binding. EPD remains responsible for RealSense camera processing, detection, localization, and tracking; Workcell Studio owns scene identity checks, camera identity checks, task binding, and adapter configuration.
+
+Required normalized fields are `scene_id`, `camera_id`, `timestamp`, `frame_id`, and `objects`. Each object requires an `object_id` or `track_id`, `label`, `confidence`, optional `attributes`, and either a finite pose (`position` plus normalized `orientation_xyzw`) or a finite `centroid`. Validation rejects duplicate object IDs, non-finite poses, non-normalized quaternions, confidence outside `[0, 1]`, and scene/camera mismatches.
+
+Generated scene packages write `generated/perception_adapter_config.yaml`. Perception-backed scenes receive camera identity, expected frames, EPD input topic/message type, required object classes, confidence threshold, task binding, and the normalized output contract. Scenes with perception disabled report `NOT_APPLICABLE`; incomplete perception-backed metadata fails generation clearly.

--- a/scenes/suction_test/cell_definition.yaml
+++ b/scenes/suction_test/cell_definition.yaml
@@ -15,9 +15,23 @@ end_effector:
   brand: generic
   grasp_frame: tool0
 camera:
-  enabled: false
-  camera_id: UNKNOWN_CAMERA
-  frame_id: UNKNOWN_FRAME
+  enabled: true
+  camera_id: realsense_suction_overhead
+  frame_id: camera_color_optical_frame
+perception:
+  enabled: true
+  mode: epd_snapshot
+  camera_id: realsense_suction_overhead
+  frame_id: camera_color_optical_frame
+  expected_frames:
+    - camera_color_optical_frame
+    - world
+  epd_input:
+    topic: /easy_perception_deployment/epd_localize_output
+    message_type: std_msgs/msg/String
+  required_object_classes:
+    - part
+  confidence_threshold: 0.6
 environment:
   frame: world
   layout: layout/workcell_studio_layout.yaml

--- a/scripts/epd_snapshot_adapter.py
+++ b/scripts/epd_snapshot_adapter.py
@@ -4,6 +4,116 @@ import argparse, json, math
 from pathlib import Path
 from typing import Any
 
+NORMALIZED_SNAPSHOT_SCHEMA_VERSION = "workcell_perception_snapshot/v1"
+
+def _finite_vec(values: Any, size: int, name: str, errors: list[str]) -> list[float] | None:
+    if not isinstance(values, list) or len(values) != size:
+        errors.append(f"{name} must be a {size}-value list")
+        return None
+    out=[]
+    for v in values:
+        try:
+            f=float(v)
+        except Exception:
+            errors.append(f"{name} contains non-numeric value")
+            return None
+        if not math.isfinite(f):
+            errors.append(f"{name} contains non-finite value")
+            return None
+        out.append(f)
+    return out
+
+def validate_normalized_snapshot(snapshot: dict[str, Any], *, expected_scene_id: str | None = None, expected_camera_id: str | None = None) -> list[str]:
+    """Validate the versioned Workcell Studio normalized EPD snapshot contract."""
+    errors: list[str] = []
+    if snapshot.get("schema_version") != NORMALIZED_SNAPSHOT_SCHEMA_VERSION:
+        errors.append(f"schema_version must be {NORMALIZED_SNAPSHOT_SCHEMA_VERSION}")
+    scene_id = snapshot.get("scene_id")
+    camera_id = snapshot.get("camera_id")
+    timestamp = snapshot.get("timestamp")
+    frame_id = snapshot.get("frame_id")
+    if not scene_id: errors.append("scene_id is required")
+    if not camera_id: errors.append("camera_id is required")
+    if not timestamp: errors.append("timestamp is required")
+    if not frame_id: errors.append("frame_id is required")
+    if expected_scene_id and scene_id != expected_scene_id:
+        errors.append(f"scene_id mismatch: expected {expected_scene_id}, got {scene_id}")
+    if expected_camera_id and camera_id != expected_camera_id:
+        errors.append(f"camera_id mismatch: expected {expected_camera_id}, got {camera_id}")
+    objects = snapshot.get("objects")
+    if not isinstance(objects, list):
+        errors.append("objects must be a list")
+        return errors
+    seen: set[str] = set()
+    for idx, obj in enumerate(objects):
+        if not isinstance(obj, dict):
+            errors.append(f"objects[{idx}] must be a mapping")
+            continue
+        oid = obj.get("object_id") or obj.get("track_id")
+        if not oid:
+            errors.append(f"objects[{idx}] requires object_id or track_id")
+        elif str(oid) in seen:
+            errors.append(f"duplicate object id: {oid}")
+        else:
+            seen.add(str(oid))
+        if not obj.get("label"):
+            errors.append(f"objects[{idx}].label is required")
+        try:
+            conf = float(obj.get("confidence"))
+            if not math.isfinite(conf) or conf < 0.0 or conf > 1.0:
+                errors.append(f"objects[{idx}].confidence must be in [0, 1]")
+        except Exception:
+            errors.append(f"objects[{idx}].confidence is required and numeric")
+        pose = obj.get("pose") if isinstance(obj.get("pose"), dict) else None
+        centroid = obj.get("centroid")
+        if pose:
+            _finite_vec(pose.get("position"), 3, f"objects[{idx}].pose.position", errors)
+            q = _finite_vec(pose.get("orientation_xyzw"), 4, f"objects[{idx}].pose.orientation_xyzw", errors)
+            if q is not None and abs(math.sqrt(sum(v*v for v in q)) - 1.0) > 1e-3:
+                errors.append(f"objects[{idx}].pose.orientation_xyzw must be normalized")
+            if pose.get("frame_id") and pose.get("frame_id") != frame_id:
+                errors.append(f"objects[{idx}].pose.frame_id must match snapshot frame_id")
+        elif centroid is not None:
+            _finite_vec(centroid, 3, f"objects[{idx}].centroid", errors)
+        else:
+            errors.append(f"objects[{idx}] requires pose or centroid")
+        attrs = obj.get("attributes", {})
+        if attrs is not None and not isinstance(attrs, dict):
+            errors.append(f"objects[{idx}].attributes must be a mapping when present")
+    return errors
+
+def normalize_detected_objects_snapshot(detected: dict[str, Any], profile: dict[str, Any]) -> dict[str, Any]:
+    perception = profile.get("perception", {}) if isinstance(profile.get("perception"), dict) else {}
+    camera = perception.get("camera", {}) if isinstance(perception.get("camera"), dict) else {}
+    scene_id = detected.get("scene_id") or perception.get("scene_id") or profile.get("scene_id")
+    camera_id = detected.get("camera_id") or camera.get("camera_id") or camera.get("id") or detected.get("camera")
+    frame_id = detected.get("frame_id") or camera.get("frame_id") or camera.get("optical_frame_id")
+    source = detected.get("source") if isinstance(detected.get("source"), dict) else {}
+    timestamp = detected.get("timestamp") or detected.get("captured_at") or source.get("captured_at")
+    out = {"schema_version": NORMALIZED_SNAPSHOT_SCHEMA_VERSION, "scene_id": scene_id, "camera_id": camera_id, "timestamp": timestamp, "frame_id": frame_id, "objects": []}
+    for obj in detected.get("objects", []):
+        if not isinstance(obj, dict):
+            continue
+        pose = obj.get("pose") if isinstance(obj.get("pose"), dict) else {}
+        centroid = obj.get("centroid")
+        item = {
+            "object_id": str(obj.get("object_id") or obj.get("id") or obj.get("name") or obj.get("tracking_id") or obj.get("track_id") or ""),
+            "track_id": obj.get("tracking_id") or obj.get("track_id"),
+            "label": obj.get("label") or obj.get("class_label") or obj.get("class") or obj.get("class_id") or obj.get("name"),
+            "confidence": obj.get("confidence"),
+            "attributes": obj.get("attributes", {}),
+        }
+        pos = pose.get("position") or pose.get("xyz") or obj.get("position")
+        quat = pose.get("orientation_xyzw") or pose.get("quaternion_xyzw")
+        if pos is not None:
+            item["pose"] = {"frame_id": pose.get("frame_id") or frame_id, "position": pos, "orientation_xyzw": quat or [0.0, 0.0, 0.0, 1.0]}
+        elif isinstance(centroid, dict):
+            item["centroid"] = [centroid.get("x"), centroid.get("y"), centroid.get("z")]
+        elif isinstance(centroid, list):
+            item["centroid"] = centroid
+        out["objects"].append(item)
+    return out
+
 def _load(path: Path)->dict[str,Any]:
     return json.loads(path.read_text(encoding='utf-8')) if path and path.exists() else {}
 
@@ -45,6 +155,14 @@ def main() -> int:
 
     if detected.get('schema_version')!='detected_objects/v1':
         raise SystemExit('invalid detected_objects schema')
+
+    normalized_snapshot = normalize_detected_objects_snapshot(detected, profile)
+    expected_scene = (profile.get('perception', {}) or {}).get('scene_id') or profile.get('scene_id')
+    expected_camera = (((profile.get('perception', {}) or {}).get('camera', {}) or {}).get('camera_id')
+                       or (((profile.get('perception', {}) or {}).get('camera', {}) or {}).get('id')))
+    snapshot_errors = validate_normalized_snapshot(normalized_snapshot, expected_scene_id=expected_scene, expected_camera_id=expected_camera)
+    if snapshot_errors:
+        raise SystemExit('invalid normalized perception snapshot: ' + '; '.join(snapshot_errors))
 
     mapping=((profile.get('perception',{}) or {}).get('object_mapping',{}))
     conf=float(mapping.get('confidence_threshold',0.5))

--- a/scripts/generate_workcell_from_cell_definition.py
+++ b/scripts/generate_workcell_from_cell_definition.py
@@ -257,6 +257,52 @@ def _render_environment_yaml(cell_def: dict[str, Any], scene_generator: Any, cel
     return _header_yaml(cell_definition_path) + _yaml_text_from(scene_generator, payload)
 
 
+
+def _build_perception_adapter_config(cell_def: dict[str, Any], task_recipe: dict[str, Any], warnings: list[str]) -> dict[str, Any]:
+    cell = cell_def.get("cell", {}) if isinstance(cell_def.get("cell"), dict) else {}
+    camera = cell_def.get("camera", {}) if isinstance(cell_def.get("camera"), dict) else {}
+    perception = cell_def.get("perception", {}) if isinstance(cell_def.get("perception"), dict) else {}
+    task = cell_def.get("task", {}) if isinstance(cell_def.get("task"), dict) else {}
+    scene_id = str(cell.get("id") or cell_def.get("scene_id") or "").strip()
+    enabled = bool(perception.get("enabled", camera.get("enabled", False)))
+    mode = str(perception.get("mode", "off" if not enabled else "epd_snapshot")).strip()
+    if not enabled or mode in {"off", "disabled", "none"}:
+        return {"schema_version": "workcell_perception_adapter_config/v1", "status": "NOT_APPLICABLE", "reason": "scene has no perception requirement", "scene_id": scene_id, "normalized_output_contract": "workcell_perception_snapshot/v1"}
+    camera_id = str(perception.get("camera_id") or camera.get("camera_id") or camera.get("id") or "").strip()
+    frame_id = str(perception.get("frame_id") or camera.get("frame_id") or camera.get("frame") or "").strip()
+    expected_frames = perception.get("expected_frames") or [f for f in [frame_id, camera.get("optical_frame_id"), (cell_def.get("environment", {}) or {}).get("frame")] if f]
+    epd = perception.get("epd_input", {}) if isinstance(perception.get("epd_input"), dict) else {}
+    required = perception.get("required_object_classes") or task.get("required_object_classes") or []
+    threshold = perception.get("confidence_threshold", 0.5)
+    blockers=[]
+    if not scene_id: blockers.append("cell.id is required for perception adapter config")
+    if not camera_id or camera_id == "UNKNOWN_CAMERA": blockers.append("camera_id is required for perception-backed scenes")
+    if not frame_id or frame_id == "UNKNOWN_FRAME": blockers.append("frame_id is required for perception-backed scenes")
+    if not epd.get("topic"): blockers.append("perception.epd_input.topic is required")
+    if not epd.get("message_type"): blockers.append("perception.epd_input.message_type is required")
+    if not isinstance(required, list) or not required: blockers.append("required_object_classes must list at least one class")
+    try:
+        threshold = float(threshold)
+        if threshold < 0.0 or threshold > 1.0: blockers.append("confidence_threshold must be in [0, 1]")
+    except Exception:
+        blockers.append("confidence_threshold must be numeric")
+        threshold = 0.5
+    if blockers:
+        raise ValueError("Invalid perception-backed scene metadata: " + "; ".join(blockers))
+    return {
+        "schema_version": "workcell_perception_adapter_config/v1",
+        "status": "READY",
+        "scene_id": scene_id,
+        "camera": {"camera_id": camera_id, "frame_id": frame_id},
+        "expected_frames": list(dict.fromkeys(str(f) for f in expected_frames if f)),
+        "epd_input": {"topic": epd.get("topic"), "message_type": epd.get("message_type")},
+        "required_object_classes": required,
+        "confidence_threshold": threshold,
+        "task_binding": {"task_id": task.get("id", task_recipe.get("id")), "pick_source": (task.get("pick") or {}).get("source_ref") or task.get("source_object"), "object_source": "epd_snapshot"},
+        "normalized_output_contract": {"schema_version": "workcell_perception_snapshot/v1", "required_fields": ["scene_id", "camera_id", "timestamp", "frame_id", "objects[].object_id_or_track_id", "objects[].label", "objects[].pose_or_centroid", "objects[].confidence"]},
+        "ownership": {"epd": "camera processing, detection, localization, tracking", "workcell_studio": "contract validation, scene/task binding, adapter configuration"},
+    }
+
 def _render_cmakelists(package_name: str) -> str:
     template_path = TEMPLATE_DIR / "CMakeLists_example.txt"
     contract_installs = """
@@ -1292,6 +1338,7 @@ def write_scene_package_contract(
                 "visual_mesh_index": "generated/scene_visual_mesh_index.json",
                 "validation_report": "generated/validation_report.md",
                 "scene_package_readiness": "generated/scene_package_readiness.json",
+                "perception_adapter_config": "generated/perception_adapter_config.yaml",
             }
         )
     scene_manifest["safety"] = {
@@ -1321,6 +1368,8 @@ def write_scene_package_contract(
     task_recipe_path.write_text(task_recipe_text, encoding="utf-8")
     (package_dir / "generated" / "task_recipe.preview.yaml").write_text(task_recipe_text, encoding="utf-8")
     (package_dir / "generated" / "scene_manifest.preview.yaml").write_text(scene_manifest_text, encoding="utf-8")
+    perception_adapter_config = _build_perception_adapter_config(loaded, task_recipe, warnings)
+    (package_dir / "generated" / "perception_adapter_config.yaml").write_text(_yaml_text_from(scene_generator, perception_adapter_config), encoding="utf-8")
     canonical_layout_text = source_snapshot.get("canonical_layout_text")
     if isinstance(canonical_layout_text, str):
         (package_dir / "layout" / "workcell_studio_layout.yaml").write_text(canonical_layout_text, encoding="utf-8")

--- a/tests/test_epd_snapshot_adapter.py
+++ b/tests/test_epd_snapshot_adapter.py
@@ -4,11 +4,71 @@ from pathlib import Path
 def test_adapter_generates_payload(tmp_path):
     profile=tmp_path/'perception_profile.yaml'
     detected=tmp_path/'detected.yaml'
-    profile.write_text(json.dumps({'perception':{'provider':'epd'}}))
-    detected.write_text(json.dumps({'schema_version':'detected_objects/v1','objects':[{'id':'o1','label':'cube','confidence':0.9,'pose':{'xyz':[1,2,3],'rpy':[0,0,0]}}]}))
+    profile.write_text(json.dumps({'scene_id':'scene1','perception':{'provider':'epd','camera':{'camera_id':'cam1','frame_id':'camera_frame'}}}))
+    detected.write_text(json.dumps({'schema_version':'detected_objects/v1','scene_id':'scene1','camera_id':'cam1','timestamp':'2026-07-22T00:00:00Z','frame_id':'camera_frame','objects':[{'id':'o1','label':'cube','confidence':0.9,'pose':{'frame_id':'camera_frame','xyz':[1,2,3],'orientation_xyzw':[0,0,0,1]}}]}))
     out=tmp_path/'bridge.json'; summary=tmp_path/'summary.json'
     p=subprocess.run([sys.executable,'scripts/epd_snapshot_adapter.py','--profile',str(profile),'--input',str(detected),'--output',str(out),'--summary',str(summary)],capture_output=True,text=True)
     assert p.returncode==0
     payload=json.loads(out.read_text())
     assert payload['dry_run_only'] is True
     assert payload['runtime_execution']['auto_execute'] is False
+
+
+
+def _load_adapter():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("epd_snapshot_adapter", "scripts/epd_snapshot_adapter.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_generator():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("generate_workcell_from_cell_definition", "scripts/generate_workcell_from_cell_definition.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_valid_localization_and_tracking_snapshots():
+    mod = _load_adapter()
+    snap = {"schema_version":"workcell_perception_snapshot/v1","scene_id":"s1","camera_id":"cam1","timestamp":"2026-07-22T00:00:00Z","frame_id":"camera_color_optical_frame","objects":[{"object_id":"obj1","track_id":"trk1","label":"part","confidence":0.7,"pose":{"frame_id":"camera_color_optical_frame","position":[0.1,0.2,0.3],"orientation_xyzw":[0,0,0,1]},"attributes":{"colour":"blue"}}]}
+    assert mod.validate_normalized_snapshot(snap, expected_scene_id="s1", expected_camera_id="cam1") == []
+    snap["objects"] = [{"track_id":"trk2","label":"part","confidence":1.0,"centroid":[0.1,0.2,0.3]}]
+    assert mod.validate_normalized_snapshot(snap, expected_scene_id="s1", expected_camera_id="cam1") == []
+
+
+def test_malformed_snapshot_rejection_and_scene_camera_mismatch():
+    mod = _load_adapter()
+    snap = {"schema_version":"workcell_perception_snapshot/v1","scene_id":"wrong","camera_id":"wrong_cam","timestamp":"now","frame_id":"camera","objects":[{"object_id":"dup","label":"part","confidence":1.2,"pose":{"frame_id":"camera","position":[0,0,float('nan')],"orientation_xyzw":[0,0,0,2]}},{"object_id":"dup","label":"part","confidence":0.5,"centroid":[0,0,0]}]}
+    errors = mod.validate_normalized_snapshot(snap, expected_scene_id="scene", expected_camera_id="cam")
+    assert any("scene_id mismatch" in e for e in errors)
+    assert any("camera_id mismatch" in e for e in errors)
+    assert any("confidence" in e for e in errors)
+    assert any("non-finite" in e for e in errors)
+    assert any("normalized" in e for e in errors)
+    assert any("duplicate" in e for e in errors)
+
+
+def test_deterministic_adapter_config_generation_and_disabled_scene():
+    gen = _load_generator()
+    cell = {"cell":{"id":"suction_test"},"camera":{"enabled":True,"camera_id":"cam","frame_id":"camera_frame"},"perception":{"enabled":True,"epd_input":{"topic":"/epd","message_type":"std_msgs/msg/String"},"required_object_classes":["part"],"confidence_threshold":0.6},"task":{"id":"pick","source_object":"part_a"}}
+    first = gen._build_perception_adapter_config(cell, {"id":"pick"}, [])
+    second = gen._build_perception_adapter_config(cell, {"id":"pick"}, [])
+    assert first == second
+    assert first["status"] == "READY"
+    assert first["normalized_output_contract"]["schema_version"] == "workcell_perception_snapshot/v1"
+    disabled = gen._build_perception_adapter_config({"cell":{"id":"plain"},"camera":{"enabled":False}}, {}, [])
+    assert disabled["status"] == "NOT_APPLICABLE"
+
+
+def test_incomplete_perception_backed_scene_rejected():
+    gen = _load_generator()
+    cell = {"cell":{"id":"bad"},"camera":{"enabled":True,"camera_id":"UNKNOWN_CAMERA","frame_id":"UNKNOWN_FRAME"},"perception":{"enabled":True}}
+    try:
+        gen._build_perception_adapter_config(cell, {}, [])
+    except ValueError as exc:
+        assert "Invalid perception-backed scene metadata" in str(exc)
+    else:
+        raise AssertionError("expected invalid perception scene to fail")

--- a/workcell_builder/workcell_builder/scripts/epd_to_workcell_snapshot_node.py
+++ b/workcell_builder/workcell_builder/scripts/epd_to_workcell_snapshot_node.py
@@ -44,7 +44,7 @@ def _normalize_detection(obj: dict, default_zone: str, min_confidence: float) ->
     }
 
 
-def build_snapshot_from_epd_payload(payload: dict, camera: str, camera_frame: str, default_zone: str, min_confidence: float = 0.0) -> dict:
+def build_snapshot_from_epd_payload(payload: dict, camera: str, camera_frame: str, default_zone: str, min_confidence: float = 0.0, scene_id: str = "") -> dict:
     objs = payload.get("objects", payload.get("detections", []))
     detections = []
     for o in objs:
@@ -52,14 +52,28 @@ def build_snapshot_from_epd_payload(payload: dict, camera: str, camera_frame: st
             d = _normalize_detection(o, default_zone, min_confidence)
             if d is not None:
                 detections.append(d)
+    normalized_objects = []
+    for d in detections:
+        position = d.get("estimated_xyz_world") or d.get("estimated_xyz_camera")
+        item = {
+            "object_id": d.get("id"),
+            "track_id": d.get("tracking_id"),
+            "label": d.get("class_label"),
+            "confidence": d.get("confidence"),
+            "attributes": {"zone_hint": d.get("zone_hint"), "segmented_cloud_available": d.get("segmented_cloud_available")},
+        }
+        if position is not None:
+            item["pose"] = {"frame_id": camera_frame, "position": position, "orientation_xyzw": [0.0, 0.0, 0.0, 1.0]}
+        normalized_objects.append(item)
     return {
-        "schema_version": 1,
+        "schema_version": "workcell_perception_snapshot/v1",
         "source": "epd_live",
         "runtime_mode": "live_adapter_metadata_only",
-        "camera": camera,
-        "camera_frame": camera_frame,
-        "timestamp_sec": time.time(),
-        "detections": detections,
+        "scene_id": scene_id,
+        "camera_id": camera,
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "frame_id": camera_frame,
+        "objects": normalized_objects,
     }
 
 
@@ -71,6 +85,7 @@ class EpdToWorkcellSnapshotNode(Node):
         self.declare_parameter("use_tracking", False)
         self.declare_parameter("output_snapshot_topic", "/workcell_studio/epd_detection_snapshot_json")
         self.declare_parameter("output_status_topic", "/workcell_studio/epd_connector_status")
+        self.declare_parameter("scene_id", "")
         self.declare_parameter("camera_name", "realsense_d435i_1")
         self.declare_parameter("camera_frame", "camera_color_optical_frame")
         self.declare_parameter("default_zone_hint", "detection_zone_1")
@@ -103,6 +118,7 @@ class EpdToWorkcellSnapshotNode(Node):
             self.get_parameter("camera_frame").value,
             self.get_parameter("default_zone_hint").value,
             float(self.get_parameter("min_confidence").value),
+            self.get_parameter("scene_id").value,
         )
         self.snapshot_pub.publish(String(data=json.dumps(snap)))
         age = 1e9 if self.last_msg_time <= 0 else max(0.0, time.time() - self.last_msg_time)
@@ -110,7 +126,7 @@ class EpdToWorkcellSnapshotNode(Node):
             "epd_connected": age <= float(self.get_parameter("stale_timeout_s").value),
             "source_topic": self.sub.topic_name,
             "last_msg_age_s": round(age, 3),
-            "detections": len(snap.get("detections", [])),
+            "detections": len(snap.get("objects", [])),
             "last_error": self.last_error,
             "camera": self.get_parameter("camera_name").value,
             "output_topic": self.get_parameter("output_snapshot_topic").value,


### PR DESCRIPTION
### Motivation
- Provide a single versioned, machine-validated perception snapshot contract so Workcell Studio can safely consume EPD outputs for task binding and adapter configuration. 
- Make scene-local adapter configuration deterministic and fail clearly for incomplete perception-backed scenes while leaving EPD responsible only for camera processing, detection, localization and tracking. 

### Description
- Add a normalized snapshot schema and validation helpers (`workcell_perception_snapshot/v1`) in `scripts/epd_snapshot_adapter.py` and use them to normalize `detected_objects/v1` inputs and reject malformed or mismatched snapshots. 
- Update the live metadata-only ROS node `workcell_builder/workcell_builder/scripts/epd_to_workcell_snapshot_node.py` to publish the consolidated normalized snapshot shape and accept a `scene_id` parameter. 
- Generate a deterministic scene-local adapter config via `_build_perception_adapter_config` in `scripts/generate_workcell_from_cell_definition.py` and write it to `generated/perception_adapter_config.yaml` (status `READY` or `NOT_APPLICABLE`). 
- Mark `scenes/suction_test/cell_definition.yaml` as a perception-backed example and document the normalized contract in `docs/manuals/DETECTED_OBJECTS_V1.md`, plus add/extend tests in `tests/test_epd_snapshot_adapter.py` for validation and config generation. 

### Testing
- Ran `python3 -m pytest tests/test_epd_snapshot_adapter.py` and all tests passed (`5 passed`).
- Generated a scene package: `python3 scripts/generate_workcell_from_cell_definition.py scenes/suction_test/cell_definition.yaml --output-dir /tmp/workcell_gen --package-name suction_test --force` and confirmed `/tmp/workcell_gen/suction_test/generated/perception_adapter_config.yaml` was produced (generation returned with existing non-perception warnings).
- Ran `python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json` and it reported `ok: True` for the checked scene. 
- Ran `git diff --check` and basic checks passed; attempt to push the branch failed because this checkout has no `origin` remote configured (commit is present locally).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60bd10e7788331bf1266c9913e0ef6)