### PR TITLE
Restore SYSTEMBOX bin blue

### DIFF
--- a/scenes/ur5_2f_test/layout/workcell_studio_layout.yaml
+++ b/scenes/ur5_2f_test/layout/workcell_studio_layout.yaml
@@ -71,7 +71,7 @@ items:
       rpy: [1.57079632679, 0.0, 1.57079632679]
       origin_offset: [-0.1738994366, 0.0, -0.10]
     material:
-      color: [0.95, 0.68, 0.20, 0.65]
+      color: [0.05, 0.35, 0.80, 1.0]
   - id: realsense_overhead
     type: realsense
     role: camera


### PR DESCRIPTION
## What changed

Changed only `target_bin_default.material.color` in `scenes/ur5_2f_test/layout/workcell_studio_layout.yaml` from translucent gold to solid industrial blue (`[0.05, 0.35, 0.80, 1.0]`).

## Why

The supplier STL has no embedded material, so Web3D uses the scene RGBA value. The previous value explicitly rendered the bin gold at 65% opacity.

## Impact

The physical SYSTEMBOX target bin in `ur5_2f_test` will render solid blue. Pose, orientation, dimensions, mesh transform, scale, exporter, viewer, and generated bundle remain unchanged.

## Validation

GitHub comparison confirms a one-file, one-line replacement. Repository CI should run before merge.