### PR TITLE
Fix Workcell Builder canvas metadata warning logger regression

### DIFF
--- a/tests/test_scene_metadata_snapshot_cache.py
+++ b/tests/test_scene_metadata_snapshot_cache.py
@@ -7,6 +7,10 @@ MAIN = (ROOT / "workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text
 WARNING_ONCE = (ROOT / "workcell_builder/workcell_builder/src_workcell_warning_once.cpp").read_text(encoding="utf-8")
 
 
+def test_canvas_model_has_no_removed_task_metadata_loader_symbol():
+    assert "log_task_metadata_loader_path_once" not in CPP
+
+
 def test_snapshot_tracks_authoritative_scene_metadata_files_and_content_identity():
     for token in [
         "environment.yaml",

--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -1014,9 +1014,9 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
   else { m.status = "READY"; }
   return m;
   } catch (const YAML::Exception & e) {
-    log_task_metadata_loader_path_once(scene_dir / "layout" / "workcell_studio_layout.yaml", std::string("YAML parse exception in preview loader: ") + e.what());
+    log_task_metadata_loader_warning_once(scene_dir / "layout" / "workcell_studio_layout.yaml", std::string("YAML parse exception in preview loader: ") + e.what());
   } catch (const std::exception & e) {
-    log_task_metadata_loader_path_once(scene_dir / "layout" / "workcell_studio_layout.yaml", std::string("std exception in preview loader: ") + e.what());
+    log_task_metadata_loader_warning_once(scene_dir / "layout" / "workcell_studio_layout.yaml", std::string("std exception in preview loader: ") + e.what());
   }
   WorkcellStudioCanvasModel fallback;
   fallback.scene_name = scene_name;


### PR DESCRIPTION
### Motivation
- The canvas model exception handlers still referenced the removed `log_task_metadata_loader_path_once()` symbol, causing a compilation/regression risk; update call sites to the new warning function while keeping the original exception messages and one-time warning behavior.

### Description
- Replaced two `log_task_metadata_loader_path_once(...)` calls with `log_task_metadata_loader_warning_once(...)` in `workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp`.
- Added a focused regression assertion `test_canvas_model_has_no_removed_task_metadata_loader_symbol` in `tests/test_scene_metadata_snapshot_cache.py` to ensure the removed symbol no longer appears in the canvas model source.

### Testing
- Ran `python3 -m pytest tests/test_scene_metadata_snapshot_cache.py -q` which passed (`14 passed`).
- Attempted `colcon build --symlink-install --packages-select workcell_builder` but `colcon` is not installed in the environment, so the package build could not be executed here.
- Ran `git diff --check` which produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64c10a42208331bf4e413a06bd3106)