### PR TITLE
Fix PreviewContext repository root wiring

### DIFF
--- a/tests/test_workcell_builder_embedded_web3d_save_roundtrip.py
+++ b/tests/test_workcell_builder_embedded_web3d_save_roundtrip.py
@@ -12,6 +12,7 @@ ROOT = Path(__file__).resolve().parents[1]
 GUI = ROOT / "workcell_builder/workcell_builder/gui"
 CONTROLLER = GUI / "embedded_web_edit_save_controller.hpp"
 MAINWINDOW = GUI / "mainwindow.cpp"
+MAINWINDOW_HEADER = GUI / "mainwindow.h"
 WORKFLOW = ROOT / "scripts/run_workcell_studio_web_edit_workflow.py"
 APPLICATOR = ROOT / "scripts/apply_workcell_studio_web_scene_edit_patch.py"
 EXPORTER = ROOT / "scripts/export_workcell_studio_web_scene.py"
@@ -72,6 +73,38 @@ def test_preview_context_is_the_primary_bounded_save_path_source():
     assert "applicationDirPath()" not in source
     assert "if (!dir.cdUp())" not in source
     assert 'value(QStringLiteral("WORKCELL_STUDIO_REPO_ROOT"))' in source
+
+
+def test_mainwindow_preview_context_uses_canonical_repository_root_not_extractor_file():
+    mainwindow = MAINWINDOW.read_text(encoding="utf-8")
+    header = MAINWINDOW_HEADER.read_text(encoding="utf-8")
+    wiring = mainwindow.split("ScenePreviewWidget::PreviewContext preview_context;", 1)[1].split(
+        "scene_preview_widget_->set_preview_context(preview_context);", 1
+    )[0]
+
+    assert "resolve_workcell_studio_repo_root" in header
+    assert "preview_context.scene_id = selected_scene_state_.name" in wiring
+    assert "selected_scene_info.canonicalFilePath()" in wiring
+    assert "preview_context.absolute_repo_root = resolve_workcell_studio_repo_root" in wiring
+    assert "resolve_scene3d_extractor_script_path" not in wiring
+    assert "extract_scene_urdf_visual_mesh_index.py" not in wiring
+    assert 'QStringLiteral("scenes/%1").arg(preview_context.scene_id)' in wiring
+    assert "expected_scene_dir" in wiring
+    assert "preview_context.absolute_repo_root.clear()" in wiring
+
+
+def test_preview_repository_root_resolver_requires_product_markers_and_directory():
+    source = MAINWINDOW.read_text(encoding="utf-8")
+    resolver = source.split("QString MainWindow::resolve_workcell_studio_repo_root", 1)[1].split(
+        "QString MainWindow::selected_scene_name", 1
+    )[0]
+
+    assert "root_info.exists()" in resolver
+    assert "root_info.isDir()" in resolver
+    assert 'QStringLiteral("scenes")' in resolver
+    assert 'QStringLiteral("scripts/run_workcell_studio_web_edit_workflow.py")' in resolver
+    assert 'QStringLiteral("workcell_studio_web/viewer/index.html")' in resolver
+    assert "extract_scene_urdf_visual_mesh_index.py" not in resolver
 
 
 def test_save_rejects_url_mismatch_stale_context_and_scene_path_escape():

--- a/tests/test_workcell_studio_helper_script_install_lookup.py
+++ b/tests/test_workcell_studio_helper_script_install_lookup.py
@@ -28,5 +28,5 @@ def test_visual_mesh_regen_uses_resolved_script_and_expected_flags():
     assert 'QCoreApplication::applicationDirPath() + "/../../../scripts/"' in MAIN
     assert 'QDir::currentPath() + "/scripts/"' in MAIN
     assert "resolve_scene3d_extractor_script_path(d)" in MAIN
-    assert '"--scene"' in MAIN
-    assert '"--prefer-xacro"' in MAIN
+    assert '--scene \\"$VISUAL_INDEX_SCENE\\"' in MAIN
+    assert '--workspace-root \\"$VISUAL_INDEX_WORKSPACE_ROOT\\"' in MAIN

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -5583,6 +5583,31 @@ QString MainWindow::resolve_scene3d_extractor_script_path(const fs::path & selec
   return find_repo_root_with_extractor(candidate_roots);
 }
 
+QString MainWindow::resolve_workcell_studio_repo_root(const fs::path & selected_scene_dir) const
+{
+  for (const QString & candidate : candidate_repo_roots_for_scene(selected_scene_dir)) {
+    const QFileInfo root_info(candidate);
+    if (!root_info.exists() || !root_info.isDir()) {
+      continue;
+    }
+
+    const QString canonical_root = root_info.canonicalFilePath();
+    const QDir root(canonical_root);
+    if (canonical_root.isEmpty() ||
+      !QFileInfo(root.filePath(QStringLiteral("scenes"))).isDir() ||
+      !QFileInfo(root.filePath(
+        QStringLiteral("scripts/run_workcell_studio_web_edit_workflow.py"))).isFile() ||
+      !QFileInfo(root.filePath(
+        QStringLiteral("workcell_studio_web/viewer/index.html"))).isFile())
+    {
+      continue;
+    }
+
+    return QDir::cleanPath(canonical_root);
+  }
+  return {};
+}
+
 QString MainWindow::selected_scene_name() const
 {
   if (!selected_scene_state_.valid) {
@@ -9378,9 +9403,9 @@ void MainWindow::populate_scene_hierarchy()
         "to rewrite generated/scene_visual_mesh_index.json for Debug 3D Preview only");
       return false;
     }
-    QString script;
-    if (!helper_script_exists("extract_scene_urdf_visual_mesh_index.py", &script)) {
-      visual_index_refresh_blocker = QStringLiteral("extractor script not found in helper script search paths");
+    const QString script = resolve_scene3d_extractor_script_path(d);
+    if (script.isEmpty()) {
+      visual_index_refresh_blocker = QStringLiteral("extractor script not found from the selected scene repository");
       return false;
     }
     if (workspace_root.trimmed().isEmpty() || !QDir(workspace_root).exists()) {
@@ -11521,9 +11546,31 @@ void MainWindow::populate_scene_hierarchy()
     scene_preview_widget_->set_scene_selected(true);
     ScenePreviewWidget::PreviewContext preview_context;
     preview_context.scene_id = selected_scene_state_.name;
-    preview_context.absolute_scene_dir = selected_scene_state_.path;
-    preview_context.absolute_repo_root = resolve_scene3d_extractor_script_path(
-      fs::path(selected_scene_state_.path.toStdString()));
+    const QFileInfo selected_scene_info(selected_scene_state_.path);
+    preview_context.absolute_scene_dir = selected_scene_info.isDir()
+      ? QDir::cleanPath(selected_scene_info.canonicalFilePath()) : QString();
+    preview_context.absolute_repo_root = resolve_workcell_studio_repo_root(
+      fs::path(preview_context.absolute_scene_dir.toStdString()));
+
+    // Only publish a repository root when the active scene is exactly its canonical
+    // <repo>/scenes/<scene_id> directory. The save controller retains the final,
+    // strict stale-context and containment checks.
+    const QString expected_scene_dir = preview_context.absolute_repo_root.isEmpty()
+      ? QString()
+      : QFileInfo(QDir(preview_context.absolute_repo_root).filePath(
+          QStringLiteral("scenes/%1").arg(preview_context.scene_id))).canonicalFilePath();
+    if (preview_context.scene_id.trimmed().isEmpty() ||
+      preview_context.absolute_scene_dir.isEmpty() || expected_scene_dir.isEmpty() ||
+      QDir::cleanPath(expected_scene_dir) != preview_context.absolute_scene_dir)
+    {
+      preview_context.absolute_repo_root.clear();
+    }
+    append_scene_diagnostic_log_once(
+      QStringLiteral("preview_context"), 0, 0,
+      QStringLiteral("PreviewContext resolved: scene_id=%1 repo_root=%2 scene_dir=%3")
+        .arg(preview_context.scene_id,
+          preview_context.absolute_repo_root.isEmpty() ? QStringLiteral("(invalid)") : preview_context.absolute_repo_root,
+          preview_context.absolute_scene_dir.isEmpty() ? QStringLiteral("(invalid)") : preview_context.absolute_scene_dir));
     scene_preview_widget_->set_preview_context(preview_context);
     apply_scene3d_product_view_layer_defaults_and_commit();
 

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -414,6 +414,7 @@ private:
   bool helper_script_exists(const QString & script_name, QString * path = nullptr) const;
   QStringList helper_script_search_paths(const QString & script_name) const;
   QString resolve_scene3d_extractor_script_path(const fs::path & selected_scene_dir) const;
+  QString resolve_workcell_studio_repo_root(const fs::path & selected_scene_dir) const;
   QString find_repo_root_with_extractor(const QStringList & candidate_roots) const;
   QStringList candidate_repo_roots_for_scene(const fs::path & selected_scene_dir) const;
   QString diagnostics_output_root() const;


### PR DESCRIPTION
### Motivation
- The PreviewContext was being populated with the extractor script file path instead of the canonical repository directory, causing PreviewContext repository-root validation failures during normal Web3D Save Layout flows.
- The GUI must publish a validated repository directory (not a script file) alongside the active scene ID and canonical scene directory so the save-controller can perform strict stale/mismatch containment checks.

### Description
- Added `MainWindow::resolve_workcell_studio_repo_root(const fs::path&)` which returns a canonical repo directory only if it exists and contains the expected product markers (`scenes/`, `scripts/run_workcell_studio_web_edit_workflow.py`, and `workcell_studio_web/viewer/index.html`).
- Changed MainWindow wiring to populate `ScenePreviewWidget::PreviewContext` with `scene_id`, a canonical `absolute_scene_dir`, and `absolute_repo_root` resolved via the new helper, and to clear `absolute_repo_root` when the active scene dir is not exactly `<repo>/scenes/<scene_id>`.
- Kept extractor-script resolution separate and updated the visual-index refresh path to call `resolve_scene3d_extractor_script_path(...)` for the extractor script when needed, rather than assigning any script path to `absolute_repo_root`.
- Added a single bounded diagnostic log entry showing `scene_id`, `repo_root`, and `scene_dir` for debuggability and updated/unit tests to cover the new resolver and PreviewContext wiring.

### Testing
- Ran `python3 -m pytest -q tests/test_workcell_builder_embedded_web3d_save_roundtrip.py tests/test_embedded_web3d_editor_bridge_static.py tests/test_workcell_studio_helper_script_install_lookup.py` and all tests passed (`32 passed`).
- Ran `git diff --check` which passed, and static assertions in the updated tests verify the MainWindow wiring and resolver behavior.
- Attempted an in-container `colcon build` but could not run because `/opt/ros/humble/setup.bash` is unavailable in the CI/container environment, so full ROS-based build and manual GUI acceptance were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69235279308331b1fb7f8df64fa41f)