### PR TITLE
Make embedded Web3D scene handoffs compositor-safe on Qt 5

### DIFF
--- a/tests/test_scene_preview_widget_lifecycle_cancellation.py
+++ b/tests/test_scene_preview_widget_lifecycle_cancellation.py
@@ -14,7 +14,7 @@ def _between(start: str, end: str) -> str:
 def test_lifecycle_cancellation_is_declared_and_used_for_destructor_scene_changes_and_force_refresh():
     assert "~ScenePreviewWidget() override;" in HDR
     assert "void cancel_embedded_web_lifecycle(bool stop_owned_server);" in HDR
-    assert "void stop_embedded_web_navigation_for_handoff();" in HDR
+    assert "void retire_embedded_web_navigation_for_handoff();" in HDR
     assert "ScenePreviewWidget::~ScenePreviewWidget()\n{\n  cancel_embedded_web_lifecycle(true);" in CPP
 
     context = _between("void ScenePreviewWidget::set_preview_context", "void ScenePreviewWidget::activate_native_compatibility_preview")
@@ -27,7 +27,7 @@ def test_lifecycle_cancellation_is_declared_and_used_for_destructor_scene_change
 
 def test_cancellation_retires_callbacks_and_owns_process_shutdown():
     helper = _between("void ScenePreviewWidget::cancel_embedded_web_lifecycle", "void ScenePreviewWidget::request_embedded_web_product_view_refresh")
-    handoff = _between("void ScenePreviewWidget::stop_embedded_web_navigation_for_handoff", "void ScenePreviewWidget::cancel_embedded_web_lifecycle")
+    handoff = _between("void ScenePreviewWidget::retire_embedded_web_navigation_for_handoff", "void ScenePreviewWidget::cancel_embedded_web_lifecycle")
     for token in [
         "++embedded_web_request_generation_",
         "process->terminate()",
@@ -39,11 +39,11 @@ def test_cancellation_retires_callbacks_and_owns_process_shutdown():
         "++embedded_web_navigation_token_",
         "embedded_editor_polling_ = false",
         "embedded_web_readiness_deadline_ = QDateTime()",
-        "embedded_web_view_->stop()",
-        "embedded_web_view_->setVisible(false)",
     ]:
         assert token in handoff
-    assert "stop_embedded_web_navigation_for_handoff();" in helper
+    assert "embedded_web_view_->stop()" not in handoff
+    assert "embedded_web_view_->setVisible(false)" not in handoff
+    assert "retire_embedded_web_navigation_for_handoff();" in helper
 
 
 def test_async_web_callbacks_guard_their_captured_request_identity():
@@ -86,7 +86,7 @@ def test_server_probe_initialization_preserves_safe_default_state():
     )
     owned = _between(
         "void ScenePreviewWidget::start_owned_embedded_web_server",
-        "void ScenePreviewWidget::stop_embedded_web_navigation_for_handoff",
+        "void ScenePreviewWidget::retire_embedded_web_navigation_for_handoff",
     )
     expected_initialization = [
         "embedded_web_server_probe_ = EmbeddedWebServerProbe{};",
@@ -124,9 +124,9 @@ def test_serialized_browser_navigation_handoff_queues_only_current_scene_load():
     mode = _between("void ScenePreviewWidget::refresh_mode_and_state", "QRectF ScenePreviewWidget::rendered_items_bounds_2d")
 
     assert "!embedded_web_active_identity_.matches_effective_request(identity)" in request
-    assert "stop_embedded_web_navigation_for_handoff();" in request
-    assert "embedded_web_view_->stop();" in browser
-    assert "embedded_web_view_->setVisible(false);" in browser
+    assert "retire_embedded_web_navigation_for_handoff();" in request
+    assert "embedded_web_view_->stop();" not in browser
+    assert "embedded_web_view_->setVisible(false);" not in browser
     assert "QTimer::singleShot(0, this, [this, identity, queued_navigation_token, viewer_url]()" in browser
     stale_guard = browser.index("if (!embedded_web_identity_is_current(identity)")
     assert browser.index("embedded_web_view_->load(viewer_url);", stale_guard) > stale_guard
@@ -135,4 +135,18 @@ def test_serialized_browser_navigation_handoff_queues_only_current_scene_load():
     assert "embedded_web_loading_identity_ != identity" in browser
     assert "embedded_web_expected_viewer_url_ != viewer_url" in browser
     assert "++embedded_web_browser_navigations_started_;" in browser
+    assert browser.count("embedded_web_view_->load(viewer_url);") == 1
+    assert "embedded_web_has_committed_surface_ ||" in mode
     assert "embedded_product_view_state_ == EmbeddedProductViewState::Ready" in mode
+
+
+def test_first_load_stays_hidden_but_committed_surface_remains_visible_during_handoff():
+    mode = _between("void ScenePreviewWidget::refresh_mode_and_state", "QRectF ScenePreviewWidget::rendered_items_bounds_2d")
+    assert "bool embedded_web_has_committed_surface_{ false };" in HDR
+    visibility = _between("const bool show_embedded_surface", "if (error_state_label_)")
+    assert "embedded_web_has_committed_surface_ ||" in visibility
+    assert "EmbeddedProductViewState::Ready" in visibility
+    assert "EmbeddedProductViewState::Failed" in visibility
+    assert "EmbeddedProductViewState::Loading" not in visibility
+    assert "EmbeddedProductViewState::WaitingForBrowserReadiness" not in visibility
+    assert "setVisible(use3d && scene_selected_ && show_embedded_surface)" in mode

--- a/tests/test_workcell_builder_embedded_web3d_readiness_policy.py
+++ b/tests/test_workcell_builder_embedded_web3d_readiness_policy.py
@@ -64,6 +64,8 @@ def test_accepted_scene_ready_transition_refreshes_visible_view_after_ready_stat
         "set_embedded_product_view_state(EmbeddedProductViewState::Ready, "
         "QStringLiteral(\"viewer ready\"));"
     )
+    commit = "embedded_web_has_committed_surface_ = true;"
+    assert poll.index(commit) < poll.index(ready_transition)
     assert poll.index(ready_transition) < poll.index("show_embedded_web_product_view();")
 
     show = _between(
@@ -162,3 +164,16 @@ def test_runtime_failure_accounting_is_request_scoped_and_deduplicated():
     assert "Suppressed duplicate Embedded Product View terminal failure" in failure
     assert "Ignored stale Embedded Product View runtime failure" in failure
     assert "set_embedded_product_view_state(EmbeddedProductViewState::Failed, detail)" in failure
+
+
+def test_stale_readiness_and_terminal_failure_cannot_commit_or_label_replacement_ready():
+    poll = _between(CPP, "void ScenePreviewWidget::poll_embedded_web_readiness", "void ScenePreviewWidget::load_prepared_embedded_web_scene")
+    stale_guard = poll.index("if (!embedded_web_identity_is_current(identity)")
+    commit = poll.index("embedded_web_has_committed_surface_ = true;")
+    assert stale_guard < commit
+    assert "navigation_token != embedded_web_navigation_token_" in poll[:commit]
+
+    failure = _between(CPP, "void ScenePreviewWidget::handle_embedded_web_runtime_failure", "void ScenePreviewWidget::ensure_embedded_web_server_started")
+    assert "set_embedded_product_view_state(EmbeddedProductViewState::Failed, detail)" in failure
+    assert "embedded_web_has_committed_surface_ = true" not in failure
+    assert "EmbeddedProductViewState::Ready" not in failure

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -994,7 +994,7 @@ void ScenePreviewWidget::start_owned_embedded_web_server(const EmbeddedWebReques
 }
 
 
-void ScenePreviewWidget::stop_embedded_web_navigation_for_handoff()
+void ScenePreviewWidget::retire_embedded_web_navigation_for_handoff()
 {
   ++embedded_web_navigation_token_;
   embedded_web_loading_navigation_token_ = 0;
@@ -1004,12 +1004,9 @@ void ScenePreviewWidget::stop_embedded_web_navigation_for_handoff()
   embedded_editor_polling_ = false;
   embedded_web_readiness_deadline_ = QDateTime();
   embedded_web_last_boot_status_.clear();
-#ifdef WORKCELL_BUILDER_HAS_WEBENGINE
-  if (embedded_web_view_) {
-    embedded_web_view_->stop();
-    embedded_web_view_->setVisible(false);
-  }
-#endif
+  // Do not stop or unmount the Qt 5 WebEngine surface here. Loading the newest
+  // guarded URL replaces any in-flight navigation, while an already committed
+  // frame remains compositor-owned and available throughout the handoff.
 }
 
 void ScenePreviewWidget::cancel_embedded_web_lifecycle(bool stop_owned_server)
@@ -1017,7 +1014,7 @@ void ScenePreviewWidget::cancel_embedded_web_lifecycle(bool stop_owned_server)
   // Every callback captures an identity.  Retiring it first makes queued browser,
   // timer, and process callbacks harmless before any UI or process state changes.
   ++embedded_web_request_generation_;
-  stop_embedded_web_navigation_for_handoff();
+  retire_embedded_web_navigation_for_handoff();
   embedded_web_has_active_identity_ = false;
   embedded_web_active_identity_ = EmbeddedWebRequestIdentity{};
   embedded_web_preparing_identity_ = EmbeddedWebRequestIdentity{};
@@ -1135,7 +1132,7 @@ void ScenePreviewWidget::request_embedded_web_product_view_refresh(bool force, c
     embedded_web_request_generation_ = identity.generation;
   } else if (embedded_web_has_active_identity_ &&
              !embedded_web_active_identity_.matches_effective_request(identity)) {
-    stop_embedded_web_navigation_for_handoff();
+    retire_embedded_web_navigation_for_handoff();
   }
 
   if (!force && embedded_web_prepare_process_ && embedded_web_prepare_process_->state() != QProcess::NotRunning) {
@@ -1661,6 +1658,7 @@ void ScenePreviewWidget::poll_embedded_web_readiness(const EmbeddedWebRequestIde
     if (contract_reason.isEmpty()) {
       native_compatibility_fallback_active_ = false;
       ++embedded_web_terminal_results_accepted_;
+      embedded_web_has_committed_surface_ = true;
       set_embedded_product_view_state(EmbeddedProductViewState::Ready, QStringLiteral("viewer ready"));
       show_embedded_web_product_view();
       poll_embedded_editor_events();
@@ -1731,8 +1729,6 @@ void ScenePreviewWidget::load_prepared_embedded_web_scene(const EmbeddedWebReque
   embedded_web_server_lifecycle_ = EmbeddedWebServerLifecycle::BrowserLoading;
   embedded_web_expected_viewer_url_ = viewer_url;
   embedded_web_last_viewer_url_ = embedded_web_expected_viewer_url_.toString();
-  embedded_web_view_->stop();
-  embedded_web_view_->setVisible(false);
   QTimer::singleShot(0, this, [this, identity, queued_navigation_token, viewer_url]() {
     if (!embedded_web_view_) return;
     if (!embedded_web_identity_is_current(identity) ||
@@ -2375,10 +2371,14 @@ void ScenePreviewWidget::refresh_mode_and_state()
   if (compatibility_scene3d_viewport_) compatibility_scene3d_viewport_->setVisible(show_native_compatibility);
   if (simple_3d_view_) simple_3d_view_->setVisible(use3d && scene_selected_ && !show_native_compatibility);
   if (web3d_selected && embedded_web_view_) {
-    // Serialized handoff keeps the previous embedded_web_view_->setVisible(use3d && scene_selected_)
-    // surface hidden until the replacement scene completes readiness.
-    embedded_web_view_->setVisible(use3d && scene_selected_ &&
-      embedded_product_view_state_ == EmbeddedProductViewState::Ready);
+    // The first load keeps the existing empty/loading presentation. Once a
+    // scene_ready result has committed a surface, keep that single WebEngine
+    // surface mounted through later Loading/Waiting handoffs so Qt 5 Chromium
+    // can retire and replace compositor resources in navigation order.
+    const bool show_embedded_surface = embedded_web_has_committed_surface_ ||
+      embedded_product_view_state_ == EmbeddedProductViewState::Ready ||
+      embedded_product_view_state_ == EmbeddedProductViewState::Failed;
+    embedded_web_view_->setVisible(use3d && scene_selected_ && show_embedded_surface);
   }
   if (error_state_label_) {
     const bool show_web3d_error = web3d_selected && use3d && scene_selected_ &&

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -404,7 +404,7 @@ private:
   void refresh_embedded_web_product_view();
   void request_embedded_web_product_view_refresh(bool force = false, const QString & origin = QStringLiteral("automatic"));
   void cancel_embedded_web_lifecycle(bool stop_owned_server);
-  void stop_embedded_web_navigation_for_handoff();
+  void retire_embedded_web_navigation_for_handoff();
   void maybe_start_next_embedded_web_prepare();
   EmbeddedWebRequestIdentity embedded_web_request_identity(quint64 generation) const;
   bool embedded_web_identity_is_current(const EmbeddedWebRequestIdentity & identity) const;
@@ -507,6 +507,7 @@ private:
   QUrl embedded_web_expected_viewer_url_;
   bool embedded_web_server_is_owned_{ false };
   bool embedded_web_has_active_identity_{ false };
+  bool embedded_web_has_committed_surface_{ false };
   bool pending_embedded_web_request_{ false };
   quint64 embedded_web_request_generation_{ 0 };
   bool pending_embedded_web_force_{ false };


### PR DESCRIPTION
### Motivation

- Switching scenes (e.g. `ur5_2f_test → suction_test → ur5_2f_test`) could provoke Qt WebEngine/Chromium compositor races and SharedImage errors because the code called `stop()` and `setVisible(false)` during ordinary handoffs, prematurely unmounting the WebEngine surface while the compositor still owned GPU resources. 
- The intent is to make ordinary scene handoffs safe for Qt 5 WebEngine by keeping the single owned `QWebEngineView` mounted and letting a guarded navigation replace the previous navigation, while preserving the existing readiness contract and lifecycle guards.

### Description

- Keep one owned `QWebEngineView` surface mounted and avoid calling `QWebEngineView::stop()` or `setVisible(false)` during ordinary scene handoffs by replacing the former `stop_embedded_web_navigation_for_handoff()` calls with `retire_embedded_web_navigation_for_handoff()` and removing stop/visibility operations from the handoff path. (edited files: `scene_preview_widget.cpp`, `scene_preview_widget.h`).
- Track a committed surface with a new `bool embedded_web_has_committed_surface_` that is set only when the newest navigation satisfies the full terminal `scene_ready` readiness contract, and use this flag to allow previously committed WebEngine frames to remain visible during subsequent `Loading` and `WaitingForBrowserReadiness` states.
- Preserve first-load empty/loading behaviour by ensuring the initial load still follows the prior hidden/loading presentation while later loads that replace a committed surface keep that single surface mounted until the replacement commits.
- Preserve all existing navigation lifecycle protections including request-generation and navigation-token guards, immutable request identity checks, stale-callback rejection, duplicate navigation coalescing, server reuse and probe logic, and the readiness contract semantics; only the surface-unmounting call sites were changed so compositor resources retire naturally via navigation order rather than forced unmounts.
- Add focused regression/contract tests (updates to `tests/test_scene_preview_widget_lifecycle_cancellation.py` and `tests/test_workcell_builder_embedded_web3d_readiness_policy.py`) that assert: no stop/hide during ordinary handoff, previously committed surface remains visible during `Loading`/`WaitingForBrowserReadiness`, first-load behaviour unchanged, only newest queued navigation triggers `load()`, stale readiness cannot commit a replacement, terminal failure cannot present stale content as current ready content, and a final accepted `scene_ready` commits the new surface.
- Change set is intentionally small and focused on the embedded WebEngine lifecycle and two test files; commit `2c43207` contains the changes and can be reverted to roll back.

### Testing

- Ran focused unit/static tests: `python3 -m pytest tests/test_scene_preview_widget_lifecycle_cancellation.py tests/test_workcell_builder_embedded_web3d_readiness_policy.py -q` — 22 passed.
- Ran `git diff --check` — no whitespace/patch errors reported.
- Attempted `colcon build` / `colcon test` for `workcell_builder`, but `colcon`/ROS 2 are not available in this container (failure: `/bin/bash: line 1: colcon: command not found`), so those build/test steps could not be executed here.

(Automated tests and static assertions above validate the lifecycle/readiness policy changes; manual Ubuntu 22.04 + ROS 2 Humble + Qt5 scene-switch acceptance must still be performed in a proper environment to confirm compositor error elimination.)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6510892d5c8331b17f5f45c39868bb)