### PR TITLE
Detect deep descendant meshes for expanded-URDF visual wrappers

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -2292,6 +2292,68 @@ try {{
     subprocess.run(["node", str(script)], cwd=ROOT, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
 
+
+def test_urdf_renderer_detects_expanded_visual_wrappers_with_deep_descendant_meshes(tmp_path):
+    script = tmp_path / "deep_visual_wrapper.mjs"
+    script.write_text(
+        f"""
+import assert from 'node:assert/strict';
+import * as THREE from {str((VIEWER / 'node_modules/three/build/three.module.js')).__repr__()};
+import URDFLoader from {str((VIEWER / 'node_modules/urdf-loader/src/URDFLoader.js')).__repr__()};
+
+globalThis.window = {{}};
+globalThis.fetch = async () => ({{ ok: true, status: 200, statusText: 'OK', text: async () => '<robot name="test"/>' }});
+const originalUrdfParse = URDFLoader.prototype.parse;
+URDFLoader.prototype.parse = function parseStub() {{
+  const robot = new THREE.Group();
+  const base = new THREE.Group();
+  base.name = 'base_link';
+  const tool = new THREE.Group();
+  tool.name = 'robotiq_85_base_link';
+
+  for (const link of [base, tool]) {{
+    const wrapper = new THREE.Object3D();
+    const importedScene = new THREE.Scene();
+    const nestedGroup = new THREE.Object3D();
+    nestedGroup.add(new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), new THREE.MeshBasicMaterial()));
+    importedScene.add(nestedGroup);
+    wrapper.add(importedScene);
+    link.add(wrapper);
+    robot.add(link);
+  }}
+
+  robot.links = {{ base_link: base, robotiq_85_base_link: tool }};
+  robot.joints = {{}};
+  robot.setJointValues = () => {{}};
+  return robot;
+}};
+
+try {{
+  const {{ loadRobotPreview }} = await import({str((VIEWER / 'urdf_robot_renderer.js')).__repr__()});
+  const result = loadRobotPreview({{
+    urdf_url: 'robot.urdf',
+    expected_robot_visual_links: ['base_link'],
+    expected_tool_visual_links: ['robotiq_85_base_link'],
+  }});
+  await result.ready;
+  assert.equal(result.diagnostics.robot_preview_loaded, true);
+  assert.equal(result.diagnostics.robot_preview_lifecycle_state, 'ready');
+  assert.deepEqual(result.diagnostics.robot_missing_required_robot_visual_links, []);
+  assert.deepEqual(result.diagnostics.robot_missing_required_tool_visual_links, []);
+  assert.deepEqual(
+    result.diagnostics.robot_visual_wrapper_world_matrices.map(entry => entry.link_name).sort(),
+    ['base_link', 'robotiq_85_base_link']
+  );
+  assert.equal(result.diagnostics.robot_descendant_render_mesh_diagnostics.length, 2);
+}} finally {{
+  URDFLoader.prototype.parse = originalUrdfParse;
+}}
+""",
+        encoding="utf-8",
+    )
+    subprocess.run(["node", str(script)], cwd=ROOT, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
 def test_viewer_browser_readiness_contract_lifecycle_and_terminal_dedup():
     js_path = VIEWER / "viewer.js"
     harness = """

--- a/workcell_studio_web/viewer/urdf_robot_renderer.js
+++ b/workcell_studio_web/viewer/urdf_robot_renderer.js
@@ -547,11 +547,25 @@ function collectLinkMatrixDiagnostics(robot, links) {
   return out;
 }
 
+function hasDescendantRenderMesh(object, links) {
+  if (!object) return false;
+  const linkObjects = new Set(Object.values(links || {}));
+  const stack = [...(object.children || [])];
+  while (stack.length) {
+    const child = stack.pop();
+    if (!child || linkObjects.has(child)) continue;
+    const type = String(child.type || '').toLowerCase();
+    if (child.isMesh || type.includes('mesh')) return true;
+    stack.push(...(child.children || []));
+  }
+  return false;
+}
+
 function isVisualWrapperCandidate(child, links) {
   if (!child || Object.values(links || {}).includes(child)) return false;
   const type = String(child.type || '').toLowerCase();
   const name = String(child.name || '').toLowerCase();
-  return child.isMesh || type.includes('mesh') || type.includes('group') || name.includes('visual') || child.children?.some?.(desc => desc?.isMesh);
+  return child.isMesh || type.includes('mesh') || type.includes('group') || name.includes('visual') || hasDescendantRenderMesh(child, links);
 }
 
 function collectVisualWrapperMatrixDiagnostics(links) {


### PR DESCRIPTION
### Motivation
- The expanded-URDF renderer only checked immediate children for mesh-backed visuals which missed meshes nested inside imported/scoped scenes, causing visual-wrapper diagnostics to be empty and preventing successful preview readiness.

### Description
- Add `hasDescendantRenderMesh(object, links)` and use it inside `isVisualWrapperCandidate` in `workcell_studio_web/viewer/urdf_robot_renderer.js` so wrapper objects that contain descendant meshes are recognized while still excluding genuine link nodes.
- Add `test_urdf_renderer_detects_expanded_visual_wrappers_with_deep_descendant_meshes` to `tests/test_workcell_studio_web_viewer_static.py` that stubs `URDFLoader.parse` with nested/imported scenes and asserts `robot_preview_loaded` is true, lifecycle is `ready`, expected visual links are populated, and descendant mesh diagnostics exist.

### Testing
- Ran `node --check workcell_studio_web/viewer/urdf_robot_renderer.js` which completed with no syntax errors.
- Ran `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py -k test_urdf_renderer_detects_expanded_visual_wrappers_with_deep_descendant_meshes` which passed (1 selected).
- Per instructions, did not run `npm build` and did not modify `dist/viewer.bundle.js`; genuine missing links and failed meshes remain fatal under existing readiness checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6347f640c08331b2ae5c22ff22b8f0)