### PR TITLE
Fix Web3D mesh-local ROS RPY rotation order

### DIFF
--- a/tests/test_web3d_mesh_ros_rpy_order.mjs
+++ b/tests/test_web3d_mesh_ros_rpy_order.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import * as THREE from '../workcell_studio_web/viewer/node_modules/three/build/three.module.js';
+
+const viewerSource = readFileSync(
+  new URL('../workcell_studio_web/viewer/viewer.js', import.meta.url),
+  'utf8',
+);
+const helperSource = viewerSource.match(
+  /function applyRosRpy\(object, rpy\) \{[\s\S]*?\n\}/,
+)?.[0];
+assert.ok(helperSource, 'viewer.js must define applyRosRpy(object, rpy)');
+const applyRosRpy = Function(`"use strict"; ${helperSource}; return applyRosRpy;`)();
+
+assert.match(
+  viewerSource,
+  /function applyMeshLocalTransform[\s\S]*?applyRosRpy\(meshObject, visualOrigin\.rpy\);/,
+  'mesh-local and URDF visual-origin RPY must use the ROS RPY helper',
+);
+
+const EPSILON = 1e-8;
+function assertVector(actual, expected, message) {
+  for (const axis of ['x', 'y', 'z']) {
+    assert.ok(
+      Math.abs(actual[axis] - expected[axis]) <= EPSILON,
+      `${message} ${axis}: expected ${expected[axis]}, got ${actual[axis]}`,
+    );
+  }
+}
+
+// Identity and each single-axis rotation have the same conventional ROS result.
+for (const { rpy, input, expected, label } of [
+  { label: 'identity', rpy: [0, 0, 0], input: [1, 2, 3], expected: [1, 2, 3] },
+  { label: 'roll', rpy: [Math.PI / 2, 0, 0], input: [0, 1, 0], expected: [0, 0, 1] },
+  { label: 'pitch', rpy: [0, Math.PI / 2, 0], input: [0, 0, 1], expected: [1, 0, 0] },
+  { label: 'yaw', rpy: [0, 0, Math.PI / 2], input: [1, 0, 0], expected: [0, 1, 0] },
+]) {
+  const object = new THREE.Object3D();
+  applyRosRpy(object, new THREE.Vector3(...rpy));
+  const actual = new THREE.Vector3(...input).applyQuaternion(object.quaternion);
+  assertVector(actual, new THREE.Vector3(...expected), label);
+}
+
+const itemRoot = new THREE.Group();
+itemRoot.position.set(0.55, -0.28, 0.20);
+const meshRoot = new THREE.Group();
+meshRoot.position.set(-0.1738994366, 0, -0.10);
+applyRosRpy(meshRoot, new THREE.Vector3(1.57079632679, 0, 1.57079632679));
+meshRoot.scale.set(0.001, 0.001, 0.001);
+itemRoot.add(meshRoot);
+
+const rawBounds = {
+  min: new THREE.Vector3(-106.69355, 0, -2.2011268),
+  max: new THREE.Vector3(106.69355, 200, 350),
+};
+const corners = [];
+for (const x of [rawBounds.min.x, rawBounds.max.x]) {
+  for (const y of [rawBounds.min.y, rawBounds.max.y]) {
+    for (const z of [rawBounds.min.z, rawBounds.max.z]) {
+      corners.push(new THREE.Vector3(x, y, z));
+    }
+  }
+}
+itemRoot.updateMatrixWorld(true);
+const finalBounds = new THREE.Box3().setFromPoints(
+  corners.map(corner => corner.applyMatrix4(meshRoot.matrixWorld)),
+);
+assertVector(finalBounds.min, new THREE.Vector3(0.37389944, -0.38669355, 0.10), 'target-bin min');
+assertVector(finalBounds.max, new THREE.Vector3(0.72610056, -0.17330645, 0.30), 'target-bin max');
+
+console.log('Web3D ROS RPY regression passed with Three.js', THREE.REVISION);

--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -550,7 +550,7 @@ def test_viewer_generated_urdf_baked_pose_mode_uses_identity_mesh_local_transfor
     assert "visualOriginOf(item)" in mesh_transform_body
     assert mesh_transform_body.index("usesBakedVisibleWorldPose(item)") < mesh_transform_body.index("visualOriginOf(item)")
     assert "meshObject.position.copy(visualOrigin.xyz)" in mesh_transform_body
-    assert "meshObject.rotation.set(visualOrigin.rpy.x, visualOrigin.rpy.y, visualOrigin.rpy.z, 'XYZ')" in mesh_transform_body
+    assert "applyRosRpy(meshObject, visualOrigin.rpy)" in mesh_transform_body
 
 
 def test_viewer_generated_urdf_unflagged_mesh_wrapper_still_applies_visual_origin():
@@ -856,13 +856,25 @@ def test_viewer_local_mesh_transform_is_applied_to_mesh_object_not_parent_pose()
     local_transform_body = js.split("function applyMeshLocalTransform", 1)[1].split("async function tryLoadMesh", 1)[0]
     assert "meshObject" in local_transform_body
     assert ".position" in local_transform_body
-    assert ".rotation" in local_transform_body
+    assert "applyRosRpy(meshObject, visualOrigin.rpy)" in local_transform_body
     assert ".scale" in local_transform_body
 
     apply_pose_body = js.split("function applyPose", 1)[1].split("function assignItemUserData", 1)[0]
     assert "mesh_local_transform" not in apply_pose_body
     assert "visual_local_transform" not in apply_pose_body
     assert "visual_origin" not in apply_pose_body
+
+
+def test_viewer_mesh_local_ros_rpy_order_regression():
+    result = subprocess.run(
+        [str(ROOT / "tests" / "test_web3d_mesh_ros_rpy_order.mjs")],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Three.js 160" in result.stdout
 
 
 def test_primary_mesh_backed_target_bin_keeps_product_visibility_scale_color_and_readiness():

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -1766,6 +1766,9 @@ function makeSensorMarker(item) {
   applyFallbackRenderMetadata(group, item, 'sensor_fallback');
   return group;
 }
+function applyRosRpy(object, rpy) {
+  object.rotation.set(rpy.x, rpy.y, rpy.z, 'ZYX');
+}
 function applyPose(object, item) {
   const validation = validateRenderableTransform(item);
   if (!validation.valid) return false;
@@ -1821,7 +1824,7 @@ function applyMeshLocalTransform(meshObject, item) {
     ? (usesUrdfFkVisualWorldPose(item) ? poseBlockOf({ xyz: [0, 0, 0], rpy: [0, 0, 0] }) : (usesBakedVisibleWorldPose(item) ? poseBlockOf({ xyz: [0, 0, 0], rpy: [0, 0, 0] }) : visualOriginOf(item)))
     : transform.pose;
   meshObject.position.copy(visualOrigin.xyz);
-  meshObject.rotation.set(visualOrigin.rpy.x, visualOrigin.rpy.y, visualOrigin.rpy.z, 'XYZ');
+  applyRosRpy(meshObject, visualOrigin.rpy);
   if (generatedUrdf) meshObject.scale.set(1, 1, 1);
   else meshObject.scale.set(transform.scale.x, transform.scale.y, transform.scale.z);
   if (!transform.valid) {


### PR DESCRIPTION
### Motivation
- A mismatch between the ROS fixed-axis RPY convention `Rz(yaw) * Ry(pitch) * Rx(roll)` and the Three.js Euler application caused mesh-local transforms (target bin) to appear rotated/sideways in Product View.
- The viewer currently applied RPY with `rotation.set(..., 'XYZ')` which composes in a different order than ROS fixed-axis RPY, producing the observed misplaced bin.

### Description
- Add a small shared helper `applyRosRpy(object, rpy)` that applies ROS fixed-axis RPY using Three.js `ZYX` Euler ordering: `object.rotation.set(rpy.x, rpy.y, rpy.z, 'ZYX')` in `viewer.js`.
- Replace direct `rotation.set(..., 'XYZ')` usages in the mesh-local transform path so `applyMeshLocalTransform()` and generated URDF visual-origin handling call `applyRosRpy(meshObject, visualOrigin.rpy)` while leaving translation and scale handling unchanged.
- Add an executable Three.js regression `tests/test_web3d_mesh_ros_rpy_order.mjs` that verifies identity and single-axis rotations and asserts the calibrated target-bin AABB maps to the expected world bounds using Three.js `0.160.0`.
- Update the focused static contract test `tests/test_workcell_studio_web_viewer_static.py` to expect the shared ROS-RPY helper call and to run the numeric Node-based regression as part of validation; keep this change limited to source and tests and do not rebuild or commit `dist/viewer.bundle.js`.

### Testing
- Ran the Node regression: `./tests/test_web3d_mesh_ros_rpy_order.mjs` and it passed with Three.js revision 160 (logged: "Web3D ROS RPY regression passed with Three.js 160").
- Ran the focused Python tests: `python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py tests/test_workcell_studio_web_mesh_staging.py` which completed with `130 passed` and `3` pre-existing Python SyntaxWarnings.
- Ran repository checks: `git diff --check` and static contract expectations against `viewer.js` to ensure the new helper is present and used; these checks passed. Safety: no launch, runtime, hardware, YAML calibration, exporter, STL assets, or `dist` bundle sources were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67775754808331a81ef267a17a8453)