### PR TITLE
Fix Robot Home linkage in scene preview UI test

### DIFF
--- a/tests/test_humble_build_regressions.py
+++ b/tests/test_humble_build_regressions.py
@@ -196,7 +196,7 @@ def test_scene_preview_widget_targets_link_qt_network():
     assert "find_package(Qt5 COMPONENTS Widgets Concurrent Svg OpenGL Network REQUIRED)" in cmake
     assert "target_link_libraries(workcell_builder" in cmake and "Qt5::Network" in cmake
     assert "ament_add_gtest(workcell_scene_preview_widget_ui_test" in cmake
-    assert "target_link_libraries(workcell_scene_preview_widget_ui_test Qt5::Widgets Qt5::OpenGL Qt5::Network OpenGL::GL)" in cmake
+    assert "target_link_libraries(workcell_scene_preview_widget_ui_test Qt5::Core Qt5::Widgets Qt5::OpenGL Qt5::Network OpenGL::GL yaml-cpp)" in cmake
 
 
 def test_scene_preview_widget_still_uses_qtcp_socket_for_server_probe():

--- a/tests/test_workcell_builder_robot_home_editor.py
+++ b/tests/test_workcell_builder_robot_home_editor.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import math
+import re
 import shutil
 import yaml
 
@@ -7,6 +8,7 @@ ROOT = Path(__file__).resolve().parents[1]
 CPP = ROOT / "workcell_builder/workcell_builder/gui/scene_select.cpp"
 H = ROOT / "workcell_builder/workcell_builder/gui/scene_select.h"
 SHARED_INITIAL = ROOT / "assets/robots/universal_robot/ur5_moveit_config/config/initial_positions.yaml"
+CMAKE = ROOT / "workcell_builder/workcell_builder/CMakeLists.txt"
 
 JOINTS = [
     ("Base", "shoulder_pan_joint", 0.0),
@@ -20,6 +22,26 @@ JOINTS = [
 
 def text():
     return CPP.read_text(encoding="utf-8") + "\n" + H.read_text(encoding="utf-8")
+
+
+def test_scene_preview_ui_target_includes_direct_robot_home_helper_implementation():
+    cmake = CMAKE.read_text(encoding="utf-8")
+    target_sources = re.search(
+        r"ament_add_gtest\(workcell_scene_preview_widget_ui_test\s+(.*?)\)",
+        cmake,
+        re.DOTALL,
+    )
+    assert target_sources is not None
+    assert "gui/scene_preview_widget.cpp" in target_sources.group(1)
+    assert "gui/robot_home_yaml_io.cpp" in target_sources.group(1)
+    target_links = re.search(
+        r"target_link_libraries\(workcell_scene_preview_widget_ui_test\s+(.*?)\)",
+        cmake,
+        re.DOTALL,
+    )
+    assert target_links is not None
+    for dependency in ("Qt5::Core", "Qt5::Widgets", "yaml-cpp"):
+        assert dependency in target_links.group(1)
 
 
 def test_suggested_ur5_joint_order_and_values_are_finite():

--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -381,6 +381,7 @@ if(BUILD_TESTING)
   ament_add_gtest(workcell_scene_preview_widget_ui_test
     test/scene_preview_widget_ui_test.cpp
     gui/scene_preview_widget.cpp
+    gui/robot_home_yaml_io.cpp
     gui/scene3d_viewport_widget.cpp
     gui/scene3d_visual_classification.cpp
     gui/object_placement_yaml_io.cpp
@@ -416,7 +417,7 @@ if(BUILD_TESTING)
   ament_add_gtest(workcell_mainwindow_rviz_preview_compile_test
     test/mainwindow_rviz_preview_compile_test.cpp)
   if(TARGET workcell_scene_preview_widget_ui_test)
-    target_link_libraries(workcell_scene_preview_widget_ui_test Qt5::Widgets Qt5::OpenGL Qt5::Network OpenGL::GL yaml-cpp)
+    target_link_libraries(workcell_scene_preview_widget_ui_test Qt5::Core Qt5::Widgets Qt5::OpenGL Qt5::Network OpenGL::GL yaml-cpp)
     if(Qt5WebEngineWidgets_FOUND)
       target_compile_definitions(workcell_scene_preview_widget_ui_test PRIVATE WORKCELL_BUILDER_HAS_WEBENGINE=1)
       target_link_libraries(workcell_scene_preview_widget_ui_test Qt5::WebEngineWidgets)


### PR DESCRIPTION
### Motivation
- The `scene_preview_widget.cpp` UI test began referencing helper functions implemented in `gui/robot_home_yaml_io.cpp` but the source was not part of the test target, causing link-time regressions.
- The UI test target also needed explicit linkage to the Qt Core component and `yaml-cpp` so the gtest binary has all required symbols.
- Add a small static assertion so future edits that remove direct helper implementations from the test target are detected by CI.

### Description
- Added `gui/robot_home_yaml_io.cpp` to the `workcell_scene_preview_widget_ui_test` source list in `workcell_builder/workcell_builder/CMakeLists.txt` so the helper implementations are compiled into the test target.
- Made the UI test target linkage explicit by adding `Qt5::Core` and ensuring `yaml-cpp` is present in the `target_link_libraries` call for `workcell_scene_preview_widget_ui_test`.
- Added `test_scene_preview_ui_target_includes_direct_robot_home_helper_implementation` to `tests/test_workcell_builder_robot_home_editor.py` to statically assert that `gui/scene_preview_widget.cpp` and `gui/robot_home_yaml_io.cpp` are present in the test's source list and that `Qt5::Core`, `Qt5::Widgets`, and `yaml-cpp` are linked.
- Updated an existing Humble build-regressions assertion in `tests/test_humble_build_regressions.py` to match the expanded test target linkage contract.
- No functional changes were made to Robot Initial Pose behavior, UI files, environment data, viewer bundles, URDFs, MoveIt, launches, controllers, or hardware settings.

### Testing
- Ran `python3 -m pytest -q tests/test_workcell_builder_robot_home_editor.py tests/test_workcell_builder_product_view_defaults.py` and got `11 passed`.
- Ran the linkage contract check `python3 -m pytest -q tests/test_humble_build_regressions.py::test_scene_preview_widget_targets_link_qt_network` and it passed (`1 passed`).
- A prior run of the complete `tests/test_humble_build_regressions.py` showed one unrelated, pre-existing assertion failure expecting `QTcpSocket` (current code uses `QTcpServer`); this was not introduced by the linkage changes and is orthogonal to the fix.
- Ran `git diff --check` with no issues reported.
- Attempts to run `colcon build` / `colcon test` / `colcon test-result` in this environment were not executed successfully because `colcon` is not available in the container; those steps are listed in the PR validation and should be run in a ROS-capable CI or developer environment to confirm binary linking end-to-end.
- All modified unit-level tests and the new static assertion passed in this environment where `colcon` is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a1a2b9c148331bd219f6adbfdc951)