### PR TITLE
Link derived place-zone overlays to destination edits

### DIFF
--- a/scripts/apply_workcell_studio_web_scene_edit_patch.py
+++ b/scripts/apply_workcell_studio_web_scene_edit_patch.py
@@ -23,7 +23,7 @@ try:
 except ImportError:  # pragma: no cover
     yaml = None  # type: ignore
 
-from validate_workcell_studio_web_scene_edit_patch import _items_by_id, _load_json, _scene_id, validate
+from validate_workcell_studio_web_scene_edit_patch import _derived_transform_target, _items_by_id, _load_json, _scene_id, validate
 
 ALLOWED_SOURCES = {
     "layout/workcell_studio_layout.yaml",
@@ -174,6 +174,12 @@ def _plan(scene_dir: Path, web_scene: dict[str, Any], patch: dict[str, Any]) -> 
     for edit in patch.get("edits", []):
         item_id = str(edit["item_id"])
         item = items[item_id]
+        derived_target = _derived_transform_target(item)
+        if derived_target:
+            raise ValueError(
+                f"{item_id}: derived place zone is a linked visual dependent of destination {derived_target!r}; "
+                "persist one update_transform edit for the destination instead"
+            )
         rel = _source_from_item(item)
         if rel is None:
             raise ValueError(f"{item_id}: ambiguous source mapping; item provenance must clearly identify layout/workcell_studio_layout.yaml or environment.yaml")

--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -254,6 +254,23 @@ def _normalise_active_place_zone(data: Dict[str, Any]) -> None:
         )
     asset, asset_source = asset_candidates[0]
     xyz, rpy, dimensions = asset.get("pose_xyz"), asset.get("pose_rpy"), asset.get("dimensions")
+    # Layout YAML is the transform authoring source used by the web editor.
+    # Prefer its matching destination record so a saved destination edit also
+    # drives the derived overlay on the very next export/reload.
+    layout = _as_map(data.get("layout"))
+    layout_matches = [
+        item for item in _as_list(layout.get("items"))
+        if isinstance(item, Mapping) and str(item.get("id", "")) == target_ref
+    ]
+    if len(layout_matches) > 1:
+        raise BlockingExportError(f"layout destination {target_ref!r} is ambiguous")
+    if layout_matches:
+        layout_target = layout_matches[0]
+        layout_pose = _as_map(layout_target.get("pose"))
+        xyz = layout_pose.get("xyz", xyz)
+        rpy = layout_pose.get("rpy", rpy)
+        dimensions = layout_target.get("dimensions", dimensions)
+        asset_source = "layout/workcell_studio_layout.yaml"
     if not (isinstance(xyz, (list, tuple)) and len(xyz) >= 3 and isinstance(rpy, (list, tuple)) and len(rpy) >= 3):
         raise BlockingExportError(f"environment.yaml physical asset {target_ref!r} must define world pose_xyz and pose_rpy")
     if not isinstance(dimensions, (list, tuple)) or len(dimensions) < 2:
@@ -270,6 +287,17 @@ def _normalise_active_place_zone(data: Dict[str, Any]) -> None:
         "task_zone": "task_zones",
         "physical_asset": asset_source,
     }
+    # A layout-authored visual may mirror the semantic environment zone under
+    # a different ID. Keep that dependent record derived in the export payload
+    # without writing its pose back to layout YAML.
+    for layout_item in _as_list(layout.get("items")):
+        if not isinstance(layout_item, dict) or str(layout_item.get("target_ref", "")).strip() != target_ref:
+            continue
+        layout_identity = " ".join(str(layout_item.get(key, "")).lower().replace("_", " ") for key in ("role", "type", "category", "id"))
+        if "place zone" not in layout_identity:
+            continue
+        layout_item["pose"] = {"xyz": list(xyz[:3]), "rpy": list(rpy[:3])}
+        layout_item["dimensions"] = [dimensions[0], dimensions[1], height]
 
 
 def _provenance(fields: Iterable[str], source: str) -> Dict[str, str]:

--- a/scripts/run_workcell_studio_web_edit_workflow.py
+++ b/scripts/run_workcell_studio_web_edit_workflow.py
@@ -23,7 +23,7 @@ for import_path in (SCRIPT_DIR, REPO_ROOT):
 
 from export_workcell_studio_web_scene import build_web_scene  # noqa: E402
 from workcell_builder_studio_panel import build_export_sources_command  # noqa: E402
-from validate_workcell_studio_web_scene_edit_patch import _load_json, _scene_id, validate  # noqa: E402
+from validate_workcell_studio_web_scene_edit_patch import _derived_transform_target, _items_by_id, _load_json, _scene_id, validate  # noqa: E402
 
 
 def _scene_id_from_dir(scene: Path) -> str:
@@ -59,6 +59,17 @@ def _validate_patch(before: dict[str, Any], patch_path: Path) -> tuple[bool, dic
     except ValueError as exc:
         return False, None, [str(exc)]
     errors = validate(before, patch)
+    if errors:
+        derived = [
+            (str(edit.get("item_id", "")), _derived_transform_target(_items_by_id(before).get(str(edit.get("item_id", "")), {})))
+            for edit in patch.get("edits", []) if isinstance(edit, dict)
+        ]
+        for item_id, target_id in derived:
+            if target_id:
+                errors.append(
+                    f"user action required: select/move destination {target_id!r}, not derived overlay {item_id!r}; "
+                    "only the destination transform is persisted and re-export regenerates the overlay"
+                )
     return not errors, patch, errors
 
 

--- a/scripts/validate_workcell_studio_web_scene_edit_patch.py
+++ b/scripts/validate_workcell_studio_web_scene_edit_patch.py
@@ -57,6 +57,13 @@ def _is_generated_robot_or_tool(item: dict[str, Any]) -> bool:
     return False
 
 
+def _derived_transform_target(item: dict[str, Any]) -> str | None:
+    """Return the authored transform owner for a derived place-zone overlay."""
+    target = str(item.get("target_ref", "")).strip()
+    identity = _identity(item).replace("-", " ")
+    return target if target and "place zone" in identity else None
+
+
 def _walk_numbers(value: Any, path: str, errors: list[str]) -> None:
     if isinstance(value, dict):
         for key, child in value.items():
@@ -97,6 +104,14 @@ def validate(web_scene: dict[str, Any], patch: dict[str, Any]) -> list[str]:
         if item is None:
             errors.append(f"{prefix}.item_id={item_id!r}: item not found in web scene")
             continue
+        derived_target = _derived_transform_target(item)
+        if derived_target:
+            if derived_target not in items:
+                errors.append(f"{prefix}.item_id={item_id!r}: derived place zone references missing destination {derived_target!r}")
+            errors.append(
+                f"{prefix}.item_id={item_id!r}: derived place zone transforms are owned by destination "
+                f"{derived_target!r}; edit that destination instead (the overlay pose and footprint are regenerated on export)"
+            )
         if item.get("locked") is True:
             errors.append(f"{prefix}.item_id={item_id!r}: locked=true items cannot be edited")
         if item.get("editable") is not True:

--- a/scripts/verify_workcell_studio_web_scene_edit_persistence.py
+++ b/scripts/verify_workcell_studio_web_scene_edit_persistence.py
@@ -15,7 +15,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from validate_workcell_studio_web_scene_edit_patch import _is_generated_robot_or_tool, _items_by_id, _load_json, _scene_id, validate
+from validate_workcell_studio_web_scene_edit_patch import _derived_transform_target, _is_generated_robot_or_tool, _items_by_id, _load_json, _scene_id, validate
 
 _ALLOWED_ITEM_METADATA = {
     "provenance",
@@ -91,6 +91,10 @@ def verify(before: dict[str, Any], patch: dict[str, Any], after: dict[str, Any])
     before_items = _items_by_id(before)
     after_items = _items_by_id(after)
     edited_ids: set[str] = set()
+    derived_dependents = {
+        item_id: target_id for item_id, item in before_items.items()
+        if (target_id := _derived_transform_target(item))
+    }
 
     for index, edit in enumerate(patch.get("edits", []) if isinstance(patch.get("edits"), list) else []):
         item_id = str(edit.get("item_id", ""))
@@ -137,6 +141,12 @@ def verify(before: dict[str, Any], patch: dict[str, Any], after: dict[str, Any])
             errors.append(f"item {item_id!r}: missing from after web_scene")
             continue
         if item_id in edited_ids:
+            continue
+        if derived_dependents.get(item_id) in edited_ids:
+            if _strip_allowed_metadata(before_item) == _strip_allowed_metadata(after_item):
+                details.append(f"PASS linked place-zone record {item_id}: remained exporter-consistent with destination {derived_dependents[item_id]}")
+            else:
+                details.append(f"PASS derived place-zone overlay {item_id}: regenerated from destination {derived_dependents[item_id]}")
             continue
         if before_item.get("locked") is True or _is_generated_robot_or_tool(before_item):
             label = "locked/generated"

--- a/tests/test_export_workcell_studio_web_scene.py
+++ b/tests/test_export_workcell_studio_web_scene.py
@@ -269,6 +269,25 @@ def test_active_place_zone_is_normalized_from_referenced_physical_asset(tmp_path
     assert zone["normalization_provenance"]["physical_asset"] == "environment.assets"
 
 
+def test_active_place_zone_prefers_saved_layout_destination_transform(tmp_path):
+    scene = tmp_path / "scene"
+    (scene / "layout").mkdir(parents=True)
+    (scene / "environment.yaml").write_text(yaml.safe_dump({
+        "task": {"place": {"target_ref": "place_area"}},
+        "task_zones": [{"id": "place_area", "target_ref": "bin", "dimensions": [0.1, 0.1, 0.01]}],
+        "environment": {"assets": [{"id": "bin", "pose_xyz": [0, 0, 0], "pose_rpy": [0, 0, 0], "dimensions": [0.2, 0.3, 0.4]}]},
+    }, sort_keys=False), encoding="utf-8")
+    (scene / "layout" / "workcell_studio_layout.yaml").write_text(yaml.safe_dump({
+        "items": [{"id": "bin", "pose": {"xyz": [1, 2, 3], "rpy": [0, 0, 0.5]}, "dimensions": [0.6, 0.7, 0.8]}],
+    }, sort_keys=False), encoding="utf-8")
+
+    zone = next(item for item in exporter.build_web_scene(scene)["zones"] if item["id"] == "place_area")
+    assert zone["pose_xyz"] == [1, 2, 3]
+    assert zone["pose_rpy"] == [0, 0, 0.5]
+    assert zone["dimensions"] == [0.6, 0.7, 0.01]
+    assert zone["normalization_provenance"]["physical_asset"] == "layout/workcell_studio_layout.yaml"
+
+
 def test_active_place_zone_rejects_ambiguous_applicable_rule_destinations(tmp_path):
     scene = tmp_path / "scene"
     scene.mkdir()

--- a/tests/test_workcell_builder_embedded_web3d_save_roundtrip.py
+++ b/tests/test_workcell_builder_embedded_web3d_save_roundtrip.py
@@ -252,15 +252,12 @@ def test_executable_target_bin_linked_save_and_reload_roundtrip(tmp_path):
         "created_at": "2026-07-28T00:00:00Z",
         "created_by": "static_web_viewer",
         "provenance": {"source_web_scene_file": before_path.name},
-        "edits": [
-            {"item_id": item_id, "operation": "update_transform", "editable_required": True,
-             "locked_required": False, "old_transform": old, "new_transform": moved(old)}
-            for item_id, old in (("target_bin_default", old_bin), ("place_zone_default", old_zone))
-        ],
+        "edits": [{"item_id": "target_bin_default", "operation": "update_transform", "editable_required": True,
+                   "locked_required": False, "old_transform": old_bin, "new_transform": moved(old_bin)}],
     }
     patch_path = output / "edit_patch.json"
     patch_path.write_text(json.dumps(patch), encoding="utf-8")
-    assert {edit["item_id"] for edit in patch["edits"]} == {"target_bin_default", "place_zone_default"}
+    assert {edit["item_id"] for edit in patch["edits"]} == {"target_bin_default"}
 
     layout_path = scene / "layout/workcell_studio_layout.yaml"
     layout_before = layout_path.read_bytes()
@@ -285,10 +282,14 @@ def test_executable_target_bin_linked_save_and_reload_roundtrip(tmp_path):
     layout_items = {item["id"]: item for item in layout["items"]}
     after = json.loads((output / "ur5_2f_test.after.web_scene.json").read_text(encoding="utf-8"))
     reloaded = {item["id"]: item for item in _rendered_items(after)}
-    for item_id, old in (("target_bin_default", old_bin), ("place_zone_default", old_zone)):
-        expected = moved(old)
-        assert layout_items[item_id]["pose"]["xyz"] == list(expected["pose"]["xyz"].values())
-        assert _transform(reloaded[item_id])["pose"] == expected["pose"]
+    expected = moved(old_bin)
+    assert layout_items["target_bin_default"]["pose"]["xyz"] == list(expected["pose"]["xyz"].values())
+    assert _transform(reloaded["target_bin_default"])["pose"] == expected["pose"]
+    # The authored overlay pose is not persisted independently. Export derives
+    # both its transform and footprint from the destination asset.
+    assert layout_items["place_zone_default"]["pose"]["xyz"] == list(old_zone["pose"]["xyz"].values())
+    assert _transform(reloaded["place_zone_default"])["pose"] == expected["pose"]
+    assert reloaded["place_zone_default"]["dimensions"][:2] == reloaded["target_bin_default"]["dimensions"][:2]
 
 
 def test_executable_linked_edit_undo_redo_preserves_canonical_selection():
@@ -300,13 +301,13 @@ const element=()=>({hidden:false,checked:false,disabled:false,textContent:'',inn
 const context={console,assert,window:{location:{search:''},dispatchEvent(){},parent:{postMessage(){}}},document:{getElementById(){return element();},createElement(){return element();}},URLSearchParams,CustomEvent:function(){},requestAnimationFrame(){},setTimeout(){},clearTimeout(){}};
 vm.createContext(context); vm.runInContext(source+`
 const object=(x,y,z)=>({position:{x,y,z,set(a,b,c){this.x=a;this.y=b;this.z=c;}},rotation:{x:0,y:0,z:0,set(a,b,c){this.x=a;this.y=b;this.z=c;}},scale:{x:1,y:1,z:1,set(a,b,c){this.x=a;this.y=b;this.z=c;}}});
-const row=(id,z)=>({item:{id,editable:true,locked:false,source_layer:'editable_layout',render_policy:'primary',transform_group:'default_drop_destination'},object3d:object(.55,-.28,z),originalTransform:null});
+const row=(id,z)=>({item:{id,editable:true,locked:false,source_layer:'editable_layout',render_policy:'primary',transform_group:'default_drop_destination',...(id==='place_zone_default'?{role:'place_zone',target_ref:'target_bin_default'}:{role:'target_bin'})},object3d:object(.55,-.28,z),originalTransform:null});
 const bin=row('target_bin_default',.2),zone=row('place_zone_default',.105); for(const item of [bin,zone]) item.originalTransform=transformFromObject(item.object3d);
 state.objects=[bin,zone];state.sceneJson={scene:{id:'ur5_2f_test'}};state.dirtyTransforms=new Map();state.undoStack=[];state.redoStack=[];state.selected='target_bin_default';
 updateLabels=()=>{};updateDirtyState=()=>{};emitDirtyChanged=()=>{};populateObjectList=()=>{};populateInspector=()=>{};
-let savedTransform=cloneTransform(bin.originalTransform);savedTransform.pose.xyz.x+=.08;assert.strictEqual(markDirtyTransform(bin,savedTransform),true);assert.strictEqual(buildEditPatch().edits.length,2);
+let savedTransform=cloneTransform(bin.originalTransform);savedTransform.pose.xyz.x+=.08;assert.strictEqual(markDirtyTransform(bin,savedTransform),true);assert.strictEqual(buildEditPatch().edits.length,1);assert.strictEqual(buildEditPatch().edits[0].item_id,'target_bin_default');
 undoPreviewEdit();assert.strictEqual(state.selected,'target_bin_default');assert.strictEqual(state.dirtyTransforms.size,0);
-redoPreviewEdit();assert.strictEqual(state.selected,'target_bin_default');assert.strictEqual(state.dirtyTransforms.size,2);
+redoPreviewEdit();assert.strictEqual(state.selected,'target_bin_default');assert.strictEqual(state.dirtyTransforms.size,1);assert.strictEqual(zone.object3d.position.x,.63);
 `,context);
 """
     result = subprocess.run(["node", "-e", harness, str(viewer)], cwd=ROOT, capture_output=True, text=True)

--- a/tests/test_workcell_studio_web_scene_edit_patch.py
+++ b/tests/test_workcell_studio_web_scene_edit_patch.py
@@ -87,6 +87,18 @@ def test_validator_rejects_missing_item_id(tmp_path):
     assert "item not found" in result.stderr
 
 
+def test_validator_rejects_direct_derived_place_zone_edit_with_destination_guidance(tmp_path):
+    web_scene = _web_scene()
+    web_scene["zones"].append({
+        "id": "place_zone", "role": "place_zone", "target_ref": "layout_bin",
+        "source_kind": "user_authored", "editable": True, "locked": False,
+    })
+    result = _run_validator(tmp_path, web_scene, _patch("place_zone"))
+    assert result.returncode == 1
+    assert "derived place zone transforms are owned by destination 'layout_bin'" in result.stderr
+    assert "edit that destination instead" in result.stderr
+
+
 def test_validator_rejects_non_finite_transform_values(tmp_path):
     patch = _patch()
     patch["edits"][0]["new_transform"]["pose"]["xyz"]["x"] = math.inf

--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -2220,7 +2220,7 @@ def test_viewer_rotate_cancels_on_selection_mode_and_scene_change_without_yaml_w
     load_file_body = _viewer_function_body(js, "async function loadFile(file)", "function safeRelativeSceneUrl")
     load_url_body = _viewer_function_body(js, "async function loadSceneUrl(rawUrl)", "if (el.resetView)")
     object_change_body = js.split("transformControls.addEventListener('objectChange'", 1)[1].split("controls.addEventListener('start'", 1)[0]
-    assert "state.directRotateDrag && state.directRotateDrag.itemId !== requestedId" in select_body
+    assert "state.directRotateDrag && state.directRotateDrag.itemId !== selectionId" in select_body
     assert "cancelDirectRotateDrag('Rotation cancelled')" in select_body
     assert "if (state.editorMode !== normalized)" in mode_body
     assert "cancelDirectRotateDrag('Rotation cancelled')" in mode_body

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -1135,8 +1135,17 @@ function meshLocalTransformOf(item) {
 function cloneTransform(transform) { return JSON.parse(JSON.stringify(transform)); }
 function sameTransform(a, b) { return JSON.stringify(a) === JSON.stringify(b); }
 function renderedById(id) { return state.objects.find(obj => obj.item.id === id); }
+function derivedTransformTargetId(item) {
+  const targetId = String(item?.target_ref || '').trim();
+  const identity = [item?.role, item?.semantic_role, item?.type, item?.category, item?.id]
+    .map(value => String(value || '').toLowerCase().replaceAll('_', ' ')).join(' ');
+  return targetId && /\bplace zone\b/.test(identity) ? targetId : '';
+}
+function isDerivedTransformDependent(item) { return Boolean(derivedTransformTargetId(item)); }
 function canonicalSelectionRendered(rendered) {
   const item = rendered?.item;
+  const derivedTarget = renderedById(derivedTransformTargetId(item));
+  if (derivedTarget && canEditItem(derivedTarget.item)) return derivedTarget;
   if (!item?.id || !isGeneratedUrdfItem(item) || isGeneratedRobotItem(item) || isGeneratedToolOrGripperItem(item)) return rendered || null;
 
   // Generated environment visuals are render children, not separate authored
@@ -1236,7 +1245,7 @@ function applyTransformChanges(changes, { updateDirty = false } = {}) {
   if (!changes.every(change => isFiniteTransform(change.after))) return false;
   for (const change of changes) {
     applyTransformToObject(change.rendered.object3d, change.after);
-    if (!updateDirty) continue;
+    if (!updateDirty || isDerivedTransformDependent(change.rendered.item)) continue;
     if (sameTransform(change.rendered.originalTransform, change.after)) state.dirtyTransforms.delete(change.rendered.item.id);
     else state.dirtyTransforms.set(change.rendered.item.id, { oldTransform: cloneTransform(change.rendered.originalTransform), newTransform: cloneTransform(change.after) });
     syncInspectorTransformFields(change.rendered);
@@ -1246,6 +1255,18 @@ function applyTransformChanges(changes, { updateDirty = false } = {}) {
 }
 function markDirtyTransform(rendered, next, { pushHistory = true, oldTransform = null, snapOptions = undefined, memberStarts = null } = {}) {
   if (!rendered || !canEditItem(rendered.item)) return false;
+  const owner = canonicalSelectionRendered(rendered);
+  if (owner && owner !== rendered) {
+    const dependentBefore = oldTransform || state.dirtyTransforms.get(rendered.item.id)?.newTransform || transformFromObject(rendered.object3d);
+    const ownerBefore = state.dirtyTransforms.get(owner.item.id)?.newTransform || transformFromObject(owner.object3d);
+    const ownerNext = cloneTransform(ownerBefore);
+    ownerNext.pose.xyz.x += next.pose.xyz.x - dependentBefore.pose.xyz.x;
+    ownerNext.pose.xyz.y += next.pose.xyz.y - dependentBefore.pose.xyz.y;
+    ownerNext.pose.xyz.z += next.pose.xyz.z - dependentBefore.pose.xyz.z;
+    ownerNext.pose.rpy.z += next.pose.rpy.z - dependentBefore.pose.rpy.z;
+    ownerNext.scale = cloneTransform(next).scale;
+    return markDirtyTransform(owner, ownerNext, { pushHistory, oldTransform: ownerBefore, snapOptions, memberStarts: memberStarts || captureTransformGroup(owner) });
+  }
   const previous = oldTransform || state.dirtyTransforms.get(rendered.item.id)?.newTransform || transformFromObject(rendered.object3d);
   const snapped = snapOptions === null ? cloneTransform(next) : snapTransform(next, snapOptions);
   const changes = linkedTransformChanges(rendered, previous, snapped, memberStarts);
@@ -3619,7 +3640,9 @@ function rankedPickingCandidates(hits) {
 }
 function selectObject(id) {
   const requestedId = String(id || '');
-  const requested = requestedId ? renderedById(requestedId) : null;
+  const rawRequested = requestedId ? renderedById(requestedId) : null;
+  const requested = canonicalSelectionRendered(rawRequested);
+  const selectionId = requested?.item?.id || requestedId;
   if (requestedId && !isNormalSelectableRendered(requested)) {
     const reason = requested ? 'diagnostic_helper_or_non_selectable' : 'missing_render_identity';
     state.ignoredSelectionKeys ||= new Set();
@@ -3631,9 +3654,9 @@ function selectObject(id) {
     return '';
   }
   const wasInitialPreviewActive = state.initialPosePreview.active;
-  if (state.directMoveDrag && state.directMoveDrag.itemId !== requestedId) cancelDirectMoveDrag('Move cancelled');
-  if (state.directRotateDrag && state.directRotateDrag.itemId !== requestedId) cancelDirectRotateDrag('Rotation cancelled');
-  id = requestedId;
+  if (state.directMoveDrag && state.directMoveDrag.itemId !== selectionId) cancelDirectMoveDrag('Move cancelled');
+  if (state.directRotateDrag && state.directRotateDrag.itemId !== selectionId) cancelDirectRotateDrag('Rotation cancelled');
+  id = selectionId;
   const previous = state.selected || '';
   state.selected = id;
   document.querySelectorAll('.object-list li').forEach(li => li.classList.toggle('selected', li.dataset.id === id));


### PR DESCRIPTION
### Motivation

- Place-zone overlays derived from a destination asset must behave as visual dependents of that destination so user edits are applied to the authoritative transform once and overlays are regenerated from the destination on export/reload.
- Ensure the viewer preview, undo/redo grouping, backend validation/apply path, export, and persistence verification all treat derived overlays consistently and provide clear user guidance when a direct overlay edit is attempted.

### Description

- Viewer: add derived detection and canonical selection routing by introducing `derivedTransformTargetId` and routing selection/drag attempts to the editable destination when present, while preserving grouped transform/undo semantics and preview updates; skip recording dependent overlay entries in dirty/persisted transforms so only the destination is persisted. (`workcell_studio_web/viewer/viewer.js`) 
- Validation: detect direct edits that target derived place-zone overlays and reject them with an actionable, user-facing error pointing to the destination asset. (`scripts/validate_workcell_studio_web_scene_edit_patch.py`) 
- Applicator/workflow: refuse to apply a patch that updates a derived overlay and instruct operators to persist the destination transform instead, and surface guidance in the workflow validation step. (`scripts/apply_workcell_studio_web_scene_edit_patch.py`, `scripts/run_workcell_studio_web_edit_workflow.py`) 
- Export/Reload: prefer a layout-authored destination transform when normalizing active place zones and regenerate authored overlay pose/footprint from the saved destination during export/reload instead of requiring a separate persisted overlay pose. (`scripts/export_workcell_studio_web_scene.py`) 
- Persistence verifier: accept the expected linked-overlay regeneration pattern (destination-only write) and report linked-overlay regeneration or exporter-consistent behavior in verification output. (`scripts/verify_workcell_studio_web_scene_edit_persistence.py`) 
- Tests: add/update regression tests to assert the new destination-only persistence, guidance messages, and viewer undo/redo/selection semantics; preserve `transform_group` and existing dirty/undo/redo behavior. 
- Note: `workcell_studio_web/viewer/viewer.bundle.js` was left unchanged in this source PR.

### Testing

- Ran targeted test suite verifying viewer/workflow/export/apply/verification behavior with: `python3 -m pytest -q tests/test_export_workcell_studio_web_scene.py tests/test_workcell_studio_web_scene_edit_persistence.py tests/test_workcell_studio_web_edit_workflow.py tests/test_workcell_studio_web_edit_generate_validate_workflow.py tests/test_workcell_builder_embedded_web3d_save_roundtrip.py tests/test_workcell_studio_web_viewer_static.py -k 'linked_transform_group or viewer_rotate_cancels or executable_target_bin or executable_linked_edit or active_place_zone or not_this_name' tests/test_workcell_studio_web_scene_edit_patch.py -k 'not viewer_files_contain'` which succeeded with `185 passed, 1 deselected`. 
- Verified Python compilation for modified scripts with `python3 -m py_compile scripts/*.py` which passed. 
- Ran repository checks `git diff --check` and confirmed no whitespace/patch issues and verified `workcell_studio_web/viewer/viewer.bundle.js` remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69b6e079808331a34998f2f327f3ca)