### PR TITLE
Fix expanded URDF package resolution in Product View runtime

### DIFF
--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -35,9 +35,9 @@ except ImportError:  # pragma: no cover - exercised only in minimal envs
     yaml = None  # type: ignore
 
 try:
-    from scripts.workcell_visual_asset_resolver import discover_package_map
+    from scripts.workcell_visual_asset_resolver import resolve_package_mesh_uri
 except ImportError:  # pragma: no cover - direct script execution fallback
-    from workcell_visual_asset_resolver import discover_package_map
+    from workcell_visual_asset_resolver import resolve_package_mesh_uri
 
 SCHEMA_VERSION = "workcell_studio_web_scene/v1"
 INPUTS = {
@@ -224,56 +224,52 @@ def _safe_relative_parts(rel: Path) -> Optional[Tuple[str, ...]]:
     return parts
 
 
-def _package_share_roots(repo_root: Path) -> List[Path]:
-    roots = [
-        repo_root / "assets",
-        repo_root / "assets" / "robots",
-        repo_root / "assets" / "environment",
-        repo_root / "assets" / "sensors",
-    ]
-    for prefix in os.environ.get("AMENT_PREFIX_PATH", "").split(os.pathsep):
-        if prefix:
-            roots.append(Path(prefix) / "share")
-    roots.append(Path("/opt/ros/humble/share"))
+def _candidate_repo_roots(scene_dir: Optional[Path] = None, output_path: Optional[Path] = None) -> List[Path]:
+    starts = [Path(__file__).resolve().parents[1], Path.cwd()]
+    if scene_dir is not None:
+        starts.extend([scene_dir, *scene_dir.parents])
+    if output_path is not None:
+        starts.extend([output_path, *output_path.parents])
     out: List[Path] = []
-    seen = set()
-    for root in roots:
-        resolved = root.resolve()
-        if str(resolved) not in seen:
-            seen.add(str(resolved))
+    seen: set[str] = set()
+    for start in starts:
+        try:
+            resolved = start.resolve()
+        except OSError:
+            resolved = start
+        if resolved.is_file():
+            resolved = resolved.parent
+        key = str(resolved)
+        if key not in seen:
+            seen.add(key)
             out.append(resolved)
     return out
 
 
+def _looks_like_repo_root(root: Path) -> bool:
+    return (root / "assets").is_dir() and (root / "scenes").is_dir() and (root / "scripts").is_dir()
+
+
+def _repo_root(scene_dir: Optional[Path] = None, output_path: Optional[Path] = None) -> Path:
+    cwd = Path.cwd().resolve()
+    if scene_dir is not None:
+        try:
+            scene_dir.resolve().relative_to(cwd)
+            if (cwd / "assets").exists() or (cwd / "scenes").exists():
+                return cwd
+        except ValueError:
+            pass
+    for candidate in _candidate_repo_roots(scene_dir, output_path):
+        if _looks_like_repo_root(candidate):
+            return candidate
+    return cwd
+
+
 def _resolve_package_uri(uri: str, repo_root: Path) -> Tuple[Optional[Path], str, Optional[Path], Optional[str]]:
-    parsed = urlparse(uri)
-    package = parsed.netloc
-    rel = Path(unquote(parsed.path).lstrip("/"))
-    rel_parts = _safe_relative_parts(rel)
-    if parsed.scheme != "package" or not package or rel_parts is None:
-        return None, package or "package", None, f"Invalid or unsafe package URI: {uri}"
-    if rel.suffix.lower() not in SUPPORTED_MESH_SUFFIXES:
-        return None, package, None, f"Unsupported mesh format for {uri}; supported formats are .stl, .dae, and .obj."
-
-    stage_rel = Path(package, *rel_parts)
-    package_map = discover_package_map(repo_root)
-    package_dir = package_map.get(package)
-    if package_dir is not None:
-        candidate = (package_dir / rel).resolve()
-        if not _is_relative_to(candidate, package_dir.resolve()):
-            return None, package, None, f"Invalid or unsafe package URI: {uri}"
-        if candidate.is_file():
-            return candidate, package, stage_rel, None
-        return None, package, None, f"Package mesh file does not exist: {uri}"
-
-    # Keep AMENT/share probing as a fallback for ROS packages that are not
-    # described by a package.xml under the repository discovery roots.
-    for root in _package_share_roots(repo_root):
-        direct = (root / package / rel).resolve()
-        if _is_relative_to(direct, root) and direct.is_file():
-            return direct, package, stage_rel, None
-    return None, package, None, f"Could not resolve package mesh URI: {uri}"
-
+    resolved, package, dest_rel, warning, _checked = resolve_package_mesh_uri(
+        uri, repo_root=repo_root, supported_suffixes=SUPPORTED_MESH_SUFFIXES
+    )
+    return resolved, package, dest_rel, warning
 
 def _resolve_local_mesh_uri(uri: str, scene_dir: Path, repo_root: Path) -> Tuple[Optional[Path], str, Optional[Path], Optional[str]]:
     source_root = "local"
@@ -550,7 +546,9 @@ def _stage_expanded_robot_urdf(payload: Json, scene_dir: Path, output_path: Path
         if not synthesized_text:
             _warn(warnings, "expanded_robot_urdf_missing", "Expanded robot URDF was not available for browser robot preview; legacy rows remain as fallback metadata only.", rel)
             return
-    repo_root = Path.cwd().resolve()
+    repo_root = _repo_root(scene_dir, output_path)
+    if not _looks_like_repo_root(repo_root):
+        _warn(warnings, "repo_root_contract_unverified", f"Repository root for expanded URDF staging does not contain assets, scenes and scripts: {repo_root}; continuing for isolated test/workspace export.", str(repo_root))
     dest = (repo_root / "build" / "workcell_studio_web_scene" / f"{scene_id}.expanded.urdf").resolve()
     dest.parent.mkdir(parents=True, exist_ok=True)
     if synthesized_text is not None:
@@ -679,7 +677,7 @@ def _stage_expanded_robot_urdf(payload: Json, scene_dir: Path, output_path: Path
     }
 
 def _stage_visual_meshes(payload: Json, scene_dir: Path, output_path: Path) -> None:
-    repo_root = Path.cwd().resolve()
+    repo_root = _repo_root(scene_dir, output_path)
     scene_id = str(payload.get("scene", {}).get("id") or scene_dir.name)
     asset_root = (repo_root / "build" / "workcell_studio_web_scene" / "assets" / scene_id).resolve()
     asset_root.mkdir(parents=True, exist_ok=True)

--- a/scripts/workcell_visual_asset_resolver.py
+++ b/scripts/workcell_visual_asset_resolver.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 from dataclasses import dataclass, asdict
+from urllib.parse import unquote, urlparse
 from pathlib import Path
 import os
 import xml.etree.ElementTree as ET
 
 MESH_EXTS = {'.stl','.dae','.obj','.mesh'}
+SUPPORTED_BROWSER_MESH_EXTS = {'.stl', '.dae', '.obj'}
 
 @dataclass
 class MeshResolution:
@@ -76,6 +78,91 @@ def discover_package_map(repo_root: Path, extra_roots: list[Path] | None = None)
     return out
 
 
+
+def _merge_package_candidates(package: str, repo_root: Path, extra_roots: list[Path] | None = None, package_map: dict[str, Path] | None = None) -> list[Path]:
+    """Return candidate package roots in Product View's authoritative order.
+
+    Candidates are accepted only when their package.xml declares ``package``.
+    A provided map is augmented with discovered roots instead of replacing
+    discovery, so an incomplete non-empty map cannot mask repository assets.
+    """
+    roots: list[Path] = []
+    seen: set[str] = set()
+
+    def add(candidate: Path | None) -> None:
+        if candidate is None:
+            return
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            resolved = candidate
+        if not resolved.exists():
+            return
+        pkg_xml = resolved / 'package.xml'
+        if pkg_xml.is_file():
+            identity = _read_package_xml_name(pkg_xml)
+            if identity != package:
+                return
+        elif resolved.name != package:
+            return
+        key = str(resolved)
+        if key not in seen:
+            seen.add(key)
+            roots.append(resolved)
+
+    # 1. Repository asset packages should win over stale installed packages.
+    repo_asset_roots = [repo_root / 'assets', repo_root / 'workcell_builder/workcell_builder/assets']
+    for root in repo_asset_roots:
+        if root.exists():
+            add(root / package)
+            for pkg_xml in root.rglob('package.xml'):
+                add(pkg_xml.parent)
+
+    # 2. Explicit/source-workspace roots, including any map passed by callers.
+    if package_map:
+        add(package_map.get(package))
+    for root in ([repo_root, repo_root / 'scenes'] + list(extra_roots or [])):
+        if root.exists():
+            for pkg_xml in root.rglob('package.xml'):
+                add(pkg_xml.parent)
+
+    # 3. AMENT_PREFIX_PATH share.
+    for prefix in os.environ.get('AMENT_PREFIX_PATH', '').split(os.pathsep):
+        if prefix:
+            add(Path(prefix) / 'share' / package)
+
+    # 4. ROS Humble share.
+    add(Path('/opt/ros/humble/share') / package)
+    return roots
+
+
+def resolve_package_mesh_uri(uri: str, *, repo_root: Path, package_map: dict[str, Path] | None = None, extra_roots: list[Path] | None = None, supported_suffixes: set[str] | None = None) -> tuple[Path | None, str, Path | None, str | None, list[Path]]:
+    parsed = urlparse(uri)
+    package = parsed.netloc
+    rel = Path(unquote(parsed.path).lstrip('/'))
+    parts = rel.parts
+    if parsed.scheme != 'package' or not package or rel.is_absolute() or not parts or any(part in ('', '.', '..') for part in parts):
+        return None, package or 'package', None, f'Invalid or unsafe package URI: {uri}', []
+    suffixes = supported_suffixes or SUPPORTED_BROWSER_MESH_EXTS
+    if rel.suffix.lower() not in suffixes:
+        return None, package, None, f'Unsupported mesh format for {uri}; supported formats are .stl, .dae, and .obj.', []
+    candidates = _merge_package_candidates(package, repo_root.resolve(), extra_roots, package_map)
+    checked: list[Path] = []
+    for package_dir in candidates:
+        candidate = (package_dir / rel).resolve()
+        checked.append(package_dir)
+        try:
+            candidate.relative_to(package_dir.resolve())
+        except ValueError:
+            return None, package, None, f'Invalid or unsafe package URI: {uri}', checked
+        if candidate.is_file():
+            return candidate, package, Path(package, *parts), None, checked
+    checked_text = ', '.join(str(p) for p in checked) or '<none>'
+    detail = f'package={package}; repository_root={repo_root.resolve()}; candidate_package_roots_checked=[{checked_text}]'
+    if checked:
+        return None, package, None, f'Package mesh file does not exist: {uri} ({detail})', checked
+    return None, package, None, f'Could not resolve package mesh URI: {uri} ({detail})', checked
+
 def resolve_mesh_uri(uri: str, *, repo_root: Path, scene_dir: Path | None = None, package_map: dict[str, Path] | None = None, asset_catalog: set[str] | None = None) -> MeshResolution:
     original = (uri or '').strip().strip('"\'')
     ext = Path(original).suffix.lower()
@@ -91,16 +178,10 @@ def resolve_mesh_uri(uri: str, *, repo_root: Path, scene_dir: Path | None = None
 
     if original.startswith('package://') and '/' in original[10:]:
         pkg, rel = original[10:].split('/', 1)
-        package_map = package_map or discover_package_map(repo_root)
-        if pkg in package_map:
-            p = package_map[pkg] / rel
-            if p.exists():
-                return found(p, 'package_uri')
-            return MeshResolution(uri, str(p.resolve()), False, ext, 'package_uri', f'missing package mesh file: {original}')
-        ros_share = Path('/opt/ros/humble/share') / pkg / rel
-        if ros_share.exists():
-            return found(ros_share, 'ros_share')
-        return MeshResolution(uri, '', False, ext, 'unresolved', f'unresolved package URI: {original}')
+        resolved, _pkg, _stage_rel, warning, _checked = resolve_package_mesh_uri(original, repo_root=repo_root, package_map=package_map)
+        if resolved is not None:
+            return found(resolved, 'package_uri')
+        return MeshResolution(uri, '', False, ext, 'unresolved', warning or f'unresolved package URI: {original}')
 
     p = Path(original)
     if p.is_absolute():

--- a/tests/test_workcell_studio_web_mesh_staging.py
+++ b/tests/test_workcell_studio_web_mesh_staging.py
@@ -551,3 +551,46 @@ def test_real_nested_robotiq_3f_package_uri_stages_from_repo_assets(monkeypatch,
     assert item["resolved_source_path"] == "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/palm.dae"
     assert item["mesh_uri"] == "build/workcell_studio_web_scene/assets/real_nested_3f_scene/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/palm.dae"
     assert (REPO_ROOT / item["mesh_uri"]).is_file()
+
+
+def test_package_resolver_augments_incomplete_map_and_waits_for_existing_mesh(tmp_path):
+    stale = tmp_path / "stale" / "share" / "aug_pkg"
+    stale.mkdir(parents=True)
+    (stale / "package.xml").write_text("<package><name>aug_pkg</name></package>\n", encoding="utf-8")
+    repo_mesh = _repo_discovered_package(tmp_path, "aug_pkg", "meshes/visual/ok.dae", "<COLLADA>repo</COLLADA>\n")
+
+    resolved, package, dest_rel, warning, checked = exporter.resolve_package_mesh_uri(
+        "package://aug_pkg/meshes/visual/ok.dae",
+        repo_root=tmp_path,
+        package_map={"aug_pkg": stale},
+        supported_suffixes=exporter.SUPPORTED_MESH_SUFFIXES,
+    )
+
+    assert resolved == repo_mesh.resolve()
+    assert package == "aug_pkg"
+    assert dest_rel == Path("aug_pkg/meshes/visual/ok.dae")
+    assert warning is None
+    assert checked[0] == repo_mesh.parents[2].resolve()
+
+
+def test_expanded_urdf_staging_uses_repository_root_when_cwd_is_scene(monkeypatch):
+    scene = REPO_ROOT / "scenes" / "ur5_2f_test"
+    source = scene / "expanded_root_regression.urdf"
+    source.write_text(
+        '<robot name="root_regression"><link name="world"/><link name="base_link"><visual><geometry><mesh filename="package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae"/></geometry></visual></link><joint name="world_to_base" type="fixed"><parent link="world"/><child link="base_link"/></joint></robot>\n',
+        encoding="utf-8",
+    )
+    try:
+        monkeypatch.chdir(scene)
+        payload = {"scene": {"id": "ur5_2f_test"}, "_visual_mesh_index_source": {"source_expanded_urdf_path": str(source)}}
+
+        exporter._stage_expanded_robot_urdf(payload, scene, scene / "tmp.web_scene.json", [])
+    finally:
+        source.unlink(missing_ok=True)
+
+    preview = payload["robot_preview"]
+    assert preview["mode"] == "expanded_urdf_loader"
+    assert preview["urdf_url"].startswith("build/workcell_studio_web_scene/")
+    diagnostics = payload["metadata"]["expanded_urdf_staging"]
+    assert diagnostics["expanded_urdf_unresolved_mesh_count"] == 0
+    assert (REPO_ROOT / "build" / "workcell_studio_web_scene" / "assets" / "ur5_2f_test" / "robotiq_85_description" / "meshes" / "visual" / "robotiq_85_base_link.dae").is_file()


### PR DESCRIPTION
### Motivation
- Expanded-URDF mesh staging used a different resolution context than normal mesh staging, causing valid package:// meshes (e.g. Robotiq 2F/3F) to fail with “Package mesh file does not exist” and abort Product View preparation. 
- The resolver semantics allowed a non-empty but incomplete provided package map to mask valid repository assets, and the staging path sometimes used the scene or output directory instead of the real repository root.

### Description
- Added a shared authoritative package resolver `resolve_package_mesh_uri` and package-candidate merger to `scripts/workcell_visual_asset_resolver.py` that augments provided maps, validates `package.xml` identity when present, and prefers repository asset packages before workspace/AMENT/share and `/opt/ros/humble/share`.
- Updated `scripts/export_workcell_studio_web_scene.py` to use the shared resolver for both normal mesh staging and every expanded-URDF robot/tool mesh reference, and to discover the repository root (`_repo_root`) so expanded-URDF staging runs from the real checkout root containing `assets`, `scenes`, and `scripts`.
- Changed candidate selection so a non-empty provided map cannot hide repository assets, do not pick a package root until the requested relative mesh file exists, and include the candidate package roots checked in unresolved diagnostics.
- Preserved existing protections (unsafe/traversal schemes, output-root/canonical URL checks) and added focused regression tests to cover incomplete-map augmentation and repository-root expanded-URDF staging; modified/added tests in `tests/test_workcell_studio_web_mesh_staging.py` accordingly.

### Testing
- Ran unit tests with `python3 -m pytest tests/test_export_workcell_studio_web_scene.py tests/test_workcell_studio_web_mesh_staging.py -q` and all tests passed (44 passed).
- Verified the freshener for canonical scenes with `python3 scripts/ensure_workcell_studio_web_scene_fresh.py --scene scenes/ur5_2f_test --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json --stage-assets --force` and `--scene scenes/ur5_3f_test`, both exited 0 and staged Robotiq meshes under `build/workcell_studio_web_scene/assets/<scene-id>/`.
- Ran `git diff --check` to ensure no whitespace/patch issues; it passed.
- Note: creating the remote PR from this environment was blocked by missing interactive GitHub credentials, but the branch and local changes are ready for a normal push/PR from an authenticated environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60d44aa8e083319e2626e574502d7b)