### PR TITLE
Fix false expanded URDF readiness failure

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -2592,3 +2592,111 @@ try {{
         encoding="utf-8",
     )
     subprocess.run(["node", str(script)], cwd=ROOT, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+def test_expanded_urdf_readiness_allows_legitimate_multi_visual_links_and_equivalent_records():
+    js_path = VIEWER / "viewer.js"
+    harness = r"""
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+let source = fs.readFileSync(process.argv[1], 'utf8').replace(/boot\(\);\s*$/, '');
+const element = () => ({ hidden: false, checked: false, disabled: false, textContent: '', className: '', innerHTML: '', classList: { toggle() {} }, setAttribute() {}, querySelector() { return { textContent: '' }; }, appendChild() {}, addEventListener() {}, getBoundingClientRect() { return { width: 800, height: 600, left: 0, top: 0 }; } });
+const context = { console, assert, window: { dispatched: [], location: { search: '' }, dispatchEvent(event) { this.dispatched.push(event?.detail?.state); }, parent: { postMessage() {} } }, document: { getElementById() { return element(); }, createElement() { return element(); } }, URLSearchParams, CustomEvent: function CustomEvent(type, init) { return { type, detail: init?.detail || {} }; }, requestAnimationFrame() { return 0; }, setTimeout() { return 1; }, clearTimeout() {} };
+vm.createContext(context);
+vm.runInContext(source + `
+state.sceneJson = { scene: { id: 'ur5_2f_test' }, robot_preview: { mode: 'expanded_urdf_loader', robot_instance_id: 'ur5', expected_robot_visual_links: ['base_link', 'shoulder_link'], expected_tool_visual_links: ['robotiq_85_base_link'] } };
+state.robotUrdfPreviewDiagnostics = { robot_preview_lifecycle_state: 'ready', robot_failed_visual_count: 0, robot_visual_wrapper_world_matrices: [
+  { link_name: 'base_link', visual_index: 0, object_name: 'visual_0' },
+  { link_name: 'base_link', visual_index: 1, object_name: 'visual_1' },
+  { link_name: 'shoulder_link', visual_index: 0, object_name: 'visual_0' },
+  { link_name: 'robotiq_85_base_link', visual_index: 0, object_name: 'visual_0' },
+  { link_name: 'robotiq_85_base_link', visual_index: 1, object_name: 'visual_1' },
+] };
+collectRenderedMeshDiagnostics = () => [
+  { id: 'table_generated', category: 'table', render_policy: 'primary', render_status: 'mesh_loaded', mesh_loaded: true, readiness_category: 'workbench_support_surface' },
+  { id: 'table_semantic_equivalent', category: 'table', render_policy: 'primary', render_status: 'mesh_loaded', mesh_loaded: true, readiness_category: 'workbench_support_surface' },
+  { id: 'camera_generated', category: 'camera', render_policy: 'primary', render_status: 'mesh_loaded', mesh_loaded: true, readiness_category: 'configured_camera' },
+  { id: 'camera_semantic_equivalent', category: 'camera', render_policy: 'primary', render_status: 'mesh_loaded', mesh_loaded: true, readiness_category: 'configured_camera' },
+];
+const diagnostics = expandedUrdfVisualReadinessDiagnostics();
+assert.strictEqual(diagnostics.required_visual_ready, true);
+assert.deepStrictEqual(diagnostics.missing_required_visuals, []);
+assert.deepStrictEqual(diagnostics.duplicate_required_visuals, []);
+assert.strictEqual(failIfExpandedUrdfExpectedVisualSetInvalid(), false);
+`, context);
+"""
+    subprocess.run(["node", "-e", harness, str(js_path)], cwd=ROOT, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def test_expanded_urdf_readiness_fails_missing_required_link_and_required_mesh_failure():
+    js_path = VIEWER / "viewer.js"
+    harness = r"""
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+let source = fs.readFileSync(process.argv[1], 'utf8').replace(/boot\(\);\s*$/, '');
+const element = () => ({ hidden: false, checked: false, disabled: false, textContent: '', className: '', innerHTML: '', classList: { toggle() {} }, setAttribute() {}, querySelector() { return { textContent: '' }; }, appendChild() {}, addEventListener() {}, getBoundingClientRect() { return { width: 800, height: 600, left: 0, top: 0 }; } });
+const context = { console, assert, window: { dispatched: [], location: { search: '' }, dispatchEvent(event) { this.dispatched.push(event?.detail?.state); }, parent: { postMessage() {} } }, document: { getElementById() { return element(); }, createElement() { return element(); } }, URLSearchParams, CustomEvent: function CustomEvent(type, init) { return { type, detail: init?.detail || {} }; }, requestAnimationFrame() { return 0; }, setTimeout() { return 1; }, clearTimeout() {} };
+vm.createContext(context);
+vm.runInContext(source + `
+state.sceneJson = { scene: { id: 'ur5_2f_test' }, robot_preview: { mode: 'expanded_urdf_loader', expected_robot_visual_links: ['base_link', 'shoulder_link'], expected_tool_visual_links: ['robotiq_85_base_link'] } };
+state.robotUrdfPreviewDiagnostics = { robot_preview_lifecycle_state: 'ready', robot_failed_visual_count: 0, robot_visual_wrapper_world_matrices: [
+  { link_name: 'base_link', visual_index: 0 },
+  { link_name: 'robotiq_85_base_link', visual_index: 0 },
+] };
+collectRenderedMeshDiagnostics = () => [
+  { id: 'table', category: 'table', render_policy: 'primary', render_status: 'mesh_loaded', mesh_loaded: true, readiness_category: 'workbench_support_surface' },
+  { id: 'camera', category: 'camera', render_policy: 'primary', render_status: 'mesh_loaded', mesh_loaded: true, readiness_category: 'configured_camera' },
+];
+let diagnostics = expandedUrdfVisualReadinessDiagnostics();
+assert.deepStrictEqual(diagnostics.missing_required_robot_visuals, ['shoulder_link']);
+assert.strictEqual(diagnostics.required_visual_ready, false);
+assert.strictEqual(failIfExpandedUrdfExpectedVisualSetInvalid(), true);
+assert.strictEqual(state.web3dReadiness.state, 'scene_failed');
+assert.ok(state.web3dReadiness.failure.missing_required_robot_visuals.includes('shoulder_link'));
+state.web3dReadiness = null;
+state.robotUrdfPreviewDiagnostics.robot_visual_wrapper_world_matrices.push({ link_name: 'shoulder_link', visual_index: 0 });
+state.robotUrdfPreviewDiagnostics.robot_failed_visual_count = 1;
+state.robotUrdfPreviewDiagnostics.robot_missing_meshes = ['/assets/robotiq_85_base_link.dae: 404'];
+diagnostics = expandedUrdfVisualReadinessDiagnostics();
+assert.strictEqual(diagnostics.required_visual_ready, false);
+assert.ok(diagnostics.failed_required_links.includes('expanded_urdf_loader'));
+assert.ok(diagnostics.failed_mesh_urls.includes('/assets/robotiq_85_base_link.dae'));
+assert.strictEqual(failIfExpandedUrdfExpectedVisualSetInvalid(), true);
+assert.strictEqual(state.web3dReadiness.state, 'scene_failed');
+assert.ok(state.web3dReadiness.failure.failed_mesh_urls.includes('/assets/robotiq_85_base_link.dae'));
+`, context);
+"""
+    subprocess.run(["node", "-e", harness, str(js_path)], cwd=ROOT, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def test_expanded_urdf_visible_ur5_2f_multi_visual_diagnostics_no_generic_false_failure():
+    js_path = VIEWER / "viewer.js"
+    harness = r"""
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+let source = fs.readFileSync(process.argv[1], 'utf8').replace(/boot\(\);\s*$/, '');
+const element = () => ({ hidden: false, checked: false, disabled: false, textContent: '', className: '', innerHTML: '', classList: { toggle() {} }, setAttribute() {}, querySelector() { return { textContent: '' }; }, appendChild() {}, addEventListener() {}, getBoundingClientRect() { return { width: 800, height: 600, left: 0, top: 0 }; } });
+const context = { console, assert, window: { dispatched: [], location: { search: '' }, dispatchEvent(event) { this.dispatched.push(event?.detail?.state); }, parent: { postMessage() {} } }, document: { getElementById() { return element(); }, createElement() { return element(); } }, URLSearchParams, CustomEvent: function CustomEvent(type, init) { return { type, detail: init?.detail || {} }; }, requestAnimationFrame() { return 0; }, setTimeout() { return 1; }, clearTimeout() {} };
+vm.createContext(context);
+vm.runInContext(source + `
+const robotLinks = ['base_link', 'shoulder_link', 'upper_arm_link', 'forearm_link', 'wrist_1_link', 'wrist_2_link', 'wrist_3_link'];
+const toolLinks = ['robotiq_85_base_link', 'robotiq_85_left_finger_link', 'robotiq_85_right_finger_link'];
+state.sceneJson = { scene: { id: 'ur5_2f_test' }, robot_preview: { mode: 'expanded_urdf_loader', robot_instance_id: 'ur5_2f', expected_robot_visual_links: robotLinks, expected_tool_visual_links: toolLinks } };
+state.robotUrdfPreviewDiagnostics = { robot_preview_lifecycle_state: 'ready', robot_failed_visual_count: 0, robot_visual_wrapper_world_matrices: robotLinks.concat(toolLinks).flatMap(link => [
+  { link_name: link, visual_index: 0, object_name: 'visual_0' },
+  { link_name: link, visual_index: 1, object_name: 'visual_1' },
+]) };
+collectRenderedMeshDiagnostics = () => [
+  { id: 'workbench_generated', category: 'table', render_policy: 'primary', render_status: 'mesh_loaded', mesh_loaded: true, readiness_category: 'workbench_support_surface' },
+  { id: 'configured_camera_generated', category: 'camera', render_policy: 'primary', render_status: 'mesh_loaded', mesh_loaded: true, readiness_category: 'configured_camera' },
+];
+const diagnostics = expandedUrdfVisualReadinessDiagnostics();
+assert.strictEqual(diagnostics.required_visual_ready, true);
+assert.deepStrictEqual(diagnostics.duplicate_required_visuals, []);
+assert.strictEqual(failIfExpandedUrdfExpectedVisualSetInvalid(), false);
+assert.notStrictEqual(state.web3dReadiness?.state, 'scene_failed');
+`, context);
+"""
+    subprocess.run(["node", "-e", harness, str(js_path)], cwd=ROOT, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/workcell_studio_web/viewer/dist/viewer.bundle.js
+++ b/workcell_studio_web/viewer/dist/viewer.bundle.js
@@ -38819,46 +38819,106 @@ function countBy(values) {
     counts[value] = (counts[value] || 0) + 1;
   return counts;
 }
+function expandedUrdfVisualIdentity(sceneId2, robotInstanceId, visual) {
+  const link = String(visual?.link_name || visual?.linkName || "").trim();
+  if (!link)
+    return "";
+  const visualName = String(visual?.visual_name || visual?.visualName || visual?.object_name || visual?.objectName || "").trim();
+  const visualIndex = visual?.visual_index ?? visual?.visualIndex;
+  const visualKey = visualIndex !== void 0 && visualIndex !== null && String(visualIndex).trim() !== "" ? `index:${String(visualIndex).trim()}` : `name:${visualName || "visual"}`;
+  return [sceneId2 || "<scene>", robotInstanceId || "<robot>", link, visualKey].join("|");
+}
+function renderedPhysicalVisualIdentity(sceneId2, entry) {
+  const category = readinessCategoryForItem(entry);
+  const link = String(entry?.link_name || entry?.link || entry?.frame || entry?.id || category || "").trim();
+  if (!link)
+    return "";
+  const visualName = String(entry?.visual_name || entry?.visualName || entry?.object_name || entry?.objectName || entry?.display_name || entry?.id || "").trim();
+  const visualIndex = entry?.visual_index ?? entry?.visualIndex;
+  const visualKey = visualIndex !== void 0 && visualIndex !== null && String(visualIndex).trim() !== "" ? `index:${String(visualIndex).trim()}` : `name:${visualName || "physical"}`;
+  return [sceneId2 || "<scene>", String(entry?.robot_instance_id || entry?.robotInstanceId || entry?.source_instance || entry?.sourceInstance || "physical").trim() || "physical", link, visualKey].join("|");
+}
+function dedupeByStableIdentity(records, identityFn) {
+  const byIdentity = /* @__PURE__ */ new Map();
+  const duplicates = [];
+  for (const record of records || []) {
+    const identity = identityFn(record);
+    if (!identity)
+      continue;
+    if (byIdentity.has(identity))
+      duplicates.push(identity);
+    else
+      byIdentity.set(identity, record);
+  }
+  return { records: Array.from(byIdentity.values()), duplicateIdentities: Array.from(new Set(duplicates)) };
+}
+function isSuccessfulPhysicalVisualDiagnostic(entry) {
+  if (!entry || entry.debug_overlay || entry.debugOverlay)
+    return false;
+  if (entry.mesh_loaded !== true && entry.meshLoaded !== true && entry.render_status !== "mesh_loaded" && entry.renderStatus !== "mesh_loaded")
+    return false;
+  return Boolean(readinessCategoryForItem(entry));
+}
+function failedRequiredMeshUrlFromEntry(entry) {
+  const url = entry?.mesh_uri || entry?.meshUri || entry?.url || entry?.source_url || entry?.sourceUrl || "";
+  return String(url || "").trim();
+}
 function expandedUrdfVisualReadinessDiagnostics() {
   const required = expandedUrdfExpectedVisualSet();
   if (!required)
     return null;
-  const urdfVisualLinks = asArray(state.robotUrdfPreviewDiagnostics?.robot_visual_wrapper_world_matrices).map((visual) => String(visual?.link_name || visual?.linkName || "").trim()).filter(Boolean);
-  const urdfCounts = countBy(urdfVisualLinks);
+  const sceneId2 = required.scene_id || required.sceneId || "";
+  const preview = state.sceneJson?.robot_preview || {};
+  const robotInstanceId = String(preview.robot_instance_id || preview.robotInstanceId || preview.instance_id || preview.instanceId || preview.id || "expanded_urdf_robot").trim();
+  const rawUrdfVisuals = asArray(state.robotUrdfPreviewDiagnostics?.robot_visual_wrapper_world_matrices);
+  const urdfDedupe = dedupeByStableIdentity(rawUrdfVisuals, (visual) => expandedUrdfVisualIdentity(sceneId2, robotInstanceId, visual));
+  const urdfVisuals = urdfDedupe.records;
+  const urdfLinksWithLoadedVisuals = new Set(urdfVisuals.map((visual) => String(visual?.link_name || visual?.linkName || "").trim()).filter(Boolean));
+  const urdfCounts = countBy(urdfVisuals.map((visual) => String(visual?.link_name || visual?.linkName || "").trim()).filter(Boolean));
   const sceneDiagnostics = collectRenderedMeshDiagnostics();
-  const categoryCounts = countBy(sceneDiagnostics.map((item) => readinessCategoryForItem(item)).filter(Boolean));
+  const physicalDiagnostics = dedupeByStableIdentity(sceneDiagnostics.filter(isSuccessfulPhysicalVisualDiagnostic), (entry) => renderedPhysicalVisualIdentity(sceneId2, entry));
+  const categoryCounts = countBy(physicalDiagnostics.records.map((item) => readinessCategoryForItem(item)).filter(Boolean));
   const missingRobot = [];
   const missingTool = [];
-  const duplicate = [];
-  const failed = [];
+  const failedLinks = [];
+  const failedMeshUrls = [];
+  const requiredLinks = new Set(required.robot_visuals.concat(required.tool_visuals));
   for (const link of required.robot_visuals) {
-    const count = urdfCounts[link] || 0;
-    if (count === 0)
+    if (!urdfLinksWithLoadedVisuals.has(link))
       missingRobot.push(link);
-    if (count > 1)
-      duplicate.push(link);
   }
   for (const link of required.tool_visuals) {
-    const count = urdfCounts[link] || 0;
-    if (count === 0)
+    if (!urdfLinksWithLoadedVisuals.has(link))
       missingTool.push(link);
-    if (count > 1)
-      duplicate.push(link);
   }
   for (const category of required.table_visuals.concat(required.camera_visuals)) {
-    const count = categoryCounts[category] || 0;
-    if (count === 0)
-      failed.push(category);
-    if (count > 1)
-      duplicate.push(category);
+    if ((categoryCounts[category] || 0) === 0)
+      failedLinks.push(category);
   }
   for (const entry of sceneDiagnostics) {
-    if (isRequiredMeshFailureStatus({ item: entry, renderInfo: { render_status: entry.render_status } }))
-      failed.push(entry.link_name || entry.id || entry.category);
+    const link = String(entry.link_name || entry.link || entry.id || entry.category || "").trim();
+    const category = readinessCategoryForItem(entry);
+    const requiredPhysical = requiredLinks.has(link) || required.table_visuals.includes(category) || required.camera_visuals.includes(category);
+    if (!requiredPhysical)
+      continue;
+    if (isRequiredMeshFailureStatus({ item: entry, renderInfo: { render_status: entry.render_status } })) {
+      failedLinks.push(link || category);
+      const url = failedRequiredMeshUrlFromEntry(entry);
+      if (url)
+        failedMeshUrls.push(url);
+    }
   }
-  if (Number(state.robotUrdfPreviewDiagnostics?.robot_failed_visual_count || 0) > 0)
-    failed.push("expanded_urdf_loader");
+  for (const detail of asArray(state.robotUrdfPreviewDiagnostics?.robot_missing_meshes)) {
+    const text = String(detail || "").trim();
+    if (text)
+      failedMeshUrls.push(text.split(": ")[0] || text);
+  }
+  if (Number(state.robotUrdfPreviewDiagnostics?.robot_failed_visual_count || 0) > 0) {
+    failedLinks.push("expanded_urdf_loader");
+  }
   const missing = missingRobot.concat(missingTool);
+  const failed = Array.from(new Set(failedLinks.filter(Boolean)));
+  const duplicatePhysicalIdentities = Array.from(new Set(urdfDedupe.duplicateIdentities.concat(physicalDiagnostics.duplicateIdentities)));
   return {
     expanded_urdf_expected_visual_set: required,
     expandedUrdfExpectedVisualSet: required,
@@ -38870,12 +38930,18 @@ function expandedUrdfVisualReadinessDiagnostics() {
     missingRequiredToolVisuals: missingTool,
     missing_required_visuals: missing,
     missingRequiredVisuals: missing,
-    duplicate_required_visuals: duplicate,
-    duplicateRequiredVisuals: duplicate,
-    failed_required_visuals: Array.from(new Set(failed)),
-    failedRequiredVisuals: Array.from(new Set(failed)),
-    required_visual_ready: missing.length === 0 && duplicate.length === 0 && failed.length === 0,
-    requiredVisualReady: missing.length === 0 && duplicate.length === 0 && failed.length === 0
+    duplicate_required_visuals: duplicatePhysicalIdentities,
+    duplicateRequiredVisuals: duplicatePhysicalIdentities,
+    duplicate_physical_visual_identities: duplicatePhysicalIdentities,
+    duplicatePhysicalVisualIdentities: duplicatePhysicalIdentities,
+    failed_required_visuals: failed,
+    failedRequiredVisuals: failed,
+    failed_required_links: failed,
+    failedRequiredLinks: failed,
+    failed_mesh_urls: Array.from(new Set(failedMeshUrls)),
+    failedMeshUrls: Array.from(new Set(failedMeshUrls)),
+    required_visual_ready: missing.length === 0 && failed.length === 0 && duplicatePhysicalIdentities.length === 0,
+    requiredVisualReady: missing.length === 0 && failed.length === 0 && duplicatePhysicalIdentities.length === 0
   };
 }
 function failIfExpandedUrdfExpectedVisualSetInvalid() {

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -495,39 +495,96 @@ function countBy(values) {
   for (const value of values || []) counts[value] = (counts[value] || 0) + 1;
   return counts;
 }
+function expandedUrdfVisualIdentity(sceneId, robotInstanceId, visual) {
+  const link = String(visual?.link_name || visual?.linkName || '').trim();
+  if (!link) return '';
+  const visualName = String(visual?.visual_name || visual?.visualName || visual?.object_name || visual?.objectName || '').trim();
+  const visualIndex = visual?.visual_index ?? visual?.visualIndex;
+  const visualKey = visualIndex !== undefined && visualIndex !== null && String(visualIndex).trim() !== ''
+    ? `index:${String(visualIndex).trim()}`
+    : `name:${visualName || 'visual'}`;
+  return [sceneId || '<scene>', robotInstanceId || '<robot>', link, visualKey].join('|');
+}
+function renderedPhysicalVisualIdentity(sceneId, entry) {
+  const category = readinessCategoryForItem(entry);
+  const link = String(entry?.link_name || entry?.link || entry?.frame || entry?.id || category || '').trim();
+  if (!link) return '';
+  const visualName = String(entry?.visual_name || entry?.visualName || entry?.object_name || entry?.objectName || entry?.display_name || entry?.id || '').trim();
+  const visualIndex = entry?.visual_index ?? entry?.visualIndex;
+  const visualKey = visualIndex !== undefined && visualIndex !== null && String(visualIndex).trim() !== ''
+    ? `index:${String(visualIndex).trim()}`
+    : `name:${visualName || 'physical'}`;
+  return [sceneId || '<scene>', String(entry?.robot_instance_id || entry?.robotInstanceId || entry?.source_instance || entry?.sourceInstance || 'physical').trim() || 'physical', link, visualKey].join('|');
+}
+function dedupeByStableIdentity(records, identityFn) {
+  const byIdentity = new Map();
+  const duplicates = [];
+  for (const record of records || []) {
+    const identity = identityFn(record);
+    if (!identity) continue;
+    if (byIdentity.has(identity)) duplicates.push(identity);
+    else byIdentity.set(identity, record);
+  }
+  return { records: Array.from(byIdentity.values()), duplicateIdentities: Array.from(new Set(duplicates)) };
+}
+function isSuccessfulPhysicalVisualDiagnostic(entry) {
+  if (!entry || entry.debug_overlay || entry.debugOverlay) return false;
+  if (entry.mesh_loaded !== true && entry.meshLoaded !== true && entry.render_status !== 'mesh_loaded' && entry.renderStatus !== 'mesh_loaded') return false;
+  return Boolean(readinessCategoryForItem(entry));
+}
+function failedRequiredMeshUrlFromEntry(entry) {
+  const url = entry?.mesh_uri || entry?.meshUri || entry?.url || entry?.source_url || entry?.sourceUrl || '';
+  return String(url || '').trim();
+}
 function expandedUrdfVisualReadinessDiagnostics() {
   const required = expandedUrdfExpectedVisualSet();
   if (!required) return null;
-  const urdfVisualLinks = asArray(state.robotUrdfPreviewDiagnostics?.robot_visual_wrapper_world_matrices)
-    .map(visual => String(visual?.link_name || visual?.linkName || '').trim())
-    .filter(Boolean);
-  const urdfCounts = countBy(urdfVisualLinks);
+  const sceneId = required.scene_id || required.sceneId || '';
+  const preview = state.sceneJson?.robot_preview || {};
+  const robotInstanceId = String(preview.robot_instance_id || preview.robotInstanceId || preview.instance_id || preview.instanceId || preview.id || 'expanded_urdf_robot').trim();
+  const rawUrdfVisuals = asArray(state.robotUrdfPreviewDiagnostics?.robot_visual_wrapper_world_matrices);
+  const urdfDedupe = dedupeByStableIdentity(rawUrdfVisuals, visual => expandedUrdfVisualIdentity(sceneId, robotInstanceId, visual));
+  const urdfVisuals = urdfDedupe.records;
+  const urdfLinksWithLoadedVisuals = new Set(urdfVisuals.map(visual => String(visual?.link_name || visual?.linkName || '').trim()).filter(Boolean));
+  const urdfCounts = countBy(urdfVisuals.map(visual => String(visual?.link_name || visual?.linkName || '').trim()).filter(Boolean));
   const sceneDiagnostics = collectRenderedMeshDiagnostics();
-  const categoryCounts = countBy(sceneDiagnostics.map(item => readinessCategoryForItem(item)).filter(Boolean));
+  const physicalDiagnostics = dedupeByStableIdentity(sceneDiagnostics.filter(isSuccessfulPhysicalVisualDiagnostic), entry => renderedPhysicalVisualIdentity(sceneId, entry));
+  const categoryCounts = countBy(physicalDiagnostics.records.map(item => readinessCategoryForItem(item)).filter(Boolean));
   const missingRobot = [];
   const missingTool = [];
-  const duplicate = [];
-  const failed = [];
+  const failedLinks = [];
+  const failedMeshUrls = [];
+  const requiredLinks = new Set(required.robot_visuals.concat(required.tool_visuals));
   for (const link of required.robot_visuals) {
-    const count = urdfCounts[link] || 0;
-    if (count === 0) missingRobot.push(link);
-    if (count > 1) duplicate.push(link);
+    if (!urdfLinksWithLoadedVisuals.has(link)) missingRobot.push(link);
   }
   for (const link of required.tool_visuals) {
-    const count = urdfCounts[link] || 0;
-    if (count === 0) missingTool.push(link);
-    if (count > 1) duplicate.push(link);
+    if (!urdfLinksWithLoadedVisuals.has(link)) missingTool.push(link);
   }
   for (const category of required.table_visuals.concat(required.camera_visuals)) {
-    const count = categoryCounts[category] || 0;
-    if (count === 0) failed.push(category);
-    if (count > 1) duplicate.push(category);
+    if ((categoryCounts[category] || 0) === 0) failedLinks.push(category);
   }
   for (const entry of sceneDiagnostics) {
-    if (isRequiredMeshFailureStatus({ item: entry, renderInfo: { render_status: entry.render_status } })) failed.push(entry.link_name || entry.id || entry.category);
+    const link = String(entry.link_name || entry.link || entry.id || entry.category || '').trim();
+    const category = readinessCategoryForItem(entry);
+    const requiredPhysical = requiredLinks.has(link) || required.table_visuals.includes(category) || required.camera_visuals.includes(category);
+    if (!requiredPhysical) continue;
+    if (isRequiredMeshFailureStatus({ item: entry, renderInfo: { render_status: entry.render_status } })) {
+      failedLinks.push(link || category);
+      const url = failedRequiredMeshUrlFromEntry(entry);
+      if (url) failedMeshUrls.push(url);
+    }
   }
-  if (Number(state.robotUrdfPreviewDiagnostics?.robot_failed_visual_count || 0) > 0) failed.push('expanded_urdf_loader');
+  for (const detail of asArray(state.robotUrdfPreviewDiagnostics?.robot_missing_meshes)) {
+    const text = String(detail || '').trim();
+    if (text) failedMeshUrls.push(text.split(': ')[0] || text);
+  }
+  if (Number(state.robotUrdfPreviewDiagnostics?.robot_failed_visual_count || 0) > 0) {
+    failedLinks.push('expanded_urdf_loader');
+  }
   const missing = missingRobot.concat(missingTool);
+  const failed = Array.from(new Set(failedLinks.filter(Boolean)));
+  const duplicatePhysicalIdentities = Array.from(new Set(urdfDedupe.duplicateIdentities.concat(physicalDiagnostics.duplicateIdentities)));
   return {
     expanded_urdf_expected_visual_set: required,
     expandedUrdfExpectedVisualSet: required,
@@ -539,12 +596,18 @@ function expandedUrdfVisualReadinessDiagnostics() {
     missingRequiredToolVisuals: missingTool,
     missing_required_visuals: missing,
     missingRequiredVisuals: missing,
-    duplicate_required_visuals: duplicate,
-    duplicateRequiredVisuals: duplicate,
-    failed_required_visuals: Array.from(new Set(failed)),
-    failedRequiredVisuals: Array.from(new Set(failed)),
-    required_visual_ready: missing.length === 0 && duplicate.length === 0 && failed.length === 0,
-    requiredVisualReady: missing.length === 0 && duplicate.length === 0 && failed.length === 0,
+    duplicate_required_visuals: duplicatePhysicalIdentities,
+    duplicateRequiredVisuals: duplicatePhysicalIdentities,
+    duplicate_physical_visual_identities: duplicatePhysicalIdentities,
+    duplicatePhysicalVisualIdentities: duplicatePhysicalIdentities,
+    failed_required_visuals: failed,
+    failedRequiredVisuals: failed,
+    failed_required_links: failed,
+    failedRequiredLinks: failed,
+    failed_mesh_urls: Array.from(new Set(failedMeshUrls)),
+    failedMeshUrls: Array.from(new Set(failedMeshUrls)),
+    required_visual_ready: missing.length === 0 && failed.length === 0 && duplicatePhysicalIdentities.length === 0,
+    requiredVisualReady: missing.length === 0 && failed.length === 0 && duplicatePhysicalIdentities.length === 0,
   };
 }
 function failIfExpandedUrdfExpectedVisualSetInvalid() {


### PR DESCRIPTION
### Motivation
- Product View sometimes emitted a generic `scene_failed` because expanded-URDF diagnostics treated multiple legitimate `<visual>` wrappers or equivalent generated/semantic records as missing/duplicated, causing false failures for UR5 + Robotiq scenes. 
- The intent is to treat a required robot/tool link as satisfied when the expected link is present and at least one physical visual loaded, while preserving fatal behavior for truly missing links or failed mesh loads.

### Description
- Change readiness logic to validate required robot/tool links by presence of the expected link and by confirming at least one successful physical visual is loaded, rather than counting visual wrappers as fatal duplicates. 
- Add stable identity de-duplication functions (`expandedUrdfVisualIdentity`, `renderedPhysicalVisualIdentity`, `dedupeByStableIdentity`) to collapse repeated diagnostic records by stable key (scene + robot instance + link + visual index/name). 
- Tighten table/camera readiness to require at least one successful physical visual and collect structured diagnostics including `missing_required_robot_visuals`, `missing_required_tool_visuals`, `failed_required_links`, `failed_mesh_urls`, and `duplicate_physical_visual_identities`. 
- Keep real missing links and required-mesh failures as terminal `scene_failed` conditions, and update three files only: `workcell_studio_web/viewer/viewer.js`, `tests/test_workcell_studio_web_viewer_static.py`, and `workcell_studio_web/viewer/dist/viewer.bundle.js` (rebuilt bundle). 

### Testing
- Ran `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py -q` and observed the test suite pass with `99 passed` (existing warnings retained). 
- In the viewer package ran `npm ci`, `npm run build:web3d`, and `npm run check:stale-bundle` and confirmed the bundle rebuilt successfully and is current. 
- Added focused tests proving multi-visual UR5/Robotiq links reach `scene_ready`, that equivalent generated/semantic records do not cause failure, that a truly missing required link causes `scene_failed`, and that a required mesh load failure causes `scene_failed` (all exercised by the updated static tests above which passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a623ecc82b88331bb09b91239c81849)