### PR TITLE
Fix physical target-bin overlay classification

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -869,13 +869,15 @@ def test_primary_mesh_backed_target_bin_keeps_product_visibility_scale_color_and
     js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
 
     grouping = js.split("function viewerGroupFor(item)", 1)[1].split("const DEBUG_OVERLAY_TOKEN_RE", 1)[0]
-    assert grouping.index("if (primaryAuthoredPhysical) return 'environment/layout';") < grouping.index("return 'zones';")
-    assert "contractCategory === 'object'" in grouping
-    assert "target bin" in grouping
+    assert grouping.index("if (isPrimaryAuthoredPhysicalMesh(item)) return 'environment/layout';") < grouping.index("return 'zones';")
+    primary_physical = js.split("function isPrimaryAuthoredPhysicalMesh(item)", 1)[1].split("function readinessCategoryForItem", 1)[0]
+    assert "contractCategory === 'object'" in primary_physical
+    assert "target bin" in primary_physical
 
     overlay_filter = js.split("function isDebugOverlayItem(item)", 1)[1].split("function isSensor(item)", 1)[0]
     assert "if (viewerGroupFor(item) === 'zones') return true;" in overlay_filter
     assert "if (isOverlayPolicyItem(item)) return true;" in overlay_filter
+    assert overlay_filter.index("if (isPrimaryAuthoredPhysicalMesh(item)) return false;") < overlay_filter.index("const identity")
     render_scene = js.split("function renderScene(items)", 1)[1].split("function loadExpandedUrdfRobotPreview", 1)[0]
     assert "object3d.visible = state.debugOverlaysVisible || !isDebugOverlayItem(item);" in render_scene
 
@@ -896,6 +898,49 @@ def test_primary_mesh_backed_target_bin_keeps_product_visibility_scale_color_and
     material = js.split("function materialFor(item)", 1)[1].split("function materialHasUsableAppearance", 1)[0]
     assert "item?.material?.color" in material
     assert "material.color.setRGB" in material
+
+
+def test_primary_target_bin_place_zone_identity_remains_physical_until_staged_mesh_loads():
+    js_path = VIEWER / "viewer.js"
+    harness = r"""
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+let source = fs.readFileSync(process.argv[1], 'utf8').replace(/boot\(\);\s*$/, '');
+const element = () => ({ hidden: false, checked: false, disabled: false, textContent: '', className: '', innerHTML: '', classList: { toggle() {} }, setAttribute() {}, querySelector() { return { textContent: '' }; }, appendChild() {}, addEventListener() {}, getBoundingClientRect() { return { width: 800, height: 600, left: 0, top: 0 }; } });
+const context = { console, assert, window: { location: { search: '' }, dispatchEvent() {}, parent: { postMessage() {} } }, document: { getElementById() { return element(); }, createElement() { return element(); } }, URLSearchParams, CustomEvent: function CustomEvent(type, init) { return { type, detail: init?.detail || {} }; }, requestAnimationFrame() { return 0; }, setTimeout() { return 1; }, clearTimeout() {} };
+vm.createContext(context);
+vm.runInContext(source + `
+const targetBin = {
+  id: 'target_bin_default',
+  display_name: 'Target bin',
+  category: 'place_zone',
+  render_policy: 'primary',
+  mesh_contract_category: 'object',
+  mesh_load_required: true,
+  mesh_uri: 'build/workcell_studio_web_scene/assets/ur5_2f_test/target_bin.stl'
+};
+const placeZone = { id: 'place_zone_default', category: 'place_zone', render_policy: 'overlay' };
+assert.strictEqual(isPrimaryAuthoredPhysicalMesh(targetBin), true);
+assert.strictEqual(isDebugOverlayItem(targetBin), false);
+assert.strictEqual(viewerGroupFor(targetBin), 'environment/layout');
+assert.strictEqual(readinessCategoryForItem(targetBin), 'authored_physical_mesh');
+assert.strictEqual(isPrimaryAuthoredPhysicalMesh(placeZone), false);
+assert.strictEqual(isDebugOverlayItem(placeZone), true);
+assert.strictEqual(viewerGroupFor(placeZone), 'zones');
+assert.strictEqual(false || !isDebugOverlayItem(targetBin), true);
+assert.strictEqual(false || !isDebugOverlayItem(placeZone), false);
+state.sceneJson = { assets: [targetBin, placeZone] };
+beginWeb3dSceneReadiness(collectItems(state.sceneJson));
+const readinessKeyForTarget = readinessKey('authored_physical_mesh', targetBin);
+assert.strictEqual(state.web3dReadiness.pending.has(readinessKeyForTarget), true);
+assert.strictEqual(state.web3dReadiness.required.authored_physical_mesh, true);
+targetBin.mesh_status = 'loaded';
+requiredReadinessCompleteForItem(targetBin);
+assert.strictEqual(state.web3dReadiness.pending.has(readinessKeyForTarget), false);
+`, context);
+"""
+    subprocess.run(["node", "-e", harness, str(js_path)], cwd=ROOT, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
 
 def test_viewer_visual_bounds_diagnostics_and_fit_bounds_contract_are_source_guarded():

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -88,9 +88,16 @@ function isPrimaryRenderableItem(item) {
 }
 function isDiagnosticOnlyItem(item) { return itemRenderPolicy(item) === 'diagnostic_only'; }
 function isOverlayPolicyItem(item) { return itemRenderPolicy(item) === 'overlay'; }
+function isPrimaryAuthoredPhysicalMesh(item) {
+  if (itemRenderPolicy(item) !== 'primary' || !truthyFlag(item?.mesh_load_required)) return false;
+  const contractCategory = String(item?.mesh_contract_category || item?.meshContractCategory || '').toLowerCase();
+  const identity = viewerGroupIdentity(item);
+  return contractCategory === 'object' || /\b(target bin|target container|destination bin)\b/.test(identity);
+}
 function readinessCategoryForItem(item) {
   if (!item || !isPrimaryRenderableItem(item) || isDebugOverlayItem(item)) return '';
   if (item?.readiness_category || item?.readinessCategory) return String(item.readiness_category || item.readinessCategory);
+  if (isPrimaryAuthoredPhysicalMesh(item)) return 'authored_physical_mesh';
   const category = meshContractCategoryOf(item);
   const identity = viewerGroupIdentity(item);
   if (category === 'camera' || isSensor(item)) return 'configured_camera';
@@ -1603,11 +1610,7 @@ function isGeneratedRobotItem(item) {
 }
 function viewerGroupFor(item) {
   const identity = viewerGroupIdentity(item);
-  const contractCategory = meshContractCategoryOf(item);
-  const primaryAuthoredPhysical = isPrimaryRenderableItem(item) && hasMeshBackedVisualContract(item) && (
-    contractCategory === 'object' || /\b(target bin|object|workpiece|part|product|bin|tray)\b/.test(identity)
-  );
-  if (primaryAuthoredPhysical) return 'environment/layout';
+  if (isPrimaryAuthoredPhysicalMesh(item)) return 'environment/layout';
   if (/\b(zone|pick zone|place zone|observation zone|spawn zone|safety zone|work envelope|reachability|collision)\b/.test(identity)) return 'zones';
   if (/\b(camera|sensor|realsense|depth camera|rgbd|lidar|vision)\b/.test(identity)) return 'sensors';
   if (isGeneratedToolOrGripperItem(item)) return 'tool/gripper';
@@ -1630,6 +1633,7 @@ function hasDimensionBackedPhysicalPrimitive(item) {
 function isDebugOverlayItem(item) {
   if (isOverlayPolicyItem(item)) return true;
   if (item?.debug_overlay === true || item?.exclude_from_fit_bounds === true || item?.source_layer === 'debug_overlay') return true;
+  if (isPrimaryAuthoredPhysicalMesh(item)) return false;
   const identity = [
     item?.source_layer,
     item?.active_visual_source,


### PR DESCRIPTION
### Motivation
- Target-bin items authored with `category=place_zone` but intended as physical meshes were being treated as debug overlays and hidden when overlays were disabled, which excluded them from readiness tracking.
- The root cause was mismatched classification between `viewerGroupFor(...)` and `isDebugOverlayItem(...)`, causing primary authored bins to be misclassified by semantic token checks.

### Description
- Add a single predicate `isPrimaryAuthoredPhysicalMesh(item)` that requires `render_policy='primary'`, `mesh_load_required=true`, and either `mesh_contract_category='object'` or a physical target-bin identity, and use it to identify authored physical meshes. 
- Use `isPrimaryAuthoredPhysicalMesh` in `readinessCategoryForItem()` to return `authored_physical_mesh` for those items.
- Use `isPrimaryAuthoredPhysicalMesh` in `viewerGroupFor()` to keep such items in `environment/layout` even when their semantic `category` is `place_zone`.
- Short-circuit `isDebugOverlayItem()` to return `false` for `isPrimaryAuthoredPhysicalMesh(item)` before applying overlay token heuristics, while preserving explicit `render_policy='overlay'` behavior.
- Add an executable regression test `test_primary_target_bin_place_zone_identity_remains_physical_until_staged_mesh_loads()` that uses a realistic `target_bin_default` record (with `category=place_zone`, `render_policy=primary`, `mesh_contract_category=object`, `mesh_load_required=true` and a staged STL URI) to verify grouping, overlay classification, and readiness pending/completion.
- Limit changes to `workcell_studio_web/viewer/viewer.js` and `tests/test_workcell_studio_web_viewer_static.py` and do not modify `dist/*` bundles or generated scene artifacts.

### Testing
- Ran the focused test suite with `python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py` and all tests passed (103 passed, 3 warnings). 
- Verified `git diff --check` and that only the intended files changed (`workcell_studio_web/viewer/viewer.js` and `tests/test_workcell_studio_web_viewer_static.py`).
- Did not run `npm run build:web3d` per the task constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67518f24a48331be93b948fd1d8d8d)