### PR TITLE
Fix Workcell Studio log issue counters

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -687,7 +687,10 @@ if(BUILD_TESTING)
     mainwindow_rviz_preview_compile_test.cpp
     rviz_preview_metadata_command_test.cpp
     visual_mesh_source_resolver_test.cpp
+    studio_log_issue_tracker_test.cpp
   )
+  ament_add_gtest(workcell_studio_log_issue_tracker_test
+    test/studio_log_issue_tracker_test.cpp)
 
   file(GLOB workcell_builder_discovered_cpp_tests RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/test ${CMAKE_CURRENT_SOURCE_DIR}/test/*.cpp)
   list(SORT workcell_builder_registered_cpp_tests)

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -1707,10 +1707,14 @@ bool MainWindow::open_scene_builder_for_selected_scene(const QString & source_ac
   try {
     refresh_scene_builder_selection_state_ui();
   } catch (const YAML::Exception & error) {
-    append_studio_log(source_action + ": scene metadata warning: " + QString::fromStdString(error.what()));
+    append_studio_log(
+      source_action + ": scene metadata warning: " + QString::fromStdString(error.what()),
+      workcell_builder::StudioLogSeverity::Warning, QStringLiteral("scene_metadata_parse"));
     QMessageBox::warning(this, "Workcell Studio", "Scene metadata could not be fully parsed. Opened with warnings.");
   } catch (const std::exception & error) {
-    append_studio_log(source_action + ": scene metadata warning: " + QString::fromStdString(error.what()));
+    append_studio_log(
+      source_action + ": scene metadata warning: " + QString::fromStdString(error.what()),
+      workcell_builder::StudioLogSeverity::Warning, QStringLiteral("scene_metadata_parse"));
     QMessageBox::warning(this, "Workcell Studio", "Scene metadata could not be fully parsed. Opened with warnings.");
   }
   show_studio_page(StudioPage::SceneBuilderPage);
@@ -2278,6 +2282,12 @@ void MainWindow::setup_studio_shell()
         "Warnings: " + m + " | Reachability: preview-only | Collision: preview-only | Safety zone: preview-only | Pick source reach: unknown | Place target reach: unknown | Warning count: 1 | Preview-only");
     }
   });
+  connect(scene_preview_widget_, &ScenePreviewWidget::studio_issue_requested, this,
+    [this](const QString & message, const QString & severity, const QString & issue_key) {
+      const auto explicit_severity = severity == QStringLiteral("Warning") ?
+        workcell_builder::StudioLogSeverity::Warning : workcell_builder::StudioLogSeverity::Error;
+      append_studio_log(message, explicit_severity, issue_key);
+    });
   connect(scene_preview_widget_, &ScenePreviewWidget::preview_item_selected, this, [this](const QString &id, const QString &role){
     apply_scene_selection(id, role, id.trimmed().isEmpty(), false);
   });
@@ -4504,6 +4514,14 @@ void MainWindow::select_scene_by_row(int row)
   sync_selected_scene_state();
   refresh_selected_scene_metadata_panel();
   if (previous_scene_path != selected_scene_path()) {
+    studio_log_issue_tracker_.set_scope(selected_scene_path().toStdString());
+    if (scene_builder_issue_count_label_) {
+      scene_builder_issue_count_label_->clear();
+      scene_builder_issue_count_label_->setVisible(false);
+    }
+    if (scene_builder_log_toggle_button_) {
+      scene_builder_log_toggle_button_->setProperty("hasIssues", false);
+    }
     visual_index_script_missing_reported_scene_key_.clear();
     visual_index_regen_failure_reported_scene_key_.clear();
     visual_index_regen_throttle_session_active_ = false;
@@ -4609,7 +4627,8 @@ void MainWindow::open_selected_scene_artifact(const QString & artifact)
   QDesktopServices::openUrl(QUrl::fromLocalFile(QString::fromStdString(target.string())));
 }
 
-void MainWindow::append_studio_log(const QString & message)
+void MainWindow::append_studio_log(
+  const QString & message, workcell_builder::StudioLogSeverity severity, const QString & issue_key)
 {
   if (studio_log_) {
     studio_log_->append(message);
@@ -4620,16 +4639,14 @@ void MainWindow::append_studio_log(const QString & message)
     const int elide_width = qMax(220, scene_builder_status_message_label_->width());
     scene_builder_status_message_label_->setText(scene_builder_status_message_label_->fontMetrics().elidedText(concise, Qt::ElideRight, elide_width));
   }
-  const QString lowered = message.toLower();
-  if (lowered.contains("error") || lowered.contains("failed") || lowered.contains("blocker")) {
-    ++scene_builder_error_count_;
-  } else if (lowered.contains("warn")) {
-    ++scene_builder_warning_count_;
-  }
+  const QString stable_key = issue_key.isEmpty() ? message : issue_key;
+  studio_log_issue_tracker_.report(severity, stable_key.toStdString());
+  const int scene_builder_error_count = studio_log_issue_tracker_.error_count();
+  const int scene_builder_warning_count = studio_log_issue_tracker_.warning_count();
   if (scene_builder_issue_count_label_) {
     const QStringList parts = {
-      scene_builder_error_count_ > 0 ? QStringLiteral("%1 %2").arg(scene_builder_error_count_).arg(scene_builder_error_count_ == 1 ? QStringLiteral("error") : QStringLiteral("errors")) : QString(),
-      scene_builder_warning_count_ > 0 ? QStringLiteral("%1 %2").arg(scene_builder_warning_count_).arg(scene_builder_warning_count_ == 1 ? QStringLiteral("warning") : QStringLiteral("warnings")) : QString()
+      scene_builder_error_count > 0 ? QStringLiteral("%1 %2").arg(scene_builder_error_count).arg(scene_builder_error_count == 1 ? QStringLiteral("error") : QStringLiteral("errors")) : QString(),
+      scene_builder_warning_count > 0 ? QStringLiteral("%1 %2").arg(scene_builder_warning_count).arg(scene_builder_warning_count == 1 ? QStringLiteral("warning") : QStringLiteral("warnings")) : QString()
     };
     QStringList visible_parts;
     for (const QString & part : parts) if (!part.isEmpty()) visible_parts << part;
@@ -4637,7 +4654,7 @@ void MainWindow::append_studio_log(const QString & message)
     scene_builder_issue_count_label_->setVisible(!visible_parts.isEmpty());
   }
   if (scene_builder_log_toggle_button_) {
-    scene_builder_log_toggle_button_->setProperty("hasIssues", scene_builder_warning_count_ > 0 || scene_builder_error_count_ > 0);
+    scene_builder_log_toggle_button_->setProperty("hasIssues", scene_builder_warning_count > 0 || scene_builder_error_count > 0);
   }
   statusBar()->showMessage(message);
 }

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -38,6 +38,7 @@
 #include "attributes/workcell.h"
 #include "workcell_studio_scene_browser.hpp"
 #include "workcell_studio_layout_merge.hpp"
+#include "studio_log_issue_tracker.hpp"
 #include "gui/scene_preview_widget.h"
 
 namespace fs = boost::filesystem;
@@ -130,7 +131,10 @@ private:
   void setup_studio_shell();
   void build_studio_header_actions();
   void apply_studio_theme();
-  void append_studio_log(const QString & message);
+  void append_studio_log(
+    const QString & message,
+    workcell_builder::StudioLogSeverity severity = workcell_builder::StudioLogSeverity::Info,
+    const QString & issue_key = QString());
   bool append_scene_diagnostic_log_once(const QString & event, int payload_revision, int payload_count, const QString & message);
   bool scene3d_debug_logging_enabled() const;
   void show_not_wired_message(const QString & action_label);
@@ -700,8 +704,7 @@ private:
   QFrame * scene_builder_log_panel_{ nullptr };
   QLabel * scene_builder_status_message_label_{ nullptr };
   QLabel * scene_builder_issue_count_label_{ nullptr };
-  int scene_builder_warning_count_{ 0 };
-  int scene_builder_error_count_{ 0 };
+  workcell_builder::StudioLogIssueTracker studio_log_issue_tracker_;
   bool scene_builder_log_collapsed_{ false };
   QToolButton * preview_more_actions_button_{ nullptr };
   QToolButton * validation_more_actions_button_{ nullptr };

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -1448,6 +1448,9 @@ void ScenePreviewWidget::on_embedded_web_prepare_finished(const EmbeddedWebReque
   const bool output_is_fresh = QFileInfo::exists(QDir(embedded_web_repo_root_).filePath(output_path));  // Contract validation supersedes mtime freshness.
   Q_UNUSED(output_is_fresh);
   auto reject_prepare = [&](const QString & reason) {
+    emit studio_issue_requested(
+      QStringLiteral("Embedded Product View scene preparation failed: %1").arg(reason),
+      QStringLiteral("Error"), QStringLiteral("embedded_product_view_scene_preparation"));
     activate_native_compatibility_preview(reason);
     record_embedded_web_prepare_terminal(identity, process, QStringLiteral("command_failure"), exit_status, exit_code,
       QStringLiteral("%1; command=%2").arg(reason, command));

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -300,6 +300,7 @@ public:
 
 signals:
   void studio_log_requested(const QString & message);
+  void studio_issue_requested(const QString & message, const QString & severity, const QString & issue_key);
   void preview_item_selected(const QString & id, const QString & role);
   void embedded_product_view_runtime_state_changed(const QString & state, bool has_usable_content);
 

--- a/workcell_builder/workcell_builder/include/studio_log_issue_tracker.hpp
+++ b/workcell_builder/workcell_builder/include/studio_log_issue_tracker.hpp
@@ -1,0 +1,46 @@
+#ifndef WORKCELL_BUILDER__STUDIO_LOG_ISSUE_TRACKER_HPP_
+#define WORKCELL_BUILDER__STUDIO_LOG_ISSUE_TRACKER_HPP_
+
+#include <string>
+#include <unordered_set>
+
+namespace workcell_builder
+{
+
+enum class StudioLogSeverity { Info, Warning, Error, Blocker };
+
+class StudioLogIssueTracker
+{
+public:
+  void set_scope(const std::string & scope)
+  {
+    if (scope == scope_) return;
+    scope_ = scope;
+    issue_keys_.clear();
+    warning_count_ = 0;
+    error_count_ = 0;
+  }
+
+  bool report(StudioLogSeverity severity, const std::string & issue_key)
+  {
+    if (severity == StudioLogSeverity::Info) return false;
+    const std::string scoped_key = scope_ + "|" + issue_key;
+    if (!issue_keys_.insert(scoped_key).second) return false;
+    if (severity == StudioLogSeverity::Warning) ++warning_count_;
+    else ++error_count_;
+    return true;
+  }
+
+  int warning_count() const { return warning_count_; }
+  int error_count() const { return error_count_; }
+
+private:
+  std::string scope_;
+  std::unordered_set<std::string> issue_keys_;
+  int warning_count_{0};
+  int error_count_{0};
+};
+
+}  // namespace workcell_builder
+
+#endif  // WORKCELL_BUILDER__STUDIO_LOG_ISSUE_TRACKER_HPP_

--- a/workcell_builder/workcell_builder/test/scene_preview_widget_ui_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene_preview_widget_ui_test.cpp
@@ -436,11 +436,9 @@ TEST(SceneBuilderWorkspaceSource, CompactBottomStatusBarUsesSingleRowAndExisting
   EXPECT_TRUE(append_block.contains(QStringLiteral("message.simplified()")));
   EXPECT_TRUE(append_block.contains(QStringLiteral("setToolTip(concise)")));
   EXPECT_TRUE(append_block.contains(QStringLiteral("elidedText(concise, Qt::ElideRight")));
-  EXPECT_TRUE(append_block.contains(QStringLiteral("scene_builder_warning_count_")));
-  EXPECT_TRUE(append_block.contains(QStringLiteral("scene_builder_error_count_")));
-  EXPECT_TRUE(append_block.contains(QStringLiteral("lowered.contains(\"warn\")")));
-  EXPECT_TRUE(append_block.contains(QStringLiteral("lowered.contains(\"error\")")));
-  EXPECT_TRUE(append_block.contains(QStringLiteral("lowered.contains(\"failed\")")));
+  EXPECT_TRUE(append_block.contains(QStringLiteral("studio_log_issue_tracker_.warning_count()")));
+  EXPECT_TRUE(append_block.contains(QStringLiteral("studio_log_issue_tracker_.error_count()")));
+  EXPECT_FALSE(append_block.contains(QStringLiteral("lowered.contains")));
   EXPECT_TRUE(append_block.contains(QStringLiteral("setVisible(!visible_parts.isEmpty())")));
   EXPECT_FALSE(append_block.contains(QStringLiteral("scene_builder_log_panel_->setVisible(true)")));
 

--- a/workcell_builder/workcell_builder/test/studio_log_issue_tracker_test.cpp
+++ b/workcell_builder/workcell_builder/test/studio_log_issue_tracker_test.cpp
@@ -1,0 +1,41 @@
+#include <gtest/gtest.h>
+
+#include "studio_log_issue_tracker.hpp"
+
+using workcell_builder::StudioLogIssueTracker;
+using workcell_builder::StudioLogSeverity;
+
+TEST(StudioLogIssueTracker, DiagnosticTextIsInfoByDefault)
+{
+  StudioLogIssueTracker tracker;
+  tracker.set_scope("scene_a");
+  for (const char * diagnostic : {"failed_required_item_count=0", "parse_error=0",
+      "missing_chain_warnings=0", "Metadata warnings: 0"}) {
+    tracker.report(StudioLogSeverity::Info, diagnostic);
+  }
+  EXPECT_EQ(tracker.error_count(), 0);
+  EXPECT_EQ(tracker.warning_count(), 0);
+}
+
+TEST(StudioLogIssueTracker, KeyedIssuesIncrementOnlyOnce)
+{
+  StudioLogIssueTracker tracker;
+  tracker.set_scope("scene_a");
+  EXPECT_TRUE(tracker.report(StudioLogSeverity::Warning, "missing_camera_metadata"));
+  EXPECT_FALSE(tracker.report(StudioLogSeverity::Warning, "missing_camera_metadata"));
+  EXPECT_EQ(tracker.warning_count(), 1);
+  EXPECT_TRUE(tracker.report(StudioLogSeverity::Error, "scene_preparation_failed"));
+  EXPECT_FALSE(tracker.report(StudioLogSeverity::Error, "scene_preparation_failed"));
+  EXPECT_EQ(tracker.error_count(), 1);
+}
+
+TEST(StudioLogIssueTracker, SceneScopeClearsVisibleCounts)
+{
+  StudioLogIssueTracker tracker;
+  tracker.set_scope("scene_a");
+  tracker.report(StudioLogSeverity::Warning, "missing_camera_metadata");
+  tracker.report(StudioLogSeverity::Error, "scene_preparation_failed");
+  tracker.set_scope("scene_b");
+  EXPECT_EQ(tracker.warning_count(), 0);
+  EXPECT_EQ(tracker.error_count(), 0);
+}


### PR DESCRIPTION
### Motivation
- The Logs badge used substring matching (e.g. "error", "warn", "failed") which caused zero-valued diagnostics and benign messages to inflate warning/error counts. 
- The goal is to count only explicit actionable issues, avoid duplicate counting, keep full log text visible, and scope counts to the active scene.

### Description
- Add a small scene-scoped issue tracker `StudioLogIssueTracker` with explicit severities `Info`, `Warning`, `Error`, and `Blocker`, and stable-key deduplication to avoid double-counting the same issue key (new file `include/studio_log_issue_tracker.hpp`).
- Replace substring-based classification with an explicit `append_studio_log` signature that accepts a `StudioLogSeverity` and optional `issue_key`, and update UI badge string generation to read counts from the tracker instead of text-searching log text (`gui/mainwindow.h`, `gui/mainwindow.cpp`).
- Emit explicit issue events from the Scene Preview path for real failures and classify existing metadata parse warnings as keyed `Warning` so actionable problems increment the counters while ordinary diagnostics remain `Info` (changes in `gui/scene_preview_widget.cpp` and wiring in `gui/mainwindow.cpp`).
- Add focused regression tests and integrate them into the test list: `test/studio_log_issue_tracker_test.cpp` and adjust test expectations that previously inspected substring logic (`test/scene_preview_widget_ui_test.cpp` and `CMakeLists.txt`).

### Testing
- Ran focused Python UI tests with `python3 -m pytest -q tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py` and received `7 passed`.
- Built and exercised a small standalone C++ checker (`g++ -std=c++17 ...`) that exercised the tracker semantics and its assertions succeeded.
- Ran `git diff --check` to ensure no whitespace/patch errors (passed locally in the environment used for the change verification).
- Attempted `colcon build --symlink-install --packages-select workcell_builder` but the `colcon` command was not available in the execution environment so a full package build was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64cc8178b88331ac0b0565ff18fbeb)