### PR TITLE
Add Product View Destination Bin selector with explicit Apply action

### DIFF
--- a/tests/test_workcell_builder_product_view_defaults.py
+++ b/tests/test_workcell_builder_product_view_defaults.py
@@ -74,6 +74,26 @@ def test_scene_preview_widget_product_defaults_turn_off_viewport_helpers_and_war
         assert expected in apply_defaults
 
 
+def test_product_view_destination_selector_is_strict_and_explicitly_applied() -> None:
+    source = SCENE_PREVIEW_CPP.read_text()
+    assert 'QStringLiteral("product_view_destination_combo")' in source
+    assert 'QStringLiteral("Apply Destination")' in source
+    refresh = source.split("void ScenePreviewWidget::refresh_product_view_destination_control()", 1)[1]
+    refresh = refresh.split("void ScenePreviewWidget::apply_product_view_destination()", 1)[0]
+    assert "EmbeddedProductViewState::Ready" in refresh
+    assert 'property("diagnostic_preview_active").toBool()' in refresh
+    assert 'task["place"]["target_ref"]' in refresh
+    assert 'zone["target_ref"]' in refresh
+    assert "discover_task_area_destinations" in refresh
+
+    apply = source.split("void ScenePreviewWidget::apply_product_view_destination()", 1)[1]
+    apply = apply.split("void ScenePreviewWidget::", 1)[0]
+    assert "zone->target_ref = destination_id.toStdString();" in apply
+    assert "save_task_zones_to_environment_yaml" in apply
+    assert 'request_embedded_web_product_view_refresh(true, QStringLiteral("destination_rebind"));' in apply
+    assert 'task["place"]["target_ref"]' not in apply
+
+
 def test_inspector_refresh_for_ur5_2f_test_uses_canonical_metadata_and_launch_path() -> None:
     assert UR5_SCENE.is_dir(), "ur5_2f_test fixture scene must exist"
     assert (UR5_SCENE / "cell_definition.yaml").is_file(), "robot metadata source must exist"

--- a/tests/test_workcell_builder_task_area_editor.py
+++ b/tests/test_workcell_builder_task_area_editor.py
@@ -4,6 +4,7 @@ REPO = Path(__file__).resolve().parents[1]
 SCENE_SELECT_CPP = REPO / "workcell_builder/workcell_builder/gui/scene_select.cpp"
 SCENE_SELECT_H = REPO / "workcell_builder/workcell_builder/gui/scene_select.h"
 YAML_IO_CPP = REPO / "workcell_builder/workcell_builder/gui/object_placement_yaml_io.cpp"
+YAML_IO_H = REPO / "workcell_builder/workcell_builder/include/object_placement_yaml_io.hpp"
 MODEL_H = REPO / "workcell_builder/workcell_builder/include/object_placement_model.hpp"
 
 
@@ -82,15 +83,17 @@ def test_no_web3d_or_generated_bundle_paths_touched_by_task_area_editor():
 def test_place_area_uses_validated_destination_selector():
     cpp = SCENE_SELECT_CPP.read_text(encoding="utf-8")
     header = SCENE_SELECT_H.read_text(encoding="utf-8")
+    discovery = YAML_IO_CPP.read_text(encoding="utf-8")
     assert 'setObjectName("task_area_destination_combo")' in cpp
     assert 'setObjectName("task_area_association_edit")' in cpp
     assert "association->setVisible(is_pick)" in cpp
     assert "combo->setVisible(!is_pick)" in cpp
     assert "task_area_destinations() const" in header
+    assert "discover_task_area_destinations(environment.string())" in cpp
     for semantic in ['"bin"', '"tote"', '"destination_container"', '"container"']:
-        assert semantic in cpp
+        assert semantic in discovery
     for excluded in ['"overlay"', '"helper"', '"robot"', '"tool"', '"camera"', '"generated_urdf"']:
-        assert excluded in cpp
+        assert excluded in discovery
     assert 'combo->addItem(QString::fromStdString(candidate.display_name), QString::fromStdString(candidate.id))' in cpp
 
 

--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -380,7 +380,9 @@ if(BUILD_TESTING)
     test/scene_preview_widget_ui_test.cpp
     gui/scene_preview_widget.cpp
     gui/scene3d_viewport_widget.cpp
-    gui/scene3d_visual_classification.cpp)
+    gui/scene3d_visual_classification.cpp
+    gui/object_placement_yaml_io.cpp
+    src_object_placement_model.cpp)
   ament_add_gtest(workcell_studio_canvas_model_mesh_test
     test/workcell_studio_canvas_model_mesh_test.cpp
     src_workcell_studio_canvas_model.cpp
@@ -412,7 +414,7 @@ if(BUILD_TESTING)
   ament_add_gtest(workcell_mainwindow_rviz_preview_compile_test
     test/mainwindow_rviz_preview_compile_test.cpp)
   if(TARGET workcell_scene_preview_widget_ui_test)
-    target_link_libraries(workcell_scene_preview_widget_ui_test Qt5::Widgets Qt5::OpenGL Qt5::Network OpenGL::GL)
+    target_link_libraries(workcell_scene_preview_widget_ui_test Qt5::Widgets Qt5::OpenGL Qt5::Network OpenGL::GL yaml-cpp)
     if(Qt5WebEngineWidgets_FOUND)
       target_compile_definitions(workcell_scene_preview_widget_ui_test PRIVATE WORKCELL_BUILDER_HAS_WEBENGINE=1)
       target_link_libraries(workcell_scene_preview_widget_ui_test Qt5::WebEngineWidgets)

--- a/workcell_builder/workcell_builder/gui/object_placement_yaml_io.cpp
+++ b/workcell_builder/workcell_builder/gui/object_placement_yaml_io.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cctype>
 #include <filesystem>
 #include <fstream>
 #include <unordered_set>
@@ -60,6 +61,59 @@ bool check_finite(const std::string & context, double value, std::vector<std::st
   if (warnings) warnings->push_back(context + " has non-finite numeric value");
   return false;
 }
+}
+
+std::vector<TaskAreaDestination> discover_task_area_destinations(
+  const std::string & path, std::vector<std::string> * warnings)
+{
+  std::vector<TaskAreaDestination> result;
+  try {
+    const YAML::Node root = YAML::LoadFile(path);
+    const YAML::Node assets = root["environment"]["assets"];
+    if (!assets || !assets.IsSequence()) return result;
+    auto normalized = [](const YAML::Node & node, const char * key) {
+      std::string value = node[key].as<std::string>("");
+      std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+      });
+      return value;
+    };
+    const auto contains_any = [](const std::string & value, const std::vector<std::string> & tokens) {
+      return std::any_of(tokens.begin(), tokens.end(), [&value](const std::string & token) {
+        return value.find(token) != std::string::npos;
+      });
+    };
+    const std::vector<std::string> destination_tokens{
+      "bin", "tote", "destination_container", "destination container", "container"};
+    const std::vector<std::string> excluded_tokens{
+      "overlay", "helper", "diagnostic", "place_zone", "pick_zone", "robot", "tool",
+      "gripper", "camera", "generated_urdf", "generated urdf"};
+    const std::vector<std::string> excluded_category_tokens{
+      "overlay", "helper", "diagnostic", "robot", "tool", "gripper", "camera",
+      "generated_urdf", "generated urdf"};
+    for (const auto & asset : assets) {
+      const std::string id = asset["id"].as<std::string>("");
+      const std::string type = normalized(asset, "type");
+      const std::string role = normalized(asset, "role");
+      const std::string category = normalized(asset, "category");
+      const std::string source_layer = normalized(asset, "source_layer");
+      const std::string active_visual_source = normalized(asset, "active_visual_source");
+      if (id.empty() || contains_any(source_layer, excluded_tokens) ||
+        contains_any(active_visual_source, excluded_tokens)) continue;
+      const bool semantic_destination = contains_any(type, destination_tokens) ||
+        contains_any(role, destination_tokens) || contains_any(category, destination_tokens);
+      const bool helper_identity = contains_any(type, excluded_tokens) ||
+        contains_any(role, excluded_tokens) || contains_any(category, excluded_category_tokens);
+      if (!semantic_destination || helper_identity) continue;
+      result.push_back({id, asset["display_name"].as<std::string>(asset["name"].as<std::string>(id))});
+    }
+    std::sort(result.begin(), result.end(), [](const auto & lhs, const auto & rhs) {
+      return lhs.display_name == rhs.display_name ? lhs.id < rhs.id : lhs.display_name < rhs.display_name;
+    });
+  } catch (const std::exception & e) {
+    if (warnings) warnings->push_back(std::string("destination discovery failed: ") + e.what());
+  }
+  return result;
 }
 
 std::vector<PlacedObject> load_placed_objects_from_environment_yaml(const std::string & path, std::vector<std::string> * warnings)

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -28,6 +28,9 @@
 #include <QSignalBlocker>
 #include <QPushButton>
 #include <functional>
+#include <algorithm>
+#include <yaml-cpp/yaml.h>
+#include "object_placement_yaml_io.hpp"
 
 namespace {
 constexpr double kOverlayFitDominanceRatio = 4.0;
@@ -291,6 +294,33 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
   toolbar_status_chip_->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
   identity_row->addWidget(toolbar_status_chip_, 0);
   controls->addLayout(identity_row);
+
+  product_view_destination_row_ = new QWidget(controls_header);
+  auto * destination_layout = new QHBoxLayout(product_view_destination_row_);
+  destination_layout->setContentsMargins(0, 0, 0, 0);
+  destination_layout->setSpacing(6);
+  destination_layout->addWidget(new QLabel(QStringLiteral("Destination Bin"), product_view_destination_row_));
+  product_view_destination_combo_ = new QComboBox(product_view_destination_row_);
+  product_view_destination_combo_->setObjectName(QStringLiteral("product_view_destination_combo"));
+  product_view_destination_combo_->setSizeAdjustPolicy(QComboBox::AdjustToContents);
+  destination_layout->addWidget(product_view_destination_combo_);
+  product_view_apply_destination_button_ = new QPushButton(QStringLiteral("Apply Destination"), product_view_destination_row_);
+  destination_layout->addWidget(product_view_apply_destination_button_);
+  product_view_destination_status_ = new QLabel(product_view_destination_row_);
+  product_view_destination_status_->setObjectName(QStringLiteral("product_view_destination_status"));
+  destination_layout->addWidget(product_view_destination_status_, 1);
+  product_view_destination_row_->setVisible(false);
+  controls->addWidget(product_view_destination_row_);
+  connect(product_view_apply_destination_button_, &QPushButton::clicked,
+    this, &ScenePreviewWidget::apply_product_view_destination);
+  connect(product_view_destination_combo_, QOverload<int>::of(&QComboBox::currentIndexChanged),
+    this, [this](int) {
+      if (!product_view_apply_destination_button_) return;
+      const bool selectable = !product_view_destination_combo_->currentData().toString().trimmed().isEmpty();
+      product_view_apply_destination_button_->setEnabled(selectable &&
+        embedded_product_view_state_ == EmbeddedProductViewState::Ready &&
+        !property("diagnostic_preview_active").toBool() && !product_view_destination_save_in_progress_);
+    });
 
   auto * backend_controls_row = new QHBoxLayout();
   mesh_preview_mode_label_ = new QLabel("Mesh Preview:", controls_header);
@@ -716,6 +746,7 @@ QString ScenePreviewWidget::embedded_web_prepare_command_for_log(const QString &
 void ScenePreviewWidget::set_embedded_product_view_state(EmbeddedProductViewState state, const QString & detail)
 {
   embedded_product_view_state_ = state;
+  refresh_product_view_destination_control();
   embedded_editor_polling_ = (state == EmbeddedProductViewState::Ready);
   if (state == EmbeddedProductViewState::Failed) embedded_web_last_error_ = detail;
   if (embedded_fit_button_ && state != EmbeddedProductViewState::Failed) {
@@ -733,6 +764,140 @@ void ScenePreviewWidget::set_embedded_product_view_state(EmbeddedProductViewStat
   else if (state == EmbeddedProductViewState::CompatibilityReady) state_text = QStringLiteral("compatibility ready");
   else if (state == EmbeddedProductViewState::Failed) state_text = QStringLiteral("failed");
   emit embedded_product_view_runtime_state_changed(state_text, runtime_preview_has_usable_content());
+}
+
+void ScenePreviewWidget::refresh_product_view_destination_control()
+{
+  if (!product_view_destination_row_) return;
+  const bool strict_ready = embedded_product_view_state_ == EmbeddedProductViewState::Ready &&
+    !property("diagnostic_preview_active").toBool() && !product_view_destination_save_in_progress_;
+  const QString environment_path = QDir(preview_context_.absolute_scene_dir).filePath(QStringLiteral("environment.yaml"));
+  active_product_view_place_zone_id_.clear();
+  QString current_destination;
+  bool editable_pick_place = false;
+  try {
+    const YAML::Node root = YAML::LoadFile(environment_path.toStdString());
+    const YAML::Node task = root["task"];
+    const std::string task_kind = task["type"].as<std::string>(task["template"].as<std::string>(""));
+    editable_pick_place = task_kind == "pick_place";
+    std::string place_zone_id = task["place"]["target_ref"].as<std::string>("");
+    if (place_zone_id.empty()) {
+      const YAML::Node rules = task["rules"];
+      if (rules && rules.IsSequence()) {
+        for (const auto & rule : rules) {
+          const YAML::Node when = rule["when"];
+          if (when && (when["always"].as<bool>(false) || when["default"].as<bool>(false))) {
+            place_zone_id = rule["destination"].as<std::string>("");
+            if (!place_zone_id.empty()) break;
+          }
+        }
+      }
+    }
+    const YAML::Node zones = root["task_zones"];
+    if (zones && zones.IsSequence()) {
+      for (const auto & zone : zones) {
+        const std::string id = zone["id"].as<std::string>("");
+        const std::string role = zone["role"].as<std::string>(zone["type"].as<std::string>(""));
+        if (id == place_zone_id && (role == "place" || role == "place_zone")) {
+          active_product_view_place_zone_id_ = QString::fromStdString(id);
+          current_destination = QString::fromStdString(zone["target_ref"].as<std::string>(""));
+          break;
+        }
+      }
+    }
+  } catch (const std::exception & e) {
+    if (product_view_destination_status_) {
+      product_view_destination_status_->setText(QStringLiteral("Destination unavailable: %1").arg(e.what()));
+    }
+  }
+
+  const bool resolved = editable_pick_place && !active_product_view_place_zone_id_.isEmpty();
+  product_view_destination_row_->setVisible(strict_ready && resolved);
+  if (!resolved) {
+    if (product_view_destination_combo_) product_view_destination_combo_->setEnabled(false);
+    if (product_view_apply_destination_button_) product_view_apply_destination_button_->setEnabled(false);
+    return;
+  }
+
+  const QSignalBlocker blocker(product_view_destination_combo_);
+  product_view_destination_combo_->clear();
+  const auto candidates = workcell_builder::discover_task_area_destinations(environment_path.toStdString());
+  for (const auto & candidate : candidates) {
+    product_view_destination_combo_->addItem(
+      QString::fromStdString(candidate.display_name), QString::fromStdString(candidate.id));
+  }
+  const int current_index = product_view_destination_combo_->findData(current_destination);
+  if (current_index >= 0) {
+    product_view_destination_combo_->setCurrentIndex(current_index);
+    product_view_destination_status_->setText(QStringLiteral("Current destination: %1").arg(current_destination));
+  } else {
+    product_view_destination_combo_->insertItem(0, QStringLiteral("Missing destination: %1").arg(
+      current_destination.isEmpty() ? QStringLiteral("<none>") : current_destination), QVariant());
+    product_view_destination_combo_->setCurrentIndex(0);
+    product_view_destination_status_->setText(QStringLiteral("Missing destination: %1").arg(
+      current_destination.isEmpty() ? QStringLiteral("<none>") : current_destination));
+  }
+  product_view_destination_combo_->setEnabled(strict_ready);
+  product_view_apply_destination_button_->setEnabled(strict_ready && current_index >= 0);
+}
+
+void ScenePreviewWidget::apply_product_view_destination()
+{
+  if (product_view_destination_save_in_progress_ || !product_view_destination_combo_ ||
+    active_product_view_place_zone_id_.isEmpty()) return;
+  const QString destination_id = product_view_destination_combo_->currentData().toString().trimmed();
+  const QString environment_path = QDir(preview_context_.absolute_scene_dir).filePath(QStringLiteral("environment.yaml"));
+  const auto candidates = workcell_builder::discover_task_area_destinations(environment_path.toStdString());
+  const bool valid_destination = std::any_of(candidates.begin(), candidates.end(), [&destination_id](const auto & candidate) {
+    return QString::fromStdString(candidate.id) == destination_id;
+  });
+  if (!valid_destination) {
+    product_view_destination_status_->setText(QStringLiteral("Missing destination: selection is not a valid physical bin."));
+    emit studio_issue_requested(product_view_destination_status_->text(), QStringLiteral("Error"),
+      QStringLiteral("product_view_destination_invalid"));
+    return;
+  }
+
+  product_view_destination_save_in_progress_ = true;
+  product_view_destination_combo_->setEnabled(false);
+  product_view_apply_destination_button_->setEnabled(false);
+  std::vector<std::string> warnings;
+  auto zones = workcell_builder::load_task_zones_from_environment_yaml(environment_path.toStdString(), &warnings);
+  const std::string place_zone_id = active_product_view_place_zone_id_.toStdString();
+  auto zone = std::find_if(zones.begin(), zones.end(), [&place_zone_id](const auto & candidate) {
+    return candidate.id == place_zone_id && (candidate.role == "place" || candidate.type == "place_zone");
+  });
+  if (zone == zones.end()) {
+    product_view_destination_save_in_progress_ = false;
+    product_view_destination_status_->setText(QStringLiteral("Save failed: active place zone could not be resolved in %1").arg(environment_path));
+    emit studio_issue_requested(product_view_destination_status_->text(), QStringLiteral("Error"),
+      QStringLiteral("product_view_destination_save"));
+    refresh_product_view_destination_control();
+    return;
+  }
+  zone->target_ref = destination_id.toStdString();
+  const QString backup_path = environment_path + QStringLiteral(".task_areas.") +
+    QDateTime::currentDateTimeUtc().toString(QStringLiteral("yyyyMMddHHmmss")) + QStringLiteral(".bak");
+  bool backup_ok = false;
+  if (QFile::exists(backup_path)) QFile::remove(backup_path);
+  backup_ok = QFile::copy(environment_path, backup_path);
+  if (!backup_ok) warnings.push_back("backup failed for " + backup_path.toStdString());
+  const auto saved = backup_ok ? workcell_builder::save_task_zones_to_environment_yaml(
+    environment_path.toStdString(), zones) : workcell_builder::PlacedObjectYamlWriteResult{};
+  product_view_destination_save_in_progress_ = false;
+  if (!saved.ok) {
+    const QString detail = warnings.empty() && saved.warnings.empty() ? QStringLiteral("unknown filesystem error") :
+      QString::fromStdString(!saved.warnings.empty() ? saved.warnings.front() : warnings.front());
+    product_view_destination_status_->setText(QStringLiteral("Save failed for %1: %2").arg(environment_path, detail));
+    emit studio_issue_requested(product_view_destination_status_->text(), QStringLiteral("Error"),
+      QStringLiteral("product_view_destination_save"));
+    refresh_product_view_destination_control();
+    return;
+  }
+  product_view_destination_status_->setText(QStringLiteral("Destination rebound to %1; refreshing Product View.").arg(destination_id));
+  emit studio_log_requested(QStringLiteral("Product View destination rebound: place zone %1 -> %2; backup: %3")
+    .arg(active_product_view_place_zone_id_, destination_id, backup_path));
+  request_embedded_web_product_view_refresh(true, QStringLiteral("destination_rebind"));
 }
 
 void ScenePreviewWidget::start_embedded_web_server_probes(

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -330,6 +330,8 @@ private:
   void refresh_toolbar_visibility();
   void refresh_toolbar_status_chip();
   void refresh_toolbar_feedback_row();
+  void refresh_product_view_destination_control();
+  void apply_product_view_destination();
   enum class EmbeddedProductViewState {
     Idle,
     Preparing,
@@ -461,6 +463,12 @@ private:
   bool task_is_ready() const;
 
   QComboBox * mode_selector_{ nullptr };
+  QWidget * product_view_destination_row_{ nullptr };
+  QComboBox * product_view_destination_combo_{ nullptr };
+  QPushButton * product_view_apply_destination_button_{ nullptr };
+  QLabel * product_view_destination_status_{ nullptr };
+  QString active_product_view_place_zone_id_;
+  bool product_view_destination_save_in_progress_{ false };
   QComboBox * interaction_mode_selector_{ nullptr };
   QComboBox * view_actions_selector_{ nullptr };
   QLabel * view_mode_label_{ nullptr };

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -3875,46 +3875,12 @@ void SceneSelect::sync_task_area_inspector()
   }
 }
 
-std::vector<SceneSelect::TaskAreaDestination> SceneSelect::task_area_destinations() const
+std::vector<workcell_builder::TaskAreaDestination> SceneSelect::task_area_destinations() const
 {
-  std::vector<TaskAreaDestination> result;
   const fs::path environment = scene_dir_for_current_selection() / "environment.yaml";
-  if (!fs::exists(environment)) return result;
-  YAML::Node root;
-  try { root = YAML::LoadFile(environment.string()); } catch (const YAML::Exception &) { return result; }
-  const YAML::Node assets = root["environment"]["assets"];
-  if (!assets || !assets.IsSequence()) return result;
-  auto normalized = [](const YAML::Node & node, const char * key) {
-    std::string value = node[key].as<std::string>("");
-    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-    return value;
-  };
-  const auto contains_any = [](const std::string & value, const std::vector<std::string> & tokens) {
-    for (const auto & token : tokens) if (value.find(token) != std::string::npos) return true;
-    return false;
-  };
-  const std::vector<std::string> destination_tokens{"bin", "tote", "destination_container", "destination container", "container"};
-  const std::vector<std::string> excluded_tokens{"overlay", "helper", "diagnostic", "place_zone", "pick_zone", "robot", "tool", "gripper", "camera", "generated_urdf", "generated urdf"};
-  for (const auto & asset : assets) {
-    const std::string id = asset["id"].as<std::string>("");
-    const std::string type = normalized(asset, "type");
-    const std::string role = normalized(asset, "role");
-    const std::string category = normalized(asset, "category");
-    const std::string source_layer = normalized(asset, "source_layer");
-    const std::string active_visual_source = normalized(asset, "active_visual_source");
-    if (id.empty() || contains_any(source_layer, excluded_tokens) ||
-      contains_any(active_visual_source, excluded_tokens)) continue;
-    const bool semantic_destination = contains_any(type, destination_tokens) ||
-      contains_any(role, destination_tokens) || contains_any(category, destination_tokens);
-    const bool helper_identity = contains_any(type, excluded_tokens) || contains_any(role, excluded_tokens);
-    if (!semantic_destination || helper_identity) continue;
-    std::string display_name = asset["display_name"].as<std::string>(asset["name"].as<std::string>(id));
-    result.push_back({id, display_name});
-  }
-  std::sort(result.begin(), result.end(), [](const auto & lhs, const auto & rhs) {
-    return lhs.display_name < rhs.display_name;
-  });
-  return result;
+  return fs::exists(environment) ?
+    workcell_builder::discover_task_area_destinations(environment.string()) :
+    std::vector<workcell_builder::TaskAreaDestination>{};
 }
 
 bool SceneSelect::is_valid_task_area_destination(const std::string & id) const

--- a/workcell_builder/workcell_builder/gui/scene_select.h
+++ b/workcell_builder/workcell_builder/gui/scene_select.h
@@ -28,6 +28,7 @@
 #include <map>
 #include <cstdint>
 #include <ctime>
+#include "object_placement_yaml_io.hpp"
 
 class QLabel;
 struct RobotHomeJointState;
@@ -226,12 +227,7 @@ private:
   void load_task_areas_for_selected_scene();
   void refresh_task_area_canvas_items();
   void sync_task_area_inspector();
-  struct TaskAreaDestination
-  {
-    std::string id;
-    std::string display_name;
-  };
-  std::vector<TaskAreaDestination> task_area_destinations() const;
+  std::vector<workcell_builder::TaskAreaDestination> task_area_destinations() const;
   bool is_valid_task_area_destination(const std::string & id) const;
   void mark_task_areas_dirty(const QString & reason);
   bool save_task_areas_to_scene(const boost::filesystem::path & scene_dir, std::string * reason);

--- a/workcell_builder/workcell_builder/include/object_placement_yaml_io.hpp
+++ b/workcell_builder/workcell_builder/include/object_placement_yaml_io.hpp
@@ -16,6 +16,17 @@ struct PlacedObjectYamlWriteResult
   size_t objects_saved{0};
 };
 
+struct TaskAreaDestination
+{
+  std::string id;
+  std::string display_name;
+};
+
+// Shared by the Task Areas editor and Product View destination selector.
+std::vector<TaskAreaDestination> discover_task_area_destinations(
+  const std::string & environment_yaml_path,
+  std::vector<std::string> * warnings = nullptr);
+
 struct RobotMountConfig
 {
   std::string parent_link{"world"};


### PR DESCRIPTION
### Motivation

- Provide an in-view control so users can rebind the active place destination from Product View without leaving the preview panel.
- Reuse the same destination discovery and semantic filtering already used by the Task Areas editor to avoid duplicate logic and ensure consistent candidate lists.
- Preserve safety and authoring semantics by requiring an explicit Apply action and by only editing authoring YAML when the scene is strict-ready and editable.

### Description

- Add a compact Product View control row (label "Destination Bin", `QComboBox` named `product_view_destination_combo`, and an "Apply Destination" `QPushButton`) to `ScenePreviewWidget` and wire UI state/enablement. 
- Show the control only for strict-ready, non-diagnostic, editable pick/place scenes where an active place zone is deterministically resolved from `task.place.target_ref` or a deterministic applicable task rule.
- Extract a shared helper `discover_task_area_destinations` into `object_placement_yaml_io.hpp/cpp` to populate candidates (includes physical bins, totes and destination containers and excludes overlays/helpers/cameras/robots/tools/generated URDF items), and make `SceneSelect` reuse that helper.
- When Apply is clicked, validate the chosen destination, create the existing timestamped backup, call the existing `save_task_zones_to_environment_yaml` path to update only the active task zone's `target_ref`, preserve `task.place.target_ref`/`intent_target_ref`, and trigger exactly one strict Product View refresh so the derived place-zone overlay is rebuilt.
- Disable the control during diagnostic preview, preparation/loading, unresolved active place zone, or while a save is in progress, and provide clear status text for current destination, missing destination, save failure, and successful rebind.
- Add small test assertions and wiring to validate the new control and discovery usage, and add `yaml-cpp` to the test target linking so discovery code is available to tests.

### Testing

- Ran the focused test matrix: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_builder_task_area_editor.py tests/test_scene_preview_widget_refresh_lifecycle.py tests/test_workcell_builder_product_view_defaults.py tests/test_workcell_builder_embedded_web3d_save_roundtrip.py`, which completed successfully (48 passed).
- Ran `git diff --check` to ensure no whitespace or patch issues (passed).
- Full CMake/Qt build of the GUI was not executed here because the local `build` directory had no configured CMake cache in this checkout; CI or a developer workstation with a sourced ROS workspace / configured CMake cache should validate an integrated build.

Safety: fake-hardware-first and runtime/hardware defaults were preserved; no URDF/MoveIt/launch/controller/hardware/runtime motion or viewer JS changes were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a075cbf648331801a4069a48ca5a9)