### PR TITLE
Canonicalize expanded URDF mesh references for Product View

### DIFF
--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -592,13 +592,21 @@ def _stage_expanded_robot_urdf(payload: Json, scene_dir: Path, output_path: Path
 
     diagnostics: Json = {
         "expanded_urdf_mesh_reference_count": 0,
+        "expanded_urdf_visual_mesh_reference_count": 0,
+        "expanded_urdf_collision_mesh_reference_count": 0,
         "expanded_urdf_staged_mesh_count": 0,
+        "expanded_urdf_visual_meshes_staged": 0,
+        "expanded_urdf_collision_meshes_staged": 0,
+        "expanded_urdf_deduplicated_reference_count": 0,
         "expanded_urdf_unresolved_mesh_count": 0,
+        "expanded_urdf_unresolved_references": [],
         "expanded_urdf_package_count": 0,
         "expanded_urdf_uses_canonical_root_relative_urls": False,
     }
     packages: set[str] = set()
     unresolved: List[str] = []
+    staged_sources: Dict[Path, str] = {}
+    staged_sources_by_kind: Dict[str, set[Path]] = {"visual": set(), "collision": set()}
 
     try:
         root = ET.fromstring(text)
@@ -607,12 +615,18 @@ def _stage_expanded_robot_urdf(payload: Json, scene_dir: Path, output_path: Path
 
     for link in root.findall("link"):
         link_name = link.get("name", "<unnamed_link>")
+        mesh_contexts: List[Tuple[str, int, ET.Element]] = []
         for visual_index, mesh in enumerate(link.findall("./visual/geometry/mesh")):
+            mesh_contexts.append(("visual", visual_index, mesh))
+        for collision_index, mesh in enumerate(link.findall("./collision/geometry/mesh")):
+            mesh_contexts.append(("collision", collision_index, mesh))
+        for mesh_kind, mesh_index, mesh in mesh_contexts:
             original = str(mesh.get("filename") or "")
             if not original:
                 continue
             diagnostics["expanded_urdf_mesh_reference_count"] += 1
-            context = f"link={link_name} visual_index={visual_index}"
+            diagnostics[f"expanded_urdf_{mesh_kind}_mesh_reference_count"] += 1
+            context = f"link={link_name} {mesh_kind}_index={mesh_index}"
             parsed = urlparse(original)
             if parsed.scheme != "package":
                 reason = "expanded robot/tool mesh filename must be a package:// URI before staging"
@@ -632,18 +646,27 @@ def _stage_expanded_robot_urdf(payload: Json, scene_dir: Path, output_path: Path
                 unresolved.append(f"{original} ({context}): {reason}")
                 _warn(warnings, "expanded_robot_urdf_mesh_unsafe", f"{reason} ({context})", original)
                 continue
-            target.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(resolved, target)
             canonical_url = "/" + os.path.relpath(target, repo_root).replace(os.sep, "/")
             if not canonical_url.startswith(f"/build/workcell_studio_web_scene/assets/{scene_id}/{package}/"):
                 reason = f"canonical staged URL contract failed for {canonical_url}"
                 unresolved.append(f"{original} ({context}): {reason}")
                 _warn(warnings, "expanded_robot_urdf_mesh_unsafe", f"{reason} ({context})", original)
                 continue
-            mesh.set("filename", canonical_url)
+            resolved_key = resolved.resolve()
+            if resolved_key in staged_sources:
+                diagnostics["expanded_urdf_deduplicated_reference_count"] += 1
+            else:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(resolved_key, target)
+                staged_sources[resolved_key] = canonical_url
+            mesh.set("filename", staged_sources[resolved_key])
+            staged_sources_by_kind[mesh_kind].add(resolved_key)
             diagnostics["expanded_urdf_staged_mesh_count"] += 1
 
+    diagnostics["expanded_urdf_visual_meshes_staged"] = len(staged_sources_by_kind["visual"])
+    diagnostics["expanded_urdf_collision_meshes_staged"] = len(staged_sources_by_kind["collision"])
     diagnostics["expanded_urdf_unresolved_mesh_count"] = len(unresolved)
+    diagnostics["expanded_urdf_unresolved_references"] = list(unresolved)
     diagnostics["expanded_urdf_package_count"] = len(packages)
     diagnostics["expanded_urdf_uses_canonical_root_relative_urls"] = (
         diagnostics["expanded_urdf_mesh_reference_count"] > 0 and not unresolved

--- a/tests/test_workcell_studio_web_mesh_staging.py
+++ b/tests/test_workcell_studio_web_mesh_staging.py
@@ -439,11 +439,17 @@ def test_known_package_missing_mesh_file_reports_missing_file(monkeypatch, tmp_p
 def _expanded_robot_scene(tmp_path: Path, scene_id: str, mesh_uris: list[tuple[str, str]]) -> Path:
     scene = _scene(tmp_path, scene_id, [])
     links = ['world', 'base_link', 'tool0', 'gripper_base_link']
-    visuals = []
+    link_blocks: dict[str, list[str]] = {}
     for link, uri in mesh_uris:
-        visuals.append(f'''  <link name="{link}">\n    <visual>\n      <origin xyz="0 0 0" rpy="0 0 0"/>\n      <geometry><mesh filename="{uri}" scale="1 1 1"/></geometry>\n    </visual>\n  </link>''')
+        kind = 'visual'
+        if '|' in link:
+            link, kind = link.split('|', 1)
+        link_blocks.setdefault(link, []).append(
+            f'    <{kind}>\n      <origin xyz="0 0 0" rpy="0 0 0"/>\n      <geometry><mesh filename="{uri}" scale="1 1 1"/></geometry>\n    </{kind}>'
+        )
+    visuals = [f'  <link name="{link}">\n' + '\n'.join(blocks) + '\n  </link>' for link, blocks in link_blocks.items()]
     for link in links:
-        if not any(v.startswith(f'  <link name="{link}"') for v in visuals):
+        if link not in link_blocks:
             visuals.append(f'  <link name="{link}"/>')
     joints = '''  <joint name="world_to_base" type="fixed"><parent link="world"/><child link="base_link"/><origin xyz="0 0 0" rpy="0 0 0"/></joint>\n  <joint name="base_to_tool" type="fixed"><parent link="base_link"/><child link="tool0"/><origin xyz="0 0 0" rpy="0 0 0"/></joint>\n  <joint name="tool_to_gripper" type="fixed"><parent link="tool0"/><child link="gripper_base_link"/><origin xyz="0 0 0" rpy="0 0 0"/></joint>'''
     (scene / 'generated' / 'expanded_scene_preview.urdf').write_text('<robot name="fixture">\n' + '\n'.join(visuals) + '\n' + joints + '\n</robot>\n', encoding='utf-8')
@@ -484,6 +490,64 @@ def test_expanded_urdf_meshes_use_canonical_root_relative_urls(monkeypatch, tmp_
     assert diagnostics['expanded_urdf_uses_canonical_root_relative_urls'] is True
 
 
+def test_expanded_urdf_visual_and_collision_meshes_are_canonicalized_once(monkeypatch, tmp_path):
+    prefix = tmp_path / 'ament'
+    _package(prefix, 'generic_robot_description', 'meshes/visual/base.dae', '<COLLADA>visual</COLLADA>')
+    _package(prefix, 'generic_robot_description', 'meshes/collision/base.stl', 'solid collision\nendsolid collision\n')
+    scene = _expanded_robot_scene(
+        tmp_path,
+        'visual_collision_scene',
+        [
+            ('base_link', 'package://generic_robot_description/meshes/visual/base.dae'),
+            ('base_link|collision', 'package://generic_robot_description/meshes/collision/base.stl'),
+            ('tool0|collision', 'package://generic_robot_description/meshes/collision/base.stl'),
+        ],
+    )
+
+    payload = _export_with_prefix(monkeypatch, scene, tmp_path / 'out' / 'scene.web_scene.json', prefix)
+    urdf_path = REPO_ROOT / payload['robot_preview']['urdf_url']
+    root = exporter.ET.fromstring(urdf_path.read_text(encoding='utf-8'))
+    filenames = [mesh.get('filename') for mesh in root.findall('.//mesh')]
+
+    assert filenames == [
+        '/build/workcell_studio_web_scene/assets/visual_collision_scene/generic_robot_description/meshes/visual/base.dae',
+        '/build/workcell_studio_web_scene/assets/visual_collision_scene/generic_robot_description/meshes/collision/base.stl',
+        '/build/workcell_studio_web_scene/assets/visual_collision_scene/generic_robot_description/meshes/collision/base.stl',
+    ]
+    assert all('package://' not in filename and 'file://' not in filename for filename in filenames)
+    diagnostics = payload['metadata']['expanded_urdf_staging']
+    assert diagnostics['expanded_urdf_mesh_reference_count'] == 3
+    assert diagnostics['expanded_urdf_visual_mesh_reference_count'] == 1
+    assert diagnostics['expanded_urdf_collision_mesh_reference_count'] == 2
+    assert diagnostics['expanded_urdf_visual_meshes_staged'] == 1
+    assert diagnostics['expanded_urdf_collision_meshes_staged'] == 1
+    assert diagnostics['expanded_urdf_deduplicated_reference_count'] == 1
+    assert diagnostics['expanded_urdf_unresolved_references'] == []
+    readiness = payload['robot_preview']
+    assert readiness['expected_visual_links'] == ['base_link']
+    assert readiness['expected_tool_visual_links'] == []
+
+
+def test_expanded_urdf_unresolved_collision_mesh_remains_blocking(monkeypatch, tmp_path):
+    monkeypatch.setenv('AMENT_PREFIX_PATH', str(tmp_path / 'ament'))
+    scene = _expanded_robot_scene(
+        tmp_path,
+        'missing_collision_expanded_scene',
+        [('base_link|collision', 'package://missing_robot/meshes/collision/base.stl')],
+    )
+
+    try:
+        exporter.build_web_scene(scene, stage_assets=True, output_path=tmp_path / 'out.json')
+    except exporter.BlockingExportError as exc:
+        message = str(exc)
+    else:  # pragma: no cover
+        raise AssertionError('missing required expanded URDF collision mesh did not fail')
+
+    assert 'package://missing_robot/meshes/collision/base.stl' in message
+    assert 'collision_index=0' in message
+    assert 'Could not resolve package mesh URI' in message
+
+
 def test_expanded_urdf_missing_required_mesh_fails_clearly(monkeypatch, tmp_path):
     monkeypatch.setenv('AMENT_PREFIX_PATH', str(tmp_path / 'ament'))
     scene = _expanded_robot_scene(
@@ -511,6 +575,7 @@ def test_expanded_urdf_rejects_unsafe_and_non_package_mesh_uris(monkeypatch, tmp
         'package://bad_pkg/../escape.dae',
         'package://bad_pkg/meshes/%2e%2e/escape.dae',
         'https://example.test/mesh.dae',
+        'file:///tmp/mesh.dae',
         '/tmp/mesh.dae',
     ]
     for index, uri in enumerate(bad_uris):


### PR DESCRIPTION
### Motivation
- The expanded-URDF staging path only rewrote visual mesh references which left collision `<mesh filename>` attributes as `package://` URIs and caused final validation to fail. 
- Product View preparation must present a browser-safe, canonical URDF with all mesh references rewritten so the viewer and downstream validation do not see package or absolute mesh URIs.

### Description
- Updated `_stage_expanded_robot_urdf` to inspect and process every `<mesh filename>` under both `<visual>` and `<collision>` using the shared package resolver (`resolve_package_mesh_uri`) so only safe `package://` candidates are accepted. 
- Staged each unique source mesh once and rewrote every URDF `<mesh filename>` to the canonical root-relative browser URL while preserving mesh scale and URDF transforms and keeping visual vs collision classification intact. 
- Added deduplication of staged sources, per-kind staging counters, and expanded diagnostics keys (`expanded_urdf_visual_mesh_reference_count`, `expanded_urdf_collision_mesh_reference_count`, `expanded_urdf_visual_meshes_staged`, `expanded_urdf_collision_meshes_staged`, `expanded_urdf_deduplicated_reference_count`, `expanded_urdf_unresolved_references`) to the metadata. 
- Added focused tests covering visual+collision canonicalization, duplicate staging deduplication, collision exclusion from visual-readiness, unresolved collision mesh blocking, and unsafe `file://`/remote URIs; modified test helper to allow specifying `visual` vs `collision` test blocks. 
- Files changed: `scripts/export_workcell_studio_web_scene.py`, `tests/test_workcell_studio_web_mesh_staging.py`.

### Testing
- Ran `python3 -m pytest tests/test_workcell_studio_web_mesh_staging.py -q` and the test suite passed (`24 passed`).
- Ran `python3 -m pytest tests/test_export_workcell_studio_web_scene.py -q` and the suite passed (`22 passed`).
- Executed the freshener for canonical scenes with staging using `python3 scripts/ensure_workcell_studio_web_scene_fresh.py --scene scenes/ur5_2f_test --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json --stage-assets --force` and `--scene scenes/ur5_3f_test` and both completed successfully with exit code 0. 
- Verified generated expanded URDFs for `ur5_2f_test` and `ur5_3f_test` contain no `package://` or `file://` mesh filenames and ran `git diff --check` with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60d7cbe1dc8331bda58533d2d3a51f)