### PR TITLE
Fix embedded Product View visibility after scene readiness

### DIFF
--- a/tests/test_workcell_builder_embedded_web3d_readiness_policy.py
+++ b/tests/test_workcell_builder_embedded_web3d_readiness_policy.py
@@ -58,6 +58,23 @@ def test_ready_requires_scene_json_and_renderer_readiness():
     assert "failed_required_count != 0" in poll
 
 
+def test_accepted_scene_ready_transition_refreshes_visible_view_after_ready_state():
+    poll = _between(CPP, "if (contract_reason.isEmpty())", "poll_embedded_editor_events();")
+    ready_transition = (
+        "set_embedded_product_view_state(EmbeddedProductViewState::Ready, "
+        "QStringLiteral(\"viewer ready\"));"
+    )
+    assert poll.index(ready_transition) < poll.index("show_embedded_web_product_view();")
+
+    show = _between(
+        CPP,
+        "void ScenePreviewWidget::show_embedded_web_product_view()",
+        "void ScenePreviewWidget::set_preview_context",
+    )
+    assert "embedded_web_view_->setVisible(scene_selected_)" in show
+    assert "refresh_mode_and_state();" in show
+
+
 def test_preparation_accepts_only_rebuilt_or_current_and_rejects_malformed_wrong_scene_missing_and_failed_command():
     prepare = _between(CPP, "void ScenePreviewWidget::on_embedded_web_prepare_finished", "void ScenePreviewWidget::start_embedded_web_readiness_polling")
     assert "freshener_status != QStringLiteral(\"current\") && freshener_status != QStringLiteral(\"rebuilt\")" in prepare

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -1648,8 +1648,8 @@ void ScenePreviewWidget::poll_embedded_web_readiness(const EmbeddedWebRequestIde
     if (contract_reason.isEmpty()) {
       native_compatibility_fallback_active_ = false;
       ++embedded_web_terminal_results_accepted_;
-      show_embedded_web_product_view();
       set_embedded_product_view_state(EmbeddedProductViewState::Ready, QStringLiteral("viewer ready"));
+      show_embedded_web_product_view();
       poll_embedded_editor_events();
       emit studio_log_requested(QStringLiteral("Embedded Product View ready after terminal scene_ready: scene=%1 json=%2 builder_revision=%3 robot_preview_lifecycle_state=%4 failed_required_item_count=0")
         .arg(identity.scene_id, expected_json_path, expected_builder_revision, robot_state.isEmpty() ? QStringLiteral("not_required") : robot_state));


### PR DESCRIPTION
### Motivation

- The embedded Web3D Product View could remain blank after a successful `scene_ready` terminal readiness because `show_embedded_web_product_view()` was called before the view was transitioned to the `Ready` state, and `show_embedded_web_product_view()` calls `refresh_mode_and_state()` which hides the view while the state was still `WaitingForBrowserReadiness`.

### Description

- Change the ordering in `poll_embedded_web_readiness()` so `set_embedded_product_view_state(EmbeddedProductViewState::Ready, ...)` is executed before `show_embedded_web_product_view()` to ensure the visibility refresh sees the `Ready` state.
- Add a focused regression test `test_accepted_scene_ready_transition_refreshes_visible_view_after_ready_state()` in `tests/test_workcell_builder_embedded_web3d_readiness_policy.py` that asserts the `Ready` state transition occurs before the `show_embedded_web_product_view()` call and that the show path updates visibility and triggers `refresh_mode_and_state()`.
- Preserve existing readiness-contract checks, stale-request guards, native compatibility fallback handling, and failure behaviour; no viewer bundles, assets, UI layouts, or other files were changed.

### Testing

- Ran `python3 -m pytest tests/test_workcell_builder_embedded_web3d_readiness_policy.py -q` and all tests passed (`13 passed`).
- Ran `git diff --check` and there were no whitespace errors.
- Attempted `colcon build` and `colcon test` for `workcell_builder` but `colcon` is not available in the execution container so those commands could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64c7fc2d5c833192e0525c45fbf3e1)