### PR TITLE
Fix expanded URDF successful readiness accounting

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -2633,6 +2633,58 @@ assert.strictEqual(state.web3dReadiness.state, 'scene_ready');
     subprocess.run(["node", "-e", harness, str(js_path)], cwd=ROOT, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
 
+
+def test_expanded_urdf_successful_16_of_16_callback_accounting_is_authoritative():
+    js_path = VIEWER / "viewer.js"
+    harness = r"""
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+let source = fs.readFileSync(process.argv[1], 'utf8').replace(/boot\(\);\s*$/, '');
+const element = () => ({ hidden: false, checked: false, disabled: false, textContent: '', className: '', innerHTML: '', classList: { toggle() {} }, setAttribute() {}, querySelector() { return { textContent: '' }; }, appendChild() {}, addEventListener() {}, getBoundingClientRect() { return { width: 800, height: 600, left: 0, top: 0 }; } });
+const context = { console, assert, window: { dispatched: [], location: { search: '' }, dispatchEvent(event) { this.dispatched.push(event?.detail?.state); }, parent: { postMessage() {} } }, document: { getElementById() { return element(); }, createElement() { return element(); } }, URLSearchParams, CustomEvent: function CustomEvent(type, init) { return { type, detail: init?.detail || {} }; }, requestAnimationFrame() { return 0; }, setTimeout() { return 1; }, clearTimeout() {} };
+vm.createContext(context);
+vm.runInContext(source + `
+const falseMissingRobotLinks = ['base_link_inertia', 'shoulder_link', 'upper_arm_link', 'forearm_link', 'wrist_1_link', 'wrist_2_link', 'wrist_3_link'];
+state.sceneJson = { scene: { id: 'ur5_2f_test' }, robot_preview: { mode: 'expanded_urdf_loader', robot_instance_id: 'ur5_2f', expected_robot_visual_links: falseMissingRobotLinks, expected_tool_visual_links: ['robotiq_85_base_link'] } };
+state.robotUrdfPreviewDiagnostics = {
+  robot_preview_lifecycle_state: 'failed',
+  robot_preview_loaded: false,
+  robot_expected_visual_count: 16,
+  robot_completed_visual_count: 16,
+  robot_loaded_visual_count: 16,
+  robot_failed_visual_count: 0,
+  robot_mesh_callbacks_complete: true,
+  robot_missing_meshes: [],
+  robot_missing_required_robot_visual_links: falseMissingRobotLinks,
+  robot_missing_required_tool_visual_links: [],
+  robot_visual_wrapper_world_matrices: []
+};
+collectRenderedMeshDiagnostics = () => [
+  { id: 'workbench_generated', category: 'table', render_policy: 'primary', render_status: 'mesh_loaded', mesh_loaded: true, readiness_category: 'workbench_support_surface' },
+  { id: 'configured_camera_generated', category: 'camera', render_policy: 'primary', render_status: 'mesh_loaded', mesh_loaded: true, readiness_category: 'configured_camera' },
+];
+const diagnostics = expandedUrdfVisualReadinessDiagnostics();
+assert.strictEqual(diagnostics.robot_expected_visual_count, 16);
+assert.strictEqual(diagnostics.robot_completed_visual_count, 16);
+assert.strictEqual(diagnostics.robot_loaded_visual_count, 16);
+assert.strictEqual(diagnostics.robot_failed_visual_count, 0);
+assert.strictEqual(diagnostics.robot_mesh_callbacks_complete, true);
+assert.strictEqual(diagnostics.robot_successful_callback_accounting, true);
+assert.deepStrictEqual(diagnostics.robot_missing_meshes, []);
+assert.deepStrictEqual(diagnostics.missing_required_visuals, []);
+assert.strictEqual(diagnostics.expanded_urdf_required_visual_counts.shoulder_link, undefined);
+state.web3dReadiness = { state: 'scene_loading', emittedSceneReady: false, required: { robot_arm: true, attached_tool_gripper: true, workbench_support_surface: true, configured_camera: true }, pending: new Set(['robot_arm:expanded_urdf_loader', 'attached_tool_gripper:expanded_urdf_loader']), failed: false, failure: null };
+assert.strictEqual(failIfExpandedUrdfExpectedVisualSetInvalid(), false);
+completeExpandedUrdfReadiness({ diagnostics: state.robotUrdfPreviewDiagnostics });
+assert.strictEqual(state.web3dReadiness.state, 'scene_ready');
+assert.ok(window.dispatched.includes('scene_ready'));
+assert.ok(!window.dispatched.includes('scene_failed'));
+`, context);
+"""
+    subprocess.run(["node", "-e", harness, str(js_path)], cwd=ROOT, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
 def test_expanded_urdf_readiness_fails_missing_required_link_and_required_mesh_failure():
     js_path = VIEWER / "viewer.js"
     harness = r"""

--- a/workcell_studio_web/viewer/dist/viewer.bundle.js
+++ b/workcell_studio_web/viewer/dist/viewer.bundle.js
@@ -38894,14 +38894,19 @@ function expandedUrdfVisualReadinessDiagnostics() {
   const urdfDedupe = dedupeByStableIdentity(rawUrdfVisuals, (visual) => expandedUrdfVisualIdentity(sceneId2, robotInstanceId, visual));
   const urdfVisuals = urdfDedupe.records;
   const urdfLinksWithLoadedVisuals = new Set(urdfVisuals.map((visual) => String(visual?.link_name || visual?.linkName || "").trim()).filter(Boolean));
-  const urdfCounts = countBy(urdfVisuals.map((visual) => String(visual?.link_name || visual?.linkName || "").trim()).filter(Boolean));
   const sceneDiagnostics = collectRenderedMeshDiagnostics();
   const physicalDiagnostics = dedupeByStableIdentity(sceneDiagnostics.filter(isSuccessfulPhysicalVisualDiagnostic), (entry) => renderedPhysicalVisualIdentity(sceneId2, entry));
   const categoryCounts = countBy(physicalDiagnostics.records.map((item) => readinessCategoryForItem(item)).filter(Boolean));
   const rendererLifecycle = String(rendererDiagnostics.robot_preview_lifecycle_state || rendererDiagnostics.robotPreviewLifecycleState || "");
   const rendererLoaded = rendererDiagnostics.robot_preview_loaded === true || rendererDiagnostics.robotPreviewLoaded === true;
+  const rendererExpectedVisualCount = Number(rendererDiagnostics.robot_expected_visual_count ?? rendererDiagnostics.robotExpectedVisualCount ?? 0) || 0;
+  const rendererCompletedVisualCount = Number(rendererDiagnostics.robot_completed_visual_count ?? rendererDiagnostics.robotCompletedVisualCount ?? 0) || 0;
+  const rendererLoadedVisualCount = Number(rendererDiagnostics.robot_loaded_visual_count ?? rendererDiagnostics.robotLoadedVisualCount ?? 0) || 0;
   const rendererFailedVisualCount = Number(rendererDiagnostics.robot_failed_visual_count ?? rendererDiagnostics.robotFailedVisualCount ?? 0) || 0;
-  const rendererReady = rendererLifecycle === "ready" && rendererLoaded && rendererFailedVisualCount === 0;
+  const rendererMissingMeshes = asArray(rendererDiagnostics.robot_missing_meshes || rendererDiagnostics.robotMissingMeshes);
+  const rendererMeshCallbacksComplete = rendererDiagnostics.robot_mesh_callbacks_complete === true || rendererDiagnostics.robotMeshCallbacksComplete === true;
+  const rendererSuccessfulCallbackAccounting = rendererMeshCallbacksComplete && rendererExpectedVisualCount > 0 && rendererCompletedVisualCount === rendererExpectedVisualCount && rendererLoadedVisualCount === rendererExpectedVisualCount && rendererFailedVisualCount === 0 && rendererMissingMeshes.length === 0;
+  const rendererReady = rendererLifecycle === "ready" && rendererLoaded && rendererFailedVisualCount === 0 && rendererMissingMeshes.length === 0 || rendererSuccessfulCallbackAccounting;
   const missingRobot = rendererReady ? [] : asArray(rendererDiagnostics.robot_missing_required_robot_visual_links || rendererDiagnostics.robotMissingRequiredRobotVisualLinks).map((value) => String(value || "").trim()).filter(Boolean);
   const missingTool = rendererReady ? [] : asArray(rendererDiagnostics.robot_missing_required_tool_visual_links || rendererDiagnostics.robotMissingRequiredToolVisualLinks).map((value) => String(value || "").trim()).filter(Boolean);
   if (!rendererReady && missingRobot.length === 0 && missingTool.length === 0 && !rendererLoaded) {
@@ -38916,7 +38921,7 @@ function expandedUrdfVisualReadinessDiagnostics() {
   }
   const failedLinks = [];
   const failedMeshUrls = [];
-  for (const detail of asArray(rendererDiagnostics.robot_missing_meshes)) {
+  for (const detail of rendererMissingMeshes) {
     const text = String(detail || "").trim();
     if (text)
       failedMeshUrls.push(text.split(": ")[0] || text);
@@ -38930,16 +38935,28 @@ function expandedUrdfVisualReadinessDiagnostics() {
   return {
     expanded_urdf_expected_visual_set: required,
     expandedUrdfExpectedVisualSet: required,
-    expanded_urdf_required_visual_counts: { ...urdfCounts, ...categoryCounts },
-    expandedUrdfRequiredVisualCounts: { ...urdfCounts, ...categoryCounts },
+    expanded_urdf_required_visual_counts: { ...categoryCounts },
+    expandedUrdfRequiredVisualCounts: { ...categoryCounts },
+    expanded_urdf_loaded_visual_link_counts: countBy(urdfVisuals.map((visual) => String(visual?.link_name || visual?.linkName || "").trim()).filter(Boolean)),
+    expandedUrdfLoadedVisualLinkCounts: countBy(urdfVisuals.map((visual) => String(visual?.link_name || visual?.linkName || "").trim()).filter(Boolean)),
     robot_preview_lifecycle_state: rendererLifecycle,
     robotPreviewLifecycleState: rendererLifecycle,
     robot_preview_loaded: rendererLoaded,
     robotPreviewLoaded: rendererLoaded,
+    robot_expected_visual_count: rendererExpectedVisualCount,
+    robotExpectedVisualCount: rendererExpectedVisualCount,
+    robot_completed_visual_count: rendererCompletedVisualCount,
+    robotCompletedVisualCount: rendererCompletedVisualCount,
+    robot_loaded_visual_count: rendererLoadedVisualCount,
+    robotLoadedVisualCount: rendererLoadedVisualCount,
     robot_failed_visual_count: rendererFailedVisualCount,
     robotFailedVisualCount: rendererFailedVisualCount,
-    robot_missing_meshes: asArray(rendererDiagnostics.robot_missing_meshes),
-    robotMissingMeshes: asArray(rendererDiagnostics.robot_missing_meshes || rendererDiagnostics.robotMissingMeshes),
+    robot_mesh_callbacks_complete: rendererMeshCallbacksComplete,
+    robotMeshCallbacksComplete: rendererMeshCallbacksComplete,
+    robot_successful_callback_accounting: rendererSuccessfulCallbackAccounting,
+    robotSuccessfulCallbackAccounting: rendererSuccessfulCallbackAccounting,
+    robot_missing_meshes: rendererMissingMeshes,
+    robotMissingMeshes: rendererMissingMeshes,
     robot_missing_required_robot_visual_links: missingRobot,
     robotMissingRequiredRobotVisualLinks: missingRobot,
     robot_missing_required_tool_visual_links: missingTool,

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -547,14 +547,25 @@ function expandedUrdfVisualReadinessDiagnostics() {
   const urdfDedupe = dedupeByStableIdentity(rawUrdfVisuals, visual => expandedUrdfVisualIdentity(sceneId, robotInstanceId, visual));
   const urdfVisuals = urdfDedupe.records;
   const urdfLinksWithLoadedVisuals = new Set(urdfVisuals.map(visual => String(visual?.link_name || visual?.linkName || '').trim()).filter(Boolean));
-  const urdfCounts = countBy(urdfVisuals.map(visual => String(visual?.link_name || visual?.linkName || '').trim()).filter(Boolean));
   const sceneDiagnostics = collectRenderedMeshDiagnostics();
   const physicalDiagnostics = dedupeByStableIdentity(sceneDiagnostics.filter(isSuccessfulPhysicalVisualDiagnostic), entry => renderedPhysicalVisualIdentity(sceneId, entry));
   const categoryCounts = countBy(physicalDiagnostics.records.map(item => readinessCategoryForItem(item)).filter(Boolean));
   const rendererLifecycle = String(rendererDiagnostics.robot_preview_lifecycle_state || rendererDiagnostics.robotPreviewLifecycleState || '');
   const rendererLoaded = rendererDiagnostics.robot_preview_loaded === true || rendererDiagnostics.robotPreviewLoaded === true;
+  const rendererExpectedVisualCount = Number(rendererDiagnostics.robot_expected_visual_count ?? rendererDiagnostics.robotExpectedVisualCount ?? 0) || 0;
+  const rendererCompletedVisualCount = Number(rendererDiagnostics.robot_completed_visual_count ?? rendererDiagnostics.robotCompletedVisualCount ?? 0) || 0;
+  const rendererLoadedVisualCount = Number(rendererDiagnostics.robot_loaded_visual_count ?? rendererDiagnostics.robotLoadedVisualCount ?? 0) || 0;
   const rendererFailedVisualCount = Number(rendererDiagnostics.robot_failed_visual_count ?? rendererDiagnostics.robotFailedVisualCount ?? 0) || 0;
-  const rendererReady = rendererLifecycle === 'ready' && rendererLoaded && rendererFailedVisualCount === 0;
+  const rendererMissingMeshes = asArray(rendererDiagnostics.robot_missing_meshes || rendererDiagnostics.robotMissingMeshes);
+  const rendererMeshCallbacksComplete = rendererDiagnostics.robot_mesh_callbacks_complete === true || rendererDiagnostics.robotMeshCallbacksComplete === true;
+  const rendererSuccessfulCallbackAccounting = rendererMeshCallbacksComplete
+    && rendererExpectedVisualCount > 0
+    && rendererCompletedVisualCount === rendererExpectedVisualCount
+    && rendererLoadedVisualCount === rendererExpectedVisualCount
+    && rendererFailedVisualCount === 0
+    && rendererMissingMeshes.length === 0;
+  const rendererReady = (rendererLifecycle === 'ready' && rendererLoaded && rendererFailedVisualCount === 0 && rendererMissingMeshes.length === 0)
+    || rendererSuccessfulCallbackAccounting;
   const missingRobot = rendererReady
     ? []
     : asArray(rendererDiagnostics.robot_missing_required_robot_visual_links || rendererDiagnostics.robotMissingRequiredRobotVisualLinks).map(value => String(value || '').trim()).filter(Boolean);
@@ -571,7 +582,7 @@ function expandedUrdfVisualReadinessDiagnostics() {
   }
   const failedLinks = [];
   const failedMeshUrls = [];
-  for (const detail of asArray(rendererDiagnostics.robot_missing_meshes)) {
+  for (const detail of rendererMissingMeshes) {
     const text = String(detail || '').trim();
     if (text) failedMeshUrls.push(text.split(': ')[0] || text);
   }
@@ -583,16 +594,28 @@ function expandedUrdfVisualReadinessDiagnostics() {
   return {
     expanded_urdf_expected_visual_set: required,
     expandedUrdfExpectedVisualSet: required,
-    expanded_urdf_required_visual_counts: { ...urdfCounts, ...categoryCounts },
-    expandedUrdfRequiredVisualCounts: { ...urdfCounts, ...categoryCounts },
+    expanded_urdf_required_visual_counts: { ...categoryCounts },
+    expandedUrdfRequiredVisualCounts: { ...categoryCounts },
+    expanded_urdf_loaded_visual_link_counts: countBy(urdfVisuals.map(visual => String(visual?.link_name || visual?.linkName || '').trim()).filter(Boolean)),
+    expandedUrdfLoadedVisualLinkCounts: countBy(urdfVisuals.map(visual => String(visual?.link_name || visual?.linkName || '').trim()).filter(Boolean)),
     robot_preview_lifecycle_state: rendererLifecycle,
     robotPreviewLifecycleState: rendererLifecycle,
     robot_preview_loaded: rendererLoaded,
     robotPreviewLoaded: rendererLoaded,
+    robot_expected_visual_count: rendererExpectedVisualCount,
+    robotExpectedVisualCount: rendererExpectedVisualCount,
+    robot_completed_visual_count: rendererCompletedVisualCount,
+    robotCompletedVisualCount: rendererCompletedVisualCount,
+    robot_loaded_visual_count: rendererLoadedVisualCount,
+    robotLoadedVisualCount: rendererLoadedVisualCount,
     robot_failed_visual_count: rendererFailedVisualCount,
     robotFailedVisualCount: rendererFailedVisualCount,
-    robot_missing_meshes: asArray(rendererDiagnostics.robot_missing_meshes),
-    robotMissingMeshes: asArray(rendererDiagnostics.robot_missing_meshes || rendererDiagnostics.robotMissingMeshes),
+    robot_mesh_callbacks_complete: rendererMeshCallbacksComplete,
+    robotMeshCallbacksComplete: rendererMeshCallbacksComplete,
+    robot_successful_callback_accounting: rendererSuccessfulCallbackAccounting,
+    robotSuccessfulCallbackAccounting: rendererSuccessfulCallbackAccounting,
+    robot_missing_meshes: rendererMissingMeshes,
+    robotMissingMeshes: rendererMissingMeshes,
     robot_missing_required_robot_visual_links: missingRobot,
     robotMissingRequiredRobotVisualLinks: missingRobot,
     robot_missing_required_tool_visual_links: missingTool,


### PR DESCRIPTION
### Motivation
- Prevent scenes from reporting `scene_failed` when the expanded-URDF renderer has completed successful mesh callbacks (expected==completed==loaded, failures==0) but legacy flattened-link diagnostics still report missing links.
- Make the renderer callback accounting authoritative in the clear-success case while keeping genuine missing-link or failed-mesh conditions fatal.

### Description
- Update `expandedUrdfVisualReadinessDiagnostics()` in `workcell_studio_web/viewer/viewer.js` to treat the renderer as ready when `robot_mesh_callbacks_complete` is true and `robot_expected_visual_count === robot_completed_visual_count === robot_loaded_visual_count` and `robot_failed_visual_count === 0` and `robot_missing_meshes` is empty, in which case missing flattened-link records are ignored. 
- Stop putting expanded-URDF link counts into `expanded_urdf_required_visual_counts` and instead expose `expanded_urdf_loaded_visual_link_counts` so loaded-link diagnostics are reported separately from category-based readiness counts. 
- Preserve fatal behavior for genuine failures: failed mesh callbacks, non-empty `robot_missing_meshes`, or explicit missing required links still cause `scene_failed`. 
- Add a regression test `test_expanded_urdf_successful_16_of_16_callback_accounting_is_authoritative()` to `tests/test_workcell_studio_web_viewer_static.py` exercising the exact 16/16/0 ur5_2f_test diagnostic case. 
- Rebuilt `workcell_studio_web/viewer/dist/viewer.bundle.js` to include the updated readiness logic.

### Testing
- Ran `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py -q` and received all tests passing (`100 passed`, 3 warnings reported by pytest). 
- Ran `cd workcell_studio_web/viewer && npm ci` which completed successfully (npm reported one moderate vulnerability and an unrelated unknown `http-proxy` env warning). 
- Ran `npm run build:web3d` in `workcell_studio_web/viewer` and the bundle rebuilt successfully. 
- Ran `npm run check:stale-bundle` and the bundle was reported current.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a633c7db8588331942ec8aa3a0c04bb)