### PR TITLE
Unblock supported-scenes Web3D acceptance CI

### DIFF
--- a/.github/workflows/web3d-visual-acceptance.yml
+++ b/.github/workflows/web3d-visual-acceptance.yml
@@ -34,9 +34,30 @@ jobs:
       - name: Install Python test, xacro and browser tooling
         run: python3 -m pip install --upgrade pip pytest playwright pyyaml xacro==2.1.1
 
+      - name: Initialize blocked matrix artifact
+        run: |
+          mkdir -p build
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          report = {
+              'schema': 'workcell_studio_web3d_supported_scenes_acceptance_matrix/v1',
+              'sequential': True,
+              'status': 'BLOCKED',
+              'failure_reason': 'Workflow preflight has not completed yet.',
+              'counts': {'PASS': 0, 'FAIL': 0, 'BLOCKED': 0},
+              'catalog_errors': [],
+              'scenes': [],
+              'scene_switch_sequence': [],
+          }
+          Path('build/web3d_supported_scenes_matrix.json').write_text(json.dumps(report, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+          PY
+
       - name: Preflight real xacro discovery
         run: |
-          python3 - <<'PY'
+          set +e
+          output=$(python3 - <<'PY' 2>&1
+
           import importlib.metadata
           import importlib.util
           import sys
@@ -58,12 +79,45 @@ jobs:
           if command[0] == 'xacro-lite' or any('xacro-lite' in str(part) for part in command):
               raise SystemExit(f'xacro-lite cannot satisfy supported-scenes acceptance: {command}')
           PY
+          )
+          rc=$?
+          if [ $rc -ne 0 ]; then
+            MATRIX_FAILURE_REASON="Preflight real xacro discovery failed: $output" python3 - <<'PY'
+          import json, os
+          from pathlib import Path
+          path = Path('build/web3d_supported_scenes_matrix.json')
+          report = json.loads(path.read_text(encoding='utf-8')) if path.is_file() else {}
+          report.update(status='BLOCKED', failure_reason=os.environ['MATRIX_FAILURE_REASON'])
+          path.parent.mkdir(parents=True, exist_ok=True)
+          path.write_text(json.dumps(report, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+          PY
+            printf '%s\n' "$output"
+            exit $rc
+          fi
+          printf '%s\n' "$output"
 
       - name: Install Playwright Chromium
         run: python3 -m playwright install --with-deps chromium
 
       - name: Run static acceptance tests
-        run: python3 -m pytest tests/test_workcell_web3d_visual_acceptance.py tests/test_workcell_studio_web_viewer_static.py -q
+        run: |
+          set +e
+          output=$(python3 -m pytest tests/test_workcell_web3d_visual_acceptance.py tests/test_workcell_studio_web_viewer_static.py -q 2>&1)
+          rc=$?
+          if [ $rc -ne 0 ]; then
+            MATRIX_FAILURE_REASON="Run static acceptance tests failed: $output" python3 - <<'PY'
+          import json, os
+          from pathlib import Path
+          path = Path('build/web3d_supported_scenes_matrix.json')
+          report = json.loads(path.read_text(encoding='utf-8')) if path.is_file() else {}
+          report.update(status='BLOCKED', failure_reason=os.environ['MATRIX_FAILURE_REASON'])
+          path.parent.mkdir(parents=True, exist_ok=True)
+          path.write_text(json.dumps(report, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+          PY
+            printf '%s\n' "$output"
+            exit $rc
+          fi
+          printf '%s\n' "$output"
 
       - name: Run offline scene readiness matrix
         run: python3 scripts/run_workcell_studio_scene_readiness_matrix.py
@@ -102,7 +156,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: supported-scenes-web3d-visual-acceptance
-          if-no-files-found: error
+          if-no-files-found: warn
           path: |
             build/web3d_supported_scenes_matrix.json
             build/workcell_studio_web_scene/*.visual_acceptance.json

--- a/tests/test_workcell_web3d_visual_acceptance.py
+++ b/tests/test_workcell_web3d_visual_acceptance.py
@@ -76,6 +76,7 @@ def test_web3d_visual_acceptance_workflow_uploads_matrix_report_and_scene_artifa
     assert "build/workcell_studio_web_scene/*.visual_acceptance.json" in text
     assert "build/workcell_studio_web_scene/*.png" in text
     assert "GITHUB_STEP_SUMMARY" in text
+    assert "if-no-files-found: warn" in text
     for token in [
         "browser runtime method",
         "screenshot artifact name",
@@ -84,6 +85,16 @@ def test_web3d_visual_acceptance_workflow_uploads_matrix_report_and_scene_artifa
     ]:
         assert token in text
 
+
+
+def test_web3d_visual_acceptance_workflow_writes_blocked_matrix_before_preflight_and_static_failures():
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "Initialize blocked matrix artifact" in text
+    assert "'status': 'BLOCKED'" in text
+    assert "Workflow preflight has not completed yet." in text
+    assert 'MATRIX_FAILURE_REASON="Preflight real xacro discovery failed: $output"' in text
+    assert 'MATRIX_FAILURE_REASON="Run static acceptance tests failed: $output"' in text
+    assert "report.update(status='BLOCKED', failure_reason=os.environ['MATRIX_FAILURE_REASON'])" in text
 
 def test_web3d_visual_acceptance_workflow_does_not_commit_generated_outputs():
     result = __import__("subprocess").run(


### PR DESCRIPTION
### Motivation
- Ensure the supported-scenes Web3D GitHub Actions job always produces `build/web3d_supported_scenes_matrix.json` even when preflight or static tests fail so CI can report the exact blocker. 
- Prevent a secondary misleading failure when optional screenshot/report artifacts are absent during artifact upload. 
- Keep Product View readiness and visual acceptance checks unchanged while making CI reliable and debuggable.

### Description
- Add an early initializer step that writes a `BLOCKED` matrix to `build/web3d_supported_scenes_matrix.json` so the artifact exists before preflight and static checks run. 
- Wrap the real `xacro` preflight and the static acceptance `pytest` invocation so on failure the exact output is stored in the matrix `failure_reason` while preserving the original exit behavior. 
- Change the `actions/upload-artifact` `if-no-files-found` setting from `error` to `warn` to avoid a second artifact-upload failure when optional screenshots/reports are missing. 
- Update static tests to assert the workflow now contains the initializer, the wrapped failure-handling tokens, and the `if-no-files-found: warn` behavior without weakening any visual acceptance assertions.

### Testing
- Ran `python3 -m pytest tests/test_workcell_web3d_visual_acceptance.py tests/test_workcell_studio_web_viewer_static.py -q` and observed all tests pass (`155 passed`). 
- Parsed and sanity-checked the modified workflow with `PyYAML` and inspected run blocks with a shell `bash -n` style validation, which succeeded. 
- Verified that the workflow will now produce `build/web3d_supported_scenes_matrix.json` with `status=BLOCKED` and an exact `failure_reason` when preflight/static steps fail, and that optional artifact uploads no longer cause a secondary hard failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63277341e88331924c51ba9ae4aadd)