### PR TITLE
Align remaining SYSTEMBOX destination sources

### DIFF
--- a/scenes/ur5_2f_test/cell_definition.yaml
+++ b/scenes/ur5_2f_test/cell_definition.yaml
@@ -63,8 +63,8 @@ task:
   - id: default_drop_zone
     frame: world
     pose_xyz:
-    - 0.5
-    - -0.3
+    - 0.55
+    - -0.28
     - 0.1
     pose_rpy:
     - 0.0

--- a/scenes/ur5_2f_test/config/workcell_builder_task_intent.yaml
+++ b/scenes/ur5_2f_test/config/workcell_builder_task_intent.yaml
@@ -17,8 +17,8 @@ place:
     id: default_drop_zone
     frame: world
     pose_xyz:
-    - 0.5
-    - -0.3
+    - 0.55
+    - -0.28
     - 0.1
     pose_rpy:
     - 0.0

--- a/scenes/ur5_2f_test/scene_manifest.yaml
+++ b/scenes/ur5_2f_test/scene_manifest.yaml
@@ -87,8 +87,8 @@ task_recipe:
   - id: default_drop_zone
     frame: world
     pose_xyz:
-    - 0.5
-    - -0.3
+    - 0.55
+    - -0.28
     - 0.1
     pose_rpy:
     - 0.0


### PR DESCRIPTION
## What changed

Aligned `default_drop_zone` from `[0.50, -0.30, 0.10]` to `[0.55, -0.28, 0.10]` in the three remaining stale scene sources:

- `scenes/ur5_2f_test/scene_manifest.yaml`
- `scenes/ur5_2f_test/cell_definition.yaml`
- `scenes/ur5_2f_test/config/workcell_builder_task_intent.yaml`

## Why

The canonical layout and `environment.yaml` already place `target_bin_default` and its destination at `[0.55, -0.28]`, but these three sources retained the older coordinates. Scene regeneration or normalization could therefore reintroduce an offset between the bin and destination metadata.

The small orange cube visible in Product View is a separate pick object, not this destination coordinate. Grouped Web3D authoring and task-state visualization are intentionally outside this small data-consistency PR.

## Scope

No bin mesh, mesh-local calibration, material, robot, gripper, camera, viewer source, generated bundle, or commissioning pick-object pose was changed.

## Validation

Verified on the branch that the stale destination block is removed from all three files and each now contains the aligned destination. Runtime scene export and GUI checks should run in CI/local ROS workspace before merging.