### PR TITLE
Install viewer Node dependencies in Web3D CI

### DIFF
--- a/.github/workflows/web3d-visual-acceptance.yml
+++ b/.github/workflows/web3d-visual-acceptance.yml
@@ -31,6 +31,13 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: workcell_studio_web/viewer/package-lock.json
+
       - name: Install Python test, xacro and browser tooling
         run: python3 -m pip install --upgrade pip pytest playwright pyyaml xacro==2.1.1
 
@@ -98,6 +105,12 @@ jobs:
 
       - name: Install Playwright Chromium
         run: python3 -m playwright install --with-deps chromium
+
+      - name: Install viewer Node dependencies and verify bundle freshness
+        working-directory: workcell_studio_web/viewer
+        run: |
+          npm ci
+          npm run check:stale-bundle
 
       - name: Run static acceptance tests
         run: |

--- a/tests/test_workcell_web3d_visual_acceptance.py
+++ b/tests/test_workcell_web3d_visual_acceptance.py
@@ -53,6 +53,17 @@ def test_web3d_visual_acceptance_workflow_requires_browser_runtime():
     assert "python3 -m playwright install --with-deps chromium" in text
 
 
+def test_web3d_visual_acceptance_workflow_installs_viewer_node_dependencies_before_static_tests():
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "actions/setup-node@v4" in text
+    assert "node-version: '20'" in text
+    assert "cache-dependency-path: workcell_studio_web/viewer/package-lock.json" in text
+    assert "working-directory: workcell_studio_web/viewer" in text
+    assert "npm ci" in text
+    assert "npm run check:stale-bundle" in text
+    assert text.index("npm ci") < text.index("Run static acceptance tests")
+
+
 def test_web3d_visual_acceptance_workflow_installs_pinned_real_xacro_and_preflights():
     text = WORKFLOW.read_text(encoding="utf-8")
     assert "xacro==2.1.1" in text


### PR DESCRIPTION
### Motivation
- Ensure the Web3D visual-acceptance workflow installs the viewer's Node dependencies so the supported-scenes browser matrix can reach execution. 
- Run the viewer bundle freshness check before static acceptance tests to detect stale committed bundles early in CI. 
- Preserve existing Python, xacro and Playwright installation steps and avoid changing viewer production code or weakening tests.

### Description
- Add `actions/setup-node@v4` to the Web3D workflow with `node-version: '20'` and npm caching keyed to `workcell_studio_web/viewer/package-lock.json`.
- Add a workflow step with `working-directory: workcell_studio_web/viewer` that runs `npm ci` and `npm run check:stale-bundle` immediately before the static acceptance tests. 
- Update the focused workflow test to assert the Node setup, `npm ci` + `npm run check:stale-bundle` presence and ordering prior to running static tests. 
- Change scope limited to the workflow and its test file (2 files modified) and does not touch viewer production code or test assertions themselves.

### Testing
- Ran `cd workcell_studio_web/viewer && npm ci && npm run check:stale-bundle`, where `npm ci` completed but `npm run check:stale-bundle` reported the committed `dist/viewer.bundle.js` is stale (preflight correctly detects drift). 
- Ran `python3 -m pytest tests/test_workcell_web3d_visual_acceptance.py tests/test_workcell_studio_web_viewer_static.py -q` and all tests passed (`156 passed`). 
- Workflow static preflight will now surface stale-bundle drift before the sequential browser matrix starts, as intended by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63327c6f3c8331bb13b7a9c3dc3ff6)