### PR TITLE
Calibrate SYSTEMBOX target bin mesh transform

### DIFF
--- a/scenes/ur5_2f_test/layout/workcell_studio_layout.yaml
+++ b/scenes/ur5_2f_test/layout/workcell_studio_layout.yaml
@@ -61,15 +61,15 @@ items:
     source_layer: editable_layout
     source: layout/workcell_studio_layout.yaml
     pose:
-      xyz: [0.55, -0.28, 0.19]
+      xyz: [0.55, -0.28, 0.20]
       rpy: [0.0, 0.0, 0.0]
-    dimensions: [0.35, 0.25, 0.18]
+    dimensions: [0.3522011268, 0.2133871002, 0.20]
     geometry_type: mesh
     mesh:
       path: assets/environment/sorting_bin_description/meshes/sorting_bin.stl
       scale: [0.001, 0.001, 0.001]
-      rpy: [0.0, 0.0, 0.0]
-      origin_offset: [0.0, 0.0, 0.0]
+      rpy: [1.57079632679, 0.0, 1.57079632679]
+      origin_offset: [-0.1738994366, 0.0, -0.10]
     material:
       color: [0.95, 0.68, 0.20, 0.65]
   - id: realsense_overhead

--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -1482,12 +1482,24 @@ def _iter_declared_physical_entries(data: Mapping[str, Any]) -> Iterable[Tuple[s
                     item.setdefault("mesh_scale", mesh_block.get("scale"))
                 mesh_rpy = mesh_block.get("rpy")
                 origin_offset = mesh_block.get("origin_offset")
-                if mesh_rpy not in (None, [], {}) or origin_offset not in (None, [], {}):
+                if (
+                    mesh_rpy not in (None, [], {})
+                    or origin_offset not in (None, [], {})
+                    or mesh_block.get("scale") not in (None, [], {})
+                ):
+                    mesh_local_transform = {
+                        # origin_offset is already expressed in metres in the
+                        # item-local frame; mesh scale applies only to vertices.
+                        "xyz": origin_offset if origin_offset not in (None, [], {}) else [0.0, 0.0, 0.0],
+                        "rpy": mesh_rpy if mesh_rpy not in (None, [], {}) else [0.0, 0.0, 0.0],
+                        "scale": mesh_block.get("scale") if mesh_block.get("scale") not in (None, [], {}) else [1.0, 1.0, 1.0],
+                    }
+                    item.setdefault("mesh_local_transform", mesh_local_transform)
                     item.setdefault(
                         "visual_origin",
                         {
-                            "xyz": origin_offset if origin_offset not in (None, [], {}) else [0.0, 0.0, 0.0],
-                            "rpy": mesh_rpy if mesh_rpy not in (None, [], {}) else [0.0, 0.0, 0.0],
+                            "xyz": mesh_local_transform["xyz"],
+                            "rpy": mesh_local_transform["rpy"],
                         },
                     )
                 # Legacy EMD object declarations often bury their visual mesh under
@@ -1510,7 +1522,7 @@ def _iter_declared_physical_entries(data: Mapping[str, Any]) -> Iterable[Tuple[s
 def _authored_item(raw: Mapping[str, Any], source: str, index: int, scene_dir: Path) -> Json:
     fields = (
         "id", "type", "role", "category", "display_name", "source_section", "link", "object_name", "frame", "pose", "pose_xyz", "pose_rpy", "dimensions",
-        "geometry_type", "primitive_geometry_type", "mesh_uri", "package_uri", "source_path", "mesh_path", "filepath", "mesh_scale", "visual_origin", "material",
+        "geometry_type", "primitive_geometry_type", "mesh_uri", "package_uri", "source_path", "mesh_path", "filepath", "mesh_scale", "mesh_local_transform", "visual_origin", "material",
         "layout_item_ref", "support_surface_ref", "task_zone_ref", "scale", "perception_mode", "runtime_enforced", "runtime_commanded",
         "support_surface_kind", "support_kind", "semantic_type", "top_surface_z_m", "topSurfaceZM", "support_surface_height_m", "supportSurfaceHeightM",
         "expected_support_footprint_m", "support_footprint_m", "footprint_m", "footprint", "table_height", "table_top_z", "surface_height_m",

--- a/tests/test_workcell_studio_web_mesh_staging.py
+++ b/tests/test_workcell_studio_web_mesh_staging.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import math
 import shutil
 import subprocess
 import sys
@@ -134,6 +135,11 @@ def test_nested_layout_target_bin_mesh_is_the_authoritative_physical_render(monk
         assert target_bin["render_owner"] == "editable_layout"
         assert target_bin["mesh_staging_status"] == "staged"
         assert target_bin["mesh_scale"] == [0.001, 0.001, 0.001]
+        assert target_bin["mesh_local_transform"] == {
+            "xyz": [0.0, 0.0, 0.0],
+            "rpy": [0.0, 0.0, 0.0],
+            "scale": [0.001, 0.001, 0.001],
+        }
         assert target_bin["visual_origin"] == {"xyz": [0.0, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]}
         assert target_bin["mesh_uri"] == target_bin["mesh_url"]
         assert target_bin["mesh_uri"].endswith("sorting_bin.stl")
@@ -145,6 +151,56 @@ def test_nested_layout_target_bin_mesh_is_the_authoritative_physical_render(monk
         assert (REPO_ROOT / target_bin["mesh_uri"]).is_file()
     finally:
         shutil.rmtree(staged_root, ignore_errors=True)
+
+
+def test_ur5_target_bin_calibrated_mesh_transform_and_bounds_survive_export():
+    scene = REPO_ROOT / "scenes" / "ur5_2f_test"
+    payload = json.loads(json.dumps(exporter.build_web_scene(scene)))
+    target_bin = _item(payload, "target_bin_default")
+
+    world_pose = {"xyz": [0.55, -0.28, 0.20], "rpy": [0.0, 0.0, 0.0]}
+    mesh_transform = {
+        "xyz": [-0.1738994366, 0.0, -0.10],
+        "rpy": [1.57079632679, 0.0, 1.57079632679],
+        "scale": [0.001, 0.001, 0.001],
+    }
+    assert target_bin["pose"] == world_pose
+    assert target_bin["mesh_local_transform"] == mesh_transform
+    assert target_bin["pose"] is not target_bin["mesh_local_transform"]
+    assert target_bin["dimensions"] == [0.3522011268, 0.2133871002, 0.20]
+
+    # Apply the exported XYZ fixed-axis RPY transform to all STL bound corners.
+    stl_bounds_mm = (
+        (-106.69355, 106.69355),
+        (0.0, 200.0),
+        (-2.2011268, 350.0),
+    )
+    roll, pitch, yaw = mesh_transform["rpy"]
+    cr, sr = math.cos(roll), math.sin(roll)
+    cp, sp = math.cos(pitch), math.sin(pitch)
+    cy, sy = math.cos(yaw), math.sin(yaw)
+    rotation = (
+        (cy * cp, cy * sp * sr - sy * cr, cy * sp * cr + sy * sr),
+        (sy * cp, sy * sp * sr + cy * cr, sy * sp * cr - cy * sr),
+        (-sp, cp * sr, cp * cr),
+    )
+    transformed = []
+    for x in stl_bounds_mm[0]:
+        for y in stl_bounds_mm[1]:
+            for z in stl_bounds_mm[2]:
+                scaled = tuple(value * scale for value, scale in zip((x, y, z), mesh_transform["scale"]))
+                rotated = tuple(sum(rotation[row][column] * scaled[column] for column in range(3)) for row in range(3))
+                transformed.append(
+                    tuple(world_pose["xyz"][axis] + mesh_transform["xyz"][axis] + rotated[axis] for axis in range(3))
+                )
+    bounds = tuple((min(point[axis] for point in transformed), max(point[axis] for point in transformed)) for axis in range(3))
+
+    expected = ((0.3738994366, 0.7261005634), (-0.38669355, -0.17330645), (0.10, 0.30))
+    for actual_axis, expected_axis in zip(bounds, expected):
+        assert all(math.isclose(actual, wanted, abs_tol=1e-9) for actual, wanted in zip(actual_axis, expected_axis))
+    assert math.isclose(sum(bounds[0]) / 2, 0.55, abs_tol=1e-9)
+    assert math.isclose(sum(bounds[1]) / 2, -0.28, abs_tol=1e-9)
+    assert math.isclose(bounds[2][0], 0.10, abs_tol=1e-9)
 
 
 def test_package_mesh_uri_is_staged_and_preserves_original_uri(monkeypatch, tmp_path):


### PR DESCRIPTION
### Motivation
- Authored nested mesh fields (`rpy`, `origin_offset`, `scale`) were normalized into `visual_origin` only, but the Web3D viewer reads `mesh_local_transform` for authored meshes, causing visual misplacement.
- The SYSTEMBOX supplier STL uses millimetre units and a rotated/local-axis convention that must be mapped into world pose and a mesh-local transform so the bin seats on the table and centers over the place zone.
- Keep backward compatibility by preserving `visual_origin` while exposing the mesh-local transform explicitly and treating `origin_offset` as metres in the item-local frame.

### Description
- Exporter: when normalizing a nested `mesh` block in `scripts/export_workcell_studio_web_scene.py`, emit `mesh_local_transform` with `xyz`, `rpy`, and `scale` (using the authored `origin_offset`, `rpy`, and `scale`), and preserve `visual_origin` for compatibility.
- Allowlist: added `mesh_local_transform` to the authored-item field allowlist so authored items carry the transform into the exported JSON payload.
- Scene calibration: updated `scenes/ur5_2f_test/layout/workcell_studio_layout.yaml` to change only `target_bin_default` to the requested calibrated values for `pose.xyz`, `dimensions`, `mesh.rpy`, and `mesh.origin_offset` so the bin is centered at [0.55, -0.28] and its base seats at world Z = 0.10.
- Tests: extended `tests/test_workcell_studio_web_mesh_staging.py` to assert that nested `mesh.rpy`/`origin_offset`/`scale` become `mesh_local_transform`, that the authored world pose remains separate from mesh-local transform, and that the computed world bounds match the expected calibrated bounds.
- Files changed: `scripts/export_workcell_studio_web_scene.py`, `scenes/ur5_2f_test/layout/workcell_studio_layout.yaml`, `tests/test_workcell_studio_web_mesh_staging.py`.

### Testing
- Ran `python3 -m pytest -q tests/test_workcell_studio_web_mesh_staging.py tests/test_workcell_studio_web_viewer_static.py` and observed `129 passed` (all tests passed).
- Ran the focused exporter test `python3 -m pytest -q tests/test_workcell_studio_web_mesh_staging.py::test_ur5_target_bin_calibrated_mesh_transform_and_bounds_survive_export` which passed (`1 passed`).
- Verified `git diff --check` and that the source changes do not include `sorting_bin.stl`, `viewer.js`, `viewer.bundle.js`, or their source maps (no generated/viewer bundles were modified).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6773e45898833198ff0bdabbb0a195)