### PR TITLE
Rebuild Web3D viewer bundle after wrapper fix

### DIFF
--- a/workcell_studio_web/viewer/dist/viewer.bundle.js
+++ b/workcell_studio_web/viewer/dist/viewer.bundle.js
@@ -37932,12 +37932,28 @@ function collectLinkMatrixDiagnostics(robot, links) {
   }
   return out;
 }
+function hasDescendantRenderMesh(object, links) {
+  if (!object)
+    return false;
+  const linkObjects = new Set(Object.values(links || {}));
+  const stack = [...object.children || []];
+  while (stack.length) {
+    const child = stack.pop();
+    if (!child || linkObjects.has(child))
+      continue;
+    const type = String(child.type || "").toLowerCase();
+    if (child.isMesh || type.includes("mesh"))
+      return true;
+    stack.push(...child.children || []);
+  }
+  return false;
+}
 function isVisualWrapperCandidate(child, links) {
   if (!child || Object.values(links || {}).includes(child))
     return false;
   const type = String(child.type || "").toLowerCase();
   const name = String(child.name || "").toLowerCase();
-  return child.isMesh || type.includes("mesh") || type.includes("group") || name.includes("visual") || child.children?.some?.((desc) => desc?.isMesh);
+  return child.isMesh || type.includes("mesh") || type.includes("group") || name.includes("visual") || hasDescendantRenderMesh(child, links);
 }
 function collectVisualWrapperMatrixDiagnostics(links) {
   const out = [];


### PR DESCRIPTION
### Motivation
- Regenerate the committed Web3D distribution artifact so the viewer includes the wrapper-related visual detection fix (ensures descendant render meshes are detected for visual-wrapper heuristics). 

### Description
- Rebuilt `workcell_studio_web/viewer/dist/viewer.bundle.js` which adds a `hasDescendantRenderMesh` helper and updates `isVisualWrapperCandidate` to call it, and kept the change strictly to the committed bundle file. 

### Testing
- Ran `npm ci`, `npm run build:web3d`, and `npm run check:stale-bundle` in `workcell_studio_web/viewer` and each command completed successfully, and `git diff --name-only` showed only `workcell_studio_web/viewer/dist/viewer.bundle.js` as the modified tracked file prior to committing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a634a0d815c8331a7c536037f6593ea)