### PR TITLE
Fix the first root-cause static release blocker

### DIFF
--- a/scripts/export_builder_scene_to_cell_definition.py
+++ b/scripts/export_builder_scene_to_cell_definition.py
@@ -449,9 +449,12 @@ def main() -> int:
     ap.add_argument("scene_path", type=Path)
     ap.add_argument("--output-dir", type=Path)
     ap.add_argument("--validate", action="store_true")
+    ap.add_argument("--json", action="store_true", help="Print the export summary JSON to stdout")
     args = ap.parse_args()
     output_dir = args.output_dir or (args.scene_path / "generated")
-    export_scene(args.scene_path, output_dir, validate=args.validate)
+    summary = export_scene(args.scene_path, output_dir, validate=args.validate)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
     return 0
 
 

--- a/scripts/validate_all_scene_builder_reproducibility.py
+++ b/scripts/validate_all_scene_builder_reproducibility.py
@@ -45,7 +45,7 @@ def evaluate_scene(scene:Path,strict:bool,in_place:bool)->dict:
     cell_def = work_scene/'generated/cell_definition.yaml'
     if not cell_def.is_file(): blockers.append('missing generated/cell_definition.yaml')
 
-    gen_code, _, gen_msg = _run(['python3', str(GENERATOR), '--cell-definition', str(cell_def), '--output-dir', str(work_scene/'generated_package'), '--json']) if cell_def.is_file() else (1,{},'skipped generation')
+    gen_code, _, gen_msg = _run(['python3', str(GENERATOR), str(cell_def), '--output-dir', str(work_scene/'generated_package'), '--package-name', scene.name, '--force']) if cell_def.is_file() else (1,{},'skipped generation')
     if gen_code != 0: blockers.append(f'generation failed: {gen_msg[:200]}')
 
     parity_status='SKIPPED'


### PR DESCRIPTION
### Motivation
- Unblock the static Workcell Studio release gate by fixing the earliest actionable FAIL in the static profile: the `scene generation reproducibility` check was failing due to a CLI contract drift between the validator and the exporter/generator tooling. 
- The validator was calling the exporter with `--json` (which the exporter did not accept) and invoking the generator with obsolete `--cell-definition`/`--json` options, causing spurious `export failed: usage: export_builder_scene_to_cell_definition.py ...` errors instead of surfacing real data/contract blockers.

### Description
- Add JSON stdout support to the exporter so callers can request the structured export summary via `--json` and avoid argparse usage failures by printing the export `summary` when requested; changed `scripts/export_builder_scene_to_cell_definition.py` to accept `--json` and emit JSON. 
- Update the reproducibility validator to invoke the current generator CLI contract (pass the cell definition as a positional argument and add `--package-name <scene.name>` and `--force`) so generation is exercised against the generator's current interface; changed `scripts/validate_all_scene_builder_reproducibility.py` accordingly. 
- Files changed: `scripts/export_builder_scene_to_cell_definition.py`, `scripts/validate_all_scene_builder_reproducibility.py`. 
- No validations were weakened or removed and fake-hardware / real-hardware defaults were not changed.

### Testing
- Ran the static release gate before changes with `python3 scripts/run_workcell_studio_release_gate.py --profile static --json-output /tmp/workcell-static.json --markdown-output /tmp/workcell-static.md` and observed the original `export failed: usage: export_builder_scene_to_cell_definition.py ...` blocker.
- Unit/fixture tests: `python3 -m pytest tests/test_all_scene_builder_reproducibility.py tests/test_builder_scene_export_to_cell_definition.py` — all tests passed (`5 passed`).
- Re-ran focused validator: `python3 scripts/validate_all_scene_builder_reproducibility.py --json --strict --output /tmp/scene_repro_after.json` — original exporter usage error is gone for valid fixtures, but the overall run still reports genuine follow-on blockers (e.g. malformed YAML in `malformed` fixture and missing required generator contract fields in some fixtures).
- Re-ran the static release gate after the fix with `python3 scripts/run_workcell_studio_release_gate.py --profile static --json-output /tmp/workcell-static-after.json --markdown-output /tmp/workcell-static-after.md` — overall status remains FAIL, but the scene-generation check now reports the next real root-cause blockers instead of the stale CLI mismatch.
- `git diff --check` passed; note that pushing the branch failed in this environment because the checkout has no `origin` remote configured (no remote push was performed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60c4808e9883319f4fa21db8ea64bd)