### PR TITLE
M1: rebuild Web3D bundle for exact selection identity

### DIFF
--- a/workcell_studio_web/viewer/dist/viewer.bundle.js
+++ b/workcell_studio_web/viewer/dist/viewer.bundle.js
@@ -39292,14 +39292,16 @@ function pushEditorEvent(type, payload = {}) {
 function currentSelectionDiagnostics() {
   const id = String(state.selected || "");
   const rendered = renderedById(id);
+  const editOwner = canonicalEditOwnerRendered(rendered);
   const item = rendered?.item || null;
   return {
     sceneId: sceneId(),
     selectedItemId: id,
+    editOwnerItemId: editOwner?.item?.id || "",
     renderIdentity: id,
     selectedItemType: rendered ? itemType(item) : "",
     selectable: Boolean(rendered && isNormalSelectableRendered(rendered)),
-    editable: Boolean(item && canEditItem(item)),
+    editable: Boolean(item && editOwner === rendered && canEditItem(item)),
     locked: Boolean(item?.locked),
     sourceLayer: String(item?.source_layer || ""),
     activeVisualSource: String(item?.active_visual_source || ""),
@@ -39310,7 +39312,8 @@ function currentSelectionDiagnostics() {
 }
 function editorState() {
   const rendered = renderedById(state.selected);
-  return { ready: Boolean(state.sceneJson && state.three?.scene), sceneId: sceneId(), selectedItemId: state.selected || "", selectedItemType: rendered ? itemType(rendered.item) : "", selectedEditable: Boolean(rendered && rendered.item && canEditItem(rendered["item"])), selectionDiagnostics: currentSelectionDiagnostics(), dirty: state.dirtyTransforms.size > 0, dirtyCount: state.dirtyTransforms.size, canUndo: state.undoStack.length > 0, canRedo: state.redoStack.length > 0, mode: state.editorMode, error: state.editorError || "" };
+  const editOwner = canonicalEditOwnerRendered(rendered);
+  return { ready: Boolean(state.sceneJson && state.three?.scene), sceneId: sceneId(), selectedItemId: state.selected || "", editOwnerItemId: editOwner?.item?.id || "", selectedItemType: rendered ? itemType(rendered.item) : "", selectedEditable: Boolean(rendered && editOwner === rendered && rendered.item && canEditItem(rendered["item"])), selectionDiagnostics: currentSelectionDiagnostics(), dirty: state.dirtyTransforms.size > 0, dirtyCount: state.dirtyTransforms.size, canUndo: state.undoStack.length > 0, canRedo: state.redoStack.length > 0, mode: state.editorMode, error: state.editorError || "" };
 }
 function emitDirtyChanged() {
   pushEditorEvent("dirty_changed", { dirty: state.dirtyTransforms.size > 0, dirtyCount: state.dirtyTransforms.size, canUndo: state.undoStack.length > 0, canRedo: state.redoStack.length > 0 });
@@ -39526,42 +39529,15 @@ function derivedTransformTargetId(item) {
 function isDerivedTransformDependent(item) {
   return Boolean(derivedTransformTargetId(item));
 }
-function canonicalSelectionRendered(rendered) {
-  const item = rendered?.item;
-  const derivedTarget = renderedById(derivedTransformTargetId(item));
-  if (derivedTarget && canEditItem(derivedTarget.item))
-    return derivedTarget;
-  if (!item?.id || !isGeneratedUrdfItem(item) || isGeneratedRobotItem(item) || isGeneratedToolOrGripperItem(item))
-    return rendered || null;
-  const explicitIds = [
-    item.canonical_scene_item_id,
-    item.canonical_item_id,
-    item.layout_item_ref,
-    item.authored_item_id,
-    item.scene_item_id,
-    item.object_ref,
-    item.support_surface_ref,
-    item.camera_id
-  ].map((value) => String(value || "").trim()).filter(Boolean);
-  for (const id of explicitIds) {
-    const candidate = renderedById(id);
-    if (candidate && !isGeneratedUrdfItem(candidate.item) && isNormalSelectableRendered(candidate))
-      return candidate;
-  }
-  const group = viewerGroupFor(item);
-  const authored = state.objects.filter(
-    (candidate) => candidate !== rendered && !isGeneratedUrdfItem(candidate.item) && isNormalSelectableRendered(candidate) && viewerGroupFor(candidate.item) === group
-  );
-  if (!authored.length)
-    return rendered;
-  const generatedIdentity = viewerGroupIdentity(item);
-  const score = (candidate) => {
-    const candidateIdentity = viewerGroupIdentity(candidate.item);
-    const semanticTokens = group === "sensors" ? ["realsense", "camera", "sensor", "depth", "rgbd"] : ["support surface", "table", "tabletop", "workbench", "fixture"];
-    return semanticTokens.reduce((total, token) => total + (generatedIdentity.includes(token) && candidateIdentity.includes(token) ? 1 : 0), 0);
-  };
-  const ranked = authored.map((candidate) => ({ candidate, score: score(candidate) })).sort((a, b) => b.score - a.score);
-  return ranked[0].score > 0 && (ranked.length === 1 || ranked[0].score > ranked[1].score) ? ranked[0].candidate : rendered;
+function inspectionSelectionRendered(rendered) {
+  return rendered?.item?.id ? rendered : null;
+}
+function canonicalEditOwnerRendered(rendered) {
+  const derivedTarget = renderedById(derivedTransformTargetId(rendered?.item));
+  return derivedTarget && canEditItem(derivedTarget.item) ? derivedTarget : inspectionSelectionRendered(rendered);
+}
+function selectionIsEditable(rendered) {
+  return Boolean(rendered && canonicalEditOwnerRendered(rendered) === rendered && canEditItem(rendered.item));
 }
 function transformFromObject(object) {
   return { pose: { xyz: { x: object.position.x, y: object.position.y, z: object.position.z }, rpy: { x: object.rotation.x, y: object.rotation.y, z: object.rotation.z } }, scale: { x: object.scale.x, y: object.scale.y, z: object.scale.z } };
@@ -39647,7 +39623,7 @@ function applyTransformChanges(changes, { updateDirty = false } = {}) {
 function markDirtyTransform(rendered, next, { pushHistory = true, oldTransform = null, snapOptions = void 0, memberStarts = null } = {}) {
   if (!rendered || !canEditItem(rendered.item))
     return false;
-  const owner = canonicalSelectionRendered(rendered);
+  const owner = canonicalEditOwnerRendered(rendered);
   if (owner && owner !== rendered) {
     const dependentBefore = oldTransform || state.dirtyTransforms.get(rendered.item.id)?.newTransform || transformFromObject(rendered.object3d);
     const ownerBefore = state.dirtyTransforms.get(owner.item.id)?.newTransform || transformFromObject(owner.object3d);
@@ -42121,7 +42097,7 @@ function rankedPickingCandidates(hits) {
   const seen = /* @__PURE__ */ new Set();
   for (const hit of hits || []) {
     const item = hit?.object?.userData?.item || hit?.object?.parent?.userData?.item;
-    const rendered = canonicalSelectionRendered(item?.id ? renderedById(item.id) : null);
+    const rendered = inspectionSelectionRendered(item?.id ? renderedById(item.id) : null);
     if (!rendered?.item?.id || seen.has(rendered.item.id))
       continue;
     seen.add(rendered.item.id);
@@ -42132,9 +42108,10 @@ function rankedPickingCandidates(hits) {
 function selectObject(id) {
   const requestedId = String(id || "");
   const rawRequested = requestedId ? renderedById(requestedId) : null;
-  const requested = canonicalSelectionRendered(rawRequested);
+  const requested = inspectionSelectionRendered(rawRequested);
   const selectionId = requested?.item?.id || requestedId;
-  if (requestedId && !isNormalSelectableRendered(requested)) {
+  const explicitlySelectable = requested && !isDiagnosticOnlyItem(requested.item) && requested.item.selectable !== false && (isNormalSelectableRendered(requested) || isOverlayPolicyItem(requested.item) || isTaskOnlyHelperItem(requested.item));
+  if (requestedId && !explicitlySelectable) {
     const reason = requested ? "diagnostic_helper_or_non_selectable" : "missing_render_identity";
     state.ignoredSelectionKeys || (state.ignoredSelectionKeys = /* @__PURE__ */ new Set());
     const warningKey = `${sceneId()}|${requestedId}|${reason}`;
@@ -42390,7 +42367,7 @@ function attachTransformGizmo(rendered) {
   const gizmo = state.three.transformControls;
   if (!gizmo)
     return;
-  if (rendered && canEditItem(rendered.item)) {
+  if (selectionIsEditable(rendered)) {
     gizmo.attach(rendered.object3d);
     gizmo.visible = true;
     gizmo.enabled = true;
@@ -42443,7 +42420,7 @@ function currentTransformFromInputs(container) {
 }
 function renderTransformInputs(rendered) {
   const item = rendered.item;
-  const editable = canEditItem(item);
+  const editable = selectionIsEditable(rendered);
   const transform = state.dirtyTransforms.get(item.id)?.newTransform || transformOf(item);
   const fields = [
     ["x", "X", transform.pose.xyz.x],
@@ -42478,7 +42455,7 @@ function wireTransformInputs(rendered) {
   if (!editor)
     return;
   editor.querySelectorAll("[data-transform-field]").forEach((input) => input.addEventListener("input", () => {
-    if (!canEditItem(rendered.item))
+    if (!selectionIsEditable(rendered))
       return;
     const next = currentTransformFromInputs(editor);
     if (Object.values(next.pose.xyz).concat(Object.values(next.pose.rpy), Object.values(next.scale)).some((v) => !Number.isFinite(v)))
@@ -42491,7 +42468,7 @@ function wireTransformInputs(rendered) {
 }
 function resetSelectedTransform(id = state.selected) {
   const rendered = state.objects.find((obj) => obj.item.id === id);
-  if (!rendered || !canEditItem(rendered.item))
+  if (!selectionIsEditable(rendered))
     return;
   markDirtyTransform(rendered, rendered.originalTransform);
   populateInspector(rendered);


### PR DESCRIPTION
### Motivation

- Regenerate the production Web3D bundle so the embedded Workcell Builder runs the source-only selection-identity fix merged in PR #2912.

### Description

- Bundle regenerated from the source merged in PR #2912 without modifying any source files or test files.
- Exact command used: `npm ci && npm run build:web3d` (sourcemap restored with `git restore workcell_studio_web/viewer/dist/viewer.bundle.js.map`).
- Committed file: `workcell_studio_web/viewer/dist/viewer.bundle.js` only.

### Testing

- `npm run check:stale-bundle`: passed; `viewer.bundle.js` reported current (hash `58f9e5cab92e026f415a7e9414d1bcc397ee7461f06351f8b331f0f54f7fec1e`).
- Focused tests: `python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py tests/test_embedded_web3d_editor_bridge_static.py tests/test_workcell_builder_selected_item_card.py` — `127 passed, 3 warnings`.
- Confirmed only `workcell_studio_web/viewer/dist/viewer.bundle.js` changed and the source map plus all source files were left untouched.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b3039a99c83318d75c1601ef94c6f)