### PR TITLE
Stabilize embedded Web3D selection across helper events

### DIFF
--- a/tests/test_embedded_web3d_editor_bridge_static.py
+++ b/tests/test_embedded_web3d_editor_bridge_static.py
@@ -92,6 +92,7 @@ def test_product_view_selection_uses_stable_identity_and_filters_helpers():
     assert "function isNormalSelectableRendered(rendered)" in VIEWER
     assert "item.selectable !== false" in VIEWER
     assert "!isDiagnosticOnlyItem(item) && !isOverlayPolicyItem(item)" in VIEWER
+    assert "!isDebugOverlayItem(item)" in VIEWER
     assert "renderedById(requestedId)" in VIEWER
     assert "missing_render_identity" in VIEWER
     assert "diagnostic_helper_or_non_selectable" in VIEWER
@@ -105,7 +106,7 @@ def test_qt_selection_clears_stale_scene_and_missing_id_callbacks():
     assert "selection_missing_after_refresh" in CPP
     assert "Preview selection cleared after refresh (id missing):" in CPP
     assert "if (!embedded_web_identity_is_current(identity)) return;" in CPP
-    assert "if (id != selected_preview_item_id_)" in CPP
+    assert "if (valid_browser_selection && browser_selected_id != selected_preview_item_id_)" in CPP
     assert "selection_update_guard_" in (ROOT / "workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text(encoding="utf-8")
 
 
@@ -115,3 +116,21 @@ def test_selection_diagnostics_are_exposed_to_qt_bridge():
     assert "selectionDiagnostics: () => currentSelectionDiagnostics()" in VIEWER
     for field in ["renderIdentity", "sourceLayer", "activeVisualSource", "diagnosticOnly", "helperOrOverlay", "objectPresent"]:
         assert field in VIEWER
+
+
+def test_qt_poll_accepts_only_final_valid_browser_selection_and_explicit_clear():
+    poll = CPP.split("void ScenePreviewWidget::poll_embedded_editor_events()", 1)[1].split("#else", 1)[0]
+    for token in [
+        'editor_state.value(QStringLiteral("selectedItemId"))',
+        'editor_state.value(QStringLiteral("selectionDiagnostics"))',
+        'editor_state.value(QStringLiteral("sceneId"))',
+        'id == browser_selected_id',
+        'selection_diagnostics.value(QStringLiteral("objectPresent")).toBool()',
+        '!selection_diagnostics.value(QStringLiteral("diagnosticOnly")).toBool()',
+        '!selection_diagnostics.value(QStringLiteral("helperOrOverlay")).toBool()',
+        'browser_scene_id == identity.scene_id',
+    ]:
+        assert token in poll
+    assert "selected_preview_item_id_ = id" not in poll
+    assert "browser_selected_id.isEmpty()" in poll
+    assert "selected_preview_item_id_.clear();" in poll

--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -1216,6 +1216,38 @@ def test_viewer_load_contract_keeps_selection_empty_until_manual_pick():
     assert "return item.id;" in pick_body
 
 
+def test_selection_rejects_late_helper_without_clearing_valid_physical_item():
+    js_path = VIEWER / "viewer.js"
+    harness = r"""
+const fs = require('fs'); const vm = require('vm'); const assert = require('assert');
+let source = fs.readFileSync(process.argv[1], 'utf8').replace(/boot\(\);\s*$/, '');
+const element = () => ({ hidden:false, checked:false, disabled:false, textContent:'', className:'', innerHTML:'', classList:{toggle(){}}, querySelector(){return null;}, querySelectorAll(){return[];}, addEventListener(){}, setAttribute(){}, appendChild(){} });
+const context = { console, assert, window:{location:{search:''},dispatchEvent(){},parent:{postMessage(){}}}, document:{getElementById(){return element();},querySelectorAll(){return[];},createElement(){return element();}}, URLSearchParams, CustomEvent:function(){}, requestAnimationFrame(){}, setTimeout(){}, clearTimeout(){} };
+vm.createContext(context);
+vm.runInContext(source + `
+updateLabels=()=>{}; populateInspector=()=>{}; attachTransformGizmo=()=>{}; detachTransformGizmo=()=>{}; refreshSelectionHighlight=()=>{}; removeSelectionHighlight=()=>{};
+const rendered = item => ({ item, object3d:{} });
+const target = rendered({id:'target_bin_default', editable:true, render_policy:'primary', mesh_load_required:true, mesh_contract_category:'object', category:'place_zone_bin', source_layer:'editable_layout'});
+const commissioning = rendered({id:'commissioning_object', editable:true, render_policy:'primary', mesh_load_required:true, mesh_contract_category:'object', source_layer:'editable_layout'});
+const robot = rendered({id:'ur5_generated', editable:false, locked:true, render_policy:'primary', role:'robot', source_layer:'locked_generated_urdf_visual'});
+const helper = rendered({id:'debug_frame_axes_tool0', editable:false, render_policy:'primary', role:'helper', source_layer:'debug_overlay'});
+state.sceneJson={scene:{id:'ur5_2f_test'}}; state.objects=[target,commissioning,robot,helper]; state.editorEvents=[];
+selectObject('target_bin_default');
+assert.strictEqual(state.selected,'target_bin_default');
+assert.strictEqual(state.editorEvents.filter(e=>e.type==='selection_changed'&&e.itemId==='target_bin_default').length,1);
+selectObject('debug_frame_axes_tool0');
+assert.strictEqual(state.selected,'target_bin_default');
+assert.strictEqual(state.editorEvents.filter(e=>e.type==='selection_changed').length,1);
+assert.strictEqual(state.editorEvents.at(-1).type,'selection_ignored');
+selectObject('commissioning_object'); assert.strictEqual(state.selected,'commissioning_object');
+selectObject('ur5_generated'); assert.strictEqual(state.selected,'ur5_generated'); assert.strictEqual(canEditItem(robot.item),false);
+selectObject('target_bin_default'); assert.strictEqual(state.selected,'target_bin_default'); assert.strictEqual(isNormalSelectableRendered(target),true);
+clearSelection(); assert.strictEqual(state.selected,''); assert.strictEqual(state.editorEvents.at(-1).itemId,'');
+`, context);
+"""
+    subprocess.run(["node", "-e", harness, str(js_path)], cwd=ROOT, check=True, capture_output=True, text=True)
+
+
 def test_viewer_status_reporting_ignores_hidden_helper_overlay_counters(tmp_path):
     js_path = VIEWER / "viewer.js"
     harness = r"""
@@ -1977,9 +2009,10 @@ fitSelection();
 assert.ok(state.editorEvents.some(event => event.type === 'fit_selection_fallback'));
 assert.strictEqual(state.editorError, 'No physical item selected; fitting the workcell');
 selectObject('helper');
+assert.strictEqual(state.selected, '');
 state.three.camera.position.copy(new MockVector3(3, 4, 5));
 fitSelection();
-assert.strictEqual(state.editorError, 'Selected item has no visible physical geometry; fitting the workcell');
+assert.strictEqual(state.editorError, 'No physical item selected; fitting the workcell');
 for (const value of [state.three.camera.position.x, state.three.camera.position.y, state.three.camera.position.z, state.three.camera.near, state.three.camera.far]) assert.strictEqual(Number.isFinite(value), true);
 `, sandbox);
 """
@@ -2126,7 +2159,7 @@ def test_viewer_rotate_cancels_on_selection_mode_and_scene_change_without_yaml_w
     load_file_body = _viewer_function_body(js, "async function loadFile(file)", "function safeRelativeSceneUrl")
     load_url_body = _viewer_function_body(js, "async function loadSceneUrl(rawUrl)", "if (el.resetView)")
     object_change_body = js.split("transformControls.addEventListener('objectChange'", 1)[1].split("controls.addEventListener('start'", 1)[0]
-    assert "state.directRotateDrag && state.directRotateDrag.itemId !== (id || '')" in select_body
+    assert "state.directRotateDrag && state.directRotateDrag.itemId !== requestedId" in select_body
     assert "cancelDirectRotateDrag('Rotation cancelled')" in select_body
     assert "if (state.editorMode !== normalized)" in mode_body
     assert "cancelDirectRotateDrag('Rotation cancelled')" in mode_body

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -1797,13 +1797,34 @@ void ScenePreviewWidget::poll_embedded_editor_events()
   embedded_web_view_->page()->runJavaScript(QString::fromUtf8(kPoll), [this, identity](const QVariant & value){
     if (!embedded_web_identity_is_current(identity)) return;
     const QVariantMap payload = value.toMap();
-    apply_embedded_editor_state(payload.value(QStringLiteral("state")).toMap());
+    const QVariantMap editor_state = payload.value(QStringLiteral("state")).toMap();
+    apply_embedded_editor_state(editor_state);
+    const QString browser_scene_id = editor_state.value(QStringLiteral("sceneId")).toString().trimmed();
+    const QString browser_selected_id = editor_state.value(QStringLiteral("selectedItemId")).toString();
+    const QVariantMap selection_diagnostics = editor_state.value(QStringLiteral("selectionDiagnostics")).toMap();
+    const bool scene_identity_matches = browser_scene_id.isEmpty() || browser_scene_id == identity.scene_id;
+    bool matching_selection_event = false;
+    QString matching_item_type;
     for (const QVariant & event_value : payload.value(QStringLiteral("events")).toList()) {
       const QVariantMap event = event_value.toMap();
       if (event.value(QStringLiteral("type")).toString() == QStringLiteral("selection_changed")) {
         const QString id = event.value(QStringLiteral("itemId")).toString();
-        if (id != selected_preview_item_id_) { selected_preview_item_id_ = id; emit preview_item_selected(id, event.value(QStringLiteral("itemType")).toString()); }
+        if (!id.isEmpty() && id == browser_selected_id) {
+          matching_selection_event = true;
+          matching_item_type = event.value(QStringLiteral("itemType")).toString();
+        }
       }
+    }
+    const bool valid_browser_selection = matching_selection_event && scene_identity_matches &&
+      selection_diagnostics.value(QStringLiteral("objectPresent")).toBool() &&
+      !selection_diagnostics.value(QStringLiteral("diagnosticOnly")).toBool() &&
+      !selection_diagnostics.value(QStringLiteral("helperOrOverlay")).toBool();
+    if (valid_browser_selection && browser_selected_id != selected_preview_item_id_) {
+      selected_preview_item_id_ = browser_selected_id;
+      emit preview_item_selected(browser_selected_id, matching_item_type);
+    } else if (browser_selected_id.isEmpty() && scene_identity_matches && !selected_preview_item_id_.isEmpty()) {
+      selected_preview_item_id_.clear();
+      emit preview_item_selected(QString(), QString());
     }
     if (embedded_editor_polling_) QTimer::singleShot(200, this, [this, identity]() {
       if (embedded_web_identity_is_current(identity)) poll_embedded_editor_events();

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -922,13 +922,13 @@ function currentSelectionDiagnostics() {
     selectedItemId: id,
     renderIdentity: id,
     selectedItemType: rendered ? itemType(item) : '',
-    selectable: Boolean(item && item.selectable !== false && !isDiagnosticOnlyItem(item) && !isOverlayPolicyItem(item)),
+    selectable: Boolean(rendered && isNormalSelectableRendered(rendered)),
     editable: Boolean(item && canEditItem(item)),
     locked: Boolean(item?.locked),
     sourceLayer: String(item?.source_layer || ''),
     activeVisualSource: String(item?.active_visual_source || ''),
     diagnosticOnly: Boolean(item && isDiagnosticOnlyItem(item)),
-    helperOrOverlay: Boolean(item && isOverlayPolicyItem(item)),
+    helperOrOverlay: Boolean(item && isDebugOverlayItem(item)),
     objectPresent: Boolean(rendered),
   };
 }
@@ -3530,18 +3530,18 @@ function refreshSelectionHighlight(rendered) {
 
 function isNormalSelectableRendered(rendered) {
   const item = rendered?.item;
-  return Boolean(item?.id) && item.selectable !== false && !isDiagnosticOnlyItem(item) && !isOverlayPolicyItem(item);
+  return Boolean(item?.id) && item.selectable !== false && !isDiagnosticOnlyItem(item) && !isOverlayPolicyItem(item) && !isDebugOverlayItem(item);
 }
 function selectObject(id) {
-  const wasInitialPreviewActive = state.initialPosePreview.active;
-  if (state.directMoveDrag && state.directMoveDrag.itemId !== (id || '')) cancelDirectMoveDrag('Move cancelled');
-  if (state.directRotateDrag && state.directRotateDrag.itemId !== (id || '')) cancelDirectRotateDrag('Rotation cancelled');
   const requestedId = String(id || '');
   const requested = requestedId ? renderedById(requestedId) : null;
   if (requestedId && !isNormalSelectableRendered(requested)) {
     pushEditorEvent('selection_ignored', { itemId: requestedId, reason: requested ? 'diagnostic_helper_or_non_selectable' : 'missing_render_identity', sceneId: sceneId() });
     return '';
   }
+  const wasInitialPreviewActive = state.initialPosePreview.active;
+  if (state.directMoveDrag && state.directMoveDrag.itemId !== requestedId) cancelDirectMoveDrag('Move cancelled');
+  if (state.directRotateDrag && state.directRotateDrag.itemId !== requestedId) cancelDirectRotateDrag('Rotation cancelled');
   id = requestedId;
   const previous = state.selected || '';
   state.selected = id;


### PR DESCRIPTION
### Motivation

- The embedded Web3D Product View could select a valid editable object (e.g. `target_bin_default`) but then accept a subsequent helper/debug selection (`debug_frame_axes_tool0`) and forward it to Qt, causing MainWindow to clear the selection because the helper ID is not resolvable as an authored scene item.  
- The selection bridge between the browser and `ScenePreviewWidget` must be deterministic and side-effect free so a late helper/debug event never replaces a last-known valid physical selection.  
- Fixing this in the viewer/bridge is the smallest safe change to restore a trustworthy hierarchy↔Web3D↔inspector selection contract before adding move/rotate/save UX work.

### Description

- Strengthened the viewer selectable predicate by updating `isNormalSelectableRendered(rendered)` to reject items that have no stable id, `selectable === false`, are `diagnostic_only`, have overlay render policy, or match the debug/helper overlay heuristic (`isDebugOverlayItem`). (`workcell_studio_web/viewer/viewer.js`).
- Made selection diagnostics use the same predicate by exposing `selectionDiagnostics.selectable` via `isNormalSelectableRendered(rendered)` and reporting `helperOrOverlay` using the debug-overlay test so Qt sees accurate diagnostics. (`workcell_studio_web/viewer/viewer.js`).
- Made rejected browser selection requests side-effect free: `selectObject()` now early-returns for missing/helper/diagnostic/non-selectable IDs and only emits the existing bounded `selection_ignored` diagnostic without changing `state.selected`, clearing the inspector, cancelling/committing transforms, or emitting `selection_changed` for invalid IDs; explicit empty selection still clears selection. (`workcell_studio_web/viewer/viewer.js`).
- Improved drag cancel semantics by comparing the active drag item to the final `requestedId` so cancellation logic no longer uses a transient mismatched id. (`workcell_studio_web/viewer/viewer.js`).
- Hardened `ScenePreviewWidget::poll_embedded_editor_events()` to reconcile the polled events with the returned browser `state`: it now reads `state` + `events` from the browser poll, extracts `sceneId`, `selectedItemId`, and `selectionDiagnostics`, ensures the polled `selection_changed` event matches the browser final `selectedItemId`, validates `objectPresent && !diagnosticOnly && !helperOrOverlay`, and only then forwards `preview_item_selected` to Qt; an explicit final empty `selectedItemId` still clears selection. Existing embedded request/identity guards remain unchanged. (`workcell_builder/workcell_builder/gui/scene_preview_widget.cpp`).
- Added focused regression tests that exercise the critical sequences and bridge behavior, including: selecting `target_bin_default` then a helper `debug_frame_axes_tool0`, commissioning object selection, explicit clear, locked generated-robot inspection, and ensuring place-zone/bin metadata does not wrongly reject authored physical meshes. (tests updated: `tests/test_workcell_studio_web_viewer_static.py`, `tests/test_embedded_web3d_editor_bridge_static.py`).
- Constrained scope: bundle rebuild (`workcell_studio_web/viewer/dist/viewer.bundle.js`) was intentionally not included in this PR and must be done in a follow-up to avoid oversized diffs.

### Testing

- Ran `node --check workcell_studio_web/viewer/viewer.js` — passed.  
- Ran unit/regression suite: `python3 -m pytest -q tests/test_embedded_web3d_editor_bridge_static.py tests/test_workcell_studio_web_viewer_static.py tests/test_workcell_builder_embedded_web3d_save_roundtrip.py` — all tests passed (125 passed); three pre-existing `SyntaxWarning` invalid-escape warnings reported but not related to these changes.  
- Ran `git diff --check` — no whitespace or diff-check issues.  
- `colcon build` / ROS Humble build was not executed because `/opt/ros/humble/setup.bash` is unavailable in the environment; no changes were made to launches, controllers, hardware defaults, or generated scene YAML.  

Files changed (key): `workcell_studio_web/viewer/viewer.js`, `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp`, `tests/test_embedded_web3d_editor_bridge_static.py`, `tests/test_workcell_studio_web_viewer_static.py`.

Separate follow-up: rebuild and commit the browser `viewer.bundle.js` only after this source PR is merged to avoid an oversized bundle diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a688d86824483318669326f1468390e)