### PR TITLE
Fix Playwright request failure handling

### DIFF
--- a/scripts/run_workcell_web3d_visual_acceptance.py
+++ b/scripts/run_workcell_web3d_visual_acceptance.py
@@ -1036,6 +1036,48 @@ def browser_command(url: str, screenshot: Path) -> dict[str, Any] | None:
     return None
 
 
+def _request_failure_error_text(failure: Any) -> str:
+    if failure is None:
+        return ""
+    if isinstance(failure, str):
+        return failure
+    if isinstance(failure, Mapping):
+        for key in ("error_text", "errorText", "message", "error"):
+            value = failure.get(key)
+            if value is not None:
+                return str(value)
+        return str(dict(failure))
+    try:
+        value = getattr(failure, "error_text")
+    except Exception as exc:
+        return f"<unreadable failure.error_text: {exc}>"
+    return "" if value is None else str(value)
+
+
+def _safe_request_field(request: Any, field: str) -> str:
+    try:
+        value = getattr(request, field)
+    except Exception as exc:
+        return f"<unreadable {field}: {exc}>"
+    return "" if value is None else str(value)
+
+
+def _record_failed_request(request: Any, failed_requests: list[str]) -> None:
+    try:
+        method = _safe_request_field(request, "method")
+        url = _safe_request_field(request, "url")
+        try:
+            failure = getattr(request, "failure", None)
+        except Exception as exc:
+            failure = f"<unreadable failure: {exc}>"
+        failed_requests.append(f"{method} {url} {_request_failure_error_text(failure)}")
+    except Exception as exc:
+        try:
+            failed_requests.append(f"<requestfailed callback error: {exc}>")
+        except Exception:
+            pass
+
+
 def run_browser(url: str, status_path: Path, screenshot_path: Path, require: bool) -> dict[str, Any]:
     js_errors: list[str] = []
     failed_requests: list[str] = []
@@ -1047,7 +1089,7 @@ def run_browser(url: str, status_path: Path, screenshot_path: Path, require: boo
             page = browser.new_page(viewport={"width": 1280, "height": 900}, ignore_https_errors=True)
             page.on("pageerror", lambda exc: js_errors.append(str(exc)))
             page.on("console", lambda msg: console_messages.append(f"{msg.type}: {msg.text}"))
-            page.on("requestfailed", lambda req: failed_requests.append(f"{req.method} {req.url} {req.failure.error_text if req.failure else ''}"))
+            page.on("requestfailed", lambda req: _record_failed_request(req, failed_requests))
             page.goto(url, wait_until="networkidle", timeout=45000)
             page.wait_for_function("window.__WORKCELL_VIEWER_STATUS__ && typeof window.__WORKCELL_VIEWER_STATUS__ === 'object'", timeout=45000)
             page.wait_for_function("() => { const s = window.__WORKCELL_VIEWER_STATUS__ || {}; const state = s.web3d_readiness_state || s.web3dReadinessState || s.viewer_boot_state || ''; return state === 'scene_ready' || state === 'scene_failed'; }", timeout=60000)

--- a/tests/test_workcell_web3d_visual_acceptance.py
+++ b/tests/test_workcell_web3d_visual_acceptance.py
@@ -1,5 +1,7 @@
 import importlib.util
 import json
+import sys
+import types
 from pathlib import Path
 
 import yaml
@@ -9,6 +11,101 @@ SCRIPT = ROOT / "scripts/run_workcell_web3d_visual_acceptance.py"
 spec = importlib.util.spec_from_file_location("web3d_acceptance", SCRIPT)
 module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
+
+
+def test_request_failure_text_handles_none_string_mapping_and_object():
+    failure_object = type("Failure", (), {"error_text": "object network reset"})()
+    assert module._request_failure_error_text(None) == ""
+    assert module._request_failure_error_text("string network reset") == "string network reset"
+    assert module._request_failure_error_text({"error_text": "dict network reset"}) == "dict network reset"
+    assert module._request_failure_error_text({"message": "dict message reset"}) == "dict message reset"
+    assert module._request_failure_error_text(failure_object) == "object network reset"
+
+
+def test_record_failed_request_records_string_object_and_dict_failures_without_throwing():
+    failures = []
+    for failure in (
+        "string failed",
+        {"error_text": "dict failed"},
+        type("Failure", (), {"error_text": "object failed"})(),
+    ):
+        request = type("Request", (), {"method": "GET", "url": "http://viewer/asset.dae", "failure": failure})()
+        module._record_failed_request(request, failures)
+
+    class BrokenRequest:
+        @property
+        def method(self):
+            raise RuntimeError("method broke")
+
+        @property
+        def url(self):
+            raise RuntimeError("url broke")
+
+        @property
+        def failure(self):
+            raise RuntimeError("failure broke")
+
+    module._record_failed_request(BrokenRequest(), failures)
+    assert any("string failed" in item for item in failures)
+    assert any("dict failed" in item for item in failures)
+    assert any("object failed" in item for item in failures)
+    assert any("unreadable method" in item and "unreadable url" in item for item in failures)
+
+
+def test_playwright_requestfailed_callback_does_not_abort_collection_and_reports_playwright(monkeypatch, tmp_path):
+    class FakePage:
+        def __init__(self):
+            self.handlers = {}
+
+        def on(self, event, callback):
+            self.handlers[event] = callback
+            if event == "requestfailed":
+                callback(type("Request", (), {"method": "GET", "url": "http://viewer/missing.dae", "failure": "net::ERR_FAILED"})())
+
+        def goto(self, *args, **kwargs):
+            return None
+
+        def wait_for_function(self, *args, **kwargs):
+            return True
+
+        def evaluate(self, script):
+            if "robot_preview_lifecycle_state" in script:
+                return "ready"
+            if "__WORKCELL_ROBOT_PREVIEW_READY__" in script:
+                return True
+            return {"robot_preview_lifecycle_state": "ready", "web3d_readiness_state": "scene_ready"}
+
+        def screenshot(self, path, full_page):
+            Path(path).write_bytes(module.PNG_1X1)
+
+    class FakeBrowser:
+        def __init__(self):
+            self.page = FakePage()
+
+        def new_page(self, **kwargs):
+            return self.page
+
+        def close(self):
+            return None
+
+    class FakePlaywright:
+        def __enter__(self):
+            self.chromium = types.SimpleNamespace(launch=lambda **kwargs: FakeBrowser())
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    fake_sync_api = types.SimpleNamespace(sync_playwright=lambda: FakePlaywright())
+    monkeypatch.setitem(sys.modules, "playwright", types.SimpleNamespace(sync_api=fake_sync_api))
+    monkeypatch.setitem(sys.modules, "playwright.sync_api", fake_sync_api)
+
+    result = module.run_browser("http://viewer", tmp_path / "status.json", tmp_path / "shot.png", require=True)
+
+    assert result["available"] is True
+    assert result["method"] == "playwright"
+    assert result["status"]["web3d_readiness_state"] == "scene_ready"
+    assert result["failed_network_requests"] == ["GET http://viewer/missing.dae net::ERR_FAILED"]
 
 
 def test_derives_scene_id_from_arbitrary_manifest_scene(tmp_path):


### PR DESCRIPTION
### Motivation
- Prevent Playwright `requestfailed` event handlers from raising when `request.failure` is unexpectedly typed or raises, which previously caused test/CI failures like `"str' object has no attribute 'error_text'"`.
- Reliably capture the real viewer/browser network failure information for the supported-scenes matrix without weakening existing readiness, timeout, or JavaScript failure checks.
- Keep browser collection robust so Playwright callbacks never abort collection and the matrix can record the real browser method (`playwright`) when available.

### Description
- Added helpers `._request_failure_error_text`, `._safe_request_field`, and `._record_failed_request` to safely format `request.failure` when it is `None`, a `str`, a `dict`/`Mapping`, or an object exposing `error_text`, and to defensively read `request.method`/`request.url`.
- Replaced the unsafe inline `requestfailed` lambda with a guarded callback call to `_record_failed_request` so browser event callbacks cannot throw and abort Playwright collection; preserved Playwright navigation, `wait_for_function` timeouts, and viewer-status evaluation.
- Added focused unit tests in `tests/test_workcell_web3d_visual_acceptance.py` that exercise None/string/dict/object failure formatting, resilience to requests with throwing properties, and a mocked Playwright run reporting `method == "playwright"` and recording failed network requests.
- Only the visual-acceptance script and its tests were modified; no production viewer code, launch files, or hardware/readiness defaults were changed.

### Testing
- Ran `python3 -m pytest tests/test_workcell_web3d_visual_acceptance.py -q`, which passed (`60 passed`).
- Verified the new tests exercise string/dict/object failure cases, a broken request property case, and a mocked Playwright flow that reports `method == "playwright"` and captures failed requests. 
- Ran repository checks (`git diff --check`) and test suite validations relevant to this change, both succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63399b5210833189c487d4f4f7db08)