### PR TITLE
Prioritize physical objects in Web3D picking

### DIFF
--- a/tests/test_embedded_web3d_editor_bridge_static.py
+++ b/tests/test_embedded_web3d_editor_bridge_static.py
@@ -115,13 +115,14 @@ def test_qt_compact_toolbar_for_embedded_web3d():
 def test_product_view_selection_uses_stable_identity_and_filters_helpers():
     assert "function isNormalSelectableRendered(rendered)" in VIEWER
     assert "item.selectable !== false" in VIEWER
-    assert "!isDiagnosticOnlyItem(item) && !isOverlayPolicyItem(item)" in VIEWER
+    assert "state.debugOverlaysVisible && (isTaskOnlyHelperItem(item)" in VIEWER
+    assert "!isTaskOnlyHelperItem(item) && !isOverlayPolicyItem(item)" in VIEWER
     assert "!isDebugOverlayItem(item)" in VIEWER
     assert "renderedById(requestedId)" in VIEWER
     assert "missing_render_identity" in VIEWER
     assert "diagnostic_helper_or_non_selectable" in VIEWER
     assert "canonicalSelectionRendered" in VIEWER
-    assert "selectObject(rendered.item.id);" in VIEWER
+    assert "selectObject(selectedCandidate.rendered.item.id);" in VIEWER
     assert "itemLabel(item)" not in VIEWER.split("function pickObject", 1)[1].split("function beginDirectMoveDrag", 1)[0]
 
 

--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -1211,10 +1211,45 @@ def test_viewer_load_contract_keeps_selection_empty_until_manual_pick():
     assert "const selected = rendered.item.id === id;" in select_body
     assert "rendered.item.locked" not in select_body
     assert "canEditItem(rendered.item)" not in select_body
-    assert "if (!isNormalSelectableRendered(rendered)) continue;" in pick_body
-    assert "canonicalSelectionRendered" in pick_body
-    assert "selectObject(rendered.item.id);" in pick_body
-    assert "return rendered.item.id;" in pick_body
+    assert "rankedPickingCandidates(hits)" in pick_body
+    assert "candidates.find(candidate => Number.isFinite(candidate.priority)" in pick_body
+    ranking_body = _viewer_function_body(js, "function rankedPickingCandidates(hits)", "function selectObject(id)")
+    assert "canonicalSelectionRendered" in ranking_body
+    assert "selectObject(selectedCandidate.rendered.item.id);" in pick_body
+    assert "return selectedCandidate.rendered.item.id;" in pick_body
+
+
+def test_raycast_ranking_prefers_authored_bin_over_place_zone_and_task_marker():
+    js_path = VIEWER / "viewer.js"
+    harness = r"""
+const fs = require('fs'); const vm = require('vm'); const assert = require('assert');
+let source = fs.readFileSync(process.argv[1], 'utf8').replace(/boot\(\);\s*$/, '');
+const element = () => ({hidden:false,checked:false,disabled:false,textContent:'',className:'',innerHTML:'',classList:{toggle(){}},querySelector(){return null;},querySelectorAll(){return[];},addEventListener(){},setAttribute(){},appendChild(){},getBoundingClientRect(){return {left:0,top:0,width:100,height:100};}});
+const context={console,assert,window:{location:{search:''},dispatchEvent(){},parent:{postMessage(){}}},document:{getElementById(){return element();},querySelectorAll(){return[];},createElement(){return element();}},URLSearchParams,CustomEvent:function(){},requestAnimationFrame(){},setTimeout(){},clearTimeout(){}};
+vm.createContext(context);
+vm.runInContext(source + `
+updateLabels=()=>{}; populateInspector=()=>{}; attachTransformGizmo=()=>{}; detachTransformGizmo=()=>{}; refreshSelectionHighlight=()=>{}; removeSelectionHighlight=()=>{};
+const rendered = item => ({item,object3d:{userData:{item}}});
+const bin=rendered({id:'target_bin_default',editable:true,locked:false,render_policy:'primary',mesh_load_required:true,mesh_contract_category:'object',category:'place_zone',source_layer:'editable_layout',transform_group:'default_drop_destination'});
+const zone=rendered({id:'place_zone_default',editable:true,locked:false,render_policy:'overlay',role:'place_zone',source_layer:'editable_layout',transform_group:'default_drop_destination'});
+const marker=rendered({id:'commissioning_object',editable:false,locked:true,render_policy:'primary',role:'task_marker',source_layer:'task_preview'});
+const robot=rendered({id:'ur5_generated',editable:false,locked:true,render_policy:'primary',role:'robot',source_layer:'locked_generated_urdf_visual'});
+state.sceneJson={scene:{id:'ur5_2f_test'}}; state.objects=[bin,zone,marker,robot]; state.editorEvents=[]; state.debugOverlaysVisible=false;
+const hits=[{object:marker.object3d,distance:1},{object:zone.object3d,distance:2},{object:bin.object3d,distance:3}];
+assert.strictEqual(rankedPickingCandidates(hits)[0].rendered.item.id,'target_bin_default');
+state.three.pointer={}; state.three.camera={}; state.three.raycaster={setFromCamera(){},intersectObjects(){return hits;}};
+assert.strictEqual(pickObject({clientX:10,clientY:10}),'target_bin_default');
+assert.strictEqual(state.selected,'target_bin_default');
+assert.strictEqual(state.editorEvents.filter(e=>e.type==='helper_pick_skipped').length,1);
+pickObject({clientX:10,clientY:10}); assert.strictEqual(state.editorEvents.filter(e=>e.type==='helper_pick_skipped').length,1);
+state.editorMode='move'; assert.strictEqual(pickObject({clientX:10,clientY:10}),'target_bin_default');
+assert.strictEqual(isNormalSelectableRendered(marker),false);
+state.debugOverlaysVisible=true; assert.strictEqual(isNormalSelectableRendered(marker),true); assert.strictEqual(pickingPriority(marker),4);
+assert.strictEqual(isNormalSelectableRendered(robot),true); assert.strictEqual(pickingPriority(robot),3);
+assert.strictEqual(editableTransformGroupMembers(bin).map(r=>r.item.id).sort().join(','),'place_zone_default,target_bin_default');
+`, context);
+"""
+    subprocess.run(["node", "-e", harness, str(js_path)], cwd=ROOT, check=True, capture_output=True, text=True)
 
 
 def test_selection_rejects_late_helper_without_clearing_valid_physical_item():

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -88,6 +88,20 @@ function isPrimaryRenderableItem(item) {
 }
 function isDiagnosticOnlyItem(item) { return itemRenderPolicy(item) === 'diagnostic_only'; }
 function isOverlayPolicyItem(item) { return itemRenderPolicy(item) === 'overlay'; }
+function isTaskOnlyHelperItem(item) {
+  const identity = [
+    item?.source_layer,
+    item?.active_visual_source,
+    item?.render_owner,
+    item?.role,
+    item?.category,
+    item?.type,
+    item?.id,
+    item?.display_name,
+  ].map(value => String(value || '').toLowerCase().replace(/[_-]+/g, ' ')).join(' ');
+  return item?.task_only === true || item?.non_blocking_pick === true ||
+    /\b(task helper|task marker|source helper|commissioning object)\b/.test(identity);
+}
 function isPrimaryAuthoredPhysicalMesh(item) {
   if (itemRenderPolicy(item) !== 'primary' || !truthyFlag(item?.mesh_load_required)) return false;
   const contractCategory = String(item?.mesh_contract_category || item?.meshContractCategory || '').toLowerCase();
@@ -1814,6 +1828,10 @@ function makePrimitiveMesh(item) {
   else {
     const dims = dimensionsFromPrimitive(primitive);
     if (!dims) return null;
+    // Zones are visual editing context, not destination volumes.  Keep place
+    // zones as a thin floor footprint so the linked physical bin remains
+    // visible and receives normal product picking.
+    if (isZone(item) && /\bplace zone\b/.test(viewerGroupIdentity(item))) dims[2] = Math.min(dims[2], 0.01);
     geometry = new THREE.BoxGeometry(dims[0], dims[1], dims[2]);
   }
   const group = new THREE.Group();
@@ -3575,7 +3593,29 @@ function refreshSelectionHighlight(rendered) {
 
 function isNormalSelectableRendered(rendered) {
   const item = rendered?.item;
-  return Boolean(item?.id) && item.selectable !== false && !isDiagnosticOnlyItem(item) && !isOverlayPolicyItem(item) && !isDebugOverlayItem(item);
+  const inspectionSelectable = state.debugOverlaysVisible && (isTaskOnlyHelperItem(item) || isOverlayPolicyItem(item) || isDebugOverlayItem(item));
+  return Boolean(item?.id) && item.selectable !== false && !isDiagnosticOnlyItem(item) && (inspectionSelectable || (!isTaskOnlyHelperItem(item) && !isOverlayPolicyItem(item) && !isDebugOverlayItem(item)));
+}
+function pickingPriority(rendered) {
+  const item = rendered?.item;
+  if (!item?.id) return Number.POSITIVE_INFINITY;
+  if (isTaskOnlyHelperItem(item) || isOverlayPolicyItem(item) || isDebugOverlayItem(item)) return state.debugOverlaysVisible ? 4 : Number.POSITIVE_INFINITY;
+  if (canEditItem(item) && isPrimaryRenderableItem(item) && isPhysicalSemanticItem(item)) return 1;
+  if (canEditItem(item) && !isGeneratedUrdfItem(item)) return 2;
+  if ((isGeneratedUrdfItem(item) || item.locked) && isPhysicalSemanticItem(item)) return 3;
+  return 2;
+}
+function rankedPickingCandidates(hits) {
+  const candidates = [];
+  const seen = new Set();
+  for (const hit of hits || []) {
+    const item = hit?.object?.userData?.item || hit?.object?.parent?.userData?.item;
+    const rendered = canonicalSelectionRendered(item?.id ? renderedById(item.id) : null);
+    if (!rendered?.item?.id || seen.has(rendered.item.id)) continue;
+    seen.add(rendered.item.id);
+    candidates.push({ rendered, hit, priority: pickingPriority(rendered) });
+  }
+  return candidates.sort((a, b) => a.priority - b.priority || Number(a.hit?.distance || 0) - Number(b.hit?.distance || 0));
 }
 function selectObject(id) {
   const requestedId = String(id || '');
@@ -3613,14 +3653,20 @@ function pickObject(event) {
   state.three.pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
   state.three.raycaster.setFromCamera(state.three.pointer, state.three.camera);
   const hits = state.three.raycaster.intersectObjects(state.objects.map(o => o.object3d), true);
-  for (const hit of hits) {
-    const item = hit?.object?.userData?.item || hit?.object?.parent?.userData?.item;
-    const rendered = canonicalSelectionRendered(item?.id ? renderedById(item.id) : null);
-    if (!isNormalSelectableRendered(rendered)) continue;
-    selectObject(rendered.item.id);
-    return rendered.item.id;
+  const candidates = rankedPickingCandidates(hits);
+  const selectedCandidate = candidates.find(candidate => Number.isFinite(candidate.priority) && isNormalSelectableRendered(candidate.rendered));
+  if (!selectedCandidate) return '';
+  const skippedHelper = candidates.find(candidate => candidate !== selectedCandidate && candidate.priority > selectedCandidate.priority && (isTaskOnlyHelperItem(candidate.rendered.item) || isDebugOverlayItem(candidate.rendered.item)));
+  if (skippedHelper) {
+    state.skippedHelperPickKeys ||= new Set();
+    const warningKey = `${sceneId()}|${skippedHelper.rendered.item.id}|${selectedCandidate.rendered.item.id}`;
+    if (!state.skippedHelperPickKeys.has(warningKey)) {
+      state.skippedHelperPickKeys.add(warningKey);
+      pushEditorEvent('helper_pick_skipped', { helperItemId: skippedHelper.rendered.item.id, selectedItemId: selectedCandidate.rendered.item.id, sceneId: sceneId() });
+    }
   }
-  return '';
+  selectObject(selectedCandidate.rendered.item.id);
+  return selectedCandidate.rendered.item.id;
 }
 
 


### PR DESCRIPTION
### Motivation
- Fix Web3D picking in `ur5_2f_test` where the task marker (`commissioning_object`) intercepted clicks meant for the visible bin mesh. 
- Ensure authored physical meshes (e.g. `target_bin_default`) win normal raycast selection while helpers/overlays remain visible but non-blocking. 
- Preserve existing selection semantics, canonical ID resolution, transform-group linking, and avoid rebuilding `viewer.bundle.js` in this PR.

### Description
- Added `isTaskOnlyHelperItem(item)` to classify task-only markers/helpers (including `commissioning_object`) as non-blocking by identity and metadata.
- Introduced semantic picking priority with `pickingPriority(rendered)` and `rankedPickingCandidates(hits)` to rank raycast hits and avoid relying on raw Three.js hit ordering.
- Rewrote `pickObject(event)` to use ranked candidates and select the top-priority authored physical object, keeping helper selection only when debug/overlay inspection is enabled.
- Adjusted `isNormalSelectableRendered(rendered)` to allow overlay/helper selection when `state.debugOverlaysVisible` is true and otherwise filter task-only helpers out of normal picks.
- Emit a single bounded diagnostic event `helper_pick_skipped` when a helper hit is skipped in favor of a physical object to avoid repeated log spam.
- Render `place_zone` primitives as a thin footprint (max 10mm thickness) so `place_zone_default` does not visually cover or block the authored bin mesh, while keeping them transform-group linked to `target_bin_default`.
- Added and updated focused static/runtime tests covering overlapping `target_bin_default`, `place_zone_default`, `commissioning_object`, generated robot inspection, canonical ID behavior, transform-group membership, helper-skip diagnostics, and repeat-suppression.

### Testing
- Ran `node --check workcell_studio_web/viewer/viewer.js` and it passed.
- Ran `python3 -m pytest -q tests/test_embedded_web3d_editor_bridge_static.py tests/test_workcell_studio_web_viewer_static.py tests/test_scene3d_selection_inspector.py` and all tests passed (`128 passed`).
- Ran `git diff --check` (no check failures) and verified modified source files only; `viewer.bundle.js` was intentionally not rebuilt and manual GUI acceptance was not executed due to no display session.
- Confirmed safety: no launch, controller, hardware, or real-robot motion defaults were changed and fake-hardware-first behavior is preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69288ee3648331840a745e12e7599f)