### PR TITLE
Resolve regenerated task destinations from authored layout

### DIFF
--- a/scripts/export_builder_scene_to_cell_definition.py
+++ b/scripts/export_builder_scene_to_cell_definition.py
@@ -112,11 +112,78 @@ def _write_structured(path: Path, payload: dict[str, Any]) -> None:
 
 
 def _find_task_intent(scene_path: Path) -> Path | None:
-    for rel in ["generated/workcell_builder_task_intent.yaml", "workcell_builder_task_intent.yaml"]:
+    # Authored inputs always win.  The generated copy is only a compatibility
+    # fallback and must never shadow the canonical config source.
+    for rel in [
+        "config/workcell_builder_task_intent.yaml",
+        "workcell_builder_task_intent.yaml",
+        "generated/workcell_builder_task_intent.yaml",
+    ]:
         cand = scene_path / rel
         if cand.is_file():
             return cand
     return None
+
+
+def _resolve_authored_task(
+    task_intent: dict[str, Any], task_intent_path: Path, environment: dict[str, Any],
+    layout: dict[str, Any], layout_path: Path,
+) -> dict[str, Any]:
+    """Resolve task IDs through environment bindings into authored layout items."""
+    def fail(identifier: Any, reason: str) -> None:
+        raise ValueError(
+            f"Task intent '{task_intent_path}' and layout '{layout_path}' cannot resolve "
+            f"identifier '{identifier}': {reason}"
+        )
+
+    if task_intent.get("schema") != "workcell_builder_task_intent/v1":
+        fail(task_intent.get("schema", "<missing schema>"), "invalid task intent schema")
+
+    items = layout.get("items")
+    if not isinstance(items, list):
+        fail("items", "authored layout does not contain an items list")
+    item_by_id = {str(item.get("id")): item for item in items
+                  if isinstance(item, dict) and item.get("id")}
+    task_zones = environment.get("task_zones")
+    zone_by_id = {str(zone.get("id")): zone for zone in task_zones
+                  if isinstance(zone, dict) and zone.get("id")} if isinstance(task_zones, list) else {}
+
+    def intent_ref(block: str, child: str) -> tuple[str, dict[str, Any]]:
+        section = task_intent.get(block)
+        ref = section.get(child) if isinstance(section, dict) else None
+        identifier = ref.get("id") if isinstance(ref, dict) else None
+        if not identifier:
+            fail(f"{block}.{child}.id", "required identifier is missing")
+        zone = zone_by_id.get(str(identifier))
+        if zone is None:
+            fail(identifier, f"not found in task_zones from authored environment for {block}.{child}.id")
+        layout_id = zone.get("layout_item_ref")
+        if not layout_id or str(layout_id) not in item_by_id:
+            fail(layout_id or identifier, f"layout_item_ref for task zone '{identifier}' is missing or unresolved")
+        return str(identifier), item_by_id[str(layout_id)]
+
+    pick_id, pick_item = intent_ref("pick", "source")
+    place_id, place_zone = intent_ref("place", "target")
+    target_ref = place_zone.get("target_ref")
+    if not target_ref or str(target_ref) not in item_by_id:
+        fail(target_ref or place_zone.get("id"), f"target_ref on place layout item '{place_zone.get('id')}' is missing or unresolved")
+    target = item_by_id[str(target_ref)]
+    zone_group = place_zone.get("transform_group")
+    target_group = target.get("transform_group")
+    if not zone_group or zone_group != target_group:
+        fail(target_ref, f"inconsistent transform_group between '{place_zone.get('id')}' and '{target_ref}'")
+    zone_pose = place_zone.get("pose")
+    target_pose = target.get("pose")
+    if not isinstance(zone_pose, dict) or zone_pose != target_pose:
+        fail(target_ref, f"inconsistent pose in transform_group '{zone_group}'")
+    for item_id, item in ((pick_item.get("id"), pick_item), (target_ref, target)):
+        pose = item.get("pose")
+        if (not isinstance(pose, dict) or not isinstance(pose.get("xyz"), list)
+                or len(pose["xyz"]) != 3 or not isinstance(pose.get("rpy"), list)
+                or len(pose["rpy"]) != 3):
+            fail(item_id, "layout pose must contain three-element xyz and rpy lists")
+    return {"pick_id": pick_id, "pick_item": pick_item, "place_id": place_id,
+            "place_zone": place_zone, "target_ref": str(target_ref), "target": target}
 
 
 def _validate_task_intent(task_intent_path: Path, scene_path: Path) -> dict[str, Any]:
@@ -220,11 +287,9 @@ def _task_type_from_meta(meta: dict[str, Any]) -> str:
 def export_scene(scene_path: Path, output_dir: Path, validate: bool) -> dict[str, Any]:
     env = _load_optional(scene_path / "environment.yaml")
     meta = _load_optional(scene_path / "workcell_builder_metadata.yaml")
-    task_zones, task_zone_counts, task_zone_ids = _extract_task_zones(env)
+    task_zones, task_zone_counts, _ = _extract_task_zones(env)
     warnings: list[str] = []
     task_intent_path = _find_task_intent(scene_path)
-    preferred_pick = "pick_zone_01" if "pick_zone_01" in task_zone_ids else (task_zones[0]["id"] if task_zones else "unknown_pick_zone")
-    preferred_place = "place_zone_01" if "place_zone_01" in task_zone_ids else (next((z["id"] for z in task_zones if z.get("role")=="place"), "unknown_place_zone"))
     builder_task_intent: dict[str, Any] = {}
     task_intent_validation: dict[str, Any] = {}
     task_recipe_generation: dict[str, Any] = {}
@@ -295,6 +360,24 @@ def export_scene(scene_path: Path, output_dir: Path, validate: bool) -> dict[str
             generated_task_intent_path = output_dir / "workcell_builder_task_intent.yaml"
             _write_structured(generated_task_intent_path, generated_intent)
             task_intent_path = generated_task_intent_path
+    if not task_intent_path:
+        raise ValueError(
+            f"Task intent '{scene_path / 'config/workcell_builder_task_intent.yaml'}' is missing; "
+            f"layout '{authored_layout_ref or scene_path / 'layout/workcell_studio_layout.yaml'}' cannot resolve task identifiers"
+        )
+    resolved_layout_path = (Path(authored_layout_ref) if authored_layout_ref else
+                            scene_path / "layout" / "workcell_studio_layout.yaml")
+    try:
+        task_intent_payload = _load_optional(task_intent_path)
+    except Exception as exc:
+        raise ValueError(
+            f"Task intent '{task_intent_path}' and layout '{resolved_layout_path}' cannot resolve "
+            f"identifier '<invalid task intent>': {exc}"
+        ) from exc
+    resolved_task = _resolve_authored_task(
+        task_intent_payload, task_intent_path, env, authored_layout,
+        resolved_layout_path,
+    )
     authored_items = authored_layout.get("items") if isinstance(authored_layout.get("items"), list) else []
     layout_assets = []
     for item in authored_items:
@@ -380,13 +463,23 @@ def export_scene(scene_path: Path, output_dir: Path, validate: bool) -> dict[str
         },
         "objects": [{"id": o["id"], "class": "part", "shape": "mesh", "color": "unknown", "material": "unknown", "frame": "world", "dimensions": o["dimensions"], "pose_xyz": [0.0,0.0,0.0], "pose_rpy": [0.0,0.0,0.0]} for o in object_entries],
         "task": {
-            "id": "default_task",
+            "id": ((task_intent_payload.get("task") or {}).get("id")
+                   if isinstance(task_intent_payload.get("task"), dict) else "default_task"),
             "type": task_type,
             "source_object": object_entries[0]["id"] if object_entries else "unknown_object",
-            "pick": {"source": {"id": preferred_pick, "type": "zone"}},
-            "place": {"target": {"id": preferred_place, "type": "zone"}},
-            "destinations": [{"id": "default_drop", "frame": "world", "pose_xyz": [0.4, 0.0, 0.2], "pose_rpy": [0.0, 0.0, 0.0]}],
-            "rules": [{"id": "default_rule", "when": {"always": True}, "destination": "default_drop"}],
+            "pick": {"source": {"id": resolved_task["pick_id"], "type": "zone",
+                                  "layout_item_ref": resolved_task["pick_item"]["id"]}},
+            "place": {"target": {"id": resolved_task["place_id"], "type": "zone",
+                                   "layout_item_ref": resolved_task["place_zone"]["id"],
+                                   "target_ref": resolved_task["target_ref"]}},
+            "destinations": [{
+                "id": resolved_task["place_id"], "target_ref": resolved_task["target_ref"],
+                "frame": authored_layout.get("frame", "world"),
+                "pose_xyz": resolved_task["target"]["pose"]["xyz"],
+                "pose_rpy": resolved_task["target"]["pose"]["rpy"],
+            }],
+            "rules": [{"id": "default_rule", "when": {"always": True},
+                       "destination": resolved_task["place_id"]}],
         },
         "grasp": {"strategy_ref": normalized_grasp.get("strategy_id") or "auto"},
         "commissioning": {"self_test_enabled": True, "export_bundle": False, "generated_by": "workcell_builder", "review_required": True, "fake_hardware_first": True, "runtime_send_disabled_by_default": True},
@@ -402,7 +495,11 @@ def export_scene(scene_path: Path, output_dir: Path, validate: bool) -> dict[str
     if task_intent_path:
         task_intent_validation = _validate_task_intent(task_intent_path, scene_path)
         if task_intent_validation.get("status") == "FAIL":
-            warnings.append("Builder task intent validation failed; preserving metadata for review.")
+            details = "; ".join(str(e) for e in task_intent_validation.get("errors", []))
+            raise ValueError(
+                f"Task intent '{task_intent_path}' and layout '{resolved_layout_path}' cannot resolve "
+                f"identifier '<invalid task intent>': {details or 'validation failed'}"
+            )
         ti = task_intent_validation.get("task_intent", {})
         builder_task_intent = {
             "schema": ti.get("schema"),

--- a/tests/test_workcell_builder_existing_scene_regeneration.py
+++ b/tests/test_workcell_builder_existing_scene_regeneration.py
@@ -4,6 +4,7 @@ import json
 import shutil
 from pathlib import Path
 
+import pytest
 import yaml
 
 from scripts.workcell_builder_gui_workflow import generate_files_from_yaml
@@ -36,6 +37,7 @@ def test_existing_scene_regeneration_uses_saved_layout_without_rewriting_authore
     shutil.copytree(SCENE, scene)
     layout_path = scene / "layout" / "workcell_studio_layout.yaml"
     environment_path = scene / "environment.yaml"
+    task_intent_path = scene / "config" / "workcell_builder_task_intent.yaml"
 
     layout = yaml.safe_load(layout_path.read_text(encoding="utf-8"))
     items = {item["id"]: item for item in layout["items"]}
@@ -47,6 +49,7 @@ def test_existing_scene_regeneration_uses_saved_layout_without_rewriting_authore
     authored_before = {
         environment_path: environment_path.read_bytes(),
         layout_path: layout_path.read_bytes(),
+        task_intent_path: task_intent_path.read_bytes(),
     }
     first = generate_files_from_yaml(scene)
     assert first["ok"], first
@@ -71,6 +74,17 @@ def test_existing_scene_regeneration_uses_saved_layout_without_rewriting_authore
     assert destination["target_ref"] == target["id"]
     assert destination["transform_group"] == target["transform_group"]
     assert destination["pose"] == target["pose"]
+    generated_cell = yaml.safe_load(
+        (scene / "generated" / "cell_definition.yaml").read_text(encoding="utf-8")
+    )
+    place = generated_cell["task"]["place"]["target"]
+    assert place["id"] == "default_drop_zone"
+    assert place["layout_item_ref"] == "place_zone_default"
+    assert place["target_ref"] == "target_bin_default"
+    generated_destination = generated_cell["task"]["destinations"][0]
+    assert generated_destination["target_ref"] == "target_bin_default"
+    assert generated_destination["pose_xyz"] == edited_xyz
+    assert generated_destination["pose_rpy"] == target["pose"]["rpy"]
     assert {path: path.read_bytes() for path in authored_before} == authored_before
 
     first_generation = {
@@ -85,3 +99,46 @@ def test_existing_scene_regeneration_uses_saved_layout_without_rewriting_authore
     }
     assert second_generation == first_generation
     assert {path: path.read_bytes() for path in authored_before} == authored_before
+
+
+@pytest.mark.parametrize(
+    ("break_contract", "unresolved_id"),
+    [
+        ("missing_pick", "missing_pick_zone"),
+        ("broken_target_ref", "missing_target_bin"),
+        ("inconsistent_group", "target_bin_default"),
+        ("invalid_intent", "invalid/task-intent-schema"),
+    ],
+)
+def test_existing_scene_regeneration_blocks_unresolved_authored_task_contract(
+    tmp_path, break_contract, unresolved_id
+):
+    scene = tmp_path / "ur5_2f_test"
+    shutil.copytree(SCENE, scene)
+    layout_path = scene / "layout" / "workcell_studio_layout.yaml"
+    intent_path = scene / "config" / "workcell_builder_task_intent.yaml"
+
+    if break_contract == "missing_pick":
+        intent = yaml.safe_load(intent_path.read_text(encoding="utf-8"))
+        intent["pick"]["source"]["id"] = unresolved_id
+        intent_path.write_text(yaml.safe_dump(intent, sort_keys=False), encoding="utf-8")
+    elif break_contract == "broken_target_ref":
+        layout = yaml.safe_load(layout_path.read_text(encoding="utf-8"))
+        next(item for item in layout["items"] if item["id"] == "place_zone_default")["target_ref"] = unresolved_id
+        layout_path.write_text(yaml.safe_dump(layout, sort_keys=False), encoding="utf-8")
+    elif break_contract == "inconsistent_group":
+        layout = yaml.safe_load(layout_path.read_text(encoding="utf-8"))
+        next(item for item in layout["items"] if item["id"] == unresolved_id)["transform_group"] = "different_group"
+        layout_path.write_text(yaml.safe_dump(layout, sort_keys=False), encoding="utf-8")
+    else:
+        intent = yaml.safe_load(intent_path.read_text(encoding="utf-8"))
+        intent["schema"] = unresolved_id
+        intent_path.write_text(yaml.safe_dump(intent, sort_keys=False), encoding="utf-8")
+
+    result = generate_files_from_yaml(scene)
+
+    assert not result["ok"]
+    assert str(intent_path) in result["error"]
+    assert str(layout_path) in result["error"]
+    assert unresolved_id in result["error"]
+    assert not (scene / "generated" / "cell_definition.yaml").exists()


### PR DESCRIPTION
### Motivation
- Ensure exports use the canonical authored task-intent (`config/workcell_builder_task_intent.yaml`) and the current authored layout so edited pick/place bindings propagate to the generated runtime handoff.
- Prevent optimistic fallbacks that emitted a hard-coded `default_drop` pose when authored task or layout bindings were stale or inconsistent.
- Treat unresolved IDs, broken `target_ref` relationships, inconsistent transform groups, and invalid task-intent payloads as blocking errors to avoid producing misleading generated artifacts.

### Description
- Prefer the canonical authored intent path by updating `_find_task_intent` to check `config/workcell_builder_task_intent.yaml` before legacy and generated locations.
- Add `_resolve_authored_task` to map task-intent pick/place identifiers through `environment.task_zones` into `layout.items`, follow `place_zone.target_ref` to the authored target, and validate `transform_group`, pose completeness, and ID resolution, raising detailed `ValueError` messages that include the task-intent and layout file paths on failure.
- Replace the hard-coded `default_drop` destination with task fields and `destinations` populated from the resolved authored target pose and layout item references so `place_zone_default -> target_bin_default` is preserved in both `generated/environment_layout.yaml` and `generated/cell_definition.yaml`.
- Convert builder task-intent validation failures from warnings into blocking export errors with diagnostics naming the offending files and identifiers.
- Extend and update the focused regeneration test to assert generated layout and cell-definition destination parity, assert authored `config/workcell_builder_task_intent.yaml` remains byte-identical after regeneration, and add parameterized cases that verify export is blocked for missing pick IDs, broken `target_ref`, inconsistent transform groups, and invalid intent schemas.

### Testing
- Ran `pytest -q tests/test_workcell_builder_existing_scene_regeneration.py tests/test_workcell_builder_export_model.py tests/test_workcell_builder_gui_generate_action.py` and received `7 passed` (all tests passed).
- Verified `python3 -m py_compile scripts/export_builder_scene_to_cell_definition.py tests/test_workcell_builder_existing_scene_regeneration.py` completed without syntax errors.
- Ran `git diff --check` to ensure no whitespace/format issues and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b10f833a88331bb47bdb0520a6b6e)