### PR TITLE
Add validated destination bin selector for place areas

### DIFF
--- a/tests/test_workcell_builder_task_area_editor.py
+++ b/tests/test_workcell_builder_task_area_editor.py
@@ -64,7 +64,7 @@ def test_task_area_save_validation_and_backup_tokens_present():
         "duplicate Pick Area ID",
         "duplicate Place Area ID",
         "unresolved Pick Object association",
-        "unresolved Destination Bin association",
+        "Missing destination:",
         "may be outside support surface",
         "Pick and Place Areas may be overlapping",
         ".task_areas.",
@@ -77,3 +77,42 @@ def test_no_web3d_or_generated_bundle_paths_touched_by_task_area_editor():
     changed_scope = "\n".join(p.name for p in [SCENE_SELECT_CPP, SCENE_SELECT_H, YAML_IO_CPP, MODEL_H])
     assert "workcell_studio_web" not in changed_scope
     assert "generated" not in changed_scope
+
+
+def test_place_area_uses_validated_destination_selector():
+    cpp = SCENE_SELECT_CPP.read_text(encoding="utf-8")
+    header = SCENE_SELECT_H.read_text(encoding="utf-8")
+    assert 'setObjectName("task_area_destination_combo")' in cpp
+    assert 'setObjectName("task_area_association_edit")' in cpp
+    assert "association->setVisible(is_pick)" in cpp
+    assert "combo->setVisible(!is_pick)" in cpp
+    assert "task_area_destinations() const" in header
+    for semantic in ['"bin"', '"tote"', '"destination_container"', '"container"']:
+        assert semantic in cpp
+    for excluded in ['"overlay"', '"helper"', '"robot"', '"tool"', '"camera"', '"generated_urdf"']:
+        assert excluded in cpp
+    assert 'combo->addItem(QString::fromStdString(candidate.display_name), QString::fromStdString(candidate.id))' in cpp
+
+
+def test_destination_selection_updates_only_place_zone_stable_id():
+    cpp = SCENE_SELECT_CPP.read_text(encoding="utf-8")
+    yaml_io = YAML_IO_CPP.read_text(encoding="utf-8")
+    selection_handler = cpp.split("QComboBox::activated", 1)[1].split("});", 1)[0]
+    assert "area.target_ref = destination_id" in selection_handler
+    assert 'mark_task_areas_dirty("Destination Bin")' in selection_handler
+    assert "task_editor_state_.place_target" not in selection_handler
+    assert 'if (!root["task"]["place"]["target_ref"])' in yaml_io
+    assert "zone.target_ref selects its physical bin" in yaml_io
+
+
+def test_missing_destination_is_visible_and_blocks_save():
+    cpp = SCENE_SELECT_CPP.read_text(encoding="utf-8")
+    assert '"Missing destination: " + a.target_ref' in cpp
+    assert "!is_valid_task_area_destination(z.target_ref)" in cpp
+    assert 'errors->push_back("Missing destination: "' in cpp
+
+
+def test_pick_area_free_text_association_is_unchanged():
+    cpp = SCENE_SELECT_CPP.read_text(encoding="utf-8")
+    assert 'if (a.role == "pick") a.object_ref = assoc->text().trimmed().toStdString();' in cpp
+    assert 'set_text("task_area_association_edit", QString::fromStdString(a.object_ref))' in cpp

--- a/workcell_builder/workcell_builder/gui/object_placement_yaml_io.cpp
+++ b/workcell_builder/workcell_builder/gui/object_placement_yaml_io.cpp
@@ -401,8 +401,10 @@ PlacedObjectYamlWriteResult save_task_zones_to_environment_yaml(const std::strin
         if (!z.object_ref.empty()) root["task"]["pick"]["object_ref"] = z.object_ref;
       }
       if (is_place) {
-        root["task"]["place"]["target_ref"] = z.id;
-        root["task"]["place"]["intent_target_ref"] = z.id;
+        // task.place.target_ref selects the place zone; zone.target_ref selects its physical bin.
+        // Preserve an existing active-zone selection when only the bin association changes.
+        if (!root["task"]["place"]["target_ref"]) root["task"]["place"]["target_ref"] = z.id;
+        if (!root["task"]["place"]["intent_target_ref"]) root["task"]["place"]["intent_target_ref"] = z.id;
       }
     }
     std::ofstream out(path);

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -44,6 +44,7 @@
 #include <QApplication>
 #include <QClipboard>
 #include <QLineEdit>
+#include <QComboBox>
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QFile>
@@ -95,6 +96,7 @@
 #include <vector>
 #include <set>
 #include <cmath>
+#include <cctype>
 #include <fstream>
 #include <functional>
 
@@ -3747,7 +3749,10 @@ void SceneSelect::initialize_task_area_editor()
   auto * w = make_spin("task_area_width_spin", 0.001, 10, 0.30); form->addRow("Width", w);
   auto * d = make_spin("task_area_depth_spin", 0.001, 10, 0.30); form->addRow("Depth", d);
   auto * h = make_spin("task_area_height_spin", 0.001, 10, 0.10); form->addRow("Height", h);
-  auto * assoc = new QLineEdit(group); assoc->setObjectName("task_area_association_edit"); form->addRow("Pick Object / Destination Bin", assoc);
+  auto * assoc = new QLineEdit(group); assoc->setObjectName("task_area_association_edit");
+  auto * association_label = new QLabel("Pick Object", group); association_label->setObjectName("task_area_association_label"); form->addRow(association_label, assoc);
+  auto * destination = new QComboBox(group); destination->setObjectName("task_area_destination_combo");
+  auto * destination_label = new QLabel("Destination Bin", group); destination_label->setObjectName("task_area_destination_label"); form->addRow(destination_label, destination);
   auto * status = new QLabel("status/warning", group); status->setObjectName("task_area_status_label"); status->setWordWrap(true); form->addRow("status/warning", status);
   layout->addLayout(form);
   ui->layoutLayout->insertWidget(1, group);
@@ -3762,11 +3767,24 @@ void SceneSelect::initialize_task_area_editor()
       a.id = name->text().trimmed().toStdString(); selected_task_area_id_ = a.id;
       a.x = snap_task_area_value(x->value()); a.y = snap_task_area_value(y->value()); a.z = snap_task_area_value(z->value());
       a.yaw = snap_task_area_value(rot->value()); a.dim_x = snap_task_area_value(w->value()); a.dim_y = snap_task_area_value(d->value()); a.dim_z = snap_task_area_value(h->value());
-      if (a.role == "pick") a.object_ref = assoc->text().trimmed().toStdString(); else a.target_ref = assoc->text().trimmed().toStdString();
+      if (a.role == "pick") a.object_ref = assoc->text().trimmed().toStdString();
       mark_task_areas_dirty("Task Area inspector"); refresh_preview_status(); break;
     }
   };
   connect(name, &QLineEdit::editingFinished, this, update); connect(assoc, &QLineEdit::editingFinished, this, update);
+  connect(destination, QOverload<int>::of(&QComboBox::activated), this, [this, destination](int index) {
+    const std::string destination_id = destination->itemData(index).toString().toStdString();
+    if (destination_id.empty()) return;
+    for (auto & area : task_area_zones_) if (area.id == selected_task_area_id_) {
+      if (area.role != "place" && area.type != "place_zone") return;
+      if (area.target_ref == destination_id) return;
+      area.target_ref = destination_id;
+      mark_task_areas_dirty("Destination Bin");
+      sync_task_area_inspector();
+      refresh_preview_status();
+      return;
+    }
+  });
   for (auto * spin : {x,y,z,rot,w,d,h}) connect(spin, &QAbstractSpinBox::editingFinished, this, update);
 }
 
@@ -3793,13 +3811,13 @@ bool SceneSelect::ensure_suggested_task_areas()
   bool changed = false;
   auto has_role = [this](const std::string & role) { for (const auto & z : task_area_zones_) if (z.role == role || z.type == role + "_zone") return true; return false; };
   if (!has_role("pick")) { workcell_builder::TaskZone z; z.id="commissioning_pick_pose"; z.type="pick_zone"; z.role="pick"; z.shape="box"; z.dim_x=.30; z.dim_y=.30; z.dim_z=.10; z.x=-.20; z.support_surface_ref="default_support_surface"; z.object_ref="Pick Object"; task_area_zones_.push_back(z); changed = true; }
-  if (!has_role("place")) { workcell_builder::TaskZone z; z.id="default_drop_zone"; z.type="place_zone"; z.role="place"; z.shape="box"; z.dim_x=.30; z.dim_y=.30; z.dim_z=.10; z.x=.25; z.support_surface_ref="default_support_surface"; z.target_ref="Destination Bin"; task_area_zones_.push_back(z); changed = true; }
+  if (!has_role("place")) { workcell_builder::TaskZone z; z.id="default_drop_zone"; z.type="place_zone"; z.role="place"; z.shape="box"; z.dim_x=.30; z.dim_y=.30; z.dim_z=.10; z.x=.25; z.support_surface_ref="default_support_surface"; task_area_zones_.push_back(z); changed = true; }
   return changed;
 }
 
 void SceneSelect::add_task_area(const std::string & role)
 {
-  workcell_builder::TaskZone z; z.id = role == "pick" ? "pick_area" : "place_area"; z.type = role + "_zone"; z.role = role; z.shape="box"; z.parent_frame="world"; z.dim_x=.30; z.dim_y=.30; z.dim_z=.10; z.x = role == "pick" ? -.20 : .25; z.support_surface_ref="default_support_surface"; if (role=="pick") z.object_ref="Pick Object"; else z.target_ref="Destination Bin";
+  workcell_builder::TaskZone z; z.id = role == "pick" ? "pick_area" : "place_area"; z.type = role + "_zone"; z.role = role; z.shape="box"; z.parent_frame="world"; z.dim_x=.30; z.dim_y=.30; z.dim_z=.10; z.x = role == "pick" ? -.20 : .25; z.support_surface_ref="default_support_surface"; if (role=="pick") z.object_ref="Pick Object";
   int suffix = 1; auto exists=[&](const std::string & id){ for (const auto & a: task_area_zones_) if (a.id==id) return true; return false;}; const std::string base=z.id; while (exists(z.id)) z.id=base+"_"+std::to_string(++suffix);
   task_area_zones_.push_back(z); selected_task_area_id_ = z.id; mark_task_areas_dirty(role == "pick" ? "Add Pick Area" : "Add Place Area"); refresh_preview_status();
 }
@@ -3824,9 +3842,87 @@ void SceneSelect::sync_task_area_inspector()
   for (const auto & a : task_area_zones_) if (a.id == selected_task_area_id_) {
     auto set_text=[this](const char * n, const QString & v){ if (auto * w=ui->layout_tab->findChild<QLineEdit *>(n)) { QSignalBlocker b(w); w->setText(v);} };
     auto set_spin=[this](const char * n, double v){ if (auto * w=ui->layout_tab->findChild<QDoubleSpinBox *>(n)) { QSignalBlocker b(w); w->setValue(v);} };
-    set_text("task_area_name_edit", QString::fromStdString(a.id)); set_spin("task_area_x_spin", a.x); set_spin("task_area_y_spin", a.y); set_spin("task_area_z_spin", a.z); set_spin("task_area_rotation_spin", a.yaw); set_spin("task_area_width_spin", a.dim_x); set_spin("task_area_depth_spin", a.dim_y); set_spin("task_area_height_spin", a.dim_z); set_text("task_area_association_edit", QString::fromStdString(a.role == "pick" ? a.object_ref : a.target_ref));
-    if (auto * l=ui->layout_tab->findChild<QLabel *>("task_area_status_label")) l->setText(QString::fromStdString((a.role=="pick" ? "Pick Area" : "Place Area") + std::string(" selected. Offline layout check only; motion planning is checked later.")));
+    const bool is_pick = a.role == "pick" || a.type == "pick_zone";
+    set_text("task_area_name_edit", QString::fromStdString(a.id)); set_spin("task_area_x_spin", a.x); set_spin("task_area_y_spin", a.y); set_spin("task_area_z_spin", a.z); set_spin("task_area_rotation_spin", a.yaw); set_spin("task_area_width_spin", a.dim_x); set_spin("task_area_depth_spin", a.dim_y); set_spin("task_area_height_spin", a.dim_z); set_text("task_area_association_edit", QString::fromStdString(a.object_ref));
+    if (auto * association = ui->layout_tab->findChild<QLineEdit *>("task_area_association_edit")) association->setVisible(is_pick);
+    if (auto * label = ui->layout_tab->findChild<QLabel *>("task_area_association_label")) label->setVisible(is_pick);
+    if (auto * label = ui->layout_tab->findChild<QLabel *>("task_area_destination_label")) label->setVisible(!is_pick);
+    bool missing_destination = false;
+    if (auto * combo = ui->layout_tab->findChild<QComboBox *>("task_area_destination_combo")) {
+      QSignalBlocker blocker(combo);
+      combo->setVisible(!is_pick);
+      combo->clear();
+      for (const auto & candidate : task_area_destinations()) {
+        combo->addItem(QString::fromStdString(candidate.display_name), QString::fromStdString(candidate.id));
+      }
+      const int current = combo->findData(QString::fromStdString(a.target_ref));
+      if (!is_pick && current < 0 && !a.target_ref.empty()) {
+        combo->insertItem(0, QString::fromStdString("Missing destination: " + a.target_ref), QVariant());
+        combo->setCurrentIndex(0);
+        missing_destination = true;
+      } else if (current >= 0) {
+        combo->setCurrentIndex(current);
+      } else {
+        combo->insertItem(0, "Choose a destination", QVariant());
+        combo->setCurrentIndex(0);
+        missing_destination = !is_pick;
+      }
+    }
+    if (auto * l=ui->layout_tab->findChild<QLabel *>("task_area_status_label")) {
+      const std::string prefix = missing_destination ? "Missing destination: " + a.target_ref + ". " : "";
+      l->setText(QString::fromStdString(prefix + (is_pick ? "Pick Area" : "Place Area") + " selected. Offline layout check only; motion planning is checked later."));
+    }
   }
+}
+
+std::vector<SceneSelect::TaskAreaDestination> SceneSelect::task_area_destinations() const
+{
+  std::vector<TaskAreaDestination> result;
+  const fs::path environment = scene_dir_for_current_selection() / "environment.yaml";
+  if (!fs::exists(environment)) return result;
+  YAML::Node root;
+  try { root = YAML::LoadFile(environment.string()); } catch (const YAML::Exception &) { return result; }
+  const YAML::Node assets = root["environment"]["assets"];
+  if (!assets || !assets.IsSequence()) return result;
+  auto normalized = [](const YAML::Node & node, const char * key) {
+    std::string value = node[key].as<std::string>("");
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return value;
+  };
+  const auto contains_any = [](const std::string & value, const std::vector<std::string> & tokens) {
+    for (const auto & token : tokens) if (value.find(token) != std::string::npos) return true;
+    return false;
+  };
+  const std::vector<std::string> destination_tokens{"bin", "tote", "destination_container", "destination container", "container"};
+  const std::vector<std::string> excluded_tokens{"overlay", "helper", "diagnostic", "place_zone", "pick_zone", "robot", "tool", "gripper", "camera", "generated_urdf", "generated urdf"};
+  for (const auto & asset : assets) {
+    const std::string id = asset["id"].as<std::string>("");
+    const std::string type = normalized(asset, "type");
+    const std::string role = normalized(asset, "role");
+    const std::string category = normalized(asset, "category");
+    const std::string source_layer = normalized(asset, "source_layer");
+    const std::string active_visual_source = normalized(asset, "active_visual_source");
+    if (id.empty() || contains_any(source_layer, excluded_tokens) ||
+      contains_any(active_visual_source, excluded_tokens)) continue;
+    const bool semantic_destination = contains_any(type, destination_tokens) ||
+      contains_any(role, destination_tokens) || contains_any(category, destination_tokens);
+    const bool helper_identity = contains_any(type, excluded_tokens) || contains_any(role, excluded_tokens);
+    if (!semantic_destination || helper_identity) continue;
+    std::string display_name = asset["display_name"].as<std::string>(asset["name"].as<std::string>(id));
+    result.push_back({id, display_name});
+  }
+  std::sort(result.begin(), result.end(), [](const auto & lhs, const auto & rhs) {
+    return lhs.display_name < rhs.display_name;
+  });
+  return result;
+}
+
+bool SceneSelect::is_valid_task_area_destination(const std::string & id) const
+{
+  const auto destinations = task_area_destinations();
+  return std::any_of(destinations.begin(), destinations.end(), [&id](const auto & destination) {
+    return destination.id == id;
+  });
 }
 
 bool SceneSelect::validate_task_areas_for_save(std::vector<std::string> * errors, std::vector<std::string> * warnings) const
@@ -3841,7 +3937,9 @@ bool SceneSelect::validate_task_areas_for_save(std::vector<std::string> * errors
     if (is_pick && !pick_ids.insert(z.id).second) errors->push_back("duplicate Pick Area ID: " + z.id);
     if (is_place && !place_ids.insert(z.id).second) errors->push_back("duplicate Place Area ID: " + z.id);
     if (is_pick && z.object_ref.empty()) errors->push_back("unresolved Pick Object association for " + z.id);
-    if (is_place && z.target_ref.empty()) errors->push_back("unresolved Destination Bin association for " + z.id);
+    if (is_place && !is_valid_task_area_destination(z.target_ref)) {
+      errors->push_back("Missing destination: " + (z.target_ref.empty() ? std::string("<none>") : z.target_ref) + " for " + z.id);
+    }
     if (std::fabs(z.x) > 1.0 || std::fabs(z.y) > 1.0) warnings->push_back(z.id + " may be outside support surface / approximate reach concern");
   }
   for (const auto & a : task_area_zones_) for (const auto & b : task_area_zones_) if (a.id < b.id && std::fabs(a.x-b.x) < (a.dim_x+b.dim_x)/2.0 && std::fabs(a.y-b.y) < (a.dim_y+b.dim_y)/2.0) warnings->push_back("Pick and Place Areas may be overlapping: " + a.id + " / " + b.id);

--- a/workcell_builder/workcell_builder/gui/scene_select.h
+++ b/workcell_builder/workcell_builder/gui/scene_select.h
@@ -226,6 +226,13 @@ private:
   void load_task_areas_for_selected_scene();
   void refresh_task_area_canvas_items();
   void sync_task_area_inspector();
+  struct TaskAreaDestination
+  {
+    std::string id;
+    std::string display_name;
+  };
+  std::vector<TaskAreaDestination> task_area_destinations() const;
+  bool is_valid_task_area_destination(const std::string & id) const;
   void mark_task_areas_dirty(const QString & reason);
   bool save_task_areas_to_scene(const boost::filesystem::path & scene_dir, std::string * reason);
   bool validate_task_areas_for_save(std::vector<std::string> * errors, std::vector<std::string> * warnings) const;


### PR DESCRIPTION
### Motivation
- Replace the fragile free-text Destination Bin association on Place Areas with a validated selector so editors pick stable scene assets instead of arbitrary strings.
- Preserve existing Pick Area free-text behavior and avoid changing exported place-zone selection semantics used elsewhere in scene generation and product view binding.

### Description
- Replace the single free-text association row with a `QComboBox` named `task_area_destination_combo` (and keep `task_area_association_edit` visible only for Pick Areas) in the Task Areas inspector UI (files changed: `scene_select.cpp`, `scene_select.h`).
- Populate the combo from the active scene `environment.yaml` `environment.assets` entries using semantic metadata (`type`, `role`, `category`) to select bins/totes/destination containers and exclude overlays/helpers/robots/tools/cameras/generated URDF items; display friendly names while storing stable asset IDs in `itemData`.
- On load, the inspector selects the task zone's existing `target_ref` when it resolves and shows `Missing destination: <id>` in the inspector when unresolved; changing the combo updates only `task_zones[].target_ref`, marks Task Areas dirty, refreshes inspector/status, and preserves `task.place.target_ref` semantics on save by adjusting the YAML writer (change in `object_placement_yaml_io.cpp`).
- Added focused tests covering the new selector discovery, exclusion rules, stable-ID persistence, unresolved destination blocking, and unchanged Pick Area association behavior (`tests/test_workcell_builder_task_area_editor.py`).

### Testing
- Ran `python3 -m pytest -q tests/test_workcell_builder_task_area_editor.py` with all tests passing (`10 passed`).
- Ran `git diff --check` with no issues found.
- `colcon build --symlink-install --packages-select workcell_builder` was not executed in this container because `colcon` is not installed (not modified by this PR).
- Commit created on branch `codex/add-destination-bin-selector` (commit id: `7cdfa48`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69c5c4e6748331bd369c8590f6fb6c)