### PR TITLE
Fix final staged mesh URL resolution in Product View

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -2358,6 +2358,77 @@ for (const url of cases) {
     subprocess.run(["node", str(script)], cwd=ROOT, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
 
+
+
+def test_load_robot_preview_preserves_canonical_mesh_urls_after_normalize_and_repo_url(tmp_path):
+    script = tmp_path / "capture_final_staged_mesh_urls.mjs"
+    script.write_text(
+        f"""
+import assert from 'node:assert/strict';
+import * as THREE from {str((VIEWER / 'node_modules/three/build/three.module.js')).__repr__()};
+import URDFLoader from {str((VIEWER / 'node_modules/urdf-loader/src/URDFLoader.js')).__repr__()};
+import {{ ColladaLoader }} from {str((VIEWER / 'node_modules/three/examples/jsm/loaders/ColladaLoader.js')).__repr__()};
+
+globalThis.window = {{}};
+const requestedUrls = [];
+const repoRootRelativeCalls = [];
+const originalUrdfLoadAsync = URDFLoader.prototype.loadAsync;
+const originalColladaLoad = ColladaLoader.prototype.load;
+
+URDFLoader.prototype.loadAsync = async function loadAsyncStub() {{
+  for (const path of [
+    'package://ur_description/meshes/ur5/visual/base.dae',
+    'package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae',
+  ]) {{
+    this.loadMeshCb(path, this.manager, new THREE.MeshPhongMaterial(), (mesh, error) => {{ if (error) throw error; }});
+  }}
+  const robot = new THREE.Group();
+  robot.links = {{ base_link: new THREE.Group(), gripper_base_link: new THREE.Group() }};
+  robot.joints = {{}};
+  robot.setJointValues = () => {{}};
+  return robot;
+}};
+
+ColladaLoader.prototype.load = function loadStub(url, onLoad) {{
+  requestedUrls.push(url);
+  this.manager?.itemStart?.(url);
+  onLoad({{ scene: new THREE.Group(), asset: {{}} }});
+  this.manager?.itemEnd?.(url);
+}};
+
+try {{
+  const {{ loadRobotPreview }} = await import({str((VIEWER / 'urdf_robot_renderer.js')).__repr__()});
+  const result = loadRobotPreview(
+    {{ urdf_url: '/build/workcell_studio_web_scene/assets/ur5_2f_test/robot.urdf' }},
+    {{
+      sceneId: 'ur5_2f_test',
+      repoRootRelativeUrl: (value) => {{
+        repoRootRelativeCalls.push(value);
+        return `/build/workcell_studio_web_scene/${{value}}`;
+      }},
+    }}
+  );
+  await result.ready;
+  assert.deepEqual(requestedUrls, [
+    '/build/workcell_studio_web_scene/assets/ur5_2f_test/ur_description/meshes/ur5/visual/base.dae',
+    '/build/workcell_studio_web_scene/assets/ur5_2f_test/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae',
+  ]);
+  assert.deepEqual(repoRootRelativeCalls, []);
+  for (const url of requestedUrls) {{
+    assert.equal((url.match(/build\/workcell_studio_web_scene/g) || []).length, 1, url);
+    assert.equal(url.includes('//build/workcell_studio_web_scene/assets'), false, url);
+    assert.equal(url.includes('/build/workcell_studio_web_scene//build/workcell_studio_web_scene/'), false, url);
+  }}
+}} finally {{
+  URDFLoader.prototype.loadAsync = originalUrdfLoadAsync;
+  ColladaLoader.prototype.load = originalColladaLoad;
+}}
+""",
+        encoding="utf-8",
+    )
+    subprocess.run(["node", str(script)], cwd=ROOT, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
 def test_urdf_renderer_accepts_only_canonical_staged_mesh_urls(tmp_path):
     script = tmp_path / "canonical_staged_mesh_policy.mjs"
     script.write_text(

--- a/workcell_studio_web/viewer/dist/viewer.bundle.js
+++ b/workcell_studio_web/viewer/dist/viewer.bundle.js
@@ -37402,7 +37402,11 @@ __export(urdf_robot_renderer_exports, {
   normalizeRosColladaScene: () => normalizeRosColladaScene
 });
 function repoUrl(context, uri) {
-  return context?.repoRootRelativeUrl ? context.repoRootRelativeUrl(uri) : uri;
+  const value = String(uri || "").trim();
+  if (value.startsWith("/build/workcell_studio_web_scene/")) {
+    return value;
+  }
+  return context?.repoRootRelativeUrl ? context.repoRootRelativeUrl(value) : value;
 }
 function safeDecodeUriSegment(segment) {
   try {

--- a/workcell_studio_web/viewer/urdf_robot_renderer.js
+++ b/workcell_studio_web/viewer/urdf_robot_renderer.js
@@ -11,7 +11,13 @@ const LEGACY_STAGED_MESH_ASSET_ROOT = STAGED_MESH_ASSET_ROOT.slice(1);
 
 
 function repoUrl(context, uri) {
-  return context?.repoRootRelativeUrl ? context.repoRootRelativeUrl(uri) : uri;
+  const value = String(uri || '').trim();
+  if (value.startsWith('/build/workcell_studio_web_scene/')) {
+    return value;
+  }
+  return context?.repoRootRelativeUrl
+    ? context.repoRootRelativeUrl(value)
+    : value;
 }
 
 function safeDecodeUriSegment(segment) {


### PR DESCRIPTION
### Motivation
- Fix missing UR5 robot and Robotiq gripper in Product View caused by canonical staged mesh URLs being passed again through the repository-root helper and producing doubled paths. 
- Ensure validated root-relative staged asset URLs beginning with `/build/workcell_studio_web_scene/` are preserved and only non-root-relative repository paths are rewritten.

### Description
- Update `repoUrl()` in `workcell_studio_web/viewer/urdf_robot_renderer.js` to return the input unchanged when it starts with `/build/workcell_studio_web_scene/` and otherwise call `context.repoRootRelativeUrl()` if present. 
- Add a focused regression test `test_load_robot_preview_preserves_canonical_mesh_urls_after_normalize_and_repo_url` to `tests/test_workcell_studio_web_viewer_static.py` that stubs `URDFLoader`/`ColladaLoader`, exercises `normalizeMeshUri()` → `repoUrl()` → `ColladaLoader.load()`, and asserts the final loader URLs for UR5 and Robotiq are exactly the expected staged paths and that `repoRootRelativeUrl()` is not called for canonical root-relative URLs. 
- Rebuild the Web3D viewer bundle so `workcell_studio_web/viewer/dist/viewer.bundle.js` includes the same URL-preservation logic.

### Testing
- Ran `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py -q`, which passed (90 tests) with 3 benign SyntaxWarnings. 
- Ran `cd workcell_studio_web/viewer && npm ci` and `npm run build:web3d` and `npm run check:stale-bundle`, which completed successfully and produced an updated `dist/viewer.bundle.js`. 
- Ran `node --check workcell_studio_web/viewer/urdf_robot_renderer.js` with no syntax errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61ec1006448331bff7042a09c7c85e)