### PR TITLE
Derive the UR5 default place zone from its target bin

### DIFF
--- a/scenes/ur5_2f_test/environment.yaml
+++ b/scenes/ur5_2f_test/environment.yaml
@@ -252,9 +252,9 @@ task_zones:
   - 0.0
   - 0.0
   dimensions:
-  - 0.2
-  - 0.2
-  - 0.1
+  - 0.352201
+  - 0.213387
+  - 0.01
   target_ref: target_bin_default
   support_surface_ref: support_surface_table
   layout_item_ref: place_zone_default

--- a/scenes/ur5_2f_test/layout/workcell_studio_layout.yaml
+++ b/scenes/ur5_2f_test/layout/workcell_studio_layout.yaml
@@ -40,14 +40,15 @@ items:
     role: place_zone
     category: work_surface
     display_name: Default Place Zone
+    target_ref: target_bin_default
     editable: true
     locked: false
     source_layer: editable_layout
     source: layout/workcell_studio_layout.yaml
     pose:
-      xyz: [0.55, -0.28, 0.105]
+      xyz: [0.55, -0.28, 0.20]
       rpy: [0.0, 0.0, 0.0]
-    dimensions: [0.35, 0.30, 0.01]
+    dimensions: [0.3522011268, 0.2133871002, 0.01]
     geometry_type: box
     primitive_geometry_type: box
     material:


### PR DESCRIPTION
### Motivation
- Ensure the authored place-zone overlay is explicitly tied to the physical target bin so the web-export normalization contract produces a derived, non-independent place overlay footprint while preserving selection/display metadata.
- Preserve the existing `default_drop_zone.target_ref` and the shared `default_drop_destination` transform group so the scene generation, URDF, launch, and safety semantics remain unchanged.

### Description
- Updated `scenes/ur5_2f_test/environment.yaml` to set `default_drop_zone` X/Y footprint to the target bin's X/Y dimensions and cap the place-zone height to `0.01` m while keeping `target_ref: target_bin_default`.
- Updated `scenes/ur5_2f_test/layout/workcell_studio_layout.yaml` to link `place_zone_default` to `target_bin_default` via `target_ref`, align its world `pose` (XYZ/RPY) and X/Y footprint to the bin, and set the place-zone height to `0.01` m while retaining `transform_group: default_drop_destination` and existing selection/display metadata (`editable`, `locked`, `source_layer`, `display_name`).
- The changes are metadata-only and do not modify robot metadata, generated URDF, launch files, runtime flags, or safety settings, and rely on the `scripts/export_workcell_studio_web_scene.py` normalization step to treat the place zone as derived from the bin rather than an independent transform source.

### Testing
- Ran `git diff --check` to validate formatting and detected no issues.
- Ran `python3 -m pytest tests/test_export_workcell_studio_web_scene.py tests/test_workcell_studio_web_mesh_staging.py -q`, which passed (`50 passed`).
- Ran `python3 -m pytest tests/test_ur5_2f_layout_roundtrip_fixture.py tests/test_workcell_builder_embedded_web3d_save_roundtrip.py tests/test_workcell_studio_web_mesh_staging.py -q`, which passed (`42 passed`).
- Executed focused export assertions using `scripts/export_workcell_studio_web_scene.build_web_scene` to verify that the place-zone resolves to the bin XYZ/RPY, uses the bin X/Y footprint, has height <= `0.01` m, and preserves the shared `default_drop_destination` transform group, and these assertions passed.
- Did not run ROS 2 build/launch since this is a metadata-only change and it does not touch generated packages, URDF, launch files, or runtime code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69b5b097dc8331b143ed904272973b)