### PR TITLE
Fix orphan Scene Builder Inspect control

### DIFF
--- a/tests/test_product_view_toolbar_more_menu.py
+++ b/tests/test_product_view_toolbar_more_menu.py
@@ -21,7 +21,8 @@ def test_product_view_primary_toolbar_keeps_only_core_controls_visible():
     assert 'primary_controls->addWidget(scene_builder_secondary_overflow_button_)' in CPP
 
     assert 'primary_controls->addWidget(place_mode_persistent_box_)' not in primary
-    assert 'primary_controls->addWidget(inspect_mode_button)' not in primary
+    assert 'make_primary_button("Inspect")' not in primary
+    assert 'inspect_mode_button' not in CPP
     assert 'controls->addWidget(camera_view)' not in CPP
     assert '  controls->addWidget(scene_builder_secondary_overflow_button_);' not in CPP
 
@@ -33,7 +34,6 @@ def test_secondary_actions_are_reused_in_more_menu_with_groups_and_state():
     )
 
     for token in [
-        'addAction(inspect_action)',
         'addAction(keep_placing_action)',
         'addAction(snap_menu_action)',
         'addAction(gizmo_menu_action)',
@@ -52,7 +52,8 @@ def test_secondary_actions_are_reused_in_more_menu_with_groups_and_state():
     assert 'scene_builder_action("layout.redo")' in more
     assert 'setShortcut(QKeySequence::Undo)' in more
     assert 'setShortcut(QKeySequence::Redo)' in more
-    assert 'QObject::connect(inspect_action, &QAction::triggered, inspect_mode_button, &QPushButton::click)' in more
+    assert 'inspect_action = scene_builder_secondary_overflow_menu_->addAction("Inspect")' in more
+    assert 'set_canvas_interaction_mode(CanvasInteractionMode::Inspect)' in more
 
     assert 'place_mode_persistent_box_->setChecked(false);' in CPP
     assert 'snap_action->setCheckable(true)' in CPP

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -2396,7 +2396,6 @@ void MainWindow::setup_studio_shell()
   auto * select_mode_button = make_primary_button("Select"); primary_controls->addWidget(select_mode_button);
   auto * place_mode_button = make_primary_button("Place Asset"); primary_controls->addWidget(place_mode_button);
   auto * move_mode_button = make_primary_button("Move"); primary_controls->addWidget(move_mode_button);
-  auto * inspect_mode_button = make_primary_button("Inspect");
   save_layout_button_ = make_primary_button("Save Layout");
   primary_controls->addWidget(save_layout_button_);
   primary_controls->addStretch(1);
@@ -2500,9 +2499,6 @@ void MainWindow::setup_studio_shell()
   scene_builder_secondary_overflow_button_->setText("Panels & Tools");
   scene_builder_secondary_overflow_button_->setPopupMode(QToolButton::InstantPopup);
   scene_builder_secondary_overflow_menu_ = new QMenu(scene_builder_secondary_overflow_button_);
-  auto * inspect_action = new QAction(inspect_mode_button->text(), scene_builder_secondary_overflow_menu_);
-  inspect_action->setToolTip(inspect_mode_button->toolTip());
-  QObject::connect(inspect_action, &QAction::triggered, inspect_mode_button, &QPushButton::click);
   auto * keep_placing_action = new QWidgetAction(scene_builder_secondary_overflow_menu_);
   keep_placing_action->setDefaultWidget(place_mode_persistent_box_);
   auto * snap_menu_action = canvas_more_menu->menuAction();
@@ -2589,7 +2585,10 @@ void MainWindow::setup_studio_shell()
     sync_scene_builder_view_actions();
   });
   sync_scene_builder_view_actions();
-  scene_builder_secondary_overflow_menu_->addAction(inspect_action);
+  auto * inspect_action = scene_builder_secondary_overflow_menu_->addAction("Inspect");
+  QObject::connect(inspect_action, &QAction::triggered, this, [this]() {
+    set_canvas_interaction_mode(CanvasInteractionMode::Inspect);
+  });
   scene_builder_secondary_overflow_menu_->addAction(keep_placing_action);
   scene_builder_secondary_overflow_menu_->addAction(snap_menu_action);
   scene_builder_secondary_overflow_menu_->addAction(gizmo_menu_action);
@@ -3202,7 +3201,6 @@ void MainWindow::setup_studio_shell()
   connect_button(select_mode_button, [this](){ set_canvas_interaction_mode(CanvasInteractionMode::Select); });
   connect_button(place_mode_button, [this](){ set_canvas_interaction_mode(CanvasInteractionMode::Place); });
   connect_button(move_mode_button, [this](){ set_canvas_interaction_mode(CanvasInteractionMode::Move); });
-  connect_button(inspect_mode_button, [this](){ set_canvas_interaction_mode(CanvasInteractionMode::Inspect); });
   if (snap_to_grid_box_) {
     connect(snap_to_grid_box_, &QCheckBox::toggled, this, [this](bool){ rebuild_digital_twin_canvas(); });
   }


### PR DESCRIPTION
### Motivation
- The Scene Builder created an unlaid-out `Inspect` `QPushButton` that remained a direct child of the page and could render at the origin, overlapping the "Scene Builder" header, so the button must be removed and the Inspect action exposed only via the Panels & Tools overflow.

### Description
- Removed the orphan `inspect_mode_button` creation and instead add `Inspect` as a `QAction` via `scene_builder_secondary_overflow_menu_->addAction("Inspect")` and connect it to `set_canvas_interaction_mode(CanvasInteractionMode::Inspect)`, preserving existing Select/Place/Move/Save controls and interaction-mode behavior; updated focused static assertions in `tests/test_product_view_toolbar_more_menu.py` accordingly.

### Testing
- Ran `python3 -m pytest tests/test_product_view_toolbar_more_menu.py -q` which passed (2 tests), and ran `git diff --check` which passed; full `python3 -m pytest tests -q` completed but included many unrelated pre-existing failures, and `colcon` build/test were not run because `colcon` is not installed in the environment.

Files changed: `workcell_builder/workcell_builder/gui/mainwindow.cpp`, `tests/test_product_view_toolbar_more_menu.py`.
Commit: `b7c9f8e` on branch `codex/fix-orphan-inspect-button`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a652767e958833182d0793f7f723777)