### PR TITLE
Fix Web3D authoring mode synchronization

### DIFF
--- a/tests/test_embedded_web3d_editor_bridge_static.py
+++ b/tests/test_embedded_web3d_editor_bridge_static.py
@@ -61,6 +61,30 @@ def test_outer_qt_authoring_controls_use_typed_web3d_bridge():
     assert 'make_primary_button("Rotate")' in main
 
 
+def test_authoring_mode_round_trip_cleanup_and_selection_preservation():
+    mode_body = VIEWER.split("function setEditorMode", 1)[1].split("function setEditorSnap", 1)[0]
+    for mode in ["'move'", "'rotate'", "'select'"]:
+        assert mode in mode_body
+    assert "cancelDirectMoveDrag('Move cancelled')" in mode_body
+    assert "cancelDirectRotateDrag('Rotation cancelled')" in mode_body
+    assert "gizmo.reset?.()" in mode_body
+    assert "gizmo.detach()" in mode_body
+    assert "state.three.controls.enabled = true" in mode_body
+    assert "state.selected =" not in mode_body
+    assert "return state.editorMode" in mode_body
+
+
+def test_browser_mode_state_synchronizes_all_qt_controls_without_stale_callbacks():
+    apply_body = CPP.split("void ScenePreviewWidget::apply_embedded_editor_state", 1)[1].split("void ScenePreviewWidget::poll_embedded_editor_events", 1)[0]
+    assert "QSignalBlocker blocker(gizmo_mode_selector_)" in apply_body
+    assert "QSignalBlocker blocker(interaction_mode_selector_)" in apply_body
+    assert "emit authoring_mode_changed(mode)" in apply_body
+    assert "state_request_token != embedded_editor_state_request_token_" in CPP
+    main = (ROOT / "workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text(encoding="utf-8")
+    for control in ["select_mode_button", "move_mode_button", "rotate_mode_button"]:
+        assert f"QSignalBlocker {control.removesuffix('_mode_button')}_blocker({control})" in main
+
+
 def test_move_mode_first_click_selects_and_starts_drag_without_bypassing_locks():
     handler = VIEWER.split("function onCanvasPointerDown", 1)[1].split("function onCanvasPointerMove", 1)[0]
     assert "const rendered = hitId ? renderedById(hitId) : null" in handler

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -2297,13 +2297,6 @@ void MainWindow::setup_studio_shell()
     refresh_preview_launch_ui();
     refresh_new_cell_checklist();
   });
-  connect(scene_preview_widget_, &ScenePreviewWidget::authoring_mode_changed, this, [this](const QString & mode) {
-    canvas_mode_ = mode == QStringLiteral("move") ? CanvasInteractionMode::Move : CanvasInteractionMode::Select;
-    if (canvas_mode_label_) canvas_mode_label_->setText(QStringLiteral("Mode: ") +
-      (mode == QStringLiteral("rotate") ? QStringLiteral("Rotate") :
-       mode == QStringLiteral("move") ? QStringLiteral("Move") : QStringLiteral("Select")));
-    refresh_scene_builder_view_chips();
-  });
   auto * scene3d_viewport = scene_preview_widget_->findChild<Scene3DViewportWidget *>();
   if (scene3d_viewport) {
     scene3d_viewport->setObjectName("scene3dViewportWidget");
@@ -2404,6 +2397,22 @@ void MainWindow::setup_studio_shell()
   auto * place_mode_button = make_primary_button("Place Asset"); primary_controls->addWidget(place_mode_button);
   auto * move_mode_button = make_primary_button("Move"); primary_controls->addWidget(move_mode_button);
   auto * rotate_mode_button = make_primary_button("Rotate"); primary_controls->addWidget(rotate_mode_button);
+  for (auto * button : {select_mode_button, move_mode_button, rotate_mode_button}) button->setCheckable(true);
+  select_mode_button->setChecked(true);
+  connect(scene_preview_widget_, &ScenePreviewWidget::authoring_mode_changed, this,
+    [this, select_mode_button, move_mode_button, rotate_mode_button](const QString & mode) {
+      const QSignalBlocker select_blocker(select_mode_button);
+      const QSignalBlocker move_blocker(move_mode_button);
+      const QSignalBlocker rotate_blocker(rotate_mode_button);
+      select_mode_button->setChecked(mode == QStringLiteral("select"));
+      move_mode_button->setChecked(mode == QStringLiteral("move"));
+      rotate_mode_button->setChecked(mode == QStringLiteral("rotate"));
+      canvas_mode_ = mode == QStringLiteral("move") ? CanvasInteractionMode::Move : CanvasInteractionMode::Select;
+      if (canvas_mode_label_) canvas_mode_label_->setText(QStringLiteral("Mode: ") +
+        (mode == QStringLiteral("rotate") ? QStringLiteral("Rotate") :
+         mode == QStringLiteral("move") ? QStringLiteral("Move") : QStringLiteral("Select")));
+      refresh_scene_builder_view_chips();
+    });
   save_layout_button_ = make_primary_button("Save Layout");
   primary_controls->addWidget(save_layout_button_);
   primary_controls->addStretch(1);

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -1754,8 +1754,10 @@ void ScenePreviewWidget::run_embedded_editor_command(const QString & script)
 {
   if (!embedded_web_view_ || embedded_product_view_state_ != EmbeddedProductViewState::Ready) return;
   const EmbeddedWebRequestIdentity identity = embedded_web_active_identity_;
-  embedded_web_view_->page()->runJavaScript(script, [this, identity](const QVariant & value){
-    if (!embedded_web_identity_is_current(identity)) return;
+  const quint64 state_request_token = ++embedded_editor_state_request_token_;
+  embedded_web_view_->page()->runJavaScript(script, [this, identity, state_request_token](const QVariant & value){
+    if (!embedded_web_identity_is_current(identity) ||
+        state_request_token != embedded_editor_state_request_token_) return;
     apply_embedded_editor_state(value.toMap());
   });
 }
@@ -1782,6 +1784,10 @@ void ScenePreviewWidget::apply_embedded_editor_state(const QVariantMap & state)
       const QSignalBlocker blocker(gizmo_mode_selector_);
       gizmo_mode_selector_->setCurrentText(label);
     }
+    if (interaction_mode_selector_ && interaction_mode_selector_->currentText() != label) {
+      const QSignalBlocker blocker(interaction_mode_selector_);
+      interaction_mode_selector_->setCurrentText(label);
+    }
     emit authoring_mode_changed(mode);
   }
   // Selection and dirty-state detail remains available through the embedded
@@ -1793,9 +1799,16 @@ void ScenePreviewWidget::poll_embedded_editor_events()
 {
   if (!embedded_editor_polling_ || !embedded_web_view_ || embedded_product_view_state_ != EmbeddedProductViewState::Ready) return;
   const EmbeddedWebRequestIdentity identity = embedded_web_active_identity_;
+  const quint64 state_request_token = ++embedded_editor_state_request_token_;
   static const char kPoll[] = "(() => { const api = window.__WORKCELL_EDITOR_API_V1__; if (!api) return {state:{},events:[]}; return {state:api.getState(),events:api.drainEvents()}; })()";
-  embedded_web_view_->page()->runJavaScript(QString::fromUtf8(kPoll), [this, identity](const QVariant & value){
+  embedded_web_view_->page()->runJavaScript(QString::fromUtf8(kPoll), [this, identity, state_request_token](const QVariant & value){
     if (!embedded_web_identity_is_current(identity)) return;
+    if (state_request_token != embedded_editor_state_request_token_) {
+      if (embedded_editor_polling_) QTimer::singleShot(200, this, [this, identity]() {
+        if (embedded_web_identity_is_current(identity)) poll_embedded_editor_events();
+      });
+      return;
+    }
     const QVariantMap payload = value.toMap();
     const QVariantMap editor_state = payload.value(QStringLiteral("state")).toMap();
     apply_embedded_editor_state(editor_state);

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -504,6 +504,7 @@ private:
   EmbeddedWebServerLifecycle embedded_web_server_lifecycle_{ EmbeddedWebServerLifecycle::ServerNotStarted };
   EmbeddedWebServerProbe embedded_web_server_probe_;
   bool embedded_editor_polling_{ false };
+  quint64 embedded_editor_state_request_token_{ 0 };
   EmbeddedWebRequestIdentity embedded_web_active_identity_;
   EmbeddedWebRequestIdentity pending_embedded_web_identity_;
   EmbeddedWebRequestIdentity embedded_web_loading_identity_;

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -3970,14 +3970,33 @@ if (el.exportEditPatch) el.exportEditPatch.addEventListener('click', exportEditP
 
 function setEditorMode(mode) {
   const normalized = mode === 'move' ? 'move' : (mode === 'rotate' ? 'rotate' : 'select');
-  if (state.editorMode !== normalized) { cancelDirectMoveDrag('Move cancelled'); cancelDirectRotateDrag('Rotation cancelled'); }
+  // Mode is the single authoring state.  Always clean up transient drag state,
+  // even when a repeated Select command arrives while a pointer callback is
+  // still in flight.
+  if (state.editorMode !== normalized) {
+    cancelDirectMoveDrag('Move cancelled');
+    cancelDirectRotateDrag('Rotation cancelled');
+  } else if (normalized === 'select') {
+    cancelDirectMoveDrag('Move cancelled');
+    cancelDirectRotateDrag('Rotation cancelled');
+  }
   state.editorMode = normalized;
   const gizmo = state.three.transformControls;
   if (gizmo) {
     if (normalized === 'move') { gizmo.setMode('translate'); gizmo.setSpace('world'); gizmo.showX = true; gizmo.showY = true; gizmo.showZ = true; gizmo.enabled = true; }
     else if (normalized === 'rotate') { gizmo.setMode('rotate'); gizmo.setSpace('world'); gizmo.showX = false; gizmo.showY = false; gizmo.showZ = true; gizmo.enabled = true; }
-    else { gizmo.enabled = false; }
+    else {
+      gizmo.reset?.();
+      gizmo.detach();
+      gizmo.visible = false;
+      gizmo.enabled = false;
+      state.gizmoDragStart = null;
+      state.gizmoDragGroupStart = null;
+    }
   }
+  if (normalized === 'select' && state.three.controls) state.three.controls.enabled = true;
+  if (normalized !== 'select') attachTransformGizmo(renderedById(state.selected));
+  return state.editorMode;
 }
 function setEditorSnap(enabled, translationMeters, rotationDegrees) {
   if (el.snapToggle) el.snapToggle.checked = Boolean(enabled);


### PR DESCRIPTION
### Motivation
- Qt and the embedded Web3D viewer could fall out of sync because multiple overlapping mode controls issued commands independently and async browser callbacks could restore stale state. 
- Returning to Select did not fully clear transient drag/gizmo state, leaving TransformControls/orbit state inconsistent.
- The goal is to make the browser `state.mode` authoritative for embedded authoring and reliably synchronize all Qt controls without feedback loops.

### Description
- Make Web3D `state.mode` authoritative and ensure Select/Move/Rotate are the single authoring state in the viewer by updating `setEditorMode` to always cancel direct drags, fully detach/reset `TransformControls`, clear gizmo drag state, and restore orbit controls when appropriate. (modified: `workcell_studio_web/viewer/viewer.js`)
- Prevent stale async browser callbacks from restoring older UI state by adding a monotonic request token and rejecting out-of-order JS responses. (modified: `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp`, `workcell_builder/workcell_builder/gui/scene_preview_widget.h`)
- Synchronize both embedded Qt selectors (`gizmo_mode_selector_` and `interaction_mode_selector_`) from the browser-reported mode using `QSignalBlocker` to avoid feedback loops. (modified: `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp`)
- Synchronize outer Select/Move/Rotate toolbar buttons to the same browser state, mark them `checkable`, and update them from the `authoring_mode_changed` signal while blocking signals to avoid looped commands. (modified: `workcell_builder/workcell_builder/gui/mainwindow.cpp`)
- Add focused static regression tests that assert round-trip mode behavior, selection preservation, drag/gizmo cleanup, Qt synchronization, and stale-callback protection. (modified: `tests/test_embedded_web3d_editor_bridge_static.py`)
- Note: this is a source-only change; the Web3D bundle (`viewer.bundle.js`) was not rebuilt here and must be handled in a follow-up bundle build PR.

### Testing
- Ran `node --check workcell_studio_web/viewer/viewer.js` and it passed. 
- Ran unit/static tests: `python3 -m pytest -q tests/test_embedded_web3d_editor_bridge_static.py tests/test_3d_canvas_selection_transform_roundtrip.py tests/test_workcell_studio_web_viewer_static.py` and all tests passed (`128 passed`).
- Ran `git diff --check` and repository diff checks were clean.
- No runtime/ROS GUI launches were run because this change is source-only and the viewer bundle rebuild is a separate follow-up task.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68a44175a0833183cf756eebd950be)