### PR TITLE
Fix Web3D exporter resolution of nested asset packages

### DIFF
--- a/scripts/workcell_visual_asset_resolver.py
+++ b/scripts/workcell_visual_asset_resolver.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, asdict
 from pathlib import Path
 import os
+import xml.etree.ElementTree as ET
 
 MESH_EXTS = {'.stl','.dae','.obj','.mesh'}
 
@@ -19,16 +20,59 @@ class MeshResolution:
         return asdict(self)
 
 
-def discover_package_map(repo_root: Path, extra_roots: list[Path] | None = None) -> dict[str, Path]:
-    roots = [repo_root, repo_root / 'assets', repo_root / 'scenes', repo_root / 'workcell_builder/workcell_builder/assets', Path('/opt/ros/humble/share')]
+def _read_package_xml_name(package_xml: Path) -> str | None:
+    try:
+        name = ET.parse(package_xml).getroot().findtext('name')
+    except ET.ParseError:
+        return None
+    name = (name or '').strip()
+    return name or None
+
+
+def _package_discovery_roots(repo_root: Path, extra_roots: list[Path] | None = None) -> list[Path]:
+    roots = [
+        repo_root,
+        repo_root / 'assets',
+        repo_root / 'scenes',
+        repo_root / 'workcell_builder/workcell_builder/assets',
+    ]
     if extra_roots:
         roots.extend(extra_roots)
-    out: dict[str, Path] = {}
+    for prefix in os.environ.get('AMENT_PREFIX_PATH', '').split(os.pathsep):
+        if prefix:
+            roots.append(Path(prefix) / 'share')
+    roots.append(Path('/opt/ros/humble/share'))
+
+    out: list[Path] = []
+    seen: set[str] = set()
     for root in roots:
+        try:
+            resolved = root.resolve()
+        except OSError:
+            resolved = root
+        key = str(resolved)
+        if key not in seen:
+            seen.add(key)
+            out.append(resolved)
+    return out
+
+
+def discover_package_map(repo_root: Path, extra_roots: list[Path] | None = None) -> dict[str, Path]:
+    """Discover ROS package names by package.xml identity, including nested assets.
+
+    The returned map is keyed by the package name declared inside package.xml,
+    not by the directory basename.  That keeps package:// URI resolution aligned
+    with ROS package identity and allows repository assets to live below nested
+    roots such as assets/end_effectors/<vendor>/<description_package>.
+    """
+    out: dict[str, Path] = {}
+    for root in _package_discovery_roots(repo_root, extra_roots):
         if not root.exists():
             continue
-        for pkg in root.rglob('package.xml'):
-            out.setdefault(pkg.parent.name, pkg.parent)
+        for pkg_xml in root.rglob('package.xml'):
+            pkg_dir = pkg_xml.parent.resolve()
+            package_name = _read_package_xml_name(pkg_xml) or pkg_dir.name
+            out.setdefault(package_name, pkg_dir)
     return out
 
 
@@ -47,10 +91,12 @@ def resolve_mesh_uri(uri: str, *, repo_root: Path, scene_dir: Path | None = None
 
     if original.startswith('package://') and '/' in original[10:]:
         pkg, rel = original[10:].split('/', 1)
-        if package_map and pkg in package_map:
+        package_map = package_map or discover_package_map(repo_root)
+        if pkg in package_map:
             p = package_map[pkg] / rel
             if p.exists():
                 return found(p, 'package_uri')
+            return MeshResolution(uri, str(p.resolve()), False, ext, 'package_uri', f'missing package mesh file: {original}')
         ros_share = Path('/opt/ros/humble/share') / pkg / rel
         if ros_share.exists():
             return found(ros_share, 'ros_share')

--- a/tests/test_workcell_studio_web_mesh_staging.py
+++ b/tests/test_workcell_studio_web_mesh_staging.py
@@ -523,3 +523,31 @@ def test_expanded_urdf_rejects_unsafe_and_non_package_mesh_uris(monkeypatch, tmp
             raise AssertionError(f'unsafe URI was accepted: {uri}')
         assert uri in message
         assert ('Invalid or unsafe package URI' in message) or ('must be a package:// URI' in message)
+
+
+def test_real_nested_robotiq_85_package_uri_stages_from_repo_assets(monkeypatch, tmp_path):
+    monkeypatch.chdir(REPO_ROOT)
+    package_uri = "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae"
+    scene = _scene(tmp_path, "real_nested_2f_scene", [{"id": "robotiq_85_base", "category": "tool", "mesh_uri": package_uri}])
+
+    payload = _export_with_prefix(monkeypatch, scene, tmp_path / "out" / "scene.web_scene.json", None)
+    item = _item(payload, "robotiq_85_base")
+
+    assert item["mesh_staging_status"] == "staged"
+    assert item["resolved_source_path"] == "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae"
+    assert item["mesh_uri"] == "build/workcell_studio_web_scene/assets/real_nested_2f_scene/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae"
+    assert (REPO_ROOT / item["mesh_uri"]).is_file()
+
+
+def test_real_nested_robotiq_3f_package_uri_stages_from_repo_assets(monkeypatch, tmp_path):
+    monkeypatch.chdir(REPO_ROOT)
+    package_uri = "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/palm.dae"
+    scene = _scene(tmp_path, "real_nested_3f_scene", [{"id": "robotiq_3f_palm", "category": "tool", "mesh_uri": package_uri}])
+
+    payload = _export_with_prefix(monkeypatch, scene, tmp_path / "out" / "scene.web_scene.json", None)
+    item = _item(payload, "robotiq_3f_palm")
+
+    assert item["mesh_staging_status"] == "staged"
+    assert item["resolved_source_path"] == "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/palm.dae"
+    assert item["mesh_uri"] == "build/workcell_studio_web_scene/assets/real_nested_3f_scene/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/palm.dae"
+    assert (REPO_ROOT / item["mesh_uri"]).is_file()


### PR DESCRIPTION
### Motivation
- The Web3D exporter failed to stage meshes referenced by `package://` URIs when the described ROS packages lived in nested repository asset folders, causing the Product View to be empty; package resolution relied on directory basenames instead of authoritative package identity.

### Description
- Update `scripts/workcell_visual_asset_resolver.py` to discover packages by their `package.xml` name, scan nested repository/asset roots and AMENT share roots, and deduplicate discovery roots to produce a package-name -> package-root map used across the exporter.
- Make `resolve_mesh_uri` use the discovered package map by default for `package://` URIs and report explicit missing-package-file diagnostics for known packages whose mesh files are absent, preserving unsafe/remote rejection policies and output-root confinement.
- Add focused regression tests to `tests/test_workcell_studio_web_mesh_staging.py` that assert real nested Robotiq 2F and 3F package URIs stage from repository assets and that staged paths and diagnostics are correct.

### Testing
- Ran `python3 -m pytest tests/test_workcell_studio_web_mesh_staging.py` and all tests passed (20 passed).
- Ran `python3 -m pytest tests/test_export_workcell_studio_web_scene.py` and all tests passed (22 passed).
- Ran the freshener `python3 scripts/ensure_workcell_studio_web_scene_fresh.py --scene scenes/ur5_2f_test --stage-assets --force` and `--scene scenes/ur5_3f_test --stage-assets --force` and both completed successfully with staged Robotiq meshes reported in the `build/workcell_studio_web_scene` asset output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60c62f7b94833191eb5fe9ceeaf094)