### PR TITLE
Fix expanded URDF children crash in Product View

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -406,11 +406,12 @@ import {{ STLLoader }} from {str((VIEWER / 'node_modules/three/examples/jsm/load
 globalThis.window = {{}};
 
 const requestedUrls = [];
-const originalUrdfLoadAsync = URDFLoader.prototype.loadAsync;
+globalThis.fetch = async () => ({{ ok: true, status: 200, statusText: 'OK', text: async () => '<robot name="test"/>' }});
+const originalUrdfParse = URDFLoader.prototype.parse;
 const originalColladaLoad = ColladaLoader.prototype.load;
 const originalStlLoad = STLLoader.prototype.load;
 
-URDFLoader.prototype.loadAsync = async function loadAsyncStub() {{
+URDFLoader.prototype.parse = function parseStub() {{
   assert.equal(this.constructor, URDFLoader);
   assert.equal(this.parseVisual, true);
   assert.equal(this.parseCollision, false);
@@ -462,7 +463,7 @@ try {{
     }}
   }}
 }} finally {{
-  URDFLoader.prototype.loadAsync = originalUrdfLoadAsync;
+  URDFLoader.prototype.parse = originalUrdfParse;
   ColladaLoader.prototype.load = originalColladaLoad;
   STLLoader.prototype.load = originalStlLoad;
 }}
@@ -1430,6 +1431,70 @@ def test_urdf_renderer_waits_for_mesh_completion_before_ready():
     assert "collectDescendantRenderMeshDiagnostics(robot.links)" in ready_section
 
 
+def test_urdf_renderer_fetches_and_validates_urdf_before_parse():
+    js = (VIEWER / "urdf_robot_renderer.js").read_text(encoding="utf-8")
+    body = _viewer_function_body(js, "export async function fetchValidatedUrdfRobotElement", "function collectLinkMatrixDiagnostics")
+    assert "fetch(urdfUrl, { cache: 'no-store' })" in body
+    assert "if (!response?.ok)" in body
+    assert "http_status=${statusText}" in js
+    assert "new DOMParser().parseFromString(text, 'application/xml')" in body
+    assert "getElementsByTagName?.('parsererror')" in body
+    assert "stage}: url=${url" in js
+    assert "validate_robot_root" in body
+    assert "expected top-level <robot> element" in body
+
+
+def test_urdf_renderer_parse_path_uses_validated_xml_element_not_load_async():
+    js = (VIEWER / "urdf_robot_renderer.js").read_text(encoding="utf-8")
+    ready_body = js.split("result.ready = (async () => {", 1)[1].split("setLifecycleState(diagnostics, 'loading_meshes');", 1)[0]
+    assert "const urdfUrl = repoUrl(rendererContext, previewConfig?.urdf_url || '');" in ready_body
+    assert "const urdfRobotElement = await fetchValidatedUrdfRobotElement(urdfUrl);" in ready_body
+    assert "const robot = loader.parse(urdfRobotElement" in ready_body
+    assert "loader.loadAsync(urdfUrl)" not in js
+
+
+def test_urdf_renderer_reports_html_malformed_xml_and_missing_robot_root_stages():
+    js = (VIEWER / "urdf_robot_renderer.js").read_text(encoding="utf-8")
+    body = _viewer_function_body(js, "export async function fetchValidatedUrdfRobotElement", "function collectLinkMatrixDiagnostics")
+    # HTTP 200 HTML and malformed XML both surface through parsererror / parse_xml instead of URDFLoader children crashes.
+    assert "parse_xml" in body
+    assert "parserError.textContent?.trim() || 'malformed XML'" in body
+    # XML without a top-level robot is rejected before URDFLoader.parse.
+    assert "String(root.tagName || '').toLowerCase() !== 'robot'" in body
+    assert "got <${root?.tagName || 'none'}>" in body
+
+
+def test_urdf_renderer_diagnostics_skip_undefined_links_and_use_optional_children():
+    js = (VIEWER / "urdf_robot_renderer.js").read_text(encoding="utf-8")
+    visual_body = _viewer_function_body(js, "function collectVisualWrapperMatrixDiagnostics", "function collectDescendantRenderMeshDiagnostics")
+    descendant_body = _viewer_function_body(js, "function collectDescendantRenderMeshDiagnostics", "function buildLookupMap")
+    assert "if (!link) continue;" in visual_body
+    assert "for (const child of link?.children || [])" in visual_body
+    assert "if (!link) continue;" in descendant_body
+    assert "for (const visual of link?.children || [])" in descendant_body
+
+
+def test_urdf_renderer_adds_successful_robot_only_after_meshes_joints_and_diagnostics():
+    js = (VIEWER / "urdf_robot_renderer.js").read_text(encoding="utf-8")
+    ready_body = js.split("result.ready = (async () => {", 1)[1].split("})().catch(err =>", 1)[0]
+    assert ready_body.index("await meshCompletion.wait();") < ready_body.index("robot.setJointValues(jointValues)")
+    assert ready_body.index("robot.setJointValues(jointValues)") < ready_body.index("diagnostics.robot_preview_loaded =")
+    assert ready_body.index("diagnostics.robot_preview_loaded =") < ready_body.index("rendererContext?.scene?.add?.(robot)")
+    assert "rendererContext?.scene?.add?.(robot);" in ready_body
+    assert "rendererContext?.onRobotLoaded?.(result);" in ready_body
+    assert ready_body.index("rendererContext?.scene?.add?.(robot)") < ready_body.index("rendererContext?.onRobotLoaded?.(result)")
+
+
+def test_urdf_renderer_optional_diagnostics_do_not_scene_fail_successful_render():
+    js = (VIEWER / "urdf_robot_renderer.js").read_text(encoding="utf-8")
+    ready_body = js.split("result.ready = (async () => {", 1)[1].split("})().catch(err =>", 1)[0]
+    assert "collectDescendantRenderMeshDiagnostics(robot.links)" in ready_body
+    assert "for (const visual of link?.children || [])" in js
+    diagnostics_tail = ready_body.split("diagnostics.robot_preview_loaded =", 1)[1]
+    assert "rendererContext?.onRobotError" not in diagnostics_tail
+    assert "throw" not in diagnostics_tail
+
+
 def test_urdf_renderer_normalizes_collada_loader_root_transform_generically():
     js = (VIEWER / "urdf_robot_renderer.js").read_text(encoding="utf-8")
     assert "function normalizeRosColladaScene" in js
@@ -2127,7 +2192,10 @@ def test_urdf_renderer_configures_active_loader_package_resolver_before_loading(
     ready_body = js.split("result.ready = (async () => {", 1)[1].split("const urdfUrl =", 1)[0]
     assert ready_body.index("const loader = new URDFLoader(manager);") < ready_body.index("configureUrdfPackageResolution(loader, manager, rendererContext, diagnostics);")
     assert ready_body.index("configureUrdfPackageResolution(loader, manager, rendererContext, diagnostics);") < ready_body.index("loader.loadMeshCb =")
-    assert js.index("loader.loadMeshCb =") < js.index("loader.loadAsync(urdfUrl)")
+    load_body = js.split("export function loadRobotPreview", 1)[1]
+    assert load_body.index("loader.loadMeshCb =") < load_body.index("fetchValidatedUrdfRobotElement(urdfUrl)")
+    assert load_body.index("fetchValidatedUrdfRobotElement(urdfUrl)") < load_body.index("loader.parse(urdfRobotElement")
+    assert "loader.loadAsync(urdfUrl)" not in js
     assert "loader.packages = resolver" in js
     assert "manager.setURLModifier(url =>" in js
 
@@ -2179,8 +2247,9 @@ import * as THREE from {str((VIEWER / 'node_modules/three/build/three.module.js'
 import URDFLoader from {str((VIEWER / 'node_modules/urdf-loader/src/URDFLoader.js')).__repr__()};
 
 globalThis.window = {{}};
-const originalUrdfLoadAsync = URDFLoader.prototype.loadAsync;
-URDFLoader.prototype.loadAsync = async function loadAsyncStub() {{
+globalThis.fetch = async () => ({{ ok: true, status: 200, statusText: 'OK', text: async () => '<robot name="test"/>' }});
+const originalUrdfParse = URDFLoader.prototype.parse;
+URDFLoader.prototype.parse = function parseStub() {{
   const robot = new THREE.Group();
   const base = new THREE.Group();
   base.name = 'base_link';
@@ -2214,7 +2283,7 @@ try {{
   assert.equal(result.diagnostics.robot_matrix_world_parity.link.comparisons[0].max_abs_delta <= 1e-5, true);
   assert.equal(result.diagnostics.robot_matrix_world_parity.visual_wrapper.comparisons[0].max_abs_delta <= 1e-5, true);
 }} finally {{
-  URDFLoader.prototype.loadAsync = originalUrdfLoadAsync;
+  URDFLoader.prototype.parse = originalUrdfParse;
 }}
 """,
         encoding="utf-8",
@@ -2372,10 +2441,11 @@ import {{ ColladaLoader }} from {str((VIEWER / 'node_modules/three/examples/jsm/
 globalThis.window = {{}};
 const requestedUrls = [];
 const repoRootRelativeCalls = [];
-const originalUrdfLoadAsync = URDFLoader.prototype.loadAsync;
+globalThis.fetch = async () => ({{ ok: true, status: 200, statusText: 'OK', text: async () => '<robot name="test"/>' }});
+const originalUrdfParse = URDFLoader.prototype.parse;
 const originalColladaLoad = ColladaLoader.prototype.load;
 
-URDFLoader.prototype.loadAsync = async function loadAsyncStub() {{
+URDFLoader.prototype.parse = function parseStub() {{
   for (const path of [
     'package://ur_description/meshes/ur5/visual/base.dae',
     'package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae',
@@ -2420,7 +2490,7 @@ try {{
     assert.equal(url.includes('/build/workcell_studio_web_scene//build/workcell_studio_web_scene/'), false, url);
   }}
 }} finally {{
-  URDFLoader.prototype.loadAsync = originalUrdfLoadAsync;
+  URDFLoader.prototype.parse = originalUrdfParse;
   ColladaLoader.prototype.load = originalColladaLoad;
 }}
 """,
@@ -2478,9 +2548,10 @@ import {{ ColladaLoader }} from {str((VIEWER / 'node_modules/three/examples/jsm/
 
 globalThis.window = {{}};
 const requestedUrls = [];
-const originalUrdfLoadAsync = URDFLoader.prototype.loadAsync;
+globalThis.fetch = async () => ({{ ok: true, status: 200, statusText: 'OK', text: async () => '<robot name="test"/>' }});
+const originalUrdfParse = URDFLoader.prototype.parse;
 const originalColladaLoad = ColladaLoader.prototype.load;
-URDFLoader.prototype.loadAsync = async function loadAsyncStub() {{
+URDFLoader.prototype.parse = function parseStub() {{
   for (const path of [
     '/build/workcell_studio_web_scene/assets/ur5_2f_test/ur_description/meshes/visual/base.dae',
     'build/workcell_studio_web_scene/assets/ur5_2f_test/robotiq_85_description/meshes/visual/gripper.dae',
@@ -2514,7 +2585,7 @@ try {{
   for (const requested of requestedUrls) assert.ok(requested.startsWith('/build/workcell_studio_web_scene/assets/'), requested);
   assert.equal(result.diagnostics.robot_failed_visual_count, 0);
 }} finally {{
-  URDFLoader.prototype.loadAsync = originalUrdfLoadAsync;
+  URDFLoader.prototype.parse = originalUrdfParse;
   ColladaLoader.prototype.load = originalColladaLoad;
 }}
 """,

--- a/workcell_studio_web/viewer/dist/viewer.bundle.js
+++ b/workcell_studio_web/viewer/dist/viewer.bundle.js
@@ -37398,6 +37398,7 @@ __export(urdf_robot_renderer_exports, {
   ROS_TO_THREE_CONVERSION_BOUNDARY: () => ROS_TO_THREE_CONVERSION_BOUNDARY,
   applyRobotJointPreview: () => applyRobotJointPreview,
   canonicalStagedMeshUrl: () => canonicalStagedMeshUrl,
+  fetchValidatedUrdfRobotElement: () => fetchValidatedUrdfRobotElement,
   loadRobotPreview: () => loadRobotPreview,
   normalizeRosColladaScene: () => normalizeRosColladaScene
 });
@@ -37845,6 +37846,46 @@ function collectMatrixParityDiagnostics(previewConfig, diagnostics) {
   diagnostics.robotMatrixWorldParity = diagnostics.robot_matrix_world_parity;
   return diagnostics.robot_matrix_world_parity;
 }
+function urdfLoadError(url, status, stage, detail) {
+  const statusText = status === null || status === void 0 ? "n/a" : String(status);
+  return new Error(`URDF preview failed at ${stage}: url=${url || "<empty>"} http_status=${statusText} detail=${detail || "unknown error"}`);
+}
+async function fetchValidatedUrdfRobotElement(urdfUrl) {
+  const response = await fetch(urdfUrl, { cache: "no-store" }).catch((err) => {
+    throw urdfLoadError(urdfUrl, null, "fetch", err?.message || String(err));
+  });
+  if (!response?.ok) {
+    throw urdfLoadError(urdfUrl, response?.status ?? null, "http", response?.statusText || "HTTP request failed");
+  }
+  const text = await response.text().catch((err) => {
+    throw urdfLoadError(urdfUrl, response?.status ?? null, "read", err?.message || String(err));
+  });
+  let document2;
+  try {
+    if (typeof DOMParser !== "undefined") {
+      document2 = new DOMParser().parseFromString(text, "application/xml");
+    } else {
+      const trimmed = String(text || "").trim();
+      const rootMatch = trimmed.match(/^<([A-Za-z_][\w:.-]*)(\s|>|\/)/);
+      const malformed = !rootMatch || /<\//i.test(trimmed) && !new RegExp(`</${rootMatch?.[1]}>\\s*$`).test(trimmed);
+      document2 = {
+        documentElement: rootMatch ? { tagName: rootMatch[1] } : null,
+        getElementsByTagName: (name) => name === "parsererror" && malformed ? [{ textContent: "malformed XML" }] : []
+      };
+    }
+  } catch (err) {
+    throw urdfLoadError(urdfUrl, response.status, "parse_xml", err?.message || String(err));
+  }
+  const parserError = document2?.getElementsByTagName?.("parsererror")?.[0];
+  if (parserError) {
+    throw urdfLoadError(urdfUrl, response.status, "parse_xml", parserError.textContent?.trim() || "malformed XML");
+  }
+  const root = document2?.documentElement;
+  if (!root || String(root.tagName || "").toLowerCase() !== "robot") {
+    throw urdfLoadError(urdfUrl, response.status, "validate_robot_root", `expected top-level <robot> element, got <${root?.tagName || "none"}>`);
+  }
+  return root;
+}
 function collectLinkMatrixDiagnostics(robot, links) {
   robot?.updateMatrixWorld?.(true);
   const out = {};
@@ -37880,7 +37921,9 @@ function collectVisualWrapperMatrixDiagnostics(links) {
   const out = [];
   for (const [linkName, link] of Object.entries(links || {})) {
     let visualIndex = 0;
-    for (const child of link.children || []) {
+    if (!link)
+      continue;
+    for (const child of link?.children || []) {
       if (!isVisualWrapperCandidate(child, links))
         continue;
       child.updateMatrixWorld?.(true);
@@ -37915,7 +37958,9 @@ function collectDescendantRenderMeshDiagnostics(links) {
   const out = [];
   for (const [linkName, link] of Object.entries(links || {})) {
     let visualIndex = 0;
-    for (const visual of link.children || []) {
+    if (!link)
+      continue;
+    for (const visual of link?.children || []) {
       if (!isVisualWrapperCandidate(visual, links))
         continue;
       let meshIndex = 0;
@@ -38080,7 +38125,8 @@ function loadRobotPreview(previewConfig, rendererContext = {}) {
     loader.workingPath = "";
     loader.loadMeshCb = (path, meshManager, material, done) => loadMesh(path, meshManager, material, done, rendererContext, diagnostics);
     const urdfUrl = repoUrl(rendererContext, previewConfig?.urdf_url || "");
-    const robot = await loader.loadAsync(urdfUrl);
+    const urdfRobotElement = await fetchValidatedUrdfRobotElement(urdfUrl);
+    const robot = loader.parse(urdfRobotElement, loader.workingPath || "");
     setLifecycleState(diagnostics, "loading_meshes");
     robot.name = rendererContext?.rootName || "workcell_studio_urdf_loader_robot";
     robot.userData.robot_render_mode = ROBOT_RENDER_MODE;

--- a/workcell_studio_web/viewer/urdf_robot_renderer.js
+++ b/workcell_studio_web/viewer/urdf_robot_renderer.js
@@ -460,6 +460,49 @@ function collectMatrixParityDiagnostics(previewConfig, diagnostics) {
   return diagnostics.robot_matrix_world_parity;
 }
 
+
+function urdfLoadError(url, status, stage, detail) {
+  const statusText = status === null || status === undefined ? 'n/a' : String(status);
+  return new Error(`URDF preview failed at ${stage}: url=${url || '<empty>'} http_status=${statusText} detail=${detail || 'unknown error'}`);
+}
+
+export async function fetchValidatedUrdfRobotElement(urdfUrl) {
+  const response = await fetch(urdfUrl, { cache: 'no-store' }).catch(err => {
+    throw urdfLoadError(urdfUrl, null, 'fetch', err?.message || String(err));
+  });
+  if (!response?.ok) {
+    throw urdfLoadError(urdfUrl, response?.status ?? null, 'http', response?.statusText || 'HTTP request failed');
+  }
+  const text = await response.text().catch(err => {
+    throw urdfLoadError(urdfUrl, response?.status ?? null, 'read', err?.message || String(err));
+  });
+  let document;
+  try {
+    if (typeof DOMParser !== 'undefined') {
+      document = new DOMParser().parseFromString(text, 'application/xml');
+    } else {
+      const trimmed = String(text || '').trim();
+      const rootMatch = trimmed.match(/^<([A-Za-z_][\w:.-]*)(\s|>|\/)/);
+      const malformed = !rootMatch || /<\//i.test(trimmed) && !new RegExp(`<\/${rootMatch?.[1]}>\\s*$`).test(trimmed);
+      document = {
+        documentElement: rootMatch ? { tagName: rootMatch[1] } : null,
+        getElementsByTagName: (name) => name === 'parsererror' && malformed ? [{ textContent: 'malformed XML' }] : [],
+      };
+    }
+  } catch (err) {
+    throw urdfLoadError(urdfUrl, response.status, 'parse_xml', err?.message || String(err));
+  }
+  const parserError = document?.getElementsByTagName?.('parsererror')?.[0];
+  if (parserError) {
+    throw urdfLoadError(urdfUrl, response.status, 'parse_xml', parserError.textContent?.trim() || 'malformed XML');
+  }
+  const root = document?.documentElement;
+  if (!root || String(root.tagName || '').toLowerCase() !== 'robot') {
+    throw urdfLoadError(urdfUrl, response.status, 'validate_robot_root', `expected top-level <robot> element, got <${root?.tagName || 'none'}>`);
+  }
+  return root;
+}
+
 function collectLinkMatrixDiagnostics(robot, links) {
   robot?.updateMatrixWorld?.(true);
   const out = {};
@@ -495,7 +538,8 @@ function collectVisualWrapperMatrixDiagnostics(links) {
   const out = [];
   for (const [linkName, link] of Object.entries(links || {})) {
     let visualIndex = 0;
-    for (const child of link.children || []) {
+    if (!link) continue;
+    for (const child of link?.children || []) {
       if (!isVisualWrapperCandidate(child, links)) continue;
       child.updateMatrixWorld?.(true);
       const position = new THREE.Vector3();
@@ -530,7 +574,8 @@ function collectDescendantRenderMeshDiagnostics(links) {
   const out = [];
   for (const [linkName, link] of Object.entries(links || {})) {
     let visualIndex = 0;
-    for (const visual of link.children || []) {
+    if (!link) continue;
+    for (const visual of link?.children || []) {
       if (!isVisualWrapperCandidate(visual, links)) continue;
       let meshIndex = 0;
       visual.updateMatrixWorld?.(true);
@@ -695,7 +740,8 @@ export function loadRobotPreview(previewConfig, rendererContext = {}) {
     loader.loadMeshCb = (path, meshManager, material, done) => loadMesh(path, meshManager, material, done, rendererContext, diagnostics);
 
     const urdfUrl = repoUrl(rendererContext, previewConfig?.urdf_url || '');
-    const robot = await loader.loadAsync(urdfUrl);
+    const urdfRobotElement = await fetchValidatedUrdfRobotElement(urdfUrl);
+    const robot = loader.parse(urdfRobotElement, loader.workingPath || '');
     setLifecycleState(diagnostics, 'loading_meshes');
     robot.name = rendererContext?.rootName || 'workcell_studio_urdf_loader_robot';
     robot.userData.robot_render_mode = ROBOT_RENDER_MODE;


### PR DESCRIPTION
Summary:
- Fetch expanded robot_preview URDFs explicitly with cache: no-store, validate HTTP success, parse XML, and require a top-level <robot> element before URDFLoader.parse().
- Guard optional robot diagnostics against undefined links / missing children so diagnostics cannot turn a successfully parsed robot into scene_failed.
- Keep package mesh URL normalization and Collada handling intact while adding the robot root only after parse, mesh completion, joint application, and diagnostics complete.
- Affected files/packages: workcell_studio_web/viewer/urdf_robot_renderer.js, workcell_studio_web/viewer/dist/viewer.bundle.js, tests/test_workcell_studio_web_viewer_static.py.

Validation:
- python3 -m pytest tests/test_workcell_studio_web_viewer_static.py -q — passed (96 passed; existing Python string escape warnings only).
- cd workcell_studio_web/viewer && npm ci — passed (npm reported one moderate vulnerability in dependency audit; no install failure).
- cd workcell_studio_web/viewer && npm run build:web3d — passed.
- cd workcell_studio_web/viewer && npm run check:stale-bundle — passed, viewer.bundle.js is current.

Safety:
- No launch, controller, hardware, runtime execution, or real-robot path changes.
- Fake-hardware defaults and guarded real-hardware behavior are unchanged.

Risks / rollback:
- Node-only tests use a minimal non-browser XML fallback for environments without DOMParser; browser Product View continues to use DOMParser.
- Roll back by reverting commit dfaaf5b if the new URDF validation path causes unexpected Product View regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a623646e290833193ee8436e3775616)