### PR TITLE
Fix canonical Web3D selection identities

### DIFF
--- a/tests/test_embedded_web3d_editor_bridge_static.py
+++ b/tests/test_embedded_web3d_editor_bridge_static.py
@@ -120,7 +120,8 @@ def test_product_view_selection_uses_stable_identity_and_filters_helpers():
     assert "renderedById(requestedId)" in VIEWER
     assert "missing_render_identity" in VIEWER
     assert "diagnostic_helper_or_non_selectable" in VIEWER
-    assert "selectObject(item.id);" in VIEWER
+    assert "canonicalSelectionRendered" in VIEWER
+    assert "selectObject(rendered.item.id);" in VIEWER
     assert "itemLabel(item)" not in VIEWER.split("function pickObject", 1)[1].split("function beginDirectMoveDrag", 1)[0]
 
 
@@ -132,6 +133,15 @@ def test_qt_selection_clears_stale_scene_and_missing_id_callbacks():
     assert "if (!embedded_web_identity_is_current(identity)) return;" in CPP
     assert "if (valid_browser_selection && browser_selected_id != selected_preview_item_id_)" in CPP
     assert "selection_update_guard_" in (ROOT / "workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text(encoding="utf-8")
+
+
+def test_missing_nonempty_selection_is_preserved_and_warning_is_bounded():
+    main = (ROOT / "workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text(encoding="utf-8")
+    body = main.split("void MainWindow::apply_scene_selection", 1)[1].split("void MainWindow::mark_layout_dirty", 1)[0]
+    assert "Ignored selection id absent from active scene payload; existing selection preserved:" in body
+    assert "emitted_scene_diagnostic_log_keys_.contains(warning_key)" in body
+    assert body.find("if (!active_scene_item_present)") < body.find("current_selected_scene_item_id_ = selected_id")
+    assert "apply_scene_selection(QString(), selected_role, true, false)" not in body
 
 
 def test_selection_diagnostics_are_exposed_to_qt_bridge():

--- a/tests/test_scene3d_selection_inspector.py
+++ b/tests/test_scene3d_selection_inspector.py
@@ -17,7 +17,7 @@ def test_inspector_exposes_transform_editor_controls_and_units():
 def test_selection_refresh_restore_and_clear_logs_present():
     assert 'Preview selection restored after refresh:' in PREVIEW_CPP
     assert 'Preview selection cleared after refresh (id missing):' in PREVIEW_CPP
-    assert 'Selection id missing after refresh, clearing atomically:' in MAIN_CPP
+    assert 'Ignored selection id absent from active scene payload; existing selection preserved:' in MAIN_CPP
     assert "Save Layout: no selected stable item id to reselect." in MAIN_CPP
 
 

--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -1212,8 +1212,9 @@ def test_viewer_load_contract_keeps_selection_empty_until_manual_pick():
     assert "rendered.item.locked" not in select_body
     assert "canEditItem(rendered.item)" not in select_body
     assert "if (!isNormalSelectableRendered(rendered)) continue;" in pick_body
-    assert "selectObject(item.id);" in pick_body
-    assert "return item.id;" in pick_body
+    assert "canonicalSelectionRendered" in pick_body
+    assert "selectObject(rendered.item.id);" in pick_body
+    assert "return rendered.item.id;" in pick_body
 
 
 def test_selection_rejects_late_helper_without_clearing_valid_physical_item():
@@ -1228,10 +1229,9 @@ vm.runInContext(source + `
 updateLabels=()=>{}; populateInspector=()=>{}; attachTransformGizmo=()=>{}; detachTransformGizmo=()=>{}; refreshSelectionHighlight=()=>{}; removeSelectionHighlight=()=>{};
 const rendered = item => ({ item, object3d:{} });
 const target = rendered({id:'target_bin_default', editable:true, render_policy:'primary', mesh_load_required:true, mesh_contract_category:'object', category:'place_zone_bin', source_layer:'editable_layout'});
-const commissioning = rendered({id:'commissioning_object', editable:true, render_policy:'primary', mesh_load_required:true, mesh_contract_category:'object', source_layer:'editable_layout'});
 const robot = rendered({id:'ur5_generated', editable:false, locked:true, render_policy:'primary', role:'robot', source_layer:'locked_generated_urdf_visual'});
 const helper = rendered({id:'debug_frame_axes_tool0', editable:false, render_policy:'primary', role:'helper', source_layer:'debug_overlay'});
-state.sceneJson={scene:{id:'ur5_2f_test'}}; state.objects=[target,commissioning,robot,helper]; state.editorEvents=[];
+state.sceneJson={scene:{id:'ur5_2f_test'}}; state.objects=[target,robot,helper]; state.editorEvents=[];
 selectObject('target_bin_default');
 assert.strictEqual(state.selected,'target_bin_default');
 assert.strictEqual(state.editorEvents.filter(e=>e.type==='selection_changed'&&e.itemId==='target_bin_default').length,1);
@@ -1239,11 +1239,37 @@ selectObject('debug_frame_axes_tool0');
 assert.strictEqual(state.selected,'target_bin_default');
 assert.strictEqual(state.editorEvents.filter(e=>e.type==='selection_changed').length,1);
 assert.strictEqual(state.editorEvents.at(-1).type,'selection_ignored');
-selectObject('commissioning_object'); assert.strictEqual(state.selected,'commissioning_object');
+selectObject('commissioning_object'); assert.strictEqual(state.selected,'target_bin_default');
+selectObject('commissioning_object'); assert.strictEqual(state.selected,'target_bin_default');
+assert.strictEqual(state.editorEvents.filter(e=>e.type==='selection_ignored'&&e.itemId==='commissioning_object').length,1);
 selectObject('ur5_generated'); assert.strictEqual(state.selected,'ur5_generated'); assert.strictEqual(canEditItem(robot.item),false);
 selectObject('target_bin_default'); assert.strictEqual(state.selected,'target_bin_default'); assert.strictEqual(isNormalSelectableRendered(target),true);
 clearSelection(); assert.strictEqual(state.selected,''); assert.strictEqual(state.editorEvents.at(-1).itemId,'');
 `, context);
+"""
+    subprocess.run(["node", "-e", harness, str(js_path)], cwd=ROOT, check=True, capture_output=True, text=True)
+
+
+def test_generated_environment_clicks_resolve_to_canonical_authored_items():
+    js_path = VIEWER / "viewer.js"
+    harness = r"""
+const fs = require('fs'); const vm = require('vm'); const assert = require('assert');
+let source = fs.readFileSync(process.argv[1], 'utf8').replace(/boot\(\);\s*$/, '');
+const element = () => ({hidden:false,checked:false,disabled:false,textContent:'',className:'',innerHTML:'',classList:{toggle(){}},querySelector(){return null;},querySelectorAll(){return[];},addEventListener(){},setAttribute(){},appendChild(){},getBoundingClientRect(){return {left:0,top:0,width:100,height:100};}});
+const context={console,assert,window:{location:{search:''},dispatchEvent(){},parent:{postMessage(){}}},document:{getElementById(){return element();},querySelectorAll(){return[];},createElement(){return element();}},URLSearchParams,CustomEvent:function(){},requestAnimationFrame(){},setTimeout(){},clearTimeout(){}};
+vm.createContext(context);
+vm.runInContext(source + `
+updateLabels=()=>{}; populateInspector=()=>{}; attachTransformGizmo=()=>{}; detachTransformGizmo=()=>{}; refreshSelectionHighlight=()=>{}; removeSelectionHighlight=()=>{};
+const rendered=item=>({item,object3d:{}});
+const camera=rendered({id:'realsense_overhead',role:'sensor',category:'camera',source_layer:'editable_layout',editable:true});
+const table=rendered({id:'support_surface_table',role:'asset',category:'support_surface',display_name:'workbench table',source_layer:'editable_layout',editable:true});
+const cameraChild=rendered({id:'urdf_visual_17_camera_link_mesh',role:'sensor',category:'camera',link:'camera_link',source:'urdf_flattened',source_layer:'locked_generated_urdf_visual',locked:true,mesh_uri:'camera.dae'});
+const tableChild=rendered({id:'urdf_visual_16_table_mesh',role:'environment',category:'workbench',link:'table',source:'urdf_flattened',source_layer:'locked_generated_urdf_visual',locked:true,mesh_uri:'table.dae'});
+state.objects=[camera,table,cameraChild,tableChild]; state.sceneJson={scene:{id:'ur5_2f_test'}};
+selectObject(canonicalSelectionRendered(cameraChild).item.id); assert.strictEqual(editorState().selectedItemId,'realsense_overhead');
+selectObject(canonicalSelectionRendered(tableChild).item.id); assert.strictEqual(editorState().selectedItemId,'support_surface_table');
+clearSelection(); assert.strictEqual(editorState().selectedItemId,'');
+`,context);
 """
     subprocess.run(["node", "-e", harness, str(js_path)], cwd=ROOT, check=True, capture_output=True, text=True)
 

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -6440,6 +6440,53 @@ void MainWindow::apply_scene_selection(const QString & id, const QString & role,
     return;
   }
 
+  const auto find_preview_item_by_id = [&](const QString & stable_id) -> const ScenePreviewWidget::PreviewItem * {
+    const QString trimmed_id = stable_id.trimmed();
+    if (trimmed_id.isEmpty()) return nullptr;
+    for (const auto & item : all_scene_preview_items_) {
+      if (item.id.trimmed() == trimmed_id) return &item;
+    }
+    return scene_preview_widget_ ? scene_preview_widget_->preview_item_by_id(trimmed_id) : nullptr;
+  };
+  const ScenePreviewWidget::PreviewItem * matched_preview_item = find_preview_item_by_id(selected_id);
+  bool active_scene_item_present = matched_preview_item != nullptr;
+  if (!active_scene_item_present && scene_hierarchy_tree_) {
+    for (int row = 0; row < scene_hierarchy_tree_->topLevelItemCount() && !active_scene_item_present; ++row) {
+      auto * tree_item = scene_hierarchy_tree_->topLevelItem(row);
+      if (!tree_item) continue;
+      active_scene_item_present = tree_item->data(0, TreeRoleId).toString().trimmed() == selected_id;
+      for (int child = 0; child < tree_item->childCount() && !active_scene_item_present; ++child) {
+        auto * node = tree_item->child(child);
+        active_scene_item_present = node && node->data(0, TreeRoleId).toString().trimmed() == selected_id;
+      }
+    }
+  }
+  if (!active_scene_item_present && digital_twin_scene_) {
+    for (auto * item : digital_twin_scene_->items()) {
+      if (item && item->data(RoleId).toString().trimmed() == selected_id) {
+        active_scene_item_present = true;
+        break;
+      }
+    }
+  }
+
+  // A non-empty ID is a selection attempt, never an implicit clear. Web3D may
+  // receive stale task references (for example commissioning_object) that are
+  // not placed objects in the active payload. Preserve the valid selection and
+  // report each missing ID only once for this scene payload.
+  if (!active_scene_item_present) {
+    const QString scene_key = selected_scene_state_.name.trimmed().isEmpty() ? selected_scene_name() : selected_scene_state_.name.trimmed();
+    const QString warning_key = QStringLiteral("missing_scene_selection|%1|%2").arg(scene_key, selected_id);
+    if (!emitted_scene_diagnostic_log_keys_.contains(warning_key)) {
+      emitted_scene_diagnostic_log_keys_.insert(warning_key);
+      append_studio_log(
+        QStringLiteral("Ignored selection id absent from active scene payload; existing selection preserved: %1").arg(selected_id),
+        workcell_builder::StudioLogSeverity::Warning,
+        warning_key);
+    }
+    return;
+  }
+
   current_selected_scene_item_id_ = selected_id;
   selection_update_guard_ = true;
 
@@ -6481,24 +6528,11 @@ void MainWindow::apply_scene_selection(const QString & id, const QString & role,
     }
   }
 
-  const auto find_preview_item_by_id = [&](const QString & stable_id) -> const ScenePreviewWidget::PreviewItem * {
-    const QString trimmed_id = stable_id.trimmed();
-    if (trimmed_id.isEmpty()) return nullptr;
-    for (const auto & item : all_scene_preview_items_) {
-      if (item.id.trimmed() == trimmed_id) return &item;
-    }
-    return scene_preview_widget_ ? scene_preview_widget_->preview_item_by_id(trimmed_id) : nullptr;
-  };
-  const ScenePreviewWidget::PreviewItem * matched_preview_item = find_preview_item_by_id(selected_id);
   if (scene_preview_widget_) scene_preview_widget_->select_preview_item(selected_id);
   selection_update_guard_ = false;
 
   const bool selection_resolved = matched_tree_item || matched_canvas_item || matched_preview_item;
-  if (!selection_resolved) {
-    append_studio_log(QString("Selection id absent from active scene payload after refresh, clearing atomically: %1").arg(selected_id));
-    apply_scene_selection(QString(), selected_role, true, false);
-    return;
-  }
+  if (!selection_resolved) return;
 
   if (matched_canvas_item) {
     select_canvas_item(matched_canvas_item);

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -1121,6 +1121,50 @@ function meshLocalTransformOf(item) {
 function cloneTransform(transform) { return JSON.parse(JSON.stringify(transform)); }
 function sameTransform(a, b) { return JSON.stringify(a) === JSON.stringify(b); }
 function renderedById(id) { return state.objects.find(obj => obj.item.id === id); }
+function canonicalSelectionRendered(rendered) {
+  const item = rendered?.item;
+  if (!item?.id || !isGeneratedUrdfItem(item) || isGeneratedRobotItem(item) || isGeneratedToolOrGripperItem(item)) return rendered || null;
+
+  // Generated environment visuals are render children, not separate authored
+  // objects. Prefer an explicit exporter reference, then resolve against the
+  // active payload's authored physical items by semantic group. Robot/tool
+  // visuals deliberately keep their stable generated IDs for read-only
+  // inspection.
+  const explicitIds = [
+    item.canonical_scene_item_id,
+    item.canonical_item_id,
+    item.layout_item_ref,
+    item.authored_item_id,
+    item.scene_item_id,
+    item.object_ref,
+    item.support_surface_ref,
+    item.camera_id,
+  ].map(value => String(value || '').trim()).filter(Boolean);
+  for (const id of explicitIds) {
+    const candidate = renderedById(id);
+    if (candidate && !isGeneratedUrdfItem(candidate.item) && isNormalSelectableRendered(candidate)) return candidate;
+  }
+
+  const group = viewerGroupFor(item);
+  const authored = state.objects.filter(candidate =>
+    candidate !== rendered &&
+    !isGeneratedUrdfItem(candidate.item) &&
+    isNormalSelectableRendered(candidate) &&
+    viewerGroupFor(candidate.item) === group
+  );
+  if (!authored.length) return rendered;
+  const generatedIdentity = viewerGroupIdentity(item);
+  const score = candidate => {
+    const candidateIdentity = viewerGroupIdentity(candidate.item);
+    const semanticTokens = group === 'sensors'
+      ? ['realsense', 'camera', 'sensor', 'depth', 'rgbd']
+      : ['support surface', 'table', 'tabletop', 'workbench', 'fixture'];
+    return semanticTokens.reduce((total, token) =>
+      total + (generatedIdentity.includes(token) && candidateIdentity.includes(token) ? 1 : 0), 0);
+  };
+  const ranked = authored.map(candidate => ({ candidate, score: score(candidate) })).sort((a, b) => b.score - a.score);
+  return ranked[0].score > 0 && (ranked.length === 1 || ranked[0].score > ranked[1].score) ? ranked[0].candidate : rendered;
+}
 function transformFromObject(object) {
   return { pose: { xyz: { x: object.position.x, y: object.position.y, z: object.position.z }, rpy: { x: object.rotation.x, y: object.rotation.y, z: object.rotation.z } }, scale: { x: object.scale.x, y: object.scale.y, z: object.scale.z } };
 }
@@ -2944,6 +2988,7 @@ function resetSceneLifecycleState() {
   state._fitBlockerWarnings = new Set();
   state._generatedUrdfFramePoseWarnings = new Set();
   state._supportSurfaceSemanticWarnings = new Set();
+  state.ignoredSelectionKeys = new Set();
   state.robotPreviewResult = null;
   state.initialPosePreview = { active: false, robotId: '', sceneKey: '' };
   state.web3dReadiness = { state: 'scene_loading', terminal: false, terminalState: '', terminalNavigationKey: web3dNavigationKey(), terminalEmissionCount: 0, statusSequence: 0, required: {}, pending: new Set(), failed: false, failure: null };
@@ -3536,7 +3581,13 @@ function selectObject(id) {
   const requestedId = String(id || '');
   const requested = requestedId ? renderedById(requestedId) : null;
   if (requestedId && !isNormalSelectableRendered(requested)) {
-    pushEditorEvent('selection_ignored', { itemId: requestedId, reason: requested ? 'diagnostic_helper_or_non_selectable' : 'missing_render_identity', sceneId: sceneId() });
+    const reason = requested ? 'diagnostic_helper_or_non_selectable' : 'missing_render_identity';
+    state.ignoredSelectionKeys ||= new Set();
+    const warningKey = `${sceneId()}|${requestedId}|${reason}`;
+    if (!state.ignoredSelectionKeys.has(warningKey)) {
+      state.ignoredSelectionKeys.add(warningKey);
+      pushEditorEvent('selection_ignored', { itemId: requestedId, reason, sceneId: sceneId() });
+    }
     return '';
   }
   const wasInitialPreviewActive = state.initialPosePreview.active;
@@ -3564,10 +3615,10 @@ function pickObject(event) {
   const hits = state.three.raycaster.intersectObjects(state.objects.map(o => o.object3d), true);
   for (const hit of hits) {
     const item = hit?.object?.userData?.item || hit?.object?.parent?.userData?.item;
-    const rendered = item?.id ? renderedById(item.id) : null;
+    const rendered = canonicalSelectionRendered(item?.id ? renderedById(item.id) : null);
     if (!isNormalSelectableRendered(rendered)) continue;
-    selectObject(item.id);
-    return item.id;
+    selectObject(rendered.item.id);
+    return rendered.item.id;
   }
   return '';
 }


### PR DESCRIPTION
### Motivation
- Web3D picking sometimes returned generated child IDs (e.g. `urdf_visual_17_camera_...`) or task-only IDs (e.g. `commissioning_object`) that MainWindow could not resolve, which cleared valid selections and produced repeated log spam.
- The viewer should map rendered child/generated visuals to canonical active-scene authored items where appropriate, preserve a valid selection when a non-empty missing ID arrives, and avoid repeated warnings for the same missing ID.

### Description
- Add `canonicalSelectionRendered` in `workcell_studio_web/viewer/viewer.js` to resolve generated environment/camera child visuals to canonical authored scene items when a unique authored candidate exists, while keeping generated robot/gripper visuals selectable as stable read-only inspection items.
- Update canvas picking to call the canonical resolver and emit the resolved canonical item ID from the viewer instead of raw child/generated IDs (picker now selects `rendered.item.id`).
- Prevent non-empty missing IDs from clearing a valid selection in `MainWindow::apply_scene_selection` by treating such IDs as selection attempts, preserving the existing selection and emitting a single bounded warning per scene+ID via `emitted_scene_diagnostic_log_keys_`.
- Bound viewer-side repeated `selection_ignored` events by tracking seen ignored-selection keys in `state.ignoredSelectionKeys` so the bridge does not spam repeated identical warnings/events.
- Add focused tests and update static JS/Qt bridge tests to cover: preserving `target_bin_default` selection when `commissioning_object` is missing, resolving camera child mesh to `realsense_overhead`, resolving table child mesh to `support_surface_table`, explicit empty clear behavior, and that missing non-empty IDs do not produce repeated clear/log events.
- Changes are source-only; the Web3D `viewer.bundle.js` rebuild is intentionally left as a separate follow-up.
- Files modified: `workcell_studio_web/viewer/viewer.js`, `workcell_builder/workcell_builder/gui/mainwindow.cpp`, and focused test updates in `tests/test_embedded_web3d_editor_bridge_static.py`, `tests/test_scene3d_selection_inspector.py`, and `tests/test_workcell_studio_web_viewer_static.py`.

### Testing
- Ran `node --check workcell_studio_web/viewer/viewer.js` — passed.
- Ran `python3 -m pytest -q tests/test_embedded_web3d_editor_bridge_static.py tests/test_scene3d_selection_inspector.py tests/test_workcell_studio_web_viewer_static.py` — all tests passed: `127 passed`, with `3` pre-existing Python SyntaxWarning messages about invalid escapes (warnings only).
- Ran `git diff --check` and committed the patch (`a33a5d3`) — no diff-check issues.
- Note: `viewer.bundle.js` rebuild was not performed in this PR and is documented as a follow-up task.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68addb6fa48331b601a4009a694291)