### PR TITLE
Fix authored target-bin rendering: classification, scaling, readiness, and material preservation

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -865,6 +865,39 @@ def test_viewer_local_mesh_transform_is_applied_to_mesh_object_not_parent_pose()
     assert "visual_origin" not in apply_pose_body
 
 
+def test_primary_mesh_backed_target_bin_keeps_product_visibility_scale_color_and_readiness():
+    js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+
+    grouping = js.split("function viewerGroupFor(item)", 1)[1].split("const DEBUG_OVERLAY_TOKEN_RE", 1)[0]
+    assert grouping.index("if (primaryAuthoredPhysical) return 'environment/layout';") < grouping.index("return 'zones';")
+    assert "contractCategory === 'object'" in grouping
+    assert "target bin" in grouping
+
+    overlay_filter = js.split("function isDebugOverlayItem(item)", 1)[1].split("function isSensor(item)", 1)[0]
+    assert "if (viewerGroupFor(item) === 'zones') return true;" in overlay_filter
+    assert "if (isOverlayPolicyItem(item)) return true;" in overlay_filter
+    render_scene = js.split("function renderScene(items)", 1)[1].split("function loadExpandedUrdfRobotPreview", 1)[0]
+    assert "object3d.visible = state.debugOverlaysVisible || !isDebugOverlayItem(item);" in render_scene
+
+    root_scale = js.split("function scaleOf(item)", 1)[1].split("function transformOf", 1)[0]
+    mesh_scale = js.split("function meshLocalTransformOf(item)", 1)[1].split("function cloneTransform", 1)[0]
+    assert "item.scale || [1, 1, 1]" in root_scale
+    assert "item.scale || item.mesh_scale" not in root_scale
+    assert "transform.scale || item?.mesh_scale" in mesh_scale
+
+    readiness = js.split("function beginWeb3dSceneReadiness(items)", 1)[1].split("function requiredReadinessCompleteForItem", 1)[0]
+    assert "pending.add(readinessKey(category, item))" in readiness
+    category = js.split("function readinessCategoryForItem(item)", 1)[1].split("function readinessKey", 1)[0]
+    assert "return 'authored_physical_mesh';" in category
+    load = js.split("async function tryLoadMesh", 1)[1].split("function collectItems", 1)[0]
+    assert load.index("setRenderInfo(rendered, 'mesh_loaded'") < load.rindex("requiredReadinessCompleteForItem(item)")
+    assert "failWeb3dSceneReadiness(item, loadUrl, `loaded mesh bounds validation failed" in load
+
+    material = js.split("function materialFor(item)", 1)[1].split("function materialHasUsableAppearance", 1)[0]
+    assert "item?.material?.color" in material
+    assert "material.color.setRGB" in material
+
+
 def test_viewer_visual_bounds_diagnostics_and_fit_bounds_contract_are_source_guarded():
     js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
     for token in [

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -97,6 +97,7 @@ function readinessCategoryForItem(item) {
   if (category === 'table' || supportSurfaceDisplayType(item) || /\b(workbench|support surface|tabletop|table)\b/.test(identity)) return 'workbench_support_surface';
   if (isGeneratedToolOrGripperItem(item) || category === 'tool') return 'attached_tool_gripper';
   if (isGeneratedRobotItem(item) || category === 'robot') return 'robot_arm';
+  if (itemRequiresMeshBackedVisual(item) && (category === 'object' || viewerGroupFor(item) === 'environment/layout')) return 'authored_physical_mesh';
   return '';
 }
 function readinessKey(category, item) { return `${category}:${item?.id || item?.link || itemLabel(item || {})}`; }
@@ -1066,7 +1067,7 @@ function poseOf(item) {
 function scaleOf(item) {
   // Generated URDF item roots are link/frame nodes. URDF mesh scale is
   // applied only to the loaded mesh/local wrapper, never to the link root.
-  const scale = isGeneratedUrdfItem(item) ? [1, 1, 1] : (item.scale || item.mesh_scale || [1, 1, 1]);
+  const scale = isGeneratedUrdfItem(item) ? [1, 1, 1] : (item.scale || [1, 1, 1]);
   return vector3(scale, [1, 1, 1]);
 }
 function transformOf(item) {
@@ -1098,7 +1099,7 @@ function meshLocalTransformOf(item) {
     reasons.push('mesh_local_transform must be an object');
   }
   const transform = source && typeof source === 'object' && !Array.isArray(source) ? source : {};
-  const scaleSource = transform.scale || item?.mesh_scale || item?.scale || [1, 1, 1];
+  const scaleSource = transform.scale || item?.mesh_scale || (isGeneratedUrdfItem(item) ? item?.scale : null) || [1, 1, 1];
   return {
     pose: {
       xyz: meshLocalVector(transform.xyz || transform.origin || transform.position, [0, 0, 0], 'mesh_local_transform.xyz', reasons),
@@ -1602,6 +1603,11 @@ function isGeneratedRobotItem(item) {
 }
 function viewerGroupFor(item) {
   const identity = viewerGroupIdentity(item);
+  const contractCategory = meshContractCategoryOf(item);
+  const primaryAuthoredPhysical = isPrimaryRenderableItem(item) && hasMeshBackedVisualContract(item) && (
+    contractCategory === 'object' || /\b(target bin|object|workpiece|part|product|bin|tray)\b/.test(identity)
+  );
+  if (primaryAuthoredPhysical) return 'environment/layout';
   if (/\b(zone|pick zone|place zone|observation zone|spawn zone|safety zone|work envelope|reachability|collision)\b/.test(identity)) return 'zones';
   if (/\b(camera|sensor|realsense|depth camera|rgbd|lidar|vision)\b/.test(identity)) return 'sensors';
   if (isGeneratedToolOrGripperItem(item)) return 'tool/gripper';
@@ -1650,7 +1656,16 @@ function materialFor(item) {
   if (isZone(item)) return new THREE.MeshBasicMaterial({ color: 0xffc857, transparent: true, opacity: 0.1, side: THREE.DoubleSide, wireframe: true, depthWrite: false });
   if (isSensor(item)) return new THREE.MeshStandardMaterial({ color: 0x5f7485, roughness: 0.62, metalness: 0.08 });
   if (item.locked || item.source_kind === 'generated_preview') return new THREE.MeshStandardMaterial({ color: 0x8b96a6, roughness: 0.76, metalness: 0.04 });
-  return new THREE.MeshStandardMaterial({ color: 0x8aa38d, roughness: 0.72, metalness: 0.02 });
+  const authoredColor = item?.material?.color || item?.material?.rgba || item?.material_color || item?.color;
+  const material = new THREE.MeshStandardMaterial({ color: 0x8aa38d, roughness: 0.72, metalness: 0.02 });
+  if (Array.isArray(authoredColor) && authoredColor.length >= 3) {
+    material.color.setRGB(Number(authoredColor[0]), Number(authoredColor[1]), Number(authoredColor[2]));
+    if (authoredColor.length > 3) {
+      material.opacity = Number(authoredColor[3]);
+      material.transparent = material.opacity < 1;
+    }
+  }
+  return material;
 }
 function materialHasUsableAppearance(material) {
   if (!material) return false;
@@ -1894,8 +1909,12 @@ async function tryLoadMesh(item, rendered, fallback) {
     item.mesh_load_error = '';
     trackMeshLoadAttempt(item, 'loaded', loadUrl, '');
     setRenderInfo(rendered, 'mesh_loaded', uri, '');
-    diagnoseLoadedMeshBounds(item, visualRoot, rendered, validationBounds);
+    const boundsValid = diagnoseLoadedMeshBounds(item, visualRoot, rendered, validationBounds);
     refreshMeshLoadUi(rendered);
+    if (!boundsValid && itemRequiresMeshBackedVisual(item)) {
+      failWeb3dSceneReadiness(item, loadUrl, `loaded mesh bounds validation failed (${item.visual_bounds_status || 'invalid'})`, { mesh_status: item.mesh_status });
+      return;
+    }
     requiredReadinessCompleteForItem(item);
   } catch (err) {
     const required = itemRequiresMeshBackedVisual(item);
@@ -2677,15 +2696,15 @@ function diagnoseLoadedMeshBounds(item, meshObject, rendered, nativeBounds = nul
   const tiny = 1e-9;
   if (!localBounds || !worldBounds || !dims || !worldDims) {
     if (isCoreMeshContractItem(item)) warnLoadedMeshBounds(item, 'loaded_mesh_bounds_invalid', 'loaded mesh produced empty or non-finite bounds');
-    return;
+    return !isCoreMeshContractItem(item);
   }
   maybeWarnSupportSurfaceSemantics(item, dims);
   const collapsedAxes = ['x', 'y', 'z'].filter(axis => dims[axis] <= tiny || worldDims[axis] <= tiny);
   if (collapsedAxes.length) {
     if (isCoreMeshContractItem(item)) warnLoadedMeshBounds(item, 'loaded_mesh_collapsed', `loaded mesh bounds are zero-volume or collapsed on ${collapsedAxes.join(', ')}`, { collapsed_axes: collapsedAxes });
-    return;
+    return !isCoreMeshContractItem(item);
   }
-  if (!expected) return;
+  if (!expected) return true;
   const axes = ['x', 'y', 'z'];
   const axisRatios = Object.fromEntries(axes.map(axis => [axis, dims[axis] / expected[axis]]));
   const maxRatio = Math.max(...Object.values(axisRatios));
@@ -2702,6 +2721,7 @@ function diagnoseLoadedMeshBounds(item, meshObject, rendered, nativeBounds = nul
     });
     else if (Math.abs(maxRatio - 1000) < 100 || Math.abs(maxRatio - 0.001) < 0.001) item.visual_bounds_status = 'corrected_by_local_unit_scale';
   }
+  return item.visual_bounds_status !== 'oversized';
 }
 function workspaceDimensionsOf(sceneJson) {
   return dimensionsVectorFrom(sceneJson?.workspace?.dimensions_m || sceneJson?.workspace?.size_m || sceneJson?.workspace_dimensions_m || sceneJson?.scene?.workspace_dimensions_m);


### PR DESCRIPTION
### Motivation

- Product View was treating a mesh-backed authored `target_bin_default` as a zone overlay and applying mesh scale twice, causing the exported bin mesh to be invisible or mis-scaled and falsely emitting `scene_ready`.
- The viewer must treat primary authored mesh-backed objects (especially mesh_contract_category=`object` and `role`/`type`=`target_bin`) as physical environment/layout items, apply authored mesh scale exactly once, and block readiness until required authored meshes are successfully loaded and validated.

### Description

- Reclassify primary authored mesh-backed items as environment/layout whenever they have an authored mesh contract (e.g. `mesh_contract_category === 'object'`) or clearly identify as target/bin-like items so the mesh-backed bin remains physical rather than a zone overlay. (viewerGroupFor/readinessCategoryForItem)
- Stop applying `mesh_scale` at the root transform and ensure authored mesh scale is applied exactly once on the loaded mesh wrapper, preserving generated URDF scaling behavior. (changed `scaleOf` and `meshLocalTransformOf` handling and `applyLoadedMeshScaleHandling` flow)
- Track required authored meshes in Web3D readiness: include them in `pending_required_loads` during `scene_loading`, only emit `scene_ready` after `mesh_loaded`, and emit `scene_failed` with the failing `item_id` and URL on preflight/fetch/loader/bounds failures. (beginWeb3dSceneReadiness, tryLoadMesh, failWeb3dSceneReadiness integration and bounds failure path)
- Preserve authored RGBA material colours for loaded STL meshes by reading `item.material.color`/`item.material.rgba`/`item.material_color` and applying `material.color.setRGB(...)` and opacity where provided. (materialFor/materializeLoadedMesh usage)
- Add focused static regression coverage verifying: primary mesh-backed `target_bin` classification is environment/layout, overlays remain hidden with overlays disabled, root vs mesh-local scaling is correct (mesh_scale applied once), readiness waits for the bin and counts it, bounds failure triggers `scene_failed`, and authored STL material colour is used. (new test in tests/test_workcell_studio_web_viewer_static.py)

### Testing

- `python3 -m pytest tests/test_workcell_studio_web_viewer_static.py -q` — 102 passed, 3 warnings. 
- `node --check workcell_studio_web/viewer/viewer.js` — bundle file syntax check passed. 
- `git diff --check` — no check errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a673f350fa48331ac4fc9cff08a1cd6)