### PR TITLE
Fix EmbeddedWebServerProbe initializer warnings

### DIFF
--- a/tests/test_scene_preview_widget_lifecycle_cancellation.py
+++ b/tests/test_scene_preview_widget_lifecycle_cancellation.py
@@ -79,6 +79,45 @@ def test_web_request_identity_binds_root_and_selected_port_for_every_async_gate(
     assert "viewer_url.setPort(identity.selected_server_port);" in browser
 
 
+def test_server_probe_initialization_preserves_safe_default_state():
+    unowned = _between(
+        "void ScenePreviewWidget::ensure_embedded_web_server_started",
+        "void ScenePreviewWidget::select_owned_embedded_web_server",
+    )
+    owned = _between(
+        "void ScenePreviewWidget::start_owned_embedded_web_server",
+        "void ScenePreviewWidget::stop_embedded_web_navigation_for_handoff",
+    )
+    expected_initialization = [
+        "embedded_web_server_probe_ = EmbeddedWebServerProbe{};",
+        "embedded_web_server_probe_.identity = identity;",
+        "embedded_web_server_probe_.port = port;",
+        "embedded_web_server_probe_.navigation_token = navigation_token;",
+    ]
+    for server_start in (unowned, owned):
+        for statement in expected_initialization:
+            assert statement in server_start
+
+    probe = HDR[HDR.index("struct EmbeddedWebServerProbe"):HDR.index("void refresh_embedded_web_product_view")]
+    for default in [
+        "int pending_replies{ 0 };",
+        "bool retryable_failure{ false };",
+        "bool terminal_recorded{ false };",
+        "QString failure_detail;",
+    ]:
+        assert default in probe
+
+
+def test_server_probe_initialization_preserves_marker_and_eight_second_deadline():
+    probes = _between(
+        "void ScenePreviewWidget::start_embedded_web_server_probes",
+        "void ScenePreviewWidget::run_embedded_web_server_probes",
+    )
+    assert "embedded_web_server_probe_ = EmbeddedWebServerProbe{};" in probes
+    assert "embedded_web_server_probe_.expected_marker = marker.readAll().trimmed();" in probes
+    assert "embedded_web_server_probe_.deadline = QDateTime::currentDateTimeUtc().addSecs(8);" in probes
+
+
 def test_serialized_browser_navigation_handoff_queues_only_current_scene_load():
     request = _between("void ScenePreviewWidget::request_embedded_web_product_view_refresh", "ScenePreviewWidget::EmbeddedWebRequestIdentity")
     browser = _between("void ScenePreviewWidget::load_prepared_embedded_web_scene", "#ifdef WORKCELL_BUILDER_HAS_WEBENGINE")

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -737,8 +737,12 @@ void ScenePreviewWidget::start_embedded_web_server_probes(
     return;
   }
   marker.seek(0);
-  embedded_web_server_probe_ = EmbeddedWebServerProbe{identity, port, navigation_token, marker.readAll().trimmed(),
-    QDateTime::currentDateTimeUtc().addSecs(8)};
+  embedded_web_server_probe_ = EmbeddedWebServerProbe{};
+  embedded_web_server_probe_.identity = identity;
+  embedded_web_server_probe_.port = port;
+  embedded_web_server_probe_.navigation_token = navigation_token;
+  embedded_web_server_probe_.expected_marker = marker.readAll().trimmed();
+  embedded_web_server_probe_.deadline = QDateTime::currentDateTimeUtc().addSecs(8);
   embedded_web_server_lifecycle_ = EmbeddedWebServerLifecycle::ServerProbing;
   set_embedded_product_view_state(EmbeddedProductViewState::Preparing, QStringLiteral("server_probing"));
   run_embedded_web_server_probes(identity, port, navigation_token);
@@ -897,7 +901,10 @@ void ScenePreviewWidget::ensure_embedded_web_server_started(const QString & repo
   // An old owned process remains tracked separately and is never confused with
   // a listener discovered at the configured port.
   embedded_web_server_is_owned_ = false;
-  embedded_web_server_probe_ = EmbeddedWebServerProbe{identity, port, navigation_token};
+  embedded_web_server_probe_ = EmbeddedWebServerProbe{};
+  embedded_web_server_probe_.identity = identity;
+  embedded_web_server_probe_.port = port;
+  embedded_web_server_probe_.navigation_token = navigation_token;
   // Probe the configured/default endpoint first; it is reusable only after all
   // resources and the repository marker have been verified.
   start_embedded_web_server_probes(identity, port, navigation_token, repo_root);
@@ -933,7 +940,10 @@ void ScenePreviewWidget::start_owned_embedded_web_server(const EmbeddedWebReques
   const QString repo_root = identity.absolute_repo_root;
   const int port = identity.selected_server_port;
   const quint64 navigation_token = ++embedded_web_navigation_token_;
-  embedded_web_server_probe_ = EmbeddedWebServerProbe{identity, port, navigation_token};
+  embedded_web_server_probe_ = EmbeddedWebServerProbe{};
+  embedded_web_server_probe_.identity = identity;
+  embedded_web_server_probe_.port = port;
+  embedded_web_server_probe_.navigation_token = navigation_token;
   if (embedded_web_server_process_ && embedded_web_server_process_->state() != QProcess::NotRunning) {
     // This is an earlier owned request, never an arbitrary listener. Retire it
     // before replacing it; callbacks remain guarded by their old identity.


### PR DESCRIPTION
### Motivation
- Silence -Wmissing-field-initializers produced by partial aggregate initialization of `EmbeddedWebServerProbe` while preserving existing probe semantics and defaults.

### Description
- Replace three occurrences of partial aggregate initialization with value-initialize-then-assign explicit member assignments for `identity`, `port`, `navigation_token`, `expected_marker`, and `deadline` in `scene_preview_widget.cpp` to avoid missing-field-initializer warnings without changing behavior. 
- Preserve existing defaults for `pending_replies`, `retryable_failure`, `terminal_recorded`, and `failure_detail`, and preserve the marker and eight-second deadline semantics used by the probe logic. 
- Add two focused regression tests validating the safe default initialization and the marker/deadline assignment in `tests/test_scene_preview_widget_lifecycle_cancellation.py`.
- Files changed: `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp`, `tests/test_scene_preview_widget_lifecycle_cancellation.py`.

### Testing
- Ran `python3 -m pytest tests/test_scene_preview_widget_lifecycle_cancellation.py tests/test_workcell_builder_embedded_web3d_readiness_policy.py -q` and received `20 passed`. 
- Ran `git diff --check` which reported no whitespace or diff-check failures. 
- Attempted `colcon build --symlink-install --packages-select workcell_builder` but `colcon` is not installed in the container so a full compile/verification of compiler warnings could not be performed.
- Note: unit tests covering Web3D lifecycle/readiness passed and the changes are minimal and scoped to probe initialization; a ROS/colcon build in a proper Humble workspace is recommended to confirm the absence of the compiler warning in the target build environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64eb0b5f3883319fb01ad3edb1d535)