### PR TITLE
Harden Product View to one lifecycle per scene selection

### DIFF
--- a/tests/test_scene_preview_widget_refresh_lifecycle.py
+++ b/tests/test_scene_preview_widget_refresh_lifecycle.py
@@ -330,3 +330,92 @@ def test_web3d_status_chip_uses_required_lifecycle_labels():
         'Web3D Product View — failed, Retry',
     ):
         assert label in status
+
+@dataclass(frozen=True)
+class SceneContextKey:
+    scene: str = ""
+    scene_dir: str = ""
+    repo_root: str = ""
+    generated_json_path: str = ""
+    fingerprint: bytes = b""
+    revision: int = 0
+
+
+class SelectionLifecycleGate:
+    def __init__(self):
+        self.generation = 0
+        self.active = None
+        self.started = []
+        self.terminal = []
+        self.deferred = 0
+        self.coalesced = 0
+        self.cancelled = []
+
+    def ready(self, key):
+        return all((key.scene, key.scene_dir, key.repo_root, key.generated_json_path, key.fingerprint)) and key.revision > 0
+
+    def request(self, key, origin="automatic", force=False):
+        if not self.ready(key):
+            self.deferred += 1
+            return None
+        if not force and self.active and self.active[0] == key:
+            self.coalesced += 1
+            return self.active
+        if self.active and self.active[0].scene != key.scene:
+            self.cancelled.append(self.active)
+        self.generation += 1
+        self.active = (key, self.generation, origin)
+        self.started.append(self.active)
+        return self.active
+
+    def callback(self, request, state):
+        if request != self.active:
+            return "stale_ignored"
+        self.terminal.append((request, state))
+        return state
+
+
+def test_initial_incomplete_scene_context_starts_no_preparation_until_payload_identity_ready():
+    lifecycle = SelectionLifecycleGate()
+    incomplete = SceneContextKey(scene="ur5_2f_test", scene_dir="/cells/ur5_2f_test", repo_root="/repo")
+    ready = SceneContextKey("ur5_2f_test", "/cells/ur5_2f_test", "/repo", "build/workcell_studio_web_scene/ur5_2f_test.web_scene.json", b"fp", 1)
+
+    assert lifecycle.request(incomplete, origin="scene_context_ready") is None
+    assert lifecycle.started == []
+    assert lifecycle.deferred == 1
+    assert lifecycle.request(ready, origin="payload_commit") == (ready, 1, "payload_commit")
+    assert lifecycle.started == [(ready, 1, "payload_commit")]
+
+
+def test_normal_selection_has_one_terminal_scene_ready_and_stale_callbacks_cannot_clear_it():
+    lifecycle = SelectionLifecycleGate()
+    old = SceneContextKey("ur5_2f_test", "/cells/ur5_2f_test", "/repo", "build/workcell_studio_web_scene/ur5_2f_test.web_scene.json", b"old", 1)
+    new = SceneContextKey("ur5_3f_test", "/cells/ur5_3f_test", "/repo", "build/workcell_studio_web_scene/ur5_3f_test.web_scene.json", b"new", 1)
+    old_request = lifecycle.request(old, origin="payload_commit")
+    new_request = lifecycle.request(new, origin="scene_switch")
+
+    assert lifecycle.cancelled == [old_request]
+    assert lifecycle.callback(old_request, "failed") == "stale_ignored"
+    assert lifecycle.callback(new_request, "scene_ready") == "scene_ready"
+    assert lifecycle.terminal == [(new_request, "scene_ready")]
+
+
+def test_cpp_defers_until_complete_context_and_payload_and_logs_origin():
+    refresh_start = CPP.index("void ScenePreviewWidget::request_embedded_web_product_view_refresh")
+    identity_start = CPP.index("ScenePreviewWidget::EmbeddedWebRequestIdentity", refresh_start)
+    refresh = CPP[refresh_start:identity_start]
+
+    assert "const bool context_ready" in refresh
+    assert "request_key.payload_revision > 0" in refresh
+    assert "Product View lifecycle deferred" in refresh
+    assert "origin=%4" in refresh
+    assert refresh.index("if (!context_ready)") < refresh.index("++embedded_web_effective_refresh_requests_received_")
+    assert "Product View lifecycle requested" in refresh
+
+
+def test_cpp_counts_effective_preparation_starts_not_incomplete_context_requests():
+    refresh_wrapper = CPP[CPP.index("void ScenePreviewWidget::refresh_embedded_web_product_view"):CPP.index("void ScenePreviewWidget::maybe_start_next_embedded_web_prepare")]
+    prepare = CPP[CPP.index("void ScenePreviewWidget::start_embedded_web_prepare"):CPP.index("void ScenePreviewWidget::on_embedded_web_prepare_finished")]
+
+    assert "++embedded_web_preparation_request_count_" not in refresh_wrapper
+    assert "++embedded_web_preparation_request_count_" in prepare

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -543,7 +543,7 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
   connect(embedded_redo_button_, &QPushButton::clicked, this, [this](){ run_embedded_editor_command(QStringLiteral("window.__WORKCELL_EDITOR_API_V1__&&window.__WORKCELL_EDITOR_API_V1__.redo()")); });
   connect(embedded_fit_button_, &QPushButton::clicked, this, [this](){
     if (embedded_product_view_state_ == EmbeddedProductViewState::Failed) {
-      request_embedded_web_product_view_refresh(true);
+      request_embedded_web_product_view_refresh(true, QStringLiteral("user_retry"));
       return;
     }
     run_embedded_editor_command(QStringLiteral("window.__WORKCELL_EDITOR_API_V1__&&window.__WORKCELL_EDITOR_API_V1__.fitScene()"));
@@ -1037,21 +1037,33 @@ void ScenePreviewWidget::cancel_embedded_web_lifecycle(bool stop_owned_server)
   }
 }
 
-void ScenePreviewWidget::request_embedded_web_product_view_refresh(bool force)
+void ScenePreviewWidget::request_embedded_web_product_view_refresh(bool force, const QString & origin)
 {
 #ifndef WORKCELL_BUILDER_HAS_WEBENGINE
-  Q_UNUSED(force);
+  Q_UNUSED(force); Q_UNUSED(origin);
   return;
 #else
   if (!embedded_web_view_) return;
-  ++embedded_web_effective_refresh_requests_received_;
+  const QString request_origin = origin.trimmed().isEmpty() ? QStringLiteral("automatic") : origin.trimmed();
   const EmbeddedWebRequestIdentity request_key = embedded_web_request_identity(0);
-  if (request_key.scene_id.isEmpty() || request_key.scene_id == QStringLiteral("No scene") ||
-      request_key.absolute_scene_dir.isEmpty() || request_key.absolute_repo_root.isEmpty() ||
-      request_key.generated_web_scene_path.isEmpty()) {
+  const bool context_ready = !request_key.scene_id.isEmpty() &&
+    request_key.scene_id != QStringLiteral("No scene") &&
+    !request_key.absolute_scene_dir.isEmpty() &&
+    !request_key.absolute_repo_root.isEmpty() &&
+    !request_key.generated_web_scene_path.isEmpty() &&
+    request_key.payload_revision > 0 && !request_key.payload_fingerprint.isEmpty();
+  if (!context_ready) {
+    emit studio_log_requested(QStringLiteral("Product View lifecycle deferred: scene=%1 generation=%2 payload_revision=%3 origin=%4 scene_dir=%5 repo_root=%6.")
+      .arg(request_key.scene_id.isEmpty() ? QStringLiteral("<unset>") : request_key.scene_id)
+      .arg(embedded_web_request_generation_)
+      .arg(request_key.payload_revision)
+      .arg(request_origin)
+      .arg(request_key.absolute_scene_dir.isEmpty() ? QStringLiteral("<unset>") : request_key.absolute_scene_dir)
+      .arg(request_key.absolute_repo_root.isEmpty() ? QStringLiteral("<unset>") : request_key.absolute_repo_root));
     set_embedded_product_view_state(EmbeddedProductViewState::Idle);
     return;
   }
+  ++embedded_web_effective_refresh_requests_received_;
 
   const bool duplicate_active = embedded_web_has_active_identity_ &&
     embedded_web_active_identity_.matches_effective_request(request_key);
@@ -1071,12 +1083,13 @@ void ScenePreviewWidget::request_embedded_web_product_view_refresh(bool force)
     const QString suppression_key = embedded_web_effective_request_key(request_key);
     if (embedded_web_last_suppressed_duplicate_key_ != suppression_key) {
       embedded_web_last_suppressed_duplicate_key_ = suppression_key;
-      emit studio_log_requested(QStringLiteral("Duplicate Product View navigation suppressed: scene=%1 payload_revision=%2 backend=%3 json=%4 fingerprint=%5.")
+      emit studio_log_requested(QStringLiteral("Duplicate Product View navigation suppressed: scene=%1 payload_revision=%2 backend=%3 json=%4 fingerprint=%5 origin=%6.")
         .arg(request_key.scene_id)
         .arg(request_key.payload_revision)
         .arg(request_key.product_view_backend)
         .arg(request_key.generated_web_scene_path)
-        .arg(QString::fromLatin1(request_key.payload_fingerprint.toHex().left(12))));
+        .arg(QString::fromLatin1(request_key.payload_fingerprint.toHex().left(12)))
+        .arg(request_origin));
     }
     return;
   }
@@ -1111,6 +1124,9 @@ void ScenePreviewWidget::request_embedded_web_product_view_refresh(bool force)
   pending_embedded_web_identity_ = identity;
   pending_embedded_web_request_ = true;
   pending_embedded_web_force_ = force;
+  emit studio_log_requested(QStringLiteral("Product View lifecycle requested: scene=%1 generation=%2 payload_revision=%3 origin=%4 force=%5.")
+    .arg(identity.scene_id).arg(identity.generation).arg(identity.payload_revision).arg(request_origin)
+    .arg(force ? QStringLiteral("true") : QStringLiteral("false")));
   maybe_start_next_embedded_web_prepare();
 #endif
 }
@@ -1218,8 +1234,7 @@ void ScenePreviewWidget::record_embedded_web_prepare_terminal(
 
 void ScenePreviewWidget::refresh_embedded_web_product_view()
 {
-  ++embedded_web_preparation_request_count_;
-  request_embedded_web_product_view_refresh(false);
+  request_embedded_web_product_view_refresh(false, QStringLiteral("automatic"));
 }
 
 void ScenePreviewWidget::maybe_start_next_embedded_web_prepare()
@@ -1316,6 +1331,7 @@ void ScenePreviewWidget::start_embedded_web_prepare(const EmbeddedWebRequestIden
   embedded_web_preparation_process_keys_.insert(process, diagnostic_key);
   embedded_web_prepare_started_at_ = QDateTime::currentDateTimeUtc();
   embedded_web_preparing_identity_ = identity;
+  ++embedded_web_preparation_request_count_;
   ++embedded_web_preparations_started_;
   connect(process, &QProcess::started, this, [this, identity, process]() {
     if (!embedded_web_identity_is_current(identity)) return;
@@ -1339,7 +1355,8 @@ void ScenePreviewWidget::start_embedded_web_prepare(const EmbeddedWebRequestIden
     on_embedded_web_prepare_finished(identity, process, exit_code, exit_status);
   });
   set_embedded_product_view_state(EmbeddedProductViewState::Preparing, scene_id);
-  emit studio_log_requested(QStringLiteral("Preparing embedded Product View from repo root %1: %2").arg(repo_root, embedded_web_prepare_command_for_log(selected_scene_dir, embedded_web_prepare_output_path_, force)));
+  emit studio_log_requested(QStringLiteral("Preparing embedded Product View: scene=%1 generation=%2 payload_revision=%3 origin=%4 repo_root=%5 command=%6").arg(identity.scene_id).arg(identity.generation).arg(identity.payload_revision)
+    .arg(force ? QStringLiteral("user_retry") : QStringLiteral("automatic"), repo_root, embedded_web_prepare_command_for_log(selected_scene_dir, embedded_web_prepare_output_path_, force)));
   embedded_web_prepare_process_->start();
 #endif
 }
@@ -1797,9 +1814,9 @@ void ScenePreviewWidget::set_preview_context(const PreviewContext & context)
 
   if (!normalized.scene_id.isEmpty()) {
     set_preview_scene_name(normalized.scene_id);
-    if (!scene_name_changed) refresh_embedded_web_product_view();
+    if (!scene_name_changed) request_embedded_web_product_view_refresh(false, QStringLiteral("scene_context_ready"));
   } else {
-    refresh_embedded_web_product_view();
+    request_embedded_web_product_view_refresh(false, QStringLiteral("scene_context_incomplete"));
   }
 }
 
@@ -2178,7 +2195,7 @@ ScenePreviewWidget::MeshPreviewMode ScenePreviewWidget::mesh_preview_mode() cons
 void ScenePreviewWidget::reload_meshes()
 {
   auto * v = active_native_viewport();
-  if (!v) { request_embedded_web_product_view_refresh(true); emit studio_log_requested("Reloaded embedded Web 3D Product View."); return; }
+  if (!v) { request_embedded_web_product_view_refresh(true, QStringLiteral("user_refresh")); emit studio_log_requested("Reloaded embedded Web 3D Product View."); return; }
   v->invalidate_mesh_cache();
   apply_product_view_defaults();
   update();

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -401,7 +401,7 @@ private:
     QString failure_detail;
   };
   void refresh_embedded_web_product_view();
-  void request_embedded_web_product_view_refresh(bool force = false);
+  void request_embedded_web_product_view_refresh(bool force = false, const QString & origin = QStringLiteral("automatic"));
   void cancel_embedded_web_lifecycle(bool stop_owned_server);
   void maybe_start_next_embedded_web_prepare();
   EmbeddedWebRequestIdentity embedded_web_request_identity(quint64 generation) const;


### PR DESCRIPTION
### Motivation
- Prevent duplicate or premature embedded Product View preparations by ensuring a single, well-formed lifecycle runs per scene selection once the scene context and final payload identity are available.
- Preserve latest-request-wins behavior for genuine rapid scene switching while coalescing duplicate refreshes that belong to the same scene/payload.
- Keep deterministic failures terminal and reachable only via explicit user Retry/Refresh, and preserve the package resolver fix from the earlier PR (#2835).

### Description
- Added an `origin` argument to `request_embedded_web_product_view_refresh` and used it to log concise lifecycle diagnostics including scene, generation, payload revision, origin, scene_dir, and repo_root.
- Gate Product View requests until the authoritative preview context and final payload identity are present (`scene_id`, `absolute_scene_dir`, `absolute_repo_root`, `generated_web_scene_path`, non-zero `payload_revision`, and non-empty `payload_fingerprint`).
- Coalesce duplicate same-scene refresh requests before allocating a new generation and include `origin` in suppression logs to help diagnostics; preserve latest-request-wins cancellation for scene switches.
- Move the effective preparation request counter increment to `start_embedded_web_prepare` so only true preparations are counted; emit a concise preparation diagnostic when a prepare starts.
- Ensure deterministic prepare failures do not automatically force a second preparation; only explicit user Retry/Refresh (now routed with `origin` values like `user_retry` / `user_refresh`) may force a new generation.
- Small API and call-site updates to propagate `origin` for scene-context-ready, scene-context-incomplete, automatic refresh, and user retry flows.
- Files changed: `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp`, `workcell_builder/workcell_builder/gui/scene_preview_widget.h`, and `tests/test_scene_preview_widget_refresh_lifecycle.py` (added focused lifecycle tests and gate model). Include lifecycle diagnostics and logging enhancements.

### Testing
- Ran unit tests: `python3 -m pytest tests/test_scene_preview_widget_refresh_lifecycle.py tests/test_workcell_builder_runtime_preview_status_flow.py -q` — all tests passed (28 passed).
- Ran `git diff --check` — no whitespace/patch issues detected.
- Attempted package build in-container: skipped because ROS 2 Humble / `colcon` were not available in this environment.
- Added and ran additional focused lifecycle model tests for incomplete context deferral, coalescing, scene-switch cancellation, stale callback isolation, and effective preparation counting — all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60d17ff36c83318646a907c1174728)