### PR TITLE
Use authoritative expanded URDF readiness

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -2222,7 +2222,8 @@ def test_viewer_uses_expanded_urdf_expected_visual_metadata_not_ur5_2f_constants
     assert "expected_tool_visual_links" in js
     assert "missing_required_robot_visuals" in js
     assert "missing_required_tool_visuals" in js
-    assert "expanded URDF expected robot/tool visuals are missing, failed, or duplicated" in js
+    assert "expanded URDF expected robot/tool visuals are missing or failed" in js
+    assert "expanded URDF renderer reported required robot/tool visual failure" in js
     readiness_body = js.split("function failExpandedUrdfReadiness", 1)[1].split("function maybeEmitSceneReady", 1)[0]
     assert "attached_tool_gripper" in readiness_body
     assert "expected_tool_visual_links" in readiness_body
@@ -2605,8 +2606,9 @@ const context = { console, assert, window: { dispatched: [], location: { search:
 vm.createContext(context);
 vm.runInContext(source + `
 state.sceneJson = { scene: { id: 'ur5_2f_test' }, robot_preview: { mode: 'expanded_urdf_loader', robot_instance_id: 'ur5', expected_robot_visual_links: ['base_link', 'shoulder_link'], expected_tool_visual_links: ['robotiq_85_base_link'] } };
-state.robotUrdfPreviewDiagnostics = { robot_preview_lifecycle_state: 'ready', robot_failed_visual_count: 0, robot_visual_wrapper_world_matrices: [
+state.robotUrdfPreviewDiagnostics = { robot_preview_lifecycle_state: 'ready', robot_preview_loaded: true, robot_failed_visual_count: 0, robot_visual_wrapper_world_matrices: [
   { link_name: 'base_link', visual_index: 0, object_name: 'visual_0' },
+  { link_name: 'base_link', visual_index: 0, object_name: 'visual_0_duplicate_wrapper' },
   { link_name: 'base_link', visual_index: 1, object_name: 'visual_1' },
   { link_name: 'shoulder_link', visual_index: 0, object_name: 'visual_0' },
   { link_name: 'robotiq_85_base_link', visual_index: 0, object_name: 'visual_0' },
@@ -2621,8 +2623,11 @@ collectRenderedMeshDiagnostics = () => [
 const diagnostics = expandedUrdfVisualReadinessDiagnostics();
 assert.strictEqual(diagnostics.required_visual_ready, true);
 assert.deepStrictEqual(diagnostics.missing_required_visuals, []);
-assert.deepStrictEqual(diagnostics.duplicate_required_visuals, []);
+assert.ok(diagnostics.duplicate_physical_visual_identities.length > 0);
+state.web3dReadiness = { state: 'scene_loading', emittedSceneReady: false, required: { robot_arm: true, attached_tool_gripper: true, workbench_support_surface: true, configured_camera: true }, pending: new Set(['robot_arm:expanded_urdf_loader', 'attached_tool_gripper:expanded_urdf_loader']), failed: false, failure: null };
 assert.strictEqual(failIfExpandedUrdfExpectedVisualSetInvalid(), false);
+completeExpandedUrdfReadiness({ diagnostics: state.robotUrdfPreviewDiagnostics });
+assert.strictEqual(state.web3dReadiness.state, 'scene_ready');
 `, context);
 """
     subprocess.run(["node", "-e", harness, str(js_path)], cwd=ROOT, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -2640,7 +2645,7 @@ const context = { console, assert, window: { dispatched: [], location: { search:
 vm.createContext(context);
 vm.runInContext(source + `
 state.sceneJson = { scene: { id: 'ur5_2f_test' }, robot_preview: { mode: 'expanded_urdf_loader', expected_robot_visual_links: ['base_link', 'shoulder_link'], expected_tool_visual_links: ['robotiq_85_base_link'] } };
-state.robotUrdfPreviewDiagnostics = { robot_preview_lifecycle_state: 'ready', robot_failed_visual_count: 0, robot_visual_wrapper_world_matrices: [
+state.robotUrdfPreviewDiagnostics = { robot_preview_lifecycle_state: 'failed', robot_preview_loaded: false, robot_failed_visual_count: 0, robot_missing_required_robot_visual_links: ['shoulder_link'], robot_missing_required_tool_visual_links: [], robot_visual_wrapper_world_matrices: [
   { link_name: 'base_link', visual_index: 0 },
   { link_name: 'robotiq_85_base_link', visual_index: 0 },
 ] };
@@ -2684,7 +2689,7 @@ vm.runInContext(source + `
 const robotLinks = ['base_link', 'shoulder_link', 'upper_arm_link', 'forearm_link', 'wrist_1_link', 'wrist_2_link', 'wrist_3_link'];
 const toolLinks = ['robotiq_85_base_link', 'robotiq_85_left_finger_link', 'robotiq_85_right_finger_link'];
 state.sceneJson = { scene: { id: 'ur5_2f_test' }, robot_preview: { mode: 'expanded_urdf_loader', robot_instance_id: 'ur5_2f', expected_robot_visual_links: robotLinks, expected_tool_visual_links: toolLinks } };
-state.robotUrdfPreviewDiagnostics = { robot_preview_lifecycle_state: 'ready', robot_failed_visual_count: 0, robot_visual_wrapper_world_matrices: robotLinks.concat(toolLinks).flatMap(link => [
+state.robotUrdfPreviewDiagnostics = { robot_preview_lifecycle_state: 'ready', robot_preview_loaded: true, robot_failed_visual_count: 0, robot_visual_wrapper_world_matrices: robotLinks.concat(toolLinks).flatMap(link => [
   { link_name: link, visual_index: 0, object_name: 'visual_0' },
   { link_name: link, visual_index: 1, object_name: 'visual_1' },
 ]) };
@@ -2694,7 +2699,7 @@ collectRenderedMeshDiagnostics = () => [
 ];
 const diagnostics = expandedUrdfVisualReadinessDiagnostics();
 assert.strictEqual(diagnostics.required_visual_ready, true);
-assert.deepStrictEqual(diagnostics.duplicate_required_visuals, []);
+assert.ok(Array.isArray(diagnostics.duplicate_physical_visual_identities));
 assert.strictEqual(failIfExpandedUrdfExpectedVisualSetInvalid(), false);
 assert.notStrictEqual(state.web3dReadiness?.state, 'scene_failed');
 `, context);

--- a/workcell_studio_web/viewer/dist/viewer.bundle.js
+++ b/workcell_studio_web/viewer/dist/viewer.bundle.js
@@ -38859,18 +38859,15 @@ function isSuccessfulPhysicalVisualDiagnostic(entry) {
     return false;
   return Boolean(readinessCategoryForItem(entry));
 }
-function failedRequiredMeshUrlFromEntry(entry) {
-  const url = entry?.mesh_uri || entry?.meshUri || entry?.url || entry?.source_url || entry?.sourceUrl || "";
-  return String(url || "").trim();
-}
 function expandedUrdfVisualReadinessDiagnostics() {
   const required = expandedUrdfExpectedVisualSet();
   if (!required)
     return null;
+  const rendererDiagnostics = state.robotUrdfPreviewDiagnostics || {};
   const sceneId2 = required.scene_id || required.sceneId || "";
   const preview = state.sceneJson?.robot_preview || {};
   const robotInstanceId = String(preview.robot_instance_id || preview.robotInstanceId || preview.instance_id || preview.instanceId || preview.id || "expanded_urdf_robot").trim();
-  const rawUrdfVisuals = asArray(state.robotUrdfPreviewDiagnostics?.robot_visual_wrapper_world_matrices);
+  const rawUrdfVisuals = asArray(rendererDiagnostics.robot_visual_wrapper_world_matrices);
   const urdfDedupe = dedupeByStableIdentity(rawUrdfVisuals, (visual) => expandedUrdfVisualIdentity(sceneId2, robotInstanceId, visual));
   const urdfVisuals = urdfDedupe.records;
   const urdfLinksWithLoadedVisuals = new Set(urdfVisuals.map((visual) => String(visual?.link_name || visual?.linkName || "").trim()).filter(Boolean));
@@ -38878,52 +38875,52 @@ function expandedUrdfVisualReadinessDiagnostics() {
   const sceneDiagnostics = collectRenderedMeshDiagnostics();
   const physicalDiagnostics = dedupeByStableIdentity(sceneDiagnostics.filter(isSuccessfulPhysicalVisualDiagnostic), (entry) => renderedPhysicalVisualIdentity(sceneId2, entry));
   const categoryCounts = countBy(physicalDiagnostics.records.map((item) => readinessCategoryForItem(item)).filter(Boolean));
-  const missingRobot = [];
-  const missingTool = [];
-  const failedLinks = [];
-  const failedMeshUrls = [];
-  const requiredLinks = new Set(required.robot_visuals.concat(required.tool_visuals));
-  for (const link of required.robot_visuals) {
-    if (!urdfLinksWithLoadedVisuals.has(link))
-      missingRobot.push(link);
-  }
-  for (const link of required.tool_visuals) {
-    if (!urdfLinksWithLoadedVisuals.has(link))
-      missingTool.push(link);
-  }
-  for (const category of required.table_visuals.concat(required.camera_visuals)) {
-    if ((categoryCounts[category] || 0) === 0)
-      failedLinks.push(category);
-  }
-  for (const entry of sceneDiagnostics) {
-    const link = String(entry.link_name || entry.link || entry.id || entry.category || "").trim();
-    const category = readinessCategoryForItem(entry);
-    const requiredPhysical = requiredLinks.has(link) || required.table_visuals.includes(category) || required.camera_visuals.includes(category);
-    if (!requiredPhysical)
-      continue;
-    if (isRequiredMeshFailureStatus({ item: entry, renderInfo: { render_status: entry.render_status } })) {
-      failedLinks.push(link || category);
-      const url = failedRequiredMeshUrlFromEntry(entry);
-      if (url)
-        failedMeshUrls.push(url);
+  const rendererLifecycle = String(rendererDiagnostics.robot_preview_lifecycle_state || rendererDiagnostics.robotPreviewLifecycleState || "");
+  const rendererLoaded = rendererDiagnostics.robot_preview_loaded === true || rendererDiagnostics.robotPreviewLoaded === true;
+  const rendererFailedVisualCount = Number(rendererDiagnostics.robot_failed_visual_count ?? rendererDiagnostics.robotFailedVisualCount ?? 0) || 0;
+  const rendererReady = rendererLifecycle === "ready" && rendererLoaded && rendererFailedVisualCount === 0;
+  const missingRobot = rendererReady ? [] : asArray(rendererDiagnostics.robot_missing_required_robot_visual_links || rendererDiagnostics.robotMissingRequiredRobotVisualLinks).map((value) => String(value || "").trim()).filter(Boolean);
+  const missingTool = rendererReady ? [] : asArray(rendererDiagnostics.robot_missing_required_tool_visual_links || rendererDiagnostics.robotMissingRequiredToolVisualLinks).map((value) => String(value || "").trim()).filter(Boolean);
+  if (!rendererReady && missingRobot.length === 0 && missingTool.length === 0 && !rendererLoaded) {
+    for (const link of required.robot_visuals) {
+      if (!urdfLinksWithLoadedVisuals.has(link))
+        missingRobot.push(link);
+    }
+    for (const link of required.tool_visuals) {
+      if (!urdfLinksWithLoadedVisuals.has(link))
+        missingTool.push(link);
     }
   }
-  for (const detail of asArray(state.robotUrdfPreviewDiagnostics?.robot_missing_meshes)) {
+  const failedLinks = [];
+  const failedMeshUrls = [];
+  for (const detail of asArray(rendererDiagnostics.robot_missing_meshes)) {
     const text = String(detail || "").trim();
     if (text)
       failedMeshUrls.push(text.split(": ")[0] || text);
   }
-  if (Number(state.robotUrdfPreviewDiagnostics?.robot_failed_visual_count || 0) > 0) {
+  if (rendererFailedVisualCount > 0)
     failedLinks.push("expanded_urdf_loader");
-  }
-  const missing = missingRobot.concat(missingTool);
+  const missing = Array.from(new Set(missingRobot.concat(missingTool).filter(Boolean)));
   const failed = Array.from(new Set(failedLinks.filter(Boolean)));
   const duplicatePhysicalIdentities = Array.from(new Set(urdfDedupe.duplicateIdentities.concat(physicalDiagnostics.duplicateIdentities)));
+  const requiredVisualReady = rendererReady || missing.length === 0 && failed.length === 0;
   return {
     expanded_urdf_expected_visual_set: required,
     expandedUrdfExpectedVisualSet: required,
     expanded_urdf_required_visual_counts: { ...urdfCounts, ...categoryCounts },
     expandedUrdfRequiredVisualCounts: { ...urdfCounts, ...categoryCounts },
+    robot_preview_lifecycle_state: rendererLifecycle,
+    robotPreviewLifecycleState: rendererLifecycle,
+    robot_preview_loaded: rendererLoaded,
+    robotPreviewLoaded: rendererLoaded,
+    robot_failed_visual_count: rendererFailedVisualCount,
+    robotFailedVisualCount: rendererFailedVisualCount,
+    robot_missing_meshes: asArray(rendererDiagnostics.robot_missing_meshes),
+    robotMissingMeshes: asArray(rendererDiagnostics.robot_missing_meshes || rendererDiagnostics.robotMissingMeshes),
+    robot_missing_required_robot_visual_links: missingRobot,
+    robotMissingRequiredRobotVisualLinks: missingRobot,
+    robot_missing_required_tool_visual_links: missingTool,
+    robotMissingRequiredToolVisualLinks: missingTool,
     missing_required_robot_visuals: missingRobot,
     missingRequiredRobotVisuals: missingRobot,
     missing_required_tool_visuals: missingTool,
@@ -38940,8 +38937,8 @@ function expandedUrdfVisualReadinessDiagnostics() {
     failedRequiredLinks: failed,
     failed_mesh_urls: Array.from(new Set(failedMeshUrls)),
     failedMeshUrls: Array.from(new Set(failedMeshUrls)),
-    required_visual_ready: missing.length === 0 && failed.length === 0 && duplicatePhysicalIdentities.length === 0,
-    requiredVisualReady: missing.length === 0 && failed.length === 0 && duplicatePhysicalIdentities.length === 0
+    required_visual_ready: requiredVisualReady,
+    requiredVisualReady
   };
 }
 function failIfExpandedUrdfExpectedVisualSetInvalid() {
@@ -38951,10 +38948,11 @@ function failIfExpandedUrdfExpectedVisualSetInvalid() {
   const diagnostics = expandedUrdfVisualReadinessDiagnostics();
   if (!diagnostics || diagnostics.required_visual_ready)
     return false;
-  const requiredCategory = diagnostics.missing_required_tool_visuals?.length ? "attached_tool_gripper" : "robot_arm";
+  const requiredCategory = diagnostics.robot_missing_required_tool_visual_links?.length ? "attached_tool_gripper" : "robot_arm";
+  const reason = diagnostics.robot_preview_loaded ? "expanded URDF renderer reported required robot/tool visual failure" : "expanded URDF expected robot/tool visuals are missing or failed";
   emitWeb3dReadinessState("scene_failed", {
     required_category: requiredCategory,
-    reason: "expanded URDF expected robot/tool visuals are missing, failed, or duplicated",
+    reason,
     ...diagnostics
   });
   return true;

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -539,10 +539,11 @@ function failedRequiredMeshUrlFromEntry(entry) {
 function expandedUrdfVisualReadinessDiagnostics() {
   const required = expandedUrdfExpectedVisualSet();
   if (!required) return null;
+  const rendererDiagnostics = state.robotUrdfPreviewDiagnostics || {};
   const sceneId = required.scene_id || required.sceneId || '';
   const preview = state.sceneJson?.robot_preview || {};
   const robotInstanceId = String(preview.robot_instance_id || preview.robotInstanceId || preview.instance_id || preview.instanceId || preview.id || 'expanded_urdf_robot').trim();
-  const rawUrdfVisuals = asArray(state.robotUrdfPreviewDiagnostics?.robot_visual_wrapper_world_matrices);
+  const rawUrdfVisuals = asArray(rendererDiagnostics.robot_visual_wrapper_world_matrices);
   const urdfDedupe = dedupeByStableIdentity(rawUrdfVisuals, visual => expandedUrdfVisualIdentity(sceneId, robotInstanceId, visual));
   const urdfVisuals = urdfDedupe.records;
   const urdfLinksWithLoadedVisuals = new Set(urdfVisuals.map(visual => String(visual?.link_name || visual?.linkName || '').trim()).filter(Boolean));
@@ -550,46 +551,52 @@ function expandedUrdfVisualReadinessDiagnostics() {
   const sceneDiagnostics = collectRenderedMeshDiagnostics();
   const physicalDiagnostics = dedupeByStableIdentity(sceneDiagnostics.filter(isSuccessfulPhysicalVisualDiagnostic), entry => renderedPhysicalVisualIdentity(sceneId, entry));
   const categoryCounts = countBy(physicalDiagnostics.records.map(item => readinessCategoryForItem(item)).filter(Boolean));
-  const missingRobot = [];
-  const missingTool = [];
-  const failedLinks = [];
-  const failedMeshUrls = [];
-  const requiredLinks = new Set(required.robot_visuals.concat(required.tool_visuals));
-  for (const link of required.robot_visuals) {
-    if (!urdfLinksWithLoadedVisuals.has(link)) missingRobot.push(link);
-  }
-  for (const link of required.tool_visuals) {
-    if (!urdfLinksWithLoadedVisuals.has(link)) missingTool.push(link);
-  }
-  for (const category of required.table_visuals.concat(required.camera_visuals)) {
-    if ((categoryCounts[category] || 0) === 0) failedLinks.push(category);
-  }
-  for (const entry of sceneDiagnostics) {
-    const link = String(entry.link_name || entry.link || entry.id || entry.category || '').trim();
-    const category = readinessCategoryForItem(entry);
-    const requiredPhysical = requiredLinks.has(link) || required.table_visuals.includes(category) || required.camera_visuals.includes(category);
-    if (!requiredPhysical) continue;
-    if (isRequiredMeshFailureStatus({ item: entry, renderInfo: { render_status: entry.render_status } })) {
-      failedLinks.push(link || category);
-      const url = failedRequiredMeshUrlFromEntry(entry);
-      if (url) failedMeshUrls.push(url);
+  const rendererLifecycle = String(rendererDiagnostics.robot_preview_lifecycle_state || rendererDiagnostics.robotPreviewLifecycleState || '');
+  const rendererLoaded = rendererDiagnostics.robot_preview_loaded === true || rendererDiagnostics.robotPreviewLoaded === true;
+  const rendererFailedVisualCount = Number(rendererDiagnostics.robot_failed_visual_count ?? rendererDiagnostics.robotFailedVisualCount ?? 0) || 0;
+  const rendererReady = rendererLifecycle === 'ready' && rendererLoaded && rendererFailedVisualCount === 0;
+  const missingRobot = rendererReady
+    ? []
+    : asArray(rendererDiagnostics.robot_missing_required_robot_visual_links || rendererDiagnostics.robotMissingRequiredRobotVisualLinks).map(value => String(value || '').trim()).filter(Boolean);
+  const missingTool = rendererReady
+    ? []
+    : asArray(rendererDiagnostics.robot_missing_required_tool_visual_links || rendererDiagnostics.robotMissingRequiredToolVisualLinks).map(value => String(value || '').trim()).filter(Boolean);
+  if (!rendererReady && missingRobot.length === 0 && missingTool.length === 0 && !rendererLoaded) {
+    for (const link of required.robot_visuals) {
+      if (!urdfLinksWithLoadedVisuals.has(link)) missingRobot.push(link);
+    }
+    for (const link of required.tool_visuals) {
+      if (!urdfLinksWithLoadedVisuals.has(link)) missingTool.push(link);
     }
   }
-  for (const detail of asArray(state.robotUrdfPreviewDiagnostics?.robot_missing_meshes)) {
+  const failedLinks = [];
+  const failedMeshUrls = [];
+  for (const detail of asArray(rendererDiagnostics.robot_missing_meshes)) {
     const text = String(detail || '').trim();
     if (text) failedMeshUrls.push(text.split(': ')[0] || text);
   }
-  if (Number(state.robotUrdfPreviewDiagnostics?.robot_failed_visual_count || 0) > 0) {
-    failedLinks.push('expanded_urdf_loader');
-  }
-  const missing = missingRobot.concat(missingTool);
+  if (rendererFailedVisualCount > 0) failedLinks.push('expanded_urdf_loader');
+  const missing = Array.from(new Set(missingRobot.concat(missingTool).filter(Boolean)));
   const failed = Array.from(new Set(failedLinks.filter(Boolean)));
   const duplicatePhysicalIdentities = Array.from(new Set(urdfDedupe.duplicateIdentities.concat(physicalDiagnostics.duplicateIdentities)));
+  const requiredVisualReady = rendererReady || (missing.length === 0 && failed.length === 0);
   return {
     expanded_urdf_expected_visual_set: required,
     expandedUrdfExpectedVisualSet: required,
     expanded_urdf_required_visual_counts: { ...urdfCounts, ...categoryCounts },
     expandedUrdfRequiredVisualCounts: { ...urdfCounts, ...categoryCounts },
+    robot_preview_lifecycle_state: rendererLifecycle,
+    robotPreviewLifecycleState: rendererLifecycle,
+    robot_preview_loaded: rendererLoaded,
+    robotPreviewLoaded: rendererLoaded,
+    robot_failed_visual_count: rendererFailedVisualCount,
+    robotFailedVisualCount: rendererFailedVisualCount,
+    robot_missing_meshes: asArray(rendererDiagnostics.robot_missing_meshes),
+    robotMissingMeshes: asArray(rendererDiagnostics.robot_missing_meshes || rendererDiagnostics.robotMissingMeshes),
+    robot_missing_required_robot_visual_links: missingRobot,
+    robotMissingRequiredRobotVisualLinks: missingRobot,
+    robot_missing_required_tool_visual_links: missingTool,
+    robotMissingRequiredToolVisualLinks: missingTool,
     missing_required_robot_visuals: missingRobot,
     missingRequiredRobotVisuals: missingRobot,
     missing_required_tool_visuals: missingTool,
@@ -606,8 +613,8 @@ function expandedUrdfVisualReadinessDiagnostics() {
     failedRequiredLinks: failed,
     failed_mesh_urls: Array.from(new Set(failedMeshUrls)),
     failedMeshUrls: Array.from(new Set(failedMeshUrls)),
-    required_visual_ready: missing.length === 0 && failed.length === 0 && duplicatePhysicalIdentities.length === 0,
-    requiredVisualReady: missing.length === 0 && failed.length === 0 && duplicatePhysicalIdentities.length === 0,
+    required_visual_ready: requiredVisualReady,
+    requiredVisualReady: requiredVisualReady,
   };
 }
 function failIfExpandedUrdfExpectedVisualSetInvalid() {
@@ -615,10 +622,13 @@ function failIfExpandedUrdfExpectedVisualSetInvalid() {
   if (expandedUrdfExpectedVisualSet() && lifecycle !== 'ready' && lifecycle !== 'failed') return false;
   const diagnostics = expandedUrdfVisualReadinessDiagnostics();
   if (!diagnostics || diagnostics.required_visual_ready) return false;
-  const requiredCategory = diagnostics.missing_required_tool_visuals?.length ? 'attached_tool_gripper' : 'robot_arm';
+  const requiredCategory = diagnostics.robot_missing_required_tool_visual_links?.length ? 'attached_tool_gripper' : 'robot_arm';
+  const reason = diagnostics.robot_preview_loaded
+    ? 'expanded URDF renderer reported required robot/tool visual failure'
+    : 'expanded URDF expected robot/tool visuals are missing or failed';
   emitWeb3dReadinessState('scene_failed', {
     required_category: requiredCategory,
-    reason: 'expanded URDF expected robot/tool visuals are missing, failed, or duplicated',
+    reason,
     ...diagnostics,
   });
   return true;


### PR DESCRIPTION
### Motivation
- The UI was marking a visible UR5 + Robotiq assembly as `scene_failed` because readiness was recomputed from wrapper counts and duplicate wrapper diagnostics instead of trusting the URDF renderer’s verdict. 
- The expanded-URDF path must treat `urdf_robot_renderer.js` diagnostics as authoritative to avoid false negative readiness while still preserving fatal renderer-reported failures.
- Duplicate physical visual identities are informative only and must not block `scene_ready`, and table/camera checks should remain the responsibility of the global Web3D readiness.

### Description
- Updated `expandedUrdfVisualReadinessDiagnostics()` in `workcell_studio_web/viewer/viewer.js` to prefer renderer-provided diagnostics (`robot_preview_lifecycle_state`, `robot_preview_loaded`, `robot_failed_visual_count`, `robot_missing_meshes`, etc.) and to treat the renderer as authoritative when lifecycle === `ready`, `robot_preview_loaded === true`, and `robot_failed_visual_count === 0`.
- Changed the failure gating in `failIfExpandedUrdfExpectedVisualSetInvalid()` so that renderer-ready state prevents wrapper-count recomputation from blocking readiness, and adjusted emitted failure reason text for renderer-reported failures.
- Made `duplicate_physical_visual_identities` diagnostic-only (no longer fatal) and removed expanded-URDF table/camera category checks so normal Web3D readiness validates those categories.
- Updated tests in `tests/test_workcell_studio_web_viewer_static.py` to cover: renderer-ready + loaded UR5/Robotiq with duplicate wrapper diagnostics reaching `scene_ready`, missing required robot link being fatal, and failed mesh callbacks remaining fatal.
- Rebuilt the web viewer bundle and included the generated artifact `workcell_studio_web/viewer/dist/viewer.bundle.js` to reflect the source change.

### Testing
- Ran unit tests with `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py -q`, which passed (`99 passed`).
- Built the web viewer with `cd workcell_studio_web/viewer && npm ci && npm run build:web3d`, which completed successfully (with a non-blocking npm audit warning).
- Verified the bundle freshness with `npm run check:stale-bundle`, which reported the bundle as current.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62421c8d4c8331b2a044e4da26f474)