### PR TITLE
Require canonical generated handoffs in explicit validation workflows

### DIFF
--- a/scripts/run_workcell_studio_web_edit_workflow.py
+++ b/scripts/run_workcell_studio_web_edit_workflow.py
@@ -105,8 +105,11 @@ def _generation_cmd(scene: Path) -> list[str]:
     ]
 
 
-def _validation_cmd(scene: Path) -> list[str]:
-    return [sys.executable, str(SCRIPT_DIR / "validate_builder_generated_scene.py"), str(scene), "--json"]
+def _validation_cmd(scene: Path, *, require_generated: bool = True) -> list[str]:
+    command = [sys.executable, str(SCRIPT_DIR / "validate_builder_generated_scene.py"), str(scene), "--json"]
+    if require_generated:
+        command.append("--require-generated")
+    return command
 
 
 def _readiness_cmd(output_dir: Path) -> list[str]:
@@ -266,7 +269,9 @@ def main(argv: list[str] | None = None) -> int:
         print("generation command/result: SKIPPED (pass --generate or --generate-and-validate)")
 
     if validate_requested:
-        validation_cmd = _validation_cmd(scene)
+        # Explicit workflow validation verifies the generated runtime handoff,
+        # rather than performing the validator's warning-only pre-export inspection.
+        validation_cmd = _validation_cmd(scene, require_generated=True)
         validation_rc = _run_step("selected-scene validation", validation_cmd)
         print(f"validation command/result: {_format_cmd(validation_cmd)} -> {'PASS' if validation_rc == 0 else 'FAIL'}")
         if validation_rc != 0:

--- a/scripts/validate_builder_generated_scene.py
+++ b/scripts/validate_builder_generated_scene.py
@@ -30,7 +30,29 @@ def _find_task_intent(scene_path: Path) -> Path | None:
     return None
 
 
-def validate_scene(scene_path: Path) -> dict[str, Any]:
+def _run_generated_validator(path: Path, validator_name: str) -> tuple[dict[str, Any], str | None]:
+    run = subprocess.run(
+        ["python3", str(SCRIPT_DIR / validator_name), str(path), "--json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    try:
+        report = json.loads(run.stdout) if run.stdout.strip() else {}
+    except json.JSONDecodeError as exc:
+        report = {}
+        return report, f"{path.relative_to(path.parent.parent)} validator returned invalid JSON: {exc}"
+
+    if run.returncode != 0 or report.get("result") == "FAIL":
+        details = report.get("errors") if isinstance(report.get("errors"), list) else []
+        detail = "; ".join(str(item) for item in details if str(item).strip())
+        if not detail:
+            detail = run.stderr.strip() or run.stdout.strip() or f"exit code {run.returncode}"
+        return report, f"{path.relative_to(path.parent.parent)} validation failed: {detail}"
+    return report, None
+
+
+def validate_scene(scene_path: Path, *, require_generated: bool = False) -> dict[str, Any]:
     checks: list[dict[str, Any]] = []
     warnings: list[str] = []
     errors: list[str] = []
@@ -68,19 +90,27 @@ def validate_scene(scene_path: Path) -> dict[str, Any]:
 
     exported_cell = scene_path / "generated" / "cell_definition.yaml"
     exported_layout = scene_path / "generated" / "environment_layout.yaml"
-    checks.append({"check": "generated/cell_definition.yaml present", "ok": exported_cell.is_file(), "optional": True})
-    checks.append({"check": "generated/environment_layout.yaml present", "ok": exported_layout.is_file(), "optional": True})
+    checks.append({"check": "generated/cell_definition.yaml present", "ok": exported_cell.is_file(), "optional": not require_generated})
+    checks.append({"check": "generated/environment_layout.yaml present", "ok": exported_layout.is_file(), "optional": not require_generated})
     export_validation = {}
     if exported_cell.is_file():
-        run = subprocess.run(["python3", str(SCRIPT_DIR / "validate_cell_definition.py"), str(exported_cell), "--json"], capture_output=True, text=True, check=False)
-        export_validation["cell_definition"] = json.loads(run.stdout) if run.stdout.strip() else {"result": "FAIL"}
+        export_validation["cell_definition"], failure = _run_generated_validator(
+            exported_cell, "validate_cell_definition.py"
+        )
+        if failure:
+            errors.append(failure)
     else:
-        warnings.append("generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh")
+        message = "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh"
+        (errors if require_generated else warnings).append(message)
     if exported_layout.is_file():
-        run = subprocess.run(["python3", str(SCRIPT_DIR / "validate_environment_layout.py"), str(exported_layout), "--json"], capture_output=True, text=True, check=False)
-        export_validation["environment_layout"] = json.loads(run.stdout) if run.stdout.strip() else {"result": "FAIL"}
+        export_validation["environment_layout"], failure = _run_generated_validator(
+            exported_layout, "validate_environment_layout.py"
+        )
+        if failure:
+            errors.append(failure)
     else:
-        warnings.append("generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh")
+        message = "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh"
+        (errors if require_generated else warnings).append(message)
 
     task_intent_report = {}
     task_flow_summary: dict[str, Any] = {}
@@ -176,9 +206,14 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("scene_path", type=Path)
     ap.add_argument("--json", action="store_true")
+    ap.add_argument(
+        "--require-generated",
+        action="store_true",
+        help="Require both canonical generated handoffs and fail when either is missing or invalid.",
+    )
     args = ap.parse_args()
 
-    report = validate_scene(args.scene_path)
+    report = validate_scene(args.scene_path, require_generated=args.require_generated)
     if args.json:
         print(json.dumps(report, indent=2))
     else:

--- a/tests/test_validate_builder_generated_scene.py
+++ b/tests/test_validate_builder_generated_scene.py
@@ -4,6 +4,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -40,6 +42,53 @@ def test_before_export_artifacts_are_warn_not_fail(tmp_path: Path) -> None:
     assert any("generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh" in w for w in report["warnings"])
     assert all("cell_definition.yaml" not in e for e in report["errors"])
     assert all("environment_layout.yaml" not in e for e in report["errors"])
+
+
+@pytest.mark.parametrize(
+    ("present_filename", "missing_filename"),
+    [
+        ("cell_definition.yaml", "environment_layout.yaml"),
+        ("environment_layout.yaml", "cell_definition.yaml"),
+    ],
+)
+def test_require_generated_fails_when_either_canonical_handoff_is_missing(
+    tmp_path: Path, present_filename: str, missing_filename: str
+) -> None:
+    _write_required_scene_files(tmp_path)
+    generated = tmp_path / "generated"
+    generated.mkdir()
+    schema = "cell_definition/v1" if present_filename == "cell_definition.yaml" else "environment_layout/v1"
+    (generated / present_filename).write_text(f"schema_version: {schema}\n", encoding="utf-8")
+
+    report = validator.validate_scene(tmp_path, require_generated=True)
+
+    assert report["ok"] is False
+    assert any(f"generated/{missing_filename} missing" in error for error in report["errors"])
+    checks = {check["check"]: check for check in report["checks"]}
+    assert checks[f"generated/{missing_filename} present"].get("optional") is False
+
+
+@pytest.mark.parametrize(
+    ("filename", "invalid_content", "expected_error"),
+    [
+        ("cell_definition.yaml", "schema_version: wrong\n", "generated/cell_definition.yaml validation failed"),
+        ("environment_layout.yaml", "schema_version: wrong\n", "generated/environment_layout.yaml validation failed"),
+    ],
+)
+def test_require_generated_fails_when_canonical_handoff_is_invalid(
+    tmp_path: Path, filename: str, invalid_content: str, expected_error: str
+) -> None:
+    _write_required_scene_files(tmp_path)
+    generated = tmp_path / "generated"
+    generated.mkdir()
+    (generated / "cell_definition.yaml").write_text("schema_version: cell_definition/v1\n", encoding="utf-8")
+    (generated / "environment_layout.yaml").write_text("schema_version: environment_layout/v1\n", encoding="utf-8")
+    (generated / filename).write_text(invalid_content, encoding="utf-8")
+
+    report = validator.validate_scene(tmp_path, require_generated=True)
+
+    assert report["ok"] is False
+    assert any(expected_error in error for error in report["errors"])
 
 
 def test_after_export_artifacts_present_are_pass(tmp_path: Path) -> None:

--- a/tests/test_workcell_studio_web_edit_generate_validate_workflow.py
+++ b/tests/test_workcell_studio_web_edit_generate_validate_workflow.py
@@ -81,7 +81,15 @@ def test_generate_and_validate_triggers_generation_validation_path(workflow, sce
     assert "validation requested: True" in out
     assert "== scene generation ==" in out
     assert "== selected-scene validation ==" in out
-    assert any("validate_builder_generated_scene.py" in " ".join(cmd) for cmd in recorder.commands)
+    validation_commands = [cmd for cmd in recorder.commands if "validate_builder_generated_scene.py" in " ".join(cmd)]
+    assert validation_commands
+    assert "--require-generated" in validation_commands[0]
+
+
+def test_validation_command_can_retain_warning_only_pre_export_contract(workflow, scene):
+    command = workflow._validation_cmd(scene, require_generated=False)
+
+    assert "--require-generated" not in command
 
 
 def test_false_generation_result_returns_nonzero_and_skips_validation(workflow, scene, monkeypatch, capsys):


### PR DESCRIPTION
### Motivation
- Make explicit generate/validate workflows fail fast when the canonical generated handoffs are missing or invalid instead of silently treating them as warnings. 
- Preserve the existing warning-only behavior for callers that intentionally inspect a pre-generation physical scene.

### Description
- Added a `--require-generated` CLI flag to `scripts/validate_builder_generated_scene.py` and a `require_generated` parameter to `validate_scene()` to treat missing/invalid `generated/cell_definition.yaml` and `generated/environment_layout.yaml` as errors instead of warnings when requested. 
- Implemented `_run_generated_validator()` to invoke subordinate validators (`validate_cell_definition.py` and `validate_environment_layout.py`), parse their JSON output, and surface validation failures and messages into the top-level `errors` list. 
- Updated `scripts/run_workcell_studio_web_edit_workflow.py` so `_validation_cmd()` includes `--require-generated` for explicit workflow validation paths (e.g. `--generate`, `--validate`, `--generate-and-validate`). 
- Added focused tests in `tests/test_validate_builder_generated_scene.py` and `tests/test_workcell_studio_web_edit_generate_validate_workflow.py` covering pre-export warning behavior, missing/invalid canonical handoffs, and the workflow's validation command construction.

### Testing
- Ran focused unit tests: `python3 -m pytest -q tests/test_validate_builder_generated_scene.py tests/test_workcell_studio_web_edit_generate_validate_workflow.py` and all tests passed (`21 passed`).
- Verified Python syntax with `python3 -m py_compile scripts/validate_builder_generated_scene.py scripts/run_workcell_studio_web_edit_workflow.py` (passed).
- Ran `git diff --check` before committing (no whitespace/errors).
- No GUI/ROS runtime launches were performed because this change only affects CLI validation and workflow orchestration; fake-hardware defaults and safety were not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b1548aab08331a11c42d674123011)