### PR TITLE
Rebuild embedded Web3D viewer bundle

### DIFF
--- a/tests/test_workcell_studio_derived_place_zone.py
+++ b/tests/test_workcell_studio_derived_place_zone.py
@@ -16,7 +16,7 @@ FIXTURE = ROOT / "scenes/ur5_2f_test"
 EXPORTER = ROOT / "scripts/export_workcell_studio_web_scene.py"
 WORKFLOW = ROOT / "scripts/run_workcell_studio_web_edit_workflow.py"
 BUNDLE = ROOT / "workcell_studio_web/viewer/dist/viewer.bundle.js"
-BUNDLE_SHA256 = "4640e94e08ebcfca1af070c37807765ff50c60b7f098e09dc271f238dbe32287"
+BUNDLE_SHA256 = "9269c990ce086df12a796c858788409d374012d5c5e4a38c3d916180ddf365eb"
 
 
 @pytest.fixture

--- a/workcell_studio_web/viewer/dist/viewer.bundle.js
+++ b/workcell_studio_web/viewer/dist/viewer.bundle.js
@@ -38362,6 +38362,19 @@ function isDiagnosticOnlyItem(item) {
 function isOverlayPolicyItem(item) {
   return itemRenderPolicy(item) === "overlay";
 }
+function isTaskOnlyHelperItem(item) {
+  const identity = [
+    item?.source_layer,
+    item?.active_visual_source,
+    item?.render_owner,
+    item?.role,
+    item?.category,
+    item?.type,
+    item?.id,
+    item?.display_name
+  ].map((value) => String(value || "").toLowerCase().replace(/[_-]+/g, " ")).join(" ");
+  return item?.task_only === true || item?.non_blocking_pick === true || /\b(task helper|task marker|source helper|commissioning object)\b/.test(identity);
+}
 function isPrimaryAuthoredPhysicalMesh(item) {
   if (itemRenderPolicy(item) !== "primary" || !truthyFlag(item?.mesh_load_required))
     return false;
@@ -39505,8 +39518,19 @@ function sameTransform(a, b) {
 function renderedById(id) {
   return state.objects.find((obj) => obj.item.id === id);
 }
+function derivedTransformTargetId(item) {
+  const targetId = String(item?.target_ref || "").trim();
+  const identity = [item?.role, item?.semantic_role, item?.type, item?.category, item?.id].map((value) => String(value || "").toLowerCase().replaceAll("_", " ")).join(" ");
+  return targetId && /\bplace zone\b/.test(identity) ? targetId : "";
+}
+function isDerivedTransformDependent(item) {
+  return Boolean(derivedTransformTargetId(item));
+}
 function canonicalSelectionRendered(rendered) {
   const item = rendered?.item;
+  const derivedTarget = renderedById(derivedTransformTargetId(item));
+  if (derivedTarget && canEditItem(derivedTarget.item))
+    return derivedTarget;
   if (!item?.id || !isGeneratedUrdfItem(item) || isGeneratedRobotItem(item) || isGeneratedToolOrGripperItem(item))
     return rendered || null;
   const explicitIds = [
@@ -39609,7 +39633,7 @@ function applyTransformChanges(changes, { updateDirty = false } = {}) {
     return false;
   for (const change of changes) {
     applyTransformToObject(change.rendered.object3d, change.after);
-    if (!updateDirty)
+    if (!updateDirty || isDerivedTransformDependent(change.rendered.item))
       continue;
     if (sameTransform(change.rendered.originalTransform, change.after))
       state.dirtyTransforms.delete(change.rendered.item.id);
@@ -39623,6 +39647,18 @@ function applyTransformChanges(changes, { updateDirty = false } = {}) {
 function markDirtyTransform(rendered, next, { pushHistory = true, oldTransform = null, snapOptions = void 0, memberStarts = null } = {}) {
   if (!rendered || !canEditItem(rendered.item))
     return false;
+  const owner = canonicalSelectionRendered(rendered);
+  if (owner && owner !== rendered) {
+    const dependentBefore = oldTransform || state.dirtyTransforms.get(rendered.item.id)?.newTransform || transformFromObject(rendered.object3d);
+    const ownerBefore = state.dirtyTransforms.get(owner.item.id)?.newTransform || transformFromObject(owner.object3d);
+    const ownerNext = cloneTransform(ownerBefore);
+    ownerNext.pose.xyz.x += next.pose.xyz.x - dependentBefore.pose.xyz.x;
+    ownerNext.pose.xyz.y += next.pose.xyz.y - dependentBefore.pose.xyz.y;
+    ownerNext.pose.xyz.z += next.pose.xyz.z - dependentBefore.pose.xyz.z;
+    ownerNext.pose.rpy.z += next.pose.rpy.z - dependentBefore.pose.rpy.z;
+    ownerNext.scale = cloneTransform(next).scale;
+    return markDirtyTransform(owner, ownerNext, { pushHistory, oldTransform: ownerBefore, snapOptions, memberStarts: memberStarts || captureTransformGroup(owner) });
+  }
   const previous = oldTransform || state.dirtyTransforms.get(rendered.item.id)?.newTransform || transformFromObject(rendered.object3d);
   const snapped = snapOptions === null ? cloneTransform(next) : snapTransform(next, snapOptions);
   const changes = linkedTransformChanges(rendered, previous, snapped, memberStarts);
@@ -40242,6 +40278,8 @@ function makePrimitiveMesh(item) {
     const dims = dimensionsFromPrimitive(primitive);
     if (!dims)
       return null;
+    if (isZone(item) && /\bplace zone\b/.test(viewerGroupIdentity(item)))
+      dims[2] = Math.min(dims[2], 0.01);
     geometry = new THREE.BoxGeometry(dims[0], dims[1], dims[2]);
   }
   const group = new THREE.Group();
@@ -42061,11 +42099,41 @@ function refreshSelectionHighlight(rendered) {
 }
 function isNormalSelectableRendered(rendered) {
   const item = rendered?.item;
-  return Boolean(item?.id) && item.selectable !== false && !isDiagnosticOnlyItem(item) && !isOverlayPolicyItem(item) && !isDebugOverlayItem(item);
+  const inspectionSelectable = state.debugOverlaysVisible && (isTaskOnlyHelperItem(item) || isOverlayPolicyItem(item) || isDebugOverlayItem(item));
+  return Boolean(item?.id) && item.selectable !== false && !isDiagnosticOnlyItem(item) && (inspectionSelectable || !isTaskOnlyHelperItem(item) && !isOverlayPolicyItem(item) && !isDebugOverlayItem(item));
+}
+function pickingPriority(rendered) {
+  const item = rendered?.item;
+  if (!item?.id)
+    return Number.POSITIVE_INFINITY;
+  if (isTaskOnlyHelperItem(item) || isOverlayPolicyItem(item) || isDebugOverlayItem(item))
+    return state.debugOverlaysVisible ? 4 : Number.POSITIVE_INFINITY;
+  if (canEditItem(item) && isPrimaryRenderableItem(item) && isPhysicalSemanticItem(item))
+    return 1;
+  if (canEditItem(item) && !isGeneratedUrdfItem(item))
+    return 2;
+  if ((isGeneratedUrdfItem(item) || item.locked) && isPhysicalSemanticItem(item))
+    return 3;
+  return 2;
+}
+function rankedPickingCandidates(hits) {
+  const candidates = [];
+  const seen = /* @__PURE__ */ new Set();
+  for (const hit of hits || []) {
+    const item = hit?.object?.userData?.item || hit?.object?.parent?.userData?.item;
+    const rendered = canonicalSelectionRendered(item?.id ? renderedById(item.id) : null);
+    if (!rendered?.item?.id || seen.has(rendered.item.id))
+      continue;
+    seen.add(rendered.item.id);
+    candidates.push({ rendered, hit, priority: pickingPriority(rendered) });
+  }
+  return candidates.sort((a, b) => a.priority - b.priority || Number(a.hit?.distance || 0) - Number(b.hit?.distance || 0));
 }
 function selectObject(id) {
   const requestedId = String(id || "");
-  const requested = requestedId ? renderedById(requestedId) : null;
+  const rawRequested = requestedId ? renderedById(requestedId) : null;
+  const requested = canonicalSelectionRendered(rawRequested);
+  const selectionId = requested?.item?.id || requestedId;
   if (requestedId && !isNormalSelectableRendered(requested)) {
     const reason = requested ? "diagnostic_helper_or_non_selectable" : "missing_render_identity";
     state.ignoredSelectionKeys || (state.ignoredSelectionKeys = /* @__PURE__ */ new Set());
@@ -42077,11 +42145,11 @@ function selectObject(id) {
     return "";
   }
   const wasInitialPreviewActive = state.initialPosePreview.active;
-  if (state.directMoveDrag && state.directMoveDrag.itemId !== requestedId)
+  if (state.directMoveDrag && state.directMoveDrag.itemId !== selectionId)
     cancelDirectMoveDrag("Move cancelled");
-  if (state.directRotateDrag && state.directRotateDrag.itemId !== requestedId)
+  if (state.directRotateDrag && state.directRotateDrag.itemId !== selectionId)
     cancelDirectRotateDrag("Rotation cancelled");
-  id = requestedId;
+  id = selectionId;
   const previous = state.selected || "";
   state.selected = id;
   document.querySelectorAll(".object-list li").forEach((li) => li.classList.toggle("selected", li.dataset.id === id));
@@ -42114,15 +42182,21 @@ function pickObject(event) {
   state.three.pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
   state.three.raycaster.setFromCamera(state.three.pointer, state.three.camera);
   const hits = state.three.raycaster.intersectObjects(state.objects.map((o) => o.object3d), true);
-  for (const hit of hits) {
-    const item = hit?.object?.userData?.item || hit?.object?.parent?.userData?.item;
-    const rendered = canonicalSelectionRendered(item?.id ? renderedById(item.id) : null);
-    if (!isNormalSelectableRendered(rendered))
-      continue;
-    selectObject(rendered.item.id);
-    return rendered.item.id;
+  const candidates = rankedPickingCandidates(hits);
+  const selectedCandidate = candidates.find((candidate) => Number.isFinite(candidate.priority) && isNormalSelectableRendered(candidate.rendered));
+  if (!selectedCandidate)
+    return "";
+  const skippedHelper = candidates.find((candidate) => candidate !== selectedCandidate && candidate.priority > selectedCandidate.priority && (isTaskOnlyHelperItem(candidate.rendered.item) || isDebugOverlayItem(candidate.rendered.item)));
+  if (skippedHelper) {
+    state.skippedHelperPickKeys || (state.skippedHelperPickKeys = /* @__PURE__ */ new Set());
+    const warningKey = `${sceneId()}|${skippedHelper.rendered.item.id}|${selectedCandidate.rendered.item.id}`;
+    if (!state.skippedHelperPickKeys.has(warningKey)) {
+      state.skippedHelperPickKeys.add(warningKey);
+      pushEditorEvent("helper_pick_skipped", { helperItemId: skippedHelper.rendered.item.id, selectedItemId: selectedCandidate.rendered.item.id, sceneId: sceneId() });
+    }
   }
-  return "";
+  selectObject(selectedCandidate.rendered.item.id);
+  return selectedCandidate.rendered.item.id;
 }
 function pointerToWorldPlane(event, z) {
   const rect = el.canvas.getBoundingClientRect();


### PR DESCRIPTION
### Motivation
- Bring the embedded Web3D runtime up to date so it includes the already-merged viewer.js changes for destination-derived place zones and improved object picking.
- This is a generated-artifact-only update and must not change source viewer files or the distributed source map.

### Description
- Rebuilt the Web3D viewer runtime and replaced `workcell_studio_web/viewer/dist/viewer.bundle.js` with the newly generated bundle that includes `derivedTransformTargetId` and `rankedPickingCandidates` logic.
- Updated the checksum fixture `BUNDLE_SHA256` in `tests/test_workcell_studio_derived_place_zone.py` to the new SHA-256 `9269c990ce086df12a796c858788409d374012d5c5e4a38c3d916180ddf365eb`.
- Committed only the generated bundle and the updated test fixture, and ensured the `viewer.bundle.js.map` file was not modified in the commit.
- No source files such as `viewer.js`, `urdf_robot_renderer.js`, `package*.json`, scene YAMLs, exporter scripts, or runtime/launch/hardware settings were changed.

### Testing
- Ran `npm ci`, `npm run build:web3d`, and `npm run check:stale-bundle`, all of which completed successfully.
- Ran `python3 -m pytest -q tests/test_workcell_studio_derived_place_zone.py` and observed `6 passed`.
- Ran `node --check workcell_studio_web/viewer/viewer.js` and verified presence checks for `derivedTransformTargetId` and `rankedPickingCandidates` in the generated bundle, all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69c370f1f88331baf2528e0e2ee405)