### PR TITLE
Quiet unchanged scene metadata cache hits

### DIFF
--- a/tests/test_scene_metadata_snapshot_cache.py
+++ b/tests/test_scene_metadata_snapshot_cache.py
@@ -23,13 +23,15 @@ def test_snapshot_tracks_authoritative_scene_metadata_files_and_content_identity
     assert "std::hash<std::string>{}(buffer.str())" in CPP
 
 
-def test_repeated_consumers_share_one_same_scene_snapshot_parse():
+def test_repeated_consumers_share_one_same_scene_snapshot_parse_without_cache_hit_log_noise():
     assert "load_scene_metadata_snapshot(scene_dir, scene_name" in CPP
     assert "snapshot_yaml(snapshot, \"environment.yaml\"" in CPP
     assert "snapshot_yaml(snapshot, \"scene_manifest.yaml\"" in CPP
     assert "snapshot_yaml(snapshot, \"environment_layout.yaml\"" in CPP
     assert "snapshot_yaml(snapshot, \"layout/workcell_studio_layout.yaml\"" in CPP
-    assert "files_parsed=0 cache_hits=" in CPP
+    assert "++cached.cache_hits;" in CPP
+    assert "files_parsed=0 cache_hits=" not in CPP
+    assert CPP.count("Workcell Studio scene metadata snapshot: scene_id=") == 1
 
 
 def test_revision_change_and_scene_switch_cannot_reuse_old_metadata():
@@ -55,9 +57,23 @@ def test_explicit_successful_mutations_invalidate_snapshot_once():
     assert "if (!state.cached.scene_dir.empty() && state.cached.scene_dir == key) state.cached = SceneMetadataSnapshot{};" in CPP
 
 
-def test_snapshot_logging_replaces_per_file_success_noise_with_one_summary():
+def test_snapshot_logging_replaces_per_file_success_noise_with_one_reload_summary():
     assert "Workcell Studio scene metadata snapshot: scene_id=" in CPP
     assert "revision=" in CPP
     assert "files_parsed=" in CPP
-    assert "cache_hits=" in CPP
+    assert "cache_hits=0" in CPP
     assert "invalidation_reason=" in CPP
+
+
+def test_fifty_unchanged_cache_reads_do_not_emit_repeated_summary_logs():
+    cache_hit_block = "if (!explicitly_invalidated && !cached.scene_dir.empty() && cached.scene_dir == key && cached.revision == revision)"
+    assert cache_hit_block in CPP
+    after_cache_hit = CPP.split(cache_hit_block, 1)[1].split("SceneMetadataSnapshot snapshot", 1)[0]
+    assert "++cached.cache_hits;" in after_cache_hit
+    assert "std::cerr" not in after_cache_hit
+
+
+def test_real_file_revision_change_emits_one_new_summary_log():
+    assert "cached.scene_dir == key ? \"file_revision_change\" : \"scene_switch\"" in CPP
+    assert "cached = snapshot;" in CPP
+    assert CPP.count("Workcell Studio scene metadata snapshot: scene_id=") == 1

--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -169,18 +169,18 @@ static SceneMetadataSnapshot load_scene_metadata_snapshot(const fs::path & scene
   SceneMetadataSnapshot & cached = state.cached;
   if (!explicitly_invalidated && !cached.scene_dir.empty() && cached.scene_dir == key && cached.revision == revision) {
     ++cached.cache_hits;
-    cached.invalidation_reason = reason.empty() ? "cache_hit" : reason;
-    std::cerr << "Workcell Studio scene metadata snapshot: scene_id=" << scene_id
-              << " revision=" << cached.revision << " files_parsed=0 cache_hits=" << cached.cache_hits
-              << " invalidation_reason=" << cached.invalidation_reason << std::endl;
     return cached;
   }
+
+  const std::string reload_reason = explicitly_invalidated ?
+    (state.invalidation_reason.empty() ? "explicit_refresh" : state.invalidation_reason) :
+    (cached.scene_dir.empty() ? "initial" : (cached.scene_dir == key ? "file_revision_change" : "scene_switch"));
 
   SceneMetadataSnapshot snapshot;
   snapshot.scene_dir = key;
   snapshot.scene_id = scene_id;
   snapshot.revision = revision;
-  snapshot.invalidation_reason = explicitly_invalidated ? state.invalidation_reason : (reason.empty() ? (cached.scene_dir.empty() ? "initial" : (cached.scene_dir == key ? "file_revision_change" : "scene_switch")) : reason);
+  snapshot.invalidation_reason = reload_reason;
   snapshot.file_revisions = revisions;
   for (const char * rel : kSceneMetadataFiles) {
     YAML::Node doc;


### PR DESCRIPTION
### Motivation
- Reduce noisy terminal output when unchanged scenes repeatedly hit the scene metadata cache while preserving thread-safe cache behavior. 
- Ensure a single actionable summary is emitted only when metadata is actually reloaded (initial load, scene switch, file revision change, or explicit invalidation). 
- Preserve YAML parse warnings and real-file-change invalidation so genuine issues remain visible immediately. 

### Description
- Removed the per-cache-hit terminal summary print in `load_scene_metadata_snapshot` so normal cache hits only increment `cache_hits` and return under the existing mutex without printing. 
- Centralised the reload/invalidation reason into a `reload_reason` string that is used when a snapshot is actually rebuilt to keep one summary log for true reloads. 
- Kept YAML parse warnings and the existing `log_task_metadata_loader_path_once` path unchanged so parse warnings still generate visible warnings. 
- Updated `tests/test_scene_metadata_snapshot_cache.py` to assert that repeated unchanged cache reads do not emit repeated summary logs and that real file revision changes still emit the single reload summary. 

### Testing
- Ran `python3 -m pytest tests/test_scene_metadata_snapshot_cache.py -q` and all tests passed (`8 passed`). 
- Attempted `colcon build --symlink-install --packages-select workcell_builder` but `colcon` is not installed in this environment, so the build was not executed here. 
- Unit tests confirm that cache hits remain functional and quiet, and that a real reload still produces a single metadata snapshot summary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a634ea0aa248331831b26f0768f79a8)