### PR TITLE
Fix Web3D physical target-bin mesh export

### DIFF
--- a/scenes/ur5_2f_test/layout/workcell_studio_layout.yaml
+++ b/scenes/ur5_2f_test/layout/workcell_studio_layout.yaml
@@ -64,8 +64,12 @@ items:
       xyz: [0.55, -0.28, 0.19]
       rpy: [0.0, 0.0, 0.0]
     dimensions: [0.35, 0.25, 0.18]
-    geometry_type: box
-    primitive_geometry_type: box
+    geometry_type: mesh
+    mesh:
+      path: assets/environment/sorting_bin_description/meshes/sorting_bin.stl
+      scale: [0.001, 0.001, 0.001]
+      rpy: [0.0, 0.0, 0.0]
+      origin_offset: [0.0, 0.0, 0.0]
     material:
       color: [0.95, 0.68, 0.20, 0.65]
   - id: realsense_overhead

--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -791,7 +791,20 @@ def _identity_text(item: Mapping[str, Any]) -> str:
     return " ".join(parts)
 
 
+def _is_tangible_target_bin(item: Mapping[str, Any]) -> bool:
+    return (
+        _has_mesh_reference(item)
+        and str(_first_present(item.get("type"), item.get("role"), "")).lower() == "target_bin"
+    )
+
+
 def _is_helper(item: Mapping[str, Any]) -> bool:
+    # A target bin is tangible product geometry even when its task-facing
+    # category also associates it with a place zone.  Keep the separate,
+    # meshless zone declaration as an overlay, but never demote the authored
+    # bin mesh itself.
+    if _is_tangible_target_bin(item):
+        return False
     text = _identity_text(item)
     return any(token in text for token in HELPER_TOKENS)
 
@@ -1456,6 +1469,27 @@ def _iter_declared_physical_entries(data: Mapping[str, Any]) -> Iterable[Tuple[s
                 item = dict(raw)
                 item.setdefault("id", str(_first_present(raw.get("id"), raw.get("name"), entry_key)))
                 item.setdefault("source_section", key)
+                # Layout YAML stores mesh authoring data as a cohesive nested
+                # block.  Normalize it before the authored-field allowlist is
+                # copied so web export does not require duplicate top-level
+                # mesh_path/mesh_scale fields.
+                mesh_block = _as_map(raw.get("mesh"))
+                mesh_path = _first_present(mesh_block.get("path"), mesh_block.get("uri"))
+                if isinstance(mesh_path, str) and mesh_path:
+                    item.setdefault("mesh_path", mesh_path)
+                    item.setdefault("geometry_type", "mesh")
+                if mesh_block.get("scale") not in (None, [], {}):
+                    item.setdefault("mesh_scale", mesh_block.get("scale"))
+                mesh_rpy = mesh_block.get("rpy")
+                origin_offset = mesh_block.get("origin_offset")
+                if mesh_rpy not in (None, [], {}) or origin_offset not in (None, [], {}):
+                    item.setdefault(
+                        "visual_origin",
+                        {
+                            "xyz": origin_offset if origin_offset not in (None, [], {}) else [0.0, 0.0, 0.0],
+                            "rpy": mesh_rpy if mesh_rpy not in (None, [], {}) else [0.0, 0.0, 0.0],
+                        },
+                    )
                 # Legacy EMD object declarations often bury their visual mesh under
                 # links.<link>.visual.geometry.filepath; expose it to the normal
                 # resolver/stager without adding section-specific render logic.
@@ -1476,8 +1510,8 @@ def _iter_declared_physical_entries(data: Mapping[str, Any]) -> Iterable[Tuple[s
 def _authored_item(raw: Mapping[str, Any], source: str, index: int, scene_dir: Path) -> Json:
     fields = (
         "id", "type", "role", "category", "display_name", "source_section", "link", "object_name", "frame", "pose", "pose_xyz", "pose_rpy", "dimensions",
-        "geometry_type", "primitive_geometry_type", "mesh_uri", "package_uri", "source_path", "mesh_path", "filepath", "material",
-        "layout_item_ref", "support_surface_ref", "task_zone_ref", "scale", "mesh_scale", "perception_mode", "runtime_enforced", "runtime_commanded",
+        "geometry_type", "primitive_geometry_type", "mesh_uri", "package_uri", "source_path", "mesh_path", "filepath", "mesh_scale", "visual_origin", "material",
+        "layout_item_ref", "support_surface_ref", "task_zone_ref", "scale", "perception_mode", "runtime_enforced", "runtime_commanded",
         "support_surface_kind", "support_kind", "semantic_type", "top_surface_z_m", "topSurfaceZM", "support_surface_height_m", "supportSurfaceHeightM",
         "expected_support_footprint_m", "support_footprint_m", "footprint_m", "footprint", "table_height", "table_top_z", "surface_height_m",
     )
@@ -1492,9 +1526,22 @@ def _authored_item(raw: Mapping[str, Any], source: str, index: int, scene_dir: P
 
 def _authored_sections(data: Dict[str, Any], scene_dir: Path, warnings: List[Json]) -> Dict[str, List[Json]]:
     sections = {"assets": [], "sensors": [], "zones": []}
+    physical_layout_items: Dict[str, Json] = {}
     if data.get("layout") is not None and "items" not in _as_map(data.get("layout")):
         _warn(warnings, "layout_items_missing", "layout/workcell_studio_layout.yaml has no items list.", INPUTS["layout"])
     for counter, (source_section, raw, source) in enumerate(_iter_declared_physical_entries(data)):
+        layout_ref = str(_first_present(raw.get("layout_item_ref"), raw.get("id"), ""))
+        existing_layout_item = physical_layout_items.get(layout_ref)
+        if source == INPUTS["environment"] and existing_layout_item is not None:
+            # environment.yaml describes semantic/task relationships for the
+            # same editable layout object.  Enrich that authoritative physical
+            # record instead of exporting a second meshless marker with the
+            # same target-bin identity.
+            for field in ("frame", "layout_item_ref", "support_surface_ref", "task_zone_ref", "perception_mode", "runtime_enforced", "runtime_commanded"):
+                if field in raw and field not in existing_layout_item:
+                    existing_layout_item[field] = raw[field]
+                    existing_layout_item["provenance"][field] = source
+            continue
         item = _authored_item(raw, source, counter, scene_dir)
         item["source_section"] = source_section
         item["active_visual_source"] = "declared_mesh" if _has_mesh_reference(item) else ("declared_primitive" if _item_local_bounds(item) is not None else "declared_physical_metadata")
@@ -1507,6 +1554,8 @@ def _authored_sections(data: Dict[str, Any], scene_dir: Path, warnings: List[Jso
             sections["zones"].append(item)
         else:
             sections["assets"].append(item)
+        if source == INPUTS["layout"] and _has_mesh_reference(item):
+            physical_layout_items[str(item.get("id"))] = item
     return sections
 
 
@@ -1688,6 +1737,8 @@ def _is_mesh_item(item: Mapping[str, Any]) -> bool:
 def _core_mesh_category(item: Mapping[str, Any], section: str) -> Optional[str]:
     if _is_helper(item) or section == "zones":
         return None
+    if section == "assets" and _is_tangible_target_bin(item):
+        return "authored_asset_object"
     text = _identity_text(item)
     role = str(item.get("role", "")).lower()
     category = str(item.get("category", "")).lower()
@@ -1736,6 +1787,8 @@ def _visual_contract_category(item: Mapping[str, Any], section: str) -> str:
     category = str(item.get("category", "")).lower()
     if section == "zones" or _is_helper(item):
         return "zone"
+    if section == "assets" and _is_tangible_target_bin(item):
+        return "object"
     if section == "sensors" or any(token in text for token in ("camera", "realsense")):
         return "camera"
     if any(token in text for token in ("table", "workbench", "support_surface")):

--- a/tests/test_workcell_studio_web_mesh_staging.py
+++ b/tests/test_workcell_studio_web_mesh_staging.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -68,6 +69,82 @@ def _all_renderable_items(payload: dict) -> list[dict]:
 
 def _item(payload: dict, item_id: str) -> dict:
     return next(item for item in _all_renderable_items(payload) if item.get("id") == item_id)
+
+
+def test_nested_layout_target_bin_mesh_is_the_authoritative_physical_render(monkeypatch, tmp_path):
+    scene = tmp_path / "nested_target_bin_scene"
+    _write_yaml(
+        scene / "layout" / "workcell_studio_layout.yaml",
+        {
+            "items": [
+                {
+                    "id": "target_bin_default",
+                    "type": "target_bin",
+                    "role": "target_bin",
+                    "category": "place_zone",
+                    "pose": {"xyz": [0.55, -0.28, 0.19], "rpy": [0.0, 0.0, 0.0]},
+                    "dimensions": [0.35, 0.25, 0.18],
+                    "geometry_type": "mesh",
+                    "mesh": {
+                        "path": "assets/environment/sorting_bin_description/meshes/sorting_bin.stl",
+                        "scale": [0.001, 0.001, 0.001],
+                        "rpy": [0.0, 0.0, 0.0],
+                        "origin_offset": [0.0, 0.0, 0.0],
+                    },
+                },
+                {
+                    "id": "place_zone_default",
+                    "type": "place_zone",
+                    "role": "place_zone",
+                    "category": "work_surface",
+                    "dimensions": [0.35, 0.30, 0.01],
+                },
+            ]
+        },
+    )
+    _write_yaml(
+        scene / "environment.yaml",
+        {
+            "scene": {"id": scene.name, "name": scene.name},
+            "environment": {
+                "assets": [
+                    {
+                        "id": "target_bin_default",
+                        "type": "target_bin",
+                        "role": "target_bin",
+                        "category": "place_zone",
+                        "layout_item_ref": "target_bin_default",
+                        "support_surface_ref": "support_surface_table",
+                        "task_zone_ref": "default_drop_zone",
+                    }
+                ]
+            },
+        },
+    )
+    staged_root = REPO_ROOT / "build" / "workcell_studio_web_scene" / "assets" / scene.name
+
+    try:
+        payload = _export_with_prefix(monkeypatch, scene, tmp_path / "out" / "scene.web_scene.json")
+        matching = [item for item in _all_renderable_items(payload) if item.get("id") == "target_bin_default"]
+
+        assert len(matching) == 1
+        target_bin = matching[0]
+        assert target_bin["source_kind"] == "user_authored"
+        assert target_bin["render_policy"] == "primary"
+        assert target_bin["render_owner"] == "editable_layout"
+        assert target_bin["mesh_staging_status"] == "staged"
+        assert target_bin["mesh_scale"] == [0.001, 0.001, 0.001]
+        assert target_bin["visual_origin"] == {"xyz": [0.0, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]}
+        assert target_bin["mesh_uri"] == target_bin["mesh_url"]
+        assert target_bin["mesh_uri"].endswith("sorting_bin.stl")
+        assert target_bin["support_surface_ref"] == "support_surface_table"
+        assert target_bin["task_zone_ref"] == "default_drop_zone"
+        assert target_bin["mesh_contract_category"] == "object"
+        assert payload["metadata"]["mesh_contract"]["mesh_contract_status"] == "passed"
+        assert any(item.get("id") == "place_zone_default" for item in payload["zones"])
+        assert (REPO_ROOT / target_bin["mesh_uri"]).is_file()
+    finally:
+        shutil.rmtree(staged_root, ignore_errors=True)
 
 
 def test_package_mesh_uri_is_staged_and_preserves_original_uri(monkeypatch, tmp_path):


### PR DESCRIPTION
### Motivation
- Nested layout mesh blocks (mesh.path/mesh.scale/mesh.rpy/origin_offset) were not normalized into the web export contract, causing authored bin meshes to become meshless markers in the viewer. 
- Tangible target bins were being classified as helper/place-zone overlays because of their `category`, which caused physical product geometry to be hidden behind an orange task marker and broke mesh staging/readiness.
- The environment record referencing the same layout item produced a second meshless renderable instead of enriching the authoritative authored layout mesh entry.

### Description
- Normalize nested layout `mesh` blocks from `layout/workcell_studio_layout.yaml` into the authored item pipeline so `mesh.path` -> `mesh_path`, `mesh.scale` -> `mesh_scale`, and nested `rpy`/`origin_offset` are preserved as `visual_origin` before copying authored fields. (changed `scripts/export_workcell_studio_web_scene.py`)
- Treat a mesh-backed `target_bin` as tangible authored asset (never demote to helper) by special-casing `target_bin` with a mesh to keep `source_kind=user_authored`, `render_policy=primary`, and `render_owner=editable_layout`, and classify its visual contract as `object`. (changed `scripts/export_workcell_studio_web_scene.py`)
- Reconcile `environment.yaml` records that reference the same `layout_item_ref` by enriching the authoritative layout item with support-surface/task-zone metadata instead of exporting a second meshless asset. (changed `scripts/export_workcell_studio_web_scene.py`)
- Wire mesh staging expectations for the canonical scene by configuring the `ur5_2f_test` target bin to reference the existing `sorting_bin.stl` with the correct `[0.001, 0.001, 0.001]` scale and origin metadata. (changed `scenes/ur5_2f_test/layout/workcell_studio_layout.yaml`)
- Add a focused regression test that creates a temporary scene with a nested `mesh` block and an `environment` asset reference to assert exactly one staged, primary `target_bin_default` with the expected mesh fields. (changed `tests/test_workcell_studio_web_mesh_staging.py`)

Files modified:
- `scripts/export_workcell_studio_web_scene.py`
- `scenes/ur5_2f_test/layout/workcell_studio_layout.yaml`
- `tests/test_workcell_studio_web_mesh_staging.py`

### Testing
- Ran the focused staging unit tests with `python3 -m pytest tests/test_workcell_studio_web_mesh_staging.py -q` and observed `25 passed`. 
- Performed a full staged export for the canonical scene with `python3 scripts/export_workcell_studio_web_scene.py --scene scenes/ur5_2f_test --output /tmp/ur5_2f_target_bin.web_scene.json --stage-assets` and verified the exported payload contains a single `target_bin_default` that is `primary`, `editable_layout`, `staged`, uses `sorting_bin.stl`, and reports a passing mesh contract. 
- Ran a broader subset of scene-contract tests with `python3 -m pytest tests/test_workcell_studio_web_scene_contract.py tests/test_scene3d_product_overlay_filtering.py tests/test_workcell_builder_product_view_defaults.py -q` and observed these focused changes did not break the target-bin behavior but surfaced three unrelated pre-existing contract expectation differences (14 passed, 3 existing assertions involving expanded-URDF mode and a missing-file status naming that remain to be reconciled). 
- Cleaned up staged test artifacts after assertions to avoid leaving build outputs behind in test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a673ad4b2bc83319391de7ec73ccdcc)