### PR TITLE
Add incomplete scene diagnostic preview (--allow-incomplete-preview)

### DIFF
--- a/scripts/ensure_workcell_studio_web_scene_fresh.py
+++ b/scripts/ensure_workcell_studio_web_scene_fresh.py
@@ -463,6 +463,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser.add_argument("--output", required=True, help="Web scene JSON output path.")
     parser.add_argument("--stage-assets", action="store_true", help="Require and regenerate staged browser assets.")
     parser.add_argument("--force", action="store_true", help="Regenerate even when freshness checks pass.")
+    parser.add_argument("--allow-incomplete-preview", action="store_true", help="Allow the exporter to produce a read-only diagnostic preview for authoring blockers.")
     args = parser.parse_args(argv)
 
     try:
@@ -510,7 +511,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             assets_stale = True
             assets_reason = "mesh index UR5 preview rows were normalized for web export"
 
-    if args.force or web_stale or assets_stale:
+    if args.force or args.allow_incomplete_preview or web_stale or assets_stale:
         reasons = []
         if args.force:
             reasons.append("forced")
@@ -522,6 +523,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         command = [sys.executable, repo_relative(exporter_script), "--scene", repo_relative(scene_dir), "--output", repo_relative(output_path)]
         if args.stage_assets:
             command.append("--stage-assets")
+        if args.allow_incomplete_preview:
+            command.append("--allow-incomplete-preview")
         atomic_export_web_scene(command, output_path)
         status = "rebuilt"
     else:

--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -2690,11 +2690,46 @@ def _apply_render_ownership_contract(payload: Json, *, expanded_urdf_active: boo
         counters["expanded_assembly_owned_physical_visuals"] = 2
     payload["render_ownership_summary"] = counters | {"duplicate_primary_identities": 0, "unknown_physical_owners": 0}
 
-def build_web_scene(scene_dir: Path, *, stage_assets: bool = False, output_path: Optional[Path] = None) -> Json:
+def _destination_blocker(exc: BlockingExportError) -> Json:
+    """Translate a destination-chain failure into stable diagnostic metadata."""
+    message = str(exc)
+    source, _, detail = message.partition(": ")
+    relationship = "destination chain"
+    marker = "relationship "
+    if marker in detail:
+        relationship = detail.split(marker, 1)[1].split(" failed", 1)[0].split(" must ", 1)[0]
+    unresolved_id = "<active destination>"
+    match = re.search(r"unresolved ID (?:'([^']+)'|\"([^\"]+)\")", detail)
+    if match:
+        unresolved_id = next(value for value in match.groups() if value is not None)
+    return {
+        "source": source or "environment.yaml",
+        "relationship": relationship,
+        "unresolved_id": unresolved_id,
+        "message": message,
+    }
+
+
+def build_web_scene(
+    scene_dir: Path,
+    *,
+    stage_assets: bool = False,
+    output_path: Optional[Path] = None,
+    allow_incomplete_preview: bool = False,
+) -> Json:
     scene_dir = scene_dir.resolve()
     warnings: List[Json] = []
     data = _load_inputs(scene_dir, warnings)
-    _normalise_active_place_zone(data)
+    authoring_blockers: List[Json] = []
+    try:
+        _normalise_active_place_zone(data)
+    except BlockingExportError as exc:
+        if not allow_incomplete_preview:
+            raise
+        # Destination resolution only enriches the derived place-zone overlay.
+        # Physical authored and generated visuals remain independent and are
+        # exported without guessing a destination or transform.
+        authoring_blockers.append(_destination_blocker(exc))
 
     manifest = _as_map(data.get("scene_manifest"))
     scene_meta = _as_map(manifest.get("scene"))
@@ -2775,6 +2810,27 @@ def build_web_scene(scene_dir: Path, *, stage_assets: bool = False, output_path:
             },
         ],
     }
+    if authoring_blockers:
+        output.update({
+            "authoring_status": "blocked",
+            "preview_mode": "diagnostic",
+            "authoring_blockers": authoring_blockers,
+        })
+        # Diagnostic preview is deliberately read-only and cannot advertise an
+        # execution path while canonical authoring relationships are invalid.
+        for section in RENDERABLE_OUTPUT_SECTIONS:
+            for item in output[section]:
+                item["editable"] = False
+                item["locked"] = True
+        for action in output["backend_actions"]:
+            if action.get("id") != "validate":
+                action["enabled"] = False
+                action["disabled_reason"] = "Fix scene authoring blockers before generation or execution."
+        output["authoring_actions"] = {
+            "save_layout_enabled": False,
+            "execution_enabled": False,
+            "disabled_reason": "Fix scene authoring blockers before saving layout or executing actions.",
+        }
     output["_visual_mesh_index_source"] = _as_map(data.get("visual_mesh_index"))
     if stage_assets:
         _stage_visual_meshes(output, scene_dir, output_path or Path("build/workcell_studio_web_scene/scene.web_scene.json"))
@@ -2798,6 +2854,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument("--output", required=True, help="Output JSON path, typically under build/")
     parser.add_argument("--stage-assets", dest="stage_assets", action="store_true", default=True, help="Copy resolvable mesh assets into build/workcell_studio_web_scene/assets/<scene_id> and rewrite mesh_uri for browser loading. Enabled by default.")
     parser.add_argument("--no-stage-assets", dest="stage_assets", action="store_false", help="Disable mesh asset staging and leave mesh URI fields unchanged.")
+    parser.add_argument("--allow-incomplete-preview", action="store_true", help="Export a read-only diagnostic preview when the authored destination chain is unresolved.")
     args = parser.parse_args(argv)
 
     scene_dir = Path(args.scene)
@@ -2807,7 +2864,8 @@ def main(argv: Optional[List[str]] = None) -> int:
         return 2
 
     try:
-        payload = build_web_scene(scene_dir, stage_assets=args.stage_assets, output_path=output_path)
+        payload = build_web_scene(scene_dir, stage_assets=args.stage_assets, output_path=output_path,
+                                  allow_incomplete_preview=args.allow_incomplete_preview)
     except BlockingExportError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 3

--- a/tests/test_export_workcell_studio_web_scene.py
+++ b/tests/test_export_workcell_studio_web_scene.py
@@ -16,6 +16,45 @@ exporter = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(exporter)
 
 
+@pytest.mark.parametrize("scene_id", ["suction_test", "ur5_3f_test"])
+def test_incomplete_destination_scenes_are_strictly_rejected_but_have_read_only_diagnostic_previews(tmp_path, scene_id):
+    scene = ROOT / "scenes" / scene_id
+    strict_output = tmp_path / f"{scene_id}.strict.json"
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--scene", str(scene), "--output", str(strict_output), "--no-stage-assets"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 3
+    assert not strict_output.exists()
+    assert "relationship" in result.stderr
+
+    payload = exporter.build_web_scene(scene, allow_incomplete_preview=True)
+    assert payload["scene_id"] == scene_id
+    assert payload["authoring_status"] == "blocked"
+    assert payload["preview_mode"] == "diagnostic"
+    assert payload["authoring_blockers"]
+    assert set(payload["authoring_blockers"][0]) == {"source", "relationship", "unresolved_id", "message"}
+    assert payload["robots"]
+    assert payload["tools"]
+    assert not any(
+        "derived_place" in str(item.get("source_kind", "")) or item.get("derived_from_destination")
+        for item in payload["zones"]
+    )
+    blocker_id = payload["authoring_blockers"][0]["unresolved_id"]
+    assert not any(item.get("id") == blocker_id for item in payload["assets"])
+    assert payload["authoring_actions"]["save_layout_enabled"] is False
+    assert all(not item.get("editable", False) for section in exporter.RENDERABLE_OUTPUT_SECTIONS for item in payload[section])
+
+
+def test_valid_scene_remains_strict_and_editable_without_diagnostic_metadata():
+    payload = exporter.build_web_scene(ROOT / "scenes" / "ur5_2f_test")
+    assert "authoring_status" not in payload
+    assert "preview_mode" not in payload
+    assert any(item.get("editable") for item in payload["assets"])
+
+
 def test_robot_preview_extraction_keeps_robot_subtree_and_excludes_scene_siblings(tmp_path):
     source = tmp_path / "expanded_scene_preview.urdf"
     text = """<?xml version="1.0"?>

--- a/tests/test_scene_preview_widget_refresh_lifecycle.py
+++ b/tests/test_scene_preview_widget_refresh_lifecycle.py
@@ -178,6 +178,15 @@ def test_cpp_coalesces_before_generation_and_retires_stale_process_before_ui_wor
     assert stale < prepare.index("const QString scene = identity.scene_id;")
 
 
+def test_product_view_retries_diagnostic_only_for_destination_authoring_blockers():
+    assert 'args << "--allow-incomplete-preview"' in CPP
+    assert 'diagnostic.stderr_tail.contains("environment.yaml:")' in CPP
+    assert 'diagnostic.stderr_tail.contains("relationship")' in CPP
+    assert "if (!diagnostic.diagnostic_preview && destination_authoring_blocker" in CPP
+    assert "Diagnostic preview — scene authoring incomplete" in CPP
+    assert 'setProperty("diagnostic_preview_active", diagnostic_preview)' in CPP
+
+
 def test_selected_scene_status_refreshes_leave_the_committed_product_payload_identity_unchanged():
     """Status/audit work must not create another Web3D payload preparation."""
 

--- a/workcell_builder/workcell_builder/gui/embedded_web_edit_save_controller.hpp
+++ b/workcell_builder/workcell_builder/gui/embedded_web_edit_save_controller.hpp
@@ -469,7 +469,12 @@ private:
       const QString reported_scene = state.value(QStringLiteral("sceneId")).toString();
       const QString url_scene = sceneIdFromViewerUrl(poll_url);
       const bool matching_scene = !url_scene.isEmpty() && reported_scene == url_scene;
-      if (save_button_) save_button_->setEnabled(ready && dirty && valid_dirty_transforms && matching_scene);
+      const bool diagnostic_preview = preview_ && preview_->property("diagnostic_preview_active").toBool();
+      if (save_button_) {
+        save_button_->setEnabled(ready && dirty && valid_dirty_transforms && matching_scene && !diagnostic_preview);
+        if (diagnostic_preview) save_button_->setToolTip(QStringLiteral(
+          "Save Layout is disabled for a diagnostic preview. Fix scene authoring blockers first."));
+      }
       if (dirty_label_) {
         const int dirty_count = state.value(QStringLiteral("dirtyCount")).toInt();
         dirty_label_->setText(dirty && matching_scene ?

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -1409,7 +1409,7 @@ void ScenePreviewWidget::emit_backend_startup_diagnostic_once()
 #endif
 }
 
-void ScenePreviewWidget::start_embedded_web_prepare(const EmbeddedWebRequestIdentity & identity, bool force)
+void ScenePreviewWidget::start_embedded_web_prepare(const EmbeddedWebRequestIdentity & identity, bool force, bool diagnostic_preview)
 {
 #ifndef WORKCELL_BUILDER_HAS_WEBENGINE
   Q_UNUSED(identity); Q_UNUSED(force);
@@ -1453,6 +1453,7 @@ void ScenePreviewWidget::start_embedded_web_prepare(const EmbeddedWebRequestIden
   embedded_web_prepare_process_->setProgram(QStringLiteral("python3"));
   QStringList args{"scripts/ensure_workcell_studio_web_scene_fresh.py", "--scene", selected_scene_dir, "--output", embedded_web_prepare_output_path_, "--stage-assets"};
   if (force) args << "--force";
+  if (diagnostic_preview) args << "--allow-incomplete-preview";
   embedded_web_prepare_process_->setArguments(args);
   embedded_web_prepare_process_->setWorkingDirectory(repo_root);
   embedded_web_prepare_process_->setProcessEnvironment(QProcessEnvironment::systemEnvironment());
@@ -1463,6 +1464,7 @@ void ScenePreviewWidget::start_embedded_web_prepare(const EmbeddedWebRequestIden
   diagnostic.identity = identity;
   diagnostic.expected_output_path = embedded_web_prepare_output_path_;
   diagnostic.expected_output_absolute_path = QDir(repo_root).filePath(diagnostic.expected_output_path);
+  diagnostic.diagnostic_preview = diagnostic_preview;
   embedded_web_preparation_diagnostics_.insert(diagnostic_key, diagnostic);
   embedded_web_preparation_process_keys_.insert(process, diagnostic_key);
   embedded_web_prepare_started_at_ = QDateTime::currentDateTimeUtc();
@@ -1566,6 +1568,17 @@ void ScenePreviewWidget::on_embedded_web_prepare_finished(const EmbeddedWebReque
   };
 
   if (exit_status != QProcess::NormalExit || exit_code != 0) {
+    const bool destination_authoring_blocker =
+      diagnostic.stderr_tail.contains("environment.yaml:") &&
+      diagnostic.stderr_tail.contains("relationship") &&
+      (diagnostic.stderr_tail.contains("unresolved ID") || diagnostic.stderr_tail.contains("ambiguous applicable destinations"));
+    if (!diagnostic.diagnostic_preview && destination_authoring_blocker && embedded_web_identity_is_current(identity)) {
+      record_embedded_web_prepare_terminal(identity, process, QStringLiteral("strict_authoring_blocked"), exit_status, exit_code,
+        QStringLiteral("strict preparation rejected an unresolved destination chain; starting diagnostic preview"));
+      emit studio_log_requested(QStringLiteral("Strict Product View preparation blocked by scene authoring for %1; retrying read-only diagnostic preview.").arg(scene));
+      start_embedded_web_prepare(identity, true, true);
+      return;
+    }
     reject_prepare(QStringLiteral("prepare command failed with exit code %1; old output is rejected even if present").arg(exit_code));
     return;
   }
@@ -1610,6 +1623,26 @@ void ScenePreviewWidget::on_embedded_web_prepare_finished(const EmbeddedWebReque
   if (web_schema != QStringLiteral("workcell_studio_web_scene/v1") || output_scene != scene) {
     reject_prepare(QStringLiteral("prepared output semantic validation failed for scene %1").arg(scene));
     return;
+  }
+
+  const bool was_diagnostic_preview = property("diagnostic_preview_active").toBool();
+  const bool diagnostic_preview = output.value(QStringLiteral("preview_mode")).toString() == QStringLiteral("diagnostic") &&
+    output.value(QStringLiteral("authoring_status")).toString() == QStringLiteral("blocked");
+  setProperty("diagnostic_preview_active", diagnostic_preview);
+  interaction_mode_selector_->setEnabled(!diagnostic_preview);
+  const QJsonArray authoring_blockers = output.value(QStringLiteral("authoring_blockers")).toArray();
+  const QString blocker_message = authoring_blockers.isEmpty() ? QString() :
+    authoring_blockers.at(0).toObject().value(QStringLiteral("message")).toString();
+  if (diagnostic_preview) {
+    const QString explanation = QStringLiteral("Diagnostic preview — scene authoring incomplete\nScene: %1\n%2").arg(scene, blocker_message);
+    toolbar_feedback_label_->setText(explanation);
+    toolbar_feedback_label_->setToolTip(QStringLiteral("Save Layout and execution actions are disabled. Fix scene authoring blockers first: %1").arg(blocker_message));
+    toolbar_feedback_row_->setVisible(true);
+    emit studio_issue_requested(explanation, QStringLiteral("Warning"), QStringLiteral("diagnostic_product_view"));
+  } else if (was_diagnostic_preview) {
+    toolbar_feedback_row_->setVisible(false);
+    toolbar_feedback_label_->clear();
+    toolbar_feedback_label_->setToolTip(QString());
   }
 
   record_embedded_web_prepare_terminal(identity, process, QStringLiteral("success"), exit_status, exit_code);

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -395,6 +395,7 @@ private:
     QByteArray stderr_tail;
     bool started{ false };
     bool terminal_recorded{ false };
+    bool diagnostic_preview{ false };
     QString terminal_outcome;
   };
   struct EmbeddedWebServerProbe
@@ -420,7 +421,7 @@ private:
   void maybe_start_next_embedded_web_prepare();
   EmbeddedWebRequestIdentity embedded_web_request_identity(quint64 generation) const;
   bool embedded_web_identity_is_current(const EmbeddedWebRequestIdentity & identity) const;
-  void start_embedded_web_prepare(const EmbeddedWebRequestIdentity & identity, bool force);
+  void start_embedded_web_prepare(const EmbeddedWebRequestIdentity & identity, bool force, bool diagnostic_preview = false);
   void on_embedded_web_prepare_finished(const EmbeddedWebRequestIdentity & identity, QProcess * process, int exit_code, QProcess::ExitStatus exit_status);
   void append_embedded_web_prepare_output(QProcess * process, bool standard_error);
   void record_embedded_web_prepare_terminal(const EmbeddedWebRequestIdentity & identity, QProcess * process,


### PR DESCRIPTION
### Motivation
- Allow Product View to render available robot, tool and authored layout geometry for incomplete or legacy scenes without weakening strict exporter/validation behaviour.
- Provide a read-only diagnostic preview mode that surfaces precise authoring blockers so users can fix scene metadata before generation or execution.

### Description
- Add a new exporter option `--allow-incomplete-preview` and forward it through the freshener (`scripts/export_workcell_studio_web_scene.py` and `scripts/ensure_workcell_studio_web_scene_fresh.py`) to enable a read-only diagnostic preview when a canonical destination chain fails to resolve.
- Keep strict behaviour unchanged so `BlockingExportError` still causes a nonzero exit by default and no stale output is overwritten or guessed destinations are invented, while diagnostic mode catches that specific error and records structured blocker metadata via `authoring_blockers`.
- When diagnostic preview is active the exporter augments payloads with `authoring_status: blocked`, `preview_mode: diagnostic`, and `authoring_blockers` entries and marks renderable items read-only (`editable=false, locked=true`) while disabling non-`validate` backend actions and save/execution paths through `authoring_actions` metadata.
- Product View preparation (`ScenePreviewWidget`) attempts strict preparation first and, if the freshener stderr indicates a destination relationship authoring blocker, retries a diagnostic-only preparation and sets `diagnostic_preview_active` to disable editing and show the banner "Diagnostic preview — scene authoring incomplete" including the blocker message and selected scene ID.
- UI integration disables `Save Layout` and other execution-related actions during diagnostic preview with explanatory tooltips by wiring `diagnostic_preview_active` into the embedded save controller and scene-preview code paths; no scene YAML files were modified and no bundle rebuild was performed.
- Add regression tests for the expected behaviour on fixtures: `suction_test` and `ur5_3f_test` (diagnostic/blocked) and `ur5_2f_test` (unchanged strict/editable).

### Testing
- Ran `python3 -m pytest -q tests/test_export_workcell_studio_web_scene.py tests/test_scene_preview_widget_refresh_lifecycle.py tests/test_workcell_builder_product_view_defaults.py` and observed `58 passed` across the suite.
- Compiled the modified exporter with `python3 -m py_compile scripts/export_workcell_studio_web_scene.py` and the compile step succeeded.
- Ran `git diff --check` to ensure no whitespace or check failures and it reported no problems.
- Did not run ROS 2/Qt GUI interactive smoke tests or `colcon build` in this environment because a sourced ROS 2 Humble workspace and display were unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a02e544308331a79a3cd49516e621)