### PR TITLE
Add sequential DB99 Modbus meter poller with reliability guards and tests

### DIFF
--- a/scripts/modbus_meter_sequence.py
+++ b/scripts/modbus_meter_sequence.py
@@ -1,0 +1,220 @@
+"""Sequential Modbus meter polling state machine.
+
+This module models the PLC/MB_CLIENT ownership contract for DB99 meter polling:
+one controller owns Request/Disconnect, emits one-scan Request pulses, waits for
+DONE/BUSY/ERROR or watchdog timeout, cools down after failures, and never
+advances to another meter/building until the active meter is terminal.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Iterable
+
+BUILDING_ORDER = (5, 12, 8, 4, 9)
+READS = ((47681, 58), (40513, 18))
+TERMINAL_RESULTS = {"DONE", "ERROR", "TIMEOUT", "SKIPPED"}
+
+
+class Step(str, Enum):
+    IDLE = "IDLE"
+    REQUEST_PULSE = "REQUEST_PULSE"
+    WAIT_FEEDBACK = "WAIT_FEEDBACK"
+    DISCONNECT_PULSE = "DISCONNECT_PULSE"
+    COOLDOWN = "COOLDOWN"
+    BETWEEN_BUILDINGS = "BETWEEN_BUILDINGS"
+    COMPLETE = "COMPLETE"
+
+
+@dataclass(frozen=True)
+class Meter:
+    building: int
+    meter: int
+    enabled: bool = True
+
+
+@dataclass(frozen=True)
+class Feedback:
+    done: bool = False
+    busy: bool = False
+    error: bool = False
+    status: int = 0
+
+
+@dataclass
+class Diagnostics:
+    active_building: int | None = None
+    active_meter: int | None = None
+    active_read_step: int | None = None
+    retry_count: int = 0
+    watchdog_elapsed_ms: int = 0
+    last_failed_meter: tuple[int, int] | None = None
+    last_modbus_status: int = 0
+    cooldown_active: bool = False
+    active_request_count: int = 0
+    active_busy_count: int = 0
+    safety_assertion_ok: bool = True
+
+
+@dataclass
+class ScanOutput:
+    request: bool = False
+    disconnect: bool = False
+    request_register: int | None = None
+    request_length: int | None = None
+    building_done_pulse: int | None = None
+    meter_result: str | None = None
+    diagnostics: Diagnostics = field(default_factory=Diagnostics)
+
+
+class SequentialMeterPoller:
+    """Single-active-meter scheduler for DB99-backed MB_CLIENT polling."""
+
+    def __init__(
+        self,
+        meters_by_building: dict[int, Iterable[int]],
+        *,
+        enabled_buildings: Iterable[int] = BUILDING_ORDER,
+        max_retries: int = 2,
+        watchdog_ms: int = 10_000,
+        cooldown_ms: int = 1_000,
+        inter_building_delay_ms: int = 2_000,
+    ) -> None:
+        self.max_retries = max_retries
+        self.watchdog_ms = watchdog_ms
+        self.cooldown_ms = cooldown_ms
+        self.inter_building_delay_ms = inter_building_delay_ms
+        enabled = set(enabled_buildings)
+        self.plan: list[Meter] = [
+            Meter(building, meter)
+            for building in BUILDING_ORDER
+            if building in enabled
+            for meter in meters_by_building.get(building, ())
+        ]
+        self.index = 0
+        self.step = Step.IDLE if self.plan else Step.COMPLETE
+        self.read_index = 0
+        self.retry_count = 0
+        self.watchdog_elapsed_ms = 0
+        self.cooldown_elapsed_ms = 0
+        self.inter_building_elapsed_ms = 0
+        self.last_failed_meter: tuple[int, int] | None = None
+        self.last_modbus_status = 0
+        self.failed_meters: list[tuple[int, int, str, int]] = []
+        self.completed_meters: list[tuple[int, int]] = []
+        self._pending_building_done: int | None = None
+
+    @property
+    def active_meter(self) -> Meter | None:
+        if self.index < len(self.plan):
+            return self.plan[self.index]
+        return None
+
+    def scan(self, feedback: Feedback | None = None, *, elapsed_ms: int = 100) -> ScanOutput:
+        feedback = feedback or Feedback()
+        out = ScanOutput()
+        if self.step is Step.COMPLETE:
+            out.diagnostics = self._diagnostics(False, feedback.busy)
+            return out
+
+        if self.step is Step.IDLE:
+            self.step = Step.REQUEST_PULSE
+
+        if self.step is Step.REQUEST_PULSE:
+            register, length = READS[self.read_index]
+            out.request = True
+            out.request_register = register
+            out.request_length = length
+            self.watchdog_elapsed_ms = 0
+            self.step = Step.WAIT_FEEDBACK
+        elif self.step is Step.WAIT_FEEDBACK:
+            self.watchdog_elapsed_ms += elapsed_ms
+            self.last_modbus_status = feedback.status
+            if feedback.done:
+                self._finish_read_or_meter("DONE")
+            elif feedback.error:
+                self._start_failure_recovery("ERROR", feedback.status)
+            elif self.watchdog_elapsed_ms >= self.watchdog_ms:
+                self._start_failure_recovery("TIMEOUT", feedback.status)
+        elif self.step is Step.DISCONNECT_PULSE:
+            out.disconnect = True
+            self.cooldown_elapsed_ms = 0
+            self.step = Step.COOLDOWN
+        elif self.step is Step.COOLDOWN:
+            self.cooldown_elapsed_ms += elapsed_ms
+            if self.cooldown_elapsed_ms >= self.cooldown_ms:
+                self.step = Step.REQUEST_PULSE
+        elif self.step is Step.BETWEEN_BUILDINGS:
+            self.inter_building_elapsed_ms += elapsed_ms
+            if self._pending_building_done is not None:
+                out.building_done_pulse = self._pending_building_done
+                self._pending_building_done = None
+            if self.inter_building_elapsed_ms >= self.inter_building_delay_ms:
+                self.step = Step.IDLE if self.active_meter else Step.COMPLETE
+                self.inter_building_elapsed_ms = 0
+
+        out.diagnostics = self._diagnostics(out.request, feedback.busy)
+        return out
+
+    def _finish_read_or_meter(self, result: str) -> None:
+        self.watchdog_elapsed_ms = 0
+        self.last_modbus_status = 0
+        if self.read_index + 1 < len(READS):
+            self.read_index += 1
+            self.step = Step.REQUEST_PULSE
+            return
+        meter = self.active_meter
+        if meter is not None:
+            self.completed_meters.append((meter.building, meter.meter))
+        self._advance_meter()
+
+    def _start_failure_recovery(self, result: str, status: int) -> None:
+        meter = self.active_meter
+        if meter is not None:
+            self.last_failed_meter = (meter.building, meter.meter)
+        self.last_modbus_status = status
+        if self.retry_count >= self.max_retries:
+            if meter is not None:
+                self.failed_meters.append((meter.building, meter.meter, result, status))
+            self.retry_count = 0
+            self.read_index = 0
+            self._advance_meter()
+        else:
+            self.retry_count += 1
+            self.step = Step.DISCONNECT_PULSE
+
+    def _advance_meter(self) -> None:
+        old = self.active_meter
+        self.index += 1
+        self.read_index = 0
+        next_meter = self.active_meter
+        if old is not None and (next_meter is None or next_meter.building != old.building):
+            self._pending_building_done = old.building
+            self.step = Step.BETWEEN_BUILDINGS
+        else:
+            self.step = Step.IDLE if next_meter else Step.COMPLETE
+
+    def _diagnostics(self, request: bool, busy: bool) -> Diagnostics:
+        active = self.active_meter
+        active_request_count = int(request)
+        active_busy_count = int(busy and self.step is Step.WAIT_FEEDBACK and not request)
+        assertion_ok = active_request_count + active_busy_count <= 1
+        return Diagnostics(
+            active_building=active.building if active else None,
+            active_meter=active.meter if active else None,
+            active_read_step=self.read_index + 1 if active and self.step is not Step.BETWEEN_BUILDINGS else None,
+            retry_count=self.retry_count,
+            watchdog_elapsed_ms=self.watchdog_elapsed_ms,
+            last_failed_meter=self.last_failed_meter,
+            last_modbus_status=self.last_modbus_status,
+            cooldown_active=self.step is Step.COOLDOWN,
+            active_request_count=active_request_count,
+            active_busy_count=active_busy_count,
+            safety_assertion_ok=assertion_ok,
+        )
+
+    def assert_single_active_transaction(self, output: ScanOutput) -> None:
+        diag = output.diagnostics
+        if diag.active_request_count + diag.active_busy_count > 1:
+            raise AssertionError("More than one meter transaction is active")

--- a/tests/test_sequential_modbus_meter_poller.py
+++ b/tests/test_sequential_modbus_meter_poller.py
@@ -1,0 +1,92 @@
+from scripts.modbus_meter_sequence import Feedback, SequentialMeterPoller
+
+
+def scan(poller, feedback=None, elapsed_ms=100):
+    output = poller.scan(feedback, elapsed_ms=elapsed_ms)
+    poller.assert_single_active_transaction(output)
+    return output
+
+
+def test_one_meter_runs_at_a_time_and_preserves_building_order():
+    poller = SequentialMeterPoller({5: [1, 2], 12: [1], 8: [1], 4: [1], 9: [1]}, inter_building_delay_ms=100)
+    seen = []
+    for _ in range(60):
+        out = scan(poller)
+        if out.request:
+            seen.append((out.diagnostics.active_building, out.diagnostics.active_meter, out.request_register))
+            scan(poller, Feedback(done=True))
+        elif out.diagnostics.active_read_step is not None:
+            followup = scan(poller, Feedback(done=True))
+            if followup.request:
+                seen.append((followup.diagnostics.active_building, followup.diagnostics.active_meter, followup.request_register))
+    assert seen[:4] == [(5, 1, 47681), (5, 1, 40513), (5, 2, 47681), (5, 2, 40513)]
+    assert [building for building, _, reg in seen if reg == 47681][:5] == [5, 5, 12, 8, 4]
+
+
+def test_next_meter_waits_for_terminal_result():
+    poller = SequentialMeterPoller({5: [1, 2]})
+    assert scan(poller).request
+    for _ in range(3):
+        out = scan(poller, Feedback(busy=True), elapsed_ms=100)
+        assert out.diagnostics.active_meter == 1
+        assert not out.request
+    assert scan(poller, Feedback(done=True)).diagnostics.active_meter == 1
+    assert scan(poller).request  # second read, still meter 1
+    scan(poller, Feedback(done=True))
+    assert scan(poller).diagnostics.active_meter == 2
+
+
+def test_timeout_causes_disconnect_cooldown_and_retry_same_meter():
+    poller = SequentialMeterPoller({5: [1]}, watchdog_ms=200, cooldown_ms=300)
+    assert scan(poller).request
+    out = scan(poller, Feedback(busy=True, status=0x7002), elapsed_ms=200)
+    assert out.diagnostics.last_failed_meter == (5, 1)
+    assert out.diagnostics.retry_count == 1
+    assert scan(poller).disconnect
+    assert scan(poller, elapsed_ms=100).diagnostics.cooldown_active
+    assert scan(poller, elapsed_ms=200).diagnostics.active_meter == 1
+    retry = scan(poller)
+    assert retry.request
+    assert retry.request_register == 47681
+
+
+def test_max_retries_cause_sequential_skip_to_next_meter():
+    poller = SequentialMeterPoller({5: [1, 2]}, max_retries=1, watchdog_ms=100, cooldown_ms=100)
+    scan(poller)  # request meter 1
+    scan(poller, Feedback(error=True, status=0x7002), elapsed_ms=100)
+    scan(poller)  # disconnect
+    scan(poller, elapsed_ms=100)  # cooldown complete
+    scan(poller)  # retry request
+    scan(poller, Feedback(error=True, status=0x7002), elapsed_ms=100)
+    assert poller.failed_meters == [(5, 1, "ERROR", 0x7002)]
+    assert scan(poller).diagnostics.active_meter == 2
+
+
+def test_next_building_cannot_start_early_and_done_pulse_precedes_delay():
+    poller = SequentialMeterPoller({5: [1], 12: [1]}, inter_building_delay_ms=500)
+    scan(poller)
+    scan(poller, Feedback(done=True))
+    scan(poller)
+    out = scan(poller, Feedback(done=True))
+    assert out.diagnostics.active_building == 12
+    pulse = scan(poller, elapsed_ms=100)
+    assert pulse.building_done_pulse == 5
+    assert not pulse.request
+    assert pulse.diagnostics.active_building == 12
+    assert scan(poller, elapsed_ms=300).diagnostics.active_building == 12
+    request = scan(poller, elapsed_ms=100)
+    assert not request.request
+    request = scan(poller)
+    assert request.request
+    assert request.diagnostics.active_building == 12
+
+
+def test_no_parallel_meter_execution_is_introduced():
+    poller = SequentialMeterPoller({5: [1, 2], 12: [1]}, watchdog_ms=1000)
+    for _ in range(50):
+        out = scan(poller, Feedback(busy=True), elapsed_ms=10)
+        diag = out.diagnostics
+        assert diag.active_request_count + diag.active_busy_count <= 1
+        assert diag.safety_assertion_ok
+        if out.request:
+            assert out.request_register in (47681, 40513)


### PR DESCRIPTION
### Motivation
- Implement a single-active-meter DB99/MB_CLIENT polling model to enforce the hard requirement that only one meter may be active at any time and to prevent the previous race that could start another meter in parallel (the 16#7002 problem). 
- Preserve the existing measurement contract (two reads per meter) and building processing order while adding robust timeout/retry/disconnect behavior to improve reliability. 
- Provide diagnostics and unit tests that prove sequential behaviour, timeout/retry handling, max-retry skip, and inter-building gating.

### Description
- Added `scripts/modbus_meter_sequence.py`, a sequential state-machine `SequentialMeterPoller` that enforces Building order 5 → 12 → 8 → 4 → 9, performs the two required reads per meter (`47681,58` then `40513,18`), emits a one-scan `Request` pulse, and waits for terminal feedback (DONE/ERROR) or watchdog timeout before advancing. 
- Implemented failure recovery that on timeout/error clears `Request`, pulses `Disconnect`, waits for a configured cooldown, retries the same meter, records failures after `max_retries`, and then skips to the next meter sequentially. 
- Added building completion logic that emits a single Building DonePulse after the final meter in a building finishes or is skipped, then applies an inter-building delay before starting the next building. 
- Exposed diagnostics fields: active building, active meter, active read step, retry count, watchdog elapsed time, last failed meter, last Modbus status, cooldown active, active Request/BUSY counts, and a safety assertion that verifies ActiveRequestCount + ActiveBusyCount ≤ 1 on each scan. 
- Added `tests/test_sequential_modbus_meter_poller.py` with regression tests that validate: single-meter-at-a-time execution, waiting for terminal results before advancing, timeout→disconnect→cooldown→retry flow, max-retry sequential skip, building gating and Building DonePulse behaviour, and that no parallel meter execution is introduced. 

### Testing
- Ran `python3 -m pytest tests/test_sequential_modbus_meter_poller.py`, all tests passed (6 passed). 
- Ran `python3 -m py_compile scripts/modbus_meter_sequence.py tests/test_sequential_modbus_meter_poller.py`, compilation passed. 
- Tests exercise watchdog/timeouts, disconnect/cooldown/retry sequences, max-retry skipping, and verify the single-active-transaction safety assertion on every scan.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60eaae23a4833198ca8ff0c9b20ec2)