### PR TITLE
Align SYSTEMBOX drop zone with target bin

### DIFF
--- a/scenes/ur5_2f_test/environment.yaml
+++ b/scenes/ur5_2f_test/environment.yaml
@@ -159,8 +159,8 @@ task:
   - id: default_drop_zone
     frame: world
     pose_xyz:
-    - 0.5
-    - -0.3
+    - 0.55
+    - -0.28
     - 0.1
     pose_rpy:
     - 0.0
@@ -244,8 +244,8 @@ task_zones:
   frame: world
   shape: box
   pose_xyz:
-  - 0.5
-  - -0.3
+  - 0.55
+  - -0.28
   - 0.1
   pose_rpy:
   - 0.0


### PR DESCRIPTION
## What changed

- Updated both `default_drop_zone` pose declarations in `scenes/ur5_2f_test/environment.yaml` from `[0.50, -0.30, 0.10]` to `[0.55, -0.28, 0.10]`.
- This matches the calibrated `target_bin_default` and editable `place_zone_default` XY centre.

## Why

The orange task destination still used an older position, so it appeared offset from the correctly calibrated SYSTEMBOX bin.

## Scope

No changes to the bin pose, mesh-local transform, scale, material, STL, Web3D viewer, robot, gripper, or generated bundle.

## Validation

- Branch is one commit ahead of current `main` and zero commits behind.
- Diff contains one file with only the two stale coordinate pairs changed.
- GitHub checks should validate the full scene/export contracts.