### PR TITLE
M1: add friendly synchronized Selected Item card

### DIFF
--- a/tests/test_embedded_web3d_editor_bridge_static.py
+++ b/tests/test_embedded_web3d_editor_bridge_static.py
@@ -161,8 +161,7 @@ def test_qt_poll_accepts_only_final_valid_browser_selection_and_explicit_clear()
         'editor_state.value(QStringLiteral("sceneId"))',
         'id == browser_selected_id',
         'selection_diagnostics.value(QStringLiteral("objectPresent")).toBool()',
-        '!selection_diagnostics.value(QStringLiteral("diagnosticOnly")).toBool()',
-        '!selection_diagnostics.value(QStringLiteral("helperOrOverlay")).toBool()',
+        'preview_item_by_id(browser_selected_id) != nullptr',
         'browser_scene_id == identity.scene_id',
     ]:
         assert token in poll

--- a/tests/test_workcell_builder_selected_item_card.py
+++ b/tests/test_workcell_builder_selected_item_card.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MAIN = (ROOT / "workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text(encoding="utf-8")
+HEADER = (ROOT / "workcell_builder/workcell_builder/gui/mainwindow.h").read_text(encoding="utf-8")
+PREVIEW = (ROOT / "workcell_builder/workcell_builder/gui/scene_preview_widget.cpp").read_text(encoding="utf-8")
+
+
+def test_compact_card_sits_between_existing_hierarchy_and_layers():
+    setup = MAIN.split('hierarchy_layout->addWidget(scene_hierarchy_tree_);', 1)[1]
+    setup = setup.split('hierarchy_layout->addWidget(preview_layers_group);', 1)[0]
+    assert 'studioSelectedItemCard' in setup
+    assert '<b>Selected Item</b>' in setup
+    assert 'new QGroupBox("Layers", hierarchy_card)' in MAIN
+    assert "QDockWidget" not in setup
+
+
+def test_hierarchy_and_web3d_share_stable_id_selection():
+    hierarchy = MAIN.split("void MainWindow::on_hierarchy_item_selected", 1)[1].split(
+        "void MainWindow::refresh_selected_item_card", 1
+    )[0]
+    assert "TreeRoleId" in hierarchy
+    assert "apply_scene_selection(selected_id" in hierarchy
+    assert "select_preview_item(selected_id)" in MAIN
+    assert "__WORKCELL_EDITOR_API_V1__&&window.__WORKCELL_EDITOR_API_V1__.selectItem" in PREVIEW
+    assert "scene_hierarchy_tree_->setCurrentItem(matched)" in MAIN
+
+
+def test_overlay_selection_is_inspect_only_and_can_enable_hidden_layer():
+    assert 'preview_item->source_layer == QStringLiteral("overlay")' in MAIN
+    assert "preview_layer_overlays_helpers_box_->setChecked(true)" in MAIN
+    assert 'preview_item.target_ref = semantic_yaml_scalar(node["target_ref"])' in MAIN
+    assert "preview_item.editable = false" in MAIN
+    assert "preview_item.locked = true" in MAIN
+    assert "This area follows %1. Move the bin instead." in MAIN
+    assert "preview_item_by_id(browser_selected_id) != nullptr" in PREVIEW
+
+
+def test_card_is_friendly_and_contextual_without_developer_metadata():
+    card = MAIN.split("void MainWindow::refresh_selected_item_card()", 1)[1].split(
+        "void MainWindow::apply_scene3d_product_view_layer_defaults", 1
+    )[0]
+    for text in [
+        "Editable physical item",
+        "Read-only destination area",
+        "Generated preview · read-only",
+        "Position derived from %1",
+        "Destination group: %1",
+        "Select an item in the hierarchy or 3D view.",
+    ]:
+        assert text in card
+    for technical in ["source_layer", "render_policy", "source_path", "mesh_load_warning"]:
+        assert f'QStringLiteral("{technical}' not in card
+    assert "scene_move_mode_button_" in HEADER
+    assert "scene_rotate_mode_button_" in HEADER
+
+
+def test_selection_poll_remains_scene_and_request_token_guarded():
+    poll = PREVIEW.split("void ScenePreviewWidget::poll_embedded_editor_events()", 1)[1].split("#else", 1)[0]
+    assert "embedded_web_identity_is_current(identity)" in poll
+    assert "state_request_token != embedded_editor_state_request_token_" in poll
+    assert "browser_scene_id == identity.scene_id" in poll

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -2137,6 +2137,27 @@ void MainWindow::setup_studio_shell()
   scene_hierarchy_tree_->setColumnWidth(1, 120);
   scene_hierarchy_tree_->setColumnWidth(2, 72);
   hierarchy_layout->addWidget(scene_hierarchy_tree_);
+  auto * selected_item_card = new QFrame(hierarchy_card);
+  selected_item_card->setObjectName("studioSelectedItemCard");
+  selected_item_card->setFrameShape(QFrame::StyledPanel);
+  auto * selected_item_layout = new QVBoxLayout(selected_item_card);
+  selected_item_layout->setContentsMargins(10, 8, 10, 8);
+  selected_item_layout->setSpacing(2);
+  selected_item_layout->addWidget(new QLabel("<b>Selected Item</b>", selected_item_card));
+  selected_item_name_label_ = new QLabel("No selection", selected_item_card);
+  selected_item_name_label_->setObjectName("selectedItemName");
+  selected_item_summary_label_ = new QLabel("Select an item in the hierarchy or 3D view.", selected_item_card);
+  selected_item_summary_label_->setWordWrap(true);
+  selected_item_id_label_ = new QLabel(selected_item_card);
+  selected_item_id_label_->setStyleSheet("color: #8aa0b5; font-size: 11px;");
+  selected_item_reason_label_ = new QLabel(selected_item_card);
+  selected_item_reason_label_->setWordWrap(true);
+  selected_item_reason_label_->setStyleSheet("color: #c9a227;");
+  selected_item_layout->addWidget(selected_item_name_label_);
+  selected_item_layout->addWidget(selected_item_summary_label_);
+  selected_item_layout->addWidget(selected_item_id_label_);
+  selected_item_layout->addWidget(selected_item_reason_label_);
+  hierarchy_layout->addWidget(selected_item_card);
   auto * preview_layers_group = new QGroupBox("Layers", hierarchy_card);
   auto * preview_layers_layout = new QVBoxLayout(preview_layers_group);
   preview_layer_editable_layout_box_ = new QCheckBox("editable layout", preview_layers_group);
@@ -2398,6 +2419,8 @@ void MainWindow::setup_studio_shell()
   auto * place_mode_button = make_primary_button("Place Asset"); primary_controls->addWidget(place_mode_button);
   auto * move_mode_button = make_primary_button("Move"); primary_controls->addWidget(move_mode_button);
   auto * rotate_mode_button = make_primary_button("Rotate"); primary_controls->addWidget(rotate_mode_button);
+  scene_move_mode_button_ = move_mode_button;
+  scene_rotate_mode_button_ = rotate_mode_button;
   for (auto * button : {select_mode_button, move_mode_button, rotate_mode_button}) button->setCheckable(true);
   select_mode_button->setChecked(true);
   connect(scene_preview_widget_, &ScenePreviewWidget::authoring_mode_changed, this,
@@ -6467,6 +6490,7 @@ void MainWindow::apply_scene_selection(const QString & id, const QString & role,
     selection_update_guard_ = false;
     sync_selected_item_state();
     refresh_selected_scene_item_labels(selected_item_state_);
+    refresh_selected_item_card();
     append_studio_log("Selected item: <none> (unknown)");
     return;
   }
@@ -6582,6 +6606,7 @@ void MainWindow::apply_scene_selection(const QString & id, const QString & role,
   }
 
   const auto selected_state = current_selected_scene_item();
+  refresh_selected_item_card();
   const QString selected_scene_name_for_log = selected_scene_state_.valid ? selected_scene_state_.name : QStringLiteral("unknown");
   const QString selected_source_layer_for_log = selected_state.source_layer.isEmpty() ? QStringLiteral("unknown") : selected_state.source_layer;
   append_studio_log(QString("Scene3D selection changed: scene=%1 id=%2 editable=%3 locked=%4 source_layer=%5")
@@ -8373,7 +8398,61 @@ void MainWindow::on_hierarchy_item_selected(QTreeWidgetItem * item)
   if (!item || selection_update_guard_) return;
   const QString selected_id = item->data(0, TreeRoleId).toString().trimmed();
   const QString selected_role = item->data(0, TreeRoleRole).toString().trimmed();
+  const auto * preview_item = scene_preview_widget_ ? scene_preview_widget_->preview_item_by_id(selected_id) : nullptr;
+  if (preview_item && preview_item->source_layer == QStringLiteral("overlay") &&
+      preview_layer_overlays_helpers_box_ && !preview_layer_overlays_helpers_box_->isChecked()) {
+    // An explicit hierarchy choice is deterministic opt-in to seeing that
+    // helper. Hidden helpers never participate in ordinary canvas picking.
+    preview_layer_overlays_helpers_box_->setChecked(true);
+  }
   apply_scene_selection(selected_id, selected_role, false, true);
+}
+
+void MainWindow::refresh_selected_item_card()
+{
+  if (!selected_item_name_label_) return;
+  const QString id = current_selected_scene_item_id_.trimmed();
+  const auto * item = scene_preview_widget_ ? scene_preview_widget_->preview_item_by_id(id) : nullptr;
+  if (id.isEmpty() || !item) {
+    selected_item_name_label_->setText(QStringLiteral("No selection"));
+    selected_item_summary_label_->setText(QStringLiteral("Select an item in the hierarchy or 3D view."));
+    selected_item_id_label_->clear();
+    selected_item_reason_label_->clear();
+    if (scene_move_mode_button_) scene_move_mode_button_->setEnabled(false);
+    if (scene_rotate_mode_button_) scene_rotate_mode_button_->setEnabled(false);
+    return;
+  }
+
+  const QString friendly_name = item->display_name.trimmed().isEmpty() ? id : item->display_name.trimmed();
+  selected_item_name_label_->setText(friendly_name);
+  selected_item_id_label_->setText(QStringLiteral("ID: %1").arg(id));
+  selected_item_id_label_->setToolTip(QStringLiteral("Stable scene item ID: %1").arg(id));
+  const bool derived_area = !item->target_ref.trimmed().isEmpty();
+  const bool generated = item->source_layer != QStringLiteral("editable_layout") && !derived_area;
+  QString kind = derived_area ? QStringLiteral("Read-only destination area") :
+    generated ? QStringLiteral("Generated preview · read-only") : QStringLiteral("Editable physical item");
+  QStringList details{kind};
+  if (derived_area) {
+    const auto * target = scene_preview_widget_->preview_item_by_id(item->target_ref);
+    details << QStringLiteral("Follows: %1").arg(target && !target->display_name.trimmed().isEmpty() ? target->display_name : item->target_ref);
+    details << QStringLiteral("Position derived from %1").arg(item->target_ref);
+  } else if (!generated) {
+    details << QStringLiteral("Position: X %1 · Y %2 · Z %3 · Yaw %4°")
+      .arg(item->x, 0, 'f', 3).arg(item->y, 0, 'f', 3).arg(item->z, 0, 'f', 3)
+      .arg(qRound(item->yaw * 180.0 / 3.14159265358979323846));
+    if (!item->transform_group.trimmed().isEmpty())
+      details << QStringLiteral("Destination group: %1").arg(item->transform_group);
+  }
+  selected_item_summary_label_->setText(details.join(QStringLiteral("\n")));
+  const bool editable = item->editable && !item->locked && !derived_area;
+  const QString reason = derived_area
+    ? QStringLiteral("This area follows %1. Move the bin instead.").arg(
+        scene_preview_widget_->preview_item_by_id(item->target_ref) ?
+          scene_preview_widget_->preview_item_by_id(item->target_ref)->display_name : item->target_ref)
+    : (!editable ? QStringLiteral("This generated item is read-only.") : QString());
+  selected_item_reason_label_->setText(reason);
+  if (scene_move_mode_button_) { scene_move_mode_button_->setEnabled(editable); scene_move_mode_button_->setToolTip(reason); }
+  if (scene_rotate_mode_button_) { scene_rotate_mode_button_->setEnabled(editable); scene_rotate_mode_button_->setToolTip(reason); }
 }
 
 
@@ -11459,9 +11538,38 @@ void MainWindow::populate_scene_hierarchy()
     }
   }
 
+  // Preserve authored relationship context for friendly inspection without
+  // exposing the source file or schema in the card. A destination area that
+  // follows a physical target is derived and therefore never transformable.
+  YAML::Node authored_layout;
+  if (read_yaml(d / "layout" / "workcell_studio_layout.yaml", &authored_layout)) {
+    const YAML::Node items = authored_layout["items"] ? authored_layout["items"] : authored_layout["placed_assets"];
+    if (items && items.IsSequence()) {
+      for (const auto & node : items) {
+        if (!node || !node.IsMap()) continue;
+        const QString authored_id = semantic_yaml_scalar(node["id"]);
+        for (auto & preview_item : preview_items) {
+          if (preview_item.id != authored_id) continue;
+          preview_item.target_ref = semantic_yaml_scalar(node["target_ref"]);
+          preview_item.transform_group = semantic_yaml_scalar(node["transform_group"]);
+          if (!preview_item.target_ref.isEmpty()) {
+            preview_item.editable = false;
+            preview_item.locked = true;
+            preview_item.source_layer = QStringLiteral("overlay");
+            preview_item.lock_reason = QStringLiteral("Derived destination area; move its linked target instead.");
+          }
+          break;
+        }
+      }
+    }
+  }
+
   scene_hierarchy_tree_->clear();
   for (const auto & p : preview_items) {
-    if (allowed_scene_roles.contains(p.role) && include_preview_item_in_hierarchy(p)) {
+    // Keep one identity tree even when helpers are visually hidden. Selecting
+    // such a row explicitly opts into its layer in on_hierarchy_item_selected().
+    if (allowed_scene_roles.contains(p.role) &&
+        (include_preview_item_in_hierarchy(p) || p.source_layer == QStringLiteral("overlay"))) {
       add_tree_node(p);
     }
   }

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -393,6 +393,7 @@ private:
   void populate_asset_catalog();
   void import_stl_to_asset_library();
   void on_hierarchy_item_selected(QTreeWidgetItem * item);
+  void refresh_selected_item_card();
   void on_asset_filter_changed(int index);
   void open_add_asset_dialog();
   void refresh_add_asset_dialog_details();
@@ -528,6 +529,12 @@ private:
   QPushButton * scene_workflow_recommendation_button_{ nullptr };
   QMenu * scene_workflow_recommendation_menu_{ nullptr };
   QTreeWidget * scene_hierarchy_tree_{ nullptr };
+  QLabel * selected_item_name_label_{ nullptr };
+  QLabel * selected_item_summary_label_{ nullptr };
+  QLabel * selected_item_id_label_{ nullptr };
+  QLabel * selected_item_reason_label_{ nullptr };
+  QPushButton * scene_move_mode_button_{ nullptr };
+  QPushButton * scene_rotate_mode_button_{ nullptr };
   QTreeWidget * asset_catalog_tree_{ nullptr };
   QTreeWidget * scene_files_tree_{ nullptr };
   QComboBox * asset_filter_combo_{ nullptr };

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -66,7 +66,8 @@ QByteArray serialized_preview_item(const ScenePreviewWidget::PreviewItem & item)
   write_bool(item.mesh_available);
   stream << item.mesh_load_warning;
   write_bool(item.selectable); write_bool(item.editable); write_bool(item.locked);
-  stream << item.lock_reason << item.metadata_tags << item.source_layer << item.active_visual_source;
+  stream << item.lock_reason << item.metadata_tags << item.target_ref << item.transform_group
+         << item.source_layer << item.active_visual_source;
   write_bool(item.linked_to_editable_layout_state); write_bool(item.metadata_complete);
   write_string_list(item.warnings);
   write_bool(item.has_mesh_metadata);
@@ -2391,10 +2392,13 @@ void ScenePreviewWidget::poll_embedded_editor_events()
         }
       }
     }
+    // scene_context_changed selections are invalidated by the identity/token
+    // guards above. Helpers and derived overlays are valid inspection selections. Editing is
+    // still governed by the payload's editable/locked contract; rejecting them
+    // here made the embedded viewer and Qt hierarchy disagree about identity.
     const bool valid_browser_selection = matching_selection_event && scene_identity_matches &&
       selection_diagnostics.value(QStringLiteral("objectPresent")).toBool() &&
-      !selection_diagnostics.value(QStringLiteral("diagnosticOnly")).toBool() &&
-      !selection_diagnostics.value(QStringLiteral("helperOrOverlay")).toBool();
+      preview_item_by_id(browser_selected_id) != nullptr;
     if (valid_browser_selection && browser_selected_id != selected_preview_item_id_) {
       selected_preview_item_id_ = browser_selected_id;
       emit preview_item_selected(browser_selected_id, matching_item_type);

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -63,6 +63,8 @@ public:
     bool locked{ false };
     QString lock_reason;
     QString metadata_tags;
+    QString target_ref;
+    QString transform_group;
     QString source_layer;
     QString active_visual_source;
     bool linked_to_editable_layout_state{ false };


### PR DESCRIPTION
### Motivation
- Users in the embedded Product View could not reliably identify or inspect non-bin items and derived overlays because hierarchy ↔ Web3D selection could disagree or produce stale selections. 
- Provide a compact, friendly inspection surface that fits between the existing Scene Hierarchy and Layers without adding a new sidebar or inspector. 
- Preserve the existing authoring, generation, and safety contracts while making selection and inspection trustworthy in the canonical ur5_2f_test workflow.

### Description
- Added a compact "Selected Item" card under the Scene Hierarchy and above Layers with friendly name, stable ID, concise type/kind, pose or linked-target context, and a short read-only reason; UI created in `mainwindow.cpp`/`mainwindow.h` and uses existing layout/controls only. 
- Synchronized selection both ways using the existing `ScenePreviewWidget::select_preview_item()` and the embedded Web3D bridge, and guarded browser callbacks with scene identity and request-token checks to avoid stale or cross-scene selection updates (`scene_preview_widget.cpp` poll logic adjusted to accept payload-present items). 
- Brought authored `target_ref` and `transform_group` context from `layout/workcell_studio_layout.yaml` into preview metadata (preview items gain `target_ref`/`transform_group`) and treat derived place zones as inspect-only by disabling Move/Rotate with a friendly reason and showing their linked target in the card. 
- Made explicit hierarchy clicks on a hidden overlay deterministically enable the existing overlays/helpers layer and select the overlay for read-only inspection, while hidden overlays remain excluded from ordinary canvas picking; no new trees, dialogs, or persistent sidebars were added and authored/YAML/generation/runtime paths were not modified.

### Testing
- Ran focused static/CI tests: `python3 -m pytest -q tests/test_embedded_web3d_editor_bridge_static.py tests/test_scene_preview_widget_refresh_lifecycle.py tests/test_workcell_builder_product_view_defaults.py tests/test_workcell_builder_selected_item_card.py`, and all tests passed (43 passed). 
- Ran `git diff --check` to ensure no whitespace issues and validated the new static test file presence; these checks passed in the container. 
- Did not run `colcon build --packages-select workcell_builder` because ROS 2 Humble is not available in this environment, and manual display-driven acceptance (screenshots and interactive checks for target bin, yellow object, and place zone) is BLOCKED because the container has no DISPLAY; manual checklist remains the final acceptance step on a display-enabled Humble workstation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b27016438833183c61b74b107136c)