### PR TITLE
Add read-only pick registry and semantic raycast resolution for expanded URDF links

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -1221,7 +1221,7 @@ def test_viewer_load_contract_keeps_selection_empty_until_manual_pick():
     assert "return selectedCandidate.rendered.item.id;" in pick_body
 
 
-def test_raycast_ranking_prefers_authored_bin_over_place_zone_and_task_marker():
+def test_raycast_registry_ancestry_distance_overlays_reload_and_empty_select():
     js_path = VIEWER / "viewer.js"
     harness = r"""
 const fs = require('fs'); const vm = require('vm'); const assert = require('assert');
@@ -1231,24 +1231,41 @@ const context={console,assert,window:{location:{search:''},dispatchEvent(){},par
 vm.createContext(context);
 vm.runInContext(source + `
 updateLabels=()=>{}; populateInspector=()=>{}; attachTransformGizmo=()=>{}; detachTransformGizmo=()=>{}; refreshSelectionHighlight=()=>{}; removeSelectionHighlight=()=>{};
-const rendered = item => ({item,object3d:{userData:{item}}});
+const node = (name='', parent=null) => ({name,parent,visible:true,userData:{},children:[],traverse(fn){fn(this); this.children.forEach(child=>child.traverse(fn));}});
+const rendered = item => { const object3d=node(item.id); object3d.userData.item=item; return {item,object3d}; };
 const bin=rendered({id:'target_bin_default',editable:true,locked:false,render_policy:'primary',mesh_load_required:true,mesh_contract_category:'object',category:'place_zone',source_layer:'editable_layout',transform_group:'default_drop_destination'});
 const zone=rendered({id:'place_zone_default',editable:true,locked:false,render_policy:'overlay',role:'place_zone',source_layer:'editable_layout',transform_group:'default_drop_destination'});
 const marker=rendered({id:'commissioning_object',editable:false,locked:true,render_policy:'primary',role:'task_marker',source_layer:'task_preview'});
-const robot=rendered({id:'ur5_generated',editable:false,locked:true,render_policy:'primary',role:'robot',source_layer:'locked_generated_urdf_visual'});
-state.sceneJson={scene:{id:'ur5_2f_test'}}; state.objects=[bin,zone,marker,robot]; state.editorEvents=[]; state.debugOverlaysVisible=false;
-const hits=[{object:marker.object3d,distance:1},{object:zone.object3d,distance:2},{object:bin.object3d,distance:3}];
-assert.strictEqual(rankedPickingCandidates(hits)[0].rendered.item.id,'target_bin_default');
+state.sceneJson={scene:{id:'ur5_2f_test'}}; state.objects=[bin,zone,marker]; state.editorEvents=[]; state.debugOverlaysVisible=false;
+const table=rendered({id:'support_surface_table',role:'table',render_policy:'primary'});
+const camera=rendered({id:'realsense_overhead',role:'sensor',render_policy:'primary'});
+const ur5={id:'ur5_generated',role:'robot',source_layer:'locked_generated_urdf_visual'};
+const tool={id:'robotiq_generated',role:'tool',source_layer:'locked_generated_urdf_visual'};
+state.objects.push(table,camera);
+const colladaChild=node('nested-collada',table.object3d); table.object3d.children.push(colladaChild);
+assert.strictEqual(itemFromRaycastHit({object:colladaChild}).item.id,'support_surface_table');
+const urdfRoot=node('urdf-root'), urdfLink=node('shoulder_link',urdfRoot), urdfMesh=node('mesh',urdfLink); urdfRoot.children=[urdfLink]; urdfLink.children=[urdfMesh];
+registerPickRecord(ur5,urdfLink,urdfRoot); assert.strictEqual(itemFromRaycastHit({object:urdfMesh}).item.id,'ur5_generated'); assert.strictEqual(state.objects.some(record=>record.item.id==='ur5_generated'),false); assert.strictEqual(selectionIsEditable(renderedById('ur5_generated')),false);
+const toolLink=node('robotiq_link',urdfRoot), toolMesh=node('tool-mesh',toolLink); toolLink.children=[toolMesh]; urdfRoot.children.push(toolLink);
+registerPickRecord(tool,toolLink,urdfRoot); assert.strictEqual(itemFromRaycastHit({object:toolMesh}).item.id,'robotiq_generated');
+const hits=[{object:table.object3d,distance:1},{object:bin.object3d,distance:3}];
+assert.strictEqual(rankedPickingCandidates(hits)[0].rendered.item.id,'support_surface_table');
 state.three.pointer={}; state.three.camera={}; state.three.raycaster={setFromCamera(){},intersectObjects(){return hits;}};
-assert.strictEqual(pickObject({clientX:10,clientY:10}),'target_bin_default');
-assert.strictEqual(state.selected,'target_bin_default');
-assert.strictEqual(state.editorEvents.filter(e=>e.type==='helper_pick_skipped').length,1);
-pickObject({clientX:10,clientY:10}); assert.strictEqual(state.editorEvents.filter(e=>e.type==='helper_pick_skipped').length,1);
-state.editorMode='move'; assert.strictEqual(pickObject({clientX:10,clientY:10}),'target_bin_default');
+assert.strictEqual(pickObject({clientX:10,clientY:10}),'support_surface_table');
+for (const candidate of [table,camera,{object3d:urdfMesh},{object3d:toolMesh}]) {
+  hits.splice(0,hits.length,{object:candidate.object3d,distance:1},{object:bin.object3d,distance:2});
+  assert.notStrictEqual(pickObject({clientX:10,clientY:10}),'target_bin_default');
+}
 assert.strictEqual(isNormalSelectableRendered(marker),false);
-state.debugOverlaysVisible=true; assert.strictEqual(isNormalSelectableRendered(marker),true); assert.strictEqual(pickingPriority(marker),4);
-assert.strictEqual(isNormalSelectableRendered(robot),true); assert.strictEqual(pickingPriority(robot),3);
+hits.splice(0,hits.length,{object:zone.object3d,distance:1},{object:bin.object3d,distance:2});
+state.debugOverlaysVisible=false; assert.strictEqual(pickObject({clientX:10,clientY:10}),'target_bin_default');
+state.debugOverlaysVisible=true; assert.strictEqual(pickObject({clientX:10,clientY:10}),'place_zone_default'); assert.strictEqual(pickingPriority(marker),4);
+const pickZone=rendered({id:'pick_zone_commissioning',role:'pick_zone',render_policy:'overlay'}); state.objects.push(pickZone);
+for (const overlay of [pickZone,zone]) { hits.splice(0,hits.length,{object:overlay.object3d,distance:1},{object:bin.object3d,distance:2}); assert.notStrictEqual(pickObject({clientX:10,clientY:10}),'target_bin_default'); }
+assert.strictEqual(isNormalSelectableRendered(renderedById('ur5_generated')),true); assert.strictEqual(pickingPriority(renderedById('ur5_generated')),3);
 assert.strictEqual(editableTransformGroupMembers(bin).map(r=>r.item.id).sort().join(','),'place_zone_default,target_bin_default');
+const staleIdentity=state.pickIdentityByObject; resetSceneLifecycleState(); assert.strictEqual(state.pickRecords.length,0); assert.notStrictEqual(state.pickIdentityByObject,staleIdentity); assert.strictEqual(renderedById('ur5_generated'),undefined);
+state.editorMode='select'; state.selected='target_bin_default'; state.three.raycaster={setFromCamera(){},intersectObjects(){return[];}}; pickObject({clientX:10,clientY:10}); assert.strictEqual(state.selected,''); assert.strictEqual(state.lastCanvasPickReason,'empty_select_click');
 `, context);
 """
     subprocess.run(["node", "-e", harness, str(js_path)], cwd=ROOT, check=True, capture_output=True, text=True)
@@ -1310,7 +1327,7 @@ assert.strictEqual(editorState().editOwnerItemId,'target_bin_default');
 assert.strictEqual(editorState().selectionDiagnostics.editOwnerItemId,'target_bin_default');
 assert.strictEqual(canonicalEditOwnerRendered(zone).item.id,'target_bin_default');
 assert.strictEqual(inspectionSelectionRendered(zone).item.id,'place_zone_default');
-assert.strictEqual(rankedPickingCandidates([{object:zone.object3d,distance:1}])[0].rendered.item.id,'place_zone_default');
+state.debugOverlaysVisible=true; assert.strictEqual(rankedPickingCandidates([{object:zone.object3d,distance:1}])[0].rendered.item.id,'place_zone_default');
 selectObject('target_bin_default'); assert.strictEqual(editorState().selectedItemId,'target_bin_default'); assert.strictEqual(editorState().selectedEditable,true);
 selectObject('ur5_generated'); assert.strictEqual(editorState().selectedItemId,'ur5_generated'); assert.strictEqual(editorState().editOwnerItemId,'ur5_generated');
 selectObject('commissioning_object'); assert.strictEqual(editorState().selectedItemId,'commissioning_object');

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -38,7 +38,7 @@ const CAMERA_PRESET_DIRECTIONS = Object.freeze({
   top: [0, -0.001, 1],
   robot: [1.1, -1.25, 0.72],
 });
-const state = { sceneJson: null, sourceWebSceneFile: '', diagnosticKeys: new Set(), frameLookup: new Map(), resolvedFramePoses: new Map(), objects: [], assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, robotUrdfPreviewDiagnostics: {}, physicalAssemblyBounds: null, finalPhysicalFitBounds: null, selected: null, three: {}, animationId: null, lastFrameBounds: null, initialCameraFit: { sceneKey: '', done: false, attempts: 0, pendingRetry: null, userControlled: false }, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: new Map(), undoStack: [], redoStack: [], gizmoDragStart: null, directMoveDrag: null, directRotateDrag: null, editorMode: 'select', editorEvents: [], editorError: '', robotPreviewResult: null, initialPosePreview: { active: false, robotId: '', sceneKey: '' }, web3dReadiness: { state: 'booting', terminal: false, terminalState: '', terminalNavigationKey: '', terminalEmissionCount: 0, statusSequence: 0, required: {}, pending: new Set(), failed: false, failure: null }, builderRevision: '', sceneJsonLoaded: false, activeNavigationKey: '' };
+const state = { sceneJson: null, sourceWebSceneFile: '', diagnosticKeys: new Set(), frameLookup: new Map(), resolvedFramePoses: new Map(), objects: [], pickRecords: [], pickIdentityByObject: new WeakMap(), assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, robotUrdfPreviewDiagnostics: {}, physicalAssemblyBounds: null, finalPhysicalFitBounds: null, selected: null, three: {}, animationId: null, lastFrameBounds: null, initialCameraFit: { sceneKey: '', done: false, attempts: 0, pendingRetry: null, userControlled: false }, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: new Map(), undoStack: [], redoStack: [], gizmoDragStart: null, directMoveDrag: null, directRotateDrag: null, editorMode: 'select', editorEvents: [], editorError: '', robotPreviewResult: null, lastRaycastHitCount: 0, lastRaycastCandidateIds: [], lastCanvasSelectedItemId: '', lastCanvasPickReason: '', initialPosePreview: { active: false, robotId: '', sceneKey: '' }, web3dReadiness: { state: 'booting', terminal: false, terminalState: '', terminalNavigationKey: '', terminalEmissionCount: 0, statusSequence: 0, required: {}, pending: new Set(), failed: false, failure: null }, builderRevision: '', sceneJsonLoaded: false, activeNavigationKey: '' };
 let robotPreviewLoadToken = 0;
 const RESET_VIEW_TITLE = 'Fit Scene / Reset View: recomputes and reapplies the fitted workcell overview from renderable bounds.';
 const STAGED_MESH_ROOTS = [
@@ -939,19 +939,23 @@ function currentSelectionDiagnostics() {
     renderIdentity: id,
     selectedItemType: rendered ? itemType(item) : '',
     selectable: Boolean(rendered && isNormalSelectableRendered(rendered)),
-    editable: Boolean(item && editOwner === rendered && canEditItem(item)),
+    editable: Boolean(item && editOwner === rendered && !rendered?.readOnlyPick && canEditItem(item)),
     locked: Boolean(item?.locked),
     sourceLayer: String(item?.source_layer || ''),
     activeVisualSource: String(item?.active_visual_source || ''),
     diagnosticOnly: Boolean(item && isDiagnosticOnlyItem(item)),
     helperOrOverlay: Boolean(item && isDebugOverlayItem(item)),
     objectPresent: Boolean(rendered),
+    lastRaycastHitCount: state.lastRaycastHitCount,
+    lastRaycastCandidateIds: [...state.lastRaycastCandidateIds],
+    lastCanvasSelectedItemId: state.lastCanvasSelectedItemId,
+    lastCanvasPickReason: state.lastCanvasPickReason,
   };
 }
 function editorState() {
   const rendered = renderedById(state.selected);
   const editOwner = canonicalEditOwnerRendered(rendered);
-  return { ready: Boolean(state.sceneJson && state.three?.scene), sceneId: sceneId(), selectedItemId: state.selected || '', editOwnerItemId: editOwner?.item?.id || '', selectedItemType: rendered ? itemType(rendered.item) : '', selectedEditable: Boolean(rendered && editOwner === rendered && rendered.item && canEditItem(rendered['item'])), selectionDiagnostics: currentSelectionDiagnostics(), dirty: state.dirtyTransforms.size > 0, dirtyCount: state.dirtyTransforms.size, canUndo: state.undoStack.length > 0, canRedo: state.redoStack.length > 0, mode: state.editorMode, error: state.editorError || '' };
+  return { ready: Boolean(state.sceneJson && state.three?.scene), sceneId: sceneId(), selectedItemId: state.selected || '', editOwnerItemId: editOwner?.item?.id || '', selectedItemType: rendered ? itemType(rendered.item) : '', selectedEditable: selectionIsEditable(rendered), selectionDiagnostics: currentSelectionDiagnostics(), lastRaycastHitCount: state.lastRaycastHitCount, lastRaycastCandidateIds: [...state.lastRaycastCandidateIds], lastCanvasSelectedItemId: state.lastCanvasSelectedItemId, lastCanvasPickReason: state.lastCanvasPickReason, dirty: state.dirtyTransforms.size > 0, dirtyCount: state.dirtyTransforms.size, canUndo: state.undoStack.length > 0, canRedo: state.redoStack.length > 0, mode: state.editorMode, error: state.editorError || '' };
 }
 function emitDirtyChanged() { pushEditorEvent('dirty_changed', { dirty: state.dirtyTransforms.size > 0, dirtyCount: state.dirtyTransforms.size, canUndo: state.undoStack.length > 0, canRedo: state.redoStack.length > 0 }); }
 function showError(message) {
@@ -1137,7 +1141,14 @@ function meshLocalTransformOf(item) {
 }
 function cloneTransform(transform) { return JSON.parse(JSON.stringify(transform)); }
 function sameTransform(a, b) { return JSON.stringify(a) === JSON.stringify(b); }
-function renderedById(id) { return state.objects.find(obj => obj.item.id === id); }
+function renderedById(id) { return state.objects.find(obj => obj.item.id === id) || state.pickRecords.find(obj => obj.item.id === id); }
+function registerPickRecord(item, object3d, root = object3d) {
+  if (!item?.id || !object3d) return null;
+  const record = { item, object3d, pickRoot: root, readOnlyPick: true };
+  state.pickRecords.push(record);
+  state.pickIdentityByObject.set(object3d, record);
+  return record;
+}
 function derivedTransformTargetId(item) {
   const targetId = String(item?.target_ref || '').trim();
   const identity = [item?.role, item?.semantic_role, item?.type, item?.category, item?.id]
@@ -1155,7 +1166,7 @@ function canonicalEditOwnerRendered(rendered) {
 // canonicalSelectionRendered intentionally retired: inspection identity must
 // never be rewritten to the transform owner.
 function selectionIsEditable(rendered) {
-  return Boolean(rendered && canonicalEditOwnerRendered(rendered) === rendered && canEditItem(rendered.item));
+  return Boolean(rendered && !rendered.readOnlyPick && canonicalEditOwnerRendered(rendered) === rendered && canEditItem(rendered.item));
 }
 function transformFromObject(object) {
   return { pose: { xyz: { x: object.position.x, y: object.position.y, z: object.position.z }, rpy: { x: object.rotation.x, y: object.rotation.y, z: object.rotation.z } }, scale: { x: object.scale.x, y: object.scale.y, z: object.scale.z } };
@@ -2981,6 +2992,12 @@ function resetSceneLifecycleState() {
   robotPreviewLoadToken += 1;
   cancelInitialCameraFitRetry();
   state.objects = [];
+  state.pickRecords = [];
+  state.pickIdentityByObject = new WeakMap();
+  state.lastRaycastHitCount = 0;
+  state.lastRaycastCandidateIds = [];
+  state.lastCanvasSelectedItemId = '';
+  state.lastCanvasPickReason = '';
   state.assemblyRoots = [];
   state.robotAssemblyDiagnostics = [];
   state.robotAssemblyRenderDiagnostics = {};
@@ -3157,6 +3174,16 @@ function loadExpandedUrdfRobotPreview(preview) {
     skippedLegacyGeneratedUrdfVisualCount: diagnostics.skipped_legacy_generated_urdf_visual_count,
     onRobotLoaded: result => {
       if (!callbackIsCurrent()) return ignoreStaleCallback();
+      const itemsByLink = new Map();
+      for (const item of collectItems(state.sceneJson || {})) {
+        if (!isGeneratedUrdfItem(item)) continue;
+        const explicitLink = String(item?.link_name || item?.link || '').trim();
+        if (explicitLink && !itemsByLink.has(explicitLink)) itemsByLink.set(explicitLink, item);
+      }
+      for (const [linkName, linkObject] of result?.links || []) {
+        const item = itemsByLink.get(String(linkName));
+        if (item) registerPickRecord(item, linkObject, result.root || linkObject);
+      }
       state.robotPreviewResult = result;
       state.robotUrdfPreviewDiagnostics = result.diagnostics;
       if (!failIfExpandedUrdfExpectedVisualSetInvalid()) completeExpandedUrdfReadiness(result);
@@ -3586,6 +3613,31 @@ function isNormalSelectableRendered(rendered) {
   const inspectionSelectable = state.debugOverlaysVisible && (isTaskOnlyHelperItem(item) || isOverlayPolicyItem(item) || isDebugOverlayItem(item));
   return Boolean(item?.id) && item.selectable !== false && !isDiagnosticOnlyItem(item) && (inspectionSelectable || (!isTaskOnlyHelperItem(item) && !isOverlayPolicyItem(item) && !isDebugOverlayItem(item)));
 }
+function excludedPickNode(node) {
+  const data = node?.userData || {};
+  const name = String(node?.name || '').toLowerCase();
+  return node?.visible === false || data.selection_outline || data.selection_highlight || data.diagnostic_only ||
+    data.hidden_overlay || data.helper_hidden || data.non_selectable || data.selectable === false ||
+    /transformcontrols|transform_controls|gizmo|selection_.*highlight/.test(name);
+}
+function itemFromRaycastHit(hit) {
+  let node = hit?.object || null;
+  let candidate = null;
+  while (node) {
+    if (excludedPickNode(node)) return null;
+    if (!candidate) {
+      const registered = state.pickIdentityByObject.get(node);
+      const item = node.userData?.item || registered?.item;
+      if (item?.id) {
+        const rendered = renderedById(item.id) || registered;
+        if (!rendered || !isNormalSelectableRendered(rendered)) return null;
+        candidate = rendered;
+      }
+    }
+    node = node.parent;
+  }
+  return candidate;
+}
 function pickingPriority(rendered) {
   const item = rendered?.item;
   if (!item?.id) return Number.POSITIVE_INFINITY;
@@ -3599,13 +3651,18 @@ function rankedPickingCandidates(hits) {
   const candidates = [];
   const seen = new Set();
   for (const hit of hits || []) {
-    const item = hit?.object?.userData?.item || hit?.object?.parent?.userData?.item;
-    const rendered = inspectionSelectionRendered(item?.id ? renderedById(item.id) : null);
+    const rendered = inspectionSelectionRendered(itemFromRaycastHit(hit));
     if (!rendered?.item?.id || seen.has(rendered.item.id)) continue;
     seen.add(rendered.item.id);
     candidates.push({ rendered, hit, priority: pickingPriority(rendered) });
   }
-  return candidates.sort((a, b) => a.priority - b.priority || Number(a.hit?.distance || 0) - Number(b.hit?.distance || 0));
+  // Coincident transparent surfaces can report tiny ordering noise. Semantic
+  // priority is only a tie-break within one millimetre; distance wins otherwise.
+  const PICK_COINCIDENCE_TOLERANCE_M = 0.001;
+  return candidates.sort((a, b) => {
+    const distanceDelta = Number(a.hit?.distance || 0) - Number(b.hit?.distance || 0);
+    return Math.abs(distanceDelta) <= PICK_COINCIDENCE_TOLERANCE_M ? a.priority - b.priority || distanceDelta : distanceDelta;
+  });
 }
 function selectObject(id) {
   const requestedId = String(id || '');
@@ -3636,7 +3693,7 @@ function selectObject(id) {
     if (rendered.labelEl) rendered.labelEl.classList.toggle('selected', selected);
   }
   updateLabels();
-  const rendered = state.objects.find(obj => obj.item.id === id);
+  const rendered = renderedById(id);
   if (rendered) { populateInspector(rendered); attachTransformGizmo(rendered); refreshSelectionHighlight(rendered); } else { detachTransformGizmo(); removeSelectionHighlight(); }
   if (previous !== (id || '')) pushEditorEvent('selection_changed', { itemId: id || '', itemType: rendered ? itemType(rendered.item) : '', editable: Boolean(rendered && rendered.item && canEditItem(rendered['item'])) });
 }
@@ -3646,10 +3703,19 @@ function pickObject(event) {
   state.three.pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
   state.three.pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
   state.three.raycaster.setFromCamera(state.three.pointer, state.three.camera);
-  const hits = state.three.raycaster.intersectObjects(state.objects.map(o => o.object3d), true);
+  const roots = [...state.objects.map(o => o.object3d), ...state.pickRecords.map(o => o.pickRoot || o.object3d)]
+    .filter((root, index, all) => root?.visible !== false && !excludedPickNode(root) && all.indexOf(root) === index);
+  const hits = state.three.raycaster.intersectObjects(roots, true);
   const candidates = rankedPickingCandidates(hits);
+  state.lastRaycastHitCount = hits.length;
+  state.lastRaycastCandidateIds = candidates.map(candidate => candidate.rendered.item.id);
   const selectedCandidate = candidates.find(candidate => Number.isFinite(candidate.priority) && isNormalSelectableRendered(candidate.rendered));
-  if (!selectedCandidate) return '';
+  if (!selectedCandidate) {
+    state.lastCanvasSelectedItemId = '';
+    state.lastCanvasPickReason = hits.length ? 'no_eligible_candidate' : 'empty_select_click';
+    if (state.editorMode === 'select') clearSelection();
+    return '';
+  }
   const skippedHelper = candidates.find(candidate => candidate !== selectedCandidate && candidate.priority > selectedCandidate.priority && (isTaskOnlyHelperItem(candidate.rendered.item) || isDebugOverlayItem(candidate.rendered.item)));
   if (skippedHelper) {
     state.skippedHelperPickKeys ||= new Set();
@@ -3660,6 +3726,8 @@ function pickObject(event) {
     }
   }
   selectObject(selectedCandidate.rendered.item.id);
+  state.lastCanvasSelectedItemId = selectedCandidate.rendered.item.id;
+  state.lastCanvasPickReason = 'eligible_candidate';
   return selectedCandidate.rendered.item.id;
 }
 
@@ -3667,9 +3735,9 @@ function pickObject(event) {
 
 function pointerToWorldPlane(event, z) { const rect = el.canvas.getBoundingClientRect(); if (!rect.width || !rect.height) return null; state.three.pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1; state.three.pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1; state.three.raycaster.setFromCamera(state.three.pointer, state.three.camera); const plane = new THREE.Plane(new THREE.Vector3(0, 0, 1), -z); const hit = new THREE.Vector3(); if (!state.three.raycaster.ray.intersectPlane(plane, hit)) return null; return Number.isFinite(hit.x) && Number.isFinite(hit.y) && Number.isFinite(hit.z) ? hit : null; }
 function snapHorizontalPreview(transform) { const snapped = snapTransform(transform, { translationAxes: ['x', 'y'], rotationAxes: [] }); snapped.pose.xyz.z = transform.pose.xyz.z; return snapped; }
-function beginDirectMoveDrag(event, rendered) { if (state.editorMode !== 'move' || !rendered || !canEditItem(rendered.item)) return false; const start = cloneTransform(state.dirtyTransforms.get(rendered.item.id)?.newTransform || transformFromObject(rendered.object3d)); const hit = pointerToWorldPlane(event, start.pose.xyz.z); if (!hit) return false; const controls = state.three.controls; state.directMoveDrag = { itemId: rendered.item.id, start, groupStart: captureTransformGroup(rendered), last: cloneTransform(start), offset: { x: start.pose.xyz.x - hit.x, y: start.pose.xyz.y - hit.y }, controlsWasEnabled: controls ? controls.enabled : true }; if (controls) controls.enabled = false; el.canvas.setPointerCapture?.(event.pointerId); el.canvas.classList.add('direct-move-dragging'); event.preventDefault(); event.stopPropagation(); return true; }
-function updateDirectMoveDrag(event) { const drag = state.directMoveDrag; if (!drag) return false; const rendered = renderedById(drag.itemId); if (!rendered || state.selected !== drag.itemId || !canEditItem(rendered.item)) return cancelDirectMoveDrag('Move cancelled'), true; const hit = pointerToWorldPlane(event, drag.start.pose.xyz.z); if (!hit) return true; const next = cloneTransform(drag.start); next.pose.xyz.x = hit.x + drag.offset.x; next.pose.xyz.y = hit.y + drag.offset.y; next.pose.xyz.z = drag.start.pose.xyz.z; const preview = snapHorizontalPreview(next); if (!isFiniteTransform(preview)) return true; drag.last = cloneTransform(preview); applyTransformChanges(linkedTransformChanges(rendered, drag.start, preview, drag.groupStart)); syncInspectorTransformFields(rendered); event.preventDefault(); event.stopPropagation(); return true; }
-function finishDirectMoveDrag(event) { const drag = state.directMoveDrag; if (!drag) return false; const rendered = renderedById(drag.itemId); const finalTransform = cloneTransform(drag.last); endDirectMoveDrag(event); if (!rendered || !canEditItem(rendered.item) || !isFiniteTransform(finalTransform)) return false; if (sameTransform(drag.start, finalTransform)) { applyTransformChanges([...drag.groupStart].map(([itemId, after]) => ({ rendered: renderedById(itemId), after }))); syncInspectorTransformFields(rendered); return true; } const committed = markDirtyTransform(rendered, finalTransform, { pushHistory: true, oldTransform: drag.start, memberStarts: drag.groupStart }); if (!committed) { applyTransformChanges([...drag.groupStart].map(([itemId, after]) => ({ rendered: renderedById(itemId), after }))); showError(`Move failed for ${itemLabel(rendered.item)}: final transform was rejected by the editor bridge.`); return true; } emitTransformCommitted(rendered); pushEditorEvent('status', { message: `Moved ${itemLabel(rendered.item)}` }); return true; }
+function beginDirectMoveDrag(event, rendered) { if (state.editorMode !== 'move' || !selectionIsEditable(rendered)) return false; const start = cloneTransform(state.dirtyTransforms.get(rendered.item.id)?.newTransform || transformFromObject(rendered.object3d)); const hit = pointerToWorldPlane(event, start.pose.xyz.z); if (!hit) return false; const controls = state.three.controls; state.directMoveDrag = { itemId: rendered.item.id, start, groupStart: captureTransformGroup(rendered), last: cloneTransform(start), offset: { x: start.pose.xyz.x - hit.x, y: start.pose.xyz.y - hit.y }, controlsWasEnabled: controls ? controls.enabled : true }; if (controls) controls.enabled = false; el.canvas.setPointerCapture?.(event.pointerId); el.canvas.classList.add('direct-move-dragging'); event.preventDefault(); event.stopPropagation(); return true; }
+function updateDirectMoveDrag(event) { const drag = state.directMoveDrag; if (!drag) return false; const rendered = renderedById(drag.itemId); if (!rendered || state.selected !== drag.itemId || !selectionIsEditable(rendered)) return cancelDirectMoveDrag('Move cancelled'), true; const hit = pointerToWorldPlane(event, drag.start.pose.xyz.z); if (!hit) return true; const next = cloneTransform(drag.start); next.pose.xyz.x = hit.x + drag.offset.x; next.pose.xyz.y = hit.y + drag.offset.y; next.pose.xyz.z = drag.start.pose.xyz.z; const preview = snapHorizontalPreview(next); if (!isFiniteTransform(preview)) return true; drag.last = cloneTransform(preview); applyTransformChanges(linkedTransformChanges(rendered, drag.start, preview, drag.groupStart)); syncInspectorTransformFields(rendered); event.preventDefault(); event.stopPropagation(); return true; }
+function finishDirectMoveDrag(event) { const drag = state.directMoveDrag; if (!drag) return false; const rendered = renderedById(drag.itemId); const finalTransform = cloneTransform(drag.last); endDirectMoveDrag(event); if (!selectionIsEditable(rendered) || !isFiniteTransform(finalTransform)) return false; if (sameTransform(drag.start, finalTransform)) { applyTransformChanges([...drag.groupStart].map(([itemId, after]) => ({ rendered: renderedById(itemId), after }))); syncInspectorTransformFields(rendered); return true; } const committed = markDirtyTransform(rendered, finalTransform, { pushHistory: true, oldTransform: drag.start, memberStarts: drag.groupStart }); if (!committed) { applyTransformChanges([...drag.groupStart].map(([itemId, after]) => ({ rendered: renderedById(itemId), after }))); showError(`Move failed for ${itemLabel(rendered.item)}: final transform was rejected by the editor bridge.`); return true; } emitTransformCommitted(rendered); pushEditorEvent('status', { message: `Moved ${itemLabel(rendered.item)}` }); return true; }
 function endDirectMoveDrag(event) { const drag = state.directMoveDrag; state.directMoveDrag = null; if (state.three.controls) state.three.controls.enabled = drag ? drag.controlsWasEnabled : state.three.controls.enabled; el.canvas.classList.remove('direct-move-dragging'); if (event?.pointerId !== undefined) el.canvas.releasePointerCapture?.(event.pointerId); }
 function cancelDirectMoveDrag(message) { const drag = state.directMoveDrag; if (!drag) return false; const rendered = renderedById(drag.itemId); if (rendered) { applyTransformChanges([...drag.groupStart].map(([itemId, after]) => ({ rendered: renderedById(itemId), after }))); syncInspectorTransformFields(rendered); } endDirectMoveDrag(); pushEditorEvent('status', { message: message || 'Move cancelled' }); return true; }
 function onCanvasPointerDown(event) { const hitId = pickObject(event); const rendered = hitId ? renderedById(hitId) : null; if (beginDirectMoveDrag(event, rendered)) return; }
@@ -3684,7 +3752,7 @@ function directRotatePreviewTransform(rendered) {
   return snapTransform(next, { translationAxes: [], rotationAxes: ['z'] });
 }
 function beginDirectRotateDrag(rendered) {
-  if (state.editorMode !== 'rotate' || !rendered || !canEditItem(rendered.item)) return false;
+  if (state.editorMode !== 'rotate' || !selectionIsEditable(rendered)) return false;
   const controls = state.three.controls;
   const start = cloneTransform(state.dirtyTransforms.get(rendered.item.id)?.newTransform || transformFromObject(rendered.object3d));
   state.directRotateDrag = { itemId: rendered.item.id, start, groupStart: captureTransformGroup(rendered), last: cloneTransform(start), controlsWasEnabled: controls ? controls.enabled : true };
@@ -3706,7 +3774,7 @@ function finishDirectRotateDrag(rendered) {
   rendered = rendered || renderedById(drag.itemId);
   const finalTransform = cloneTransform(drag.last);
   endDirectRotateDrag();
-  if (!rendered || !canEditItem(rendered.item) || !isFiniteTransform(finalTransform)) return false;
+  if (!selectionIsEditable(rendered) || !isFiniteTransform(finalTransform)) return false;
   if (sameTransform(drag.start, finalTransform)) { applyTransformToObject(rendered.object3d, drag.start); syncInspectorTransformFields(rendered); return true; }
   const committed = markDirtyTransform(rendered, finalTransform, { pushHistory: true, oldTransform: drag.start, snapOptions: { translationAxes: [], rotationAxes: ['z'] }, memberStarts: drag.groupStart });
   if (!committed) { applyTransformToObject(rendered.object3d, drag.start); showError(`Rotation failed for ${itemLabel(rendered.item)}: final transform was rejected by the editor bridge.`); return true; }


### PR DESCRIPTION
### Motivation
- Prevent nested loader/URDF geometry from collapsing onto the wrong editable identity during canvas picks while keeping editable render records and edit ownership unchanged. 
- Make expanded URDF link visuals selectable as a read-only inspection identity without affecting transform edit lists, undo/redo, save patches, or readiness counts.

### Description
- Added a lightweight read-only pick registry and weak-object identity lookup (`state.pickRecords`, `state.pickIdentityByObject`, and `registerPickRecord`) and ensured it is initialized/cleared in `resetSceneLifecycleState()` so stale callbacks cannot restore old records. (modified `workcell_studio_web/viewer/viewer.js`)
- Implemented `itemFromRaycastHit(hit)` that walks the full ancestry from `hit.object` and rejects selection outlines, transform gizmos, diagnostic/helper/hidden nodes, and nodes explicitly marked non-selectable; it returns a semantic rendered record without altering `state.objects`.
- Updated `renderedById(id)` to search normal editable `state.objects` first and then read-only pick records so inspector/highlight/selection events may reference pick-only entries while editing remains governed by existing editability contracts.
- In `loadExpandedUrdfRobotPreview(preview)` used the existing `onRobotLoaded` callback and `result.links` to match loaded URDF link names against generated robot/tool items in `state.sceneJson`, register matched link objects (without inventing IDs), and preserve the `loadToken`/scene-ID stale-callback guard.
- Replaced raycast roots used by `pickObject()` with visible normal render roots plus visible registered URDF roots, deduplicated roots, excluded overlays/helpers/gizmos, and applied a distance-first sort with a small 1 mm coincidence tolerance for semantic priority.
- Kept pick-only records read-only for editing by excluding `readOnlyPick` entries from `selectionIsEditable` and transform-grab paths so transform gizmos and edits remain restricted to the canonical editable owners.
- Exposed compact canvas diagnostics through `currentSelectionDiagnostics()` and `editorState()` via `lastRaycastHitCount`, `lastRaycastCandidateIds`, `lastCanvasSelectedItemId`, and `lastCanvasPickReason` without adding UI or per-frame logging. (two source files changed: `viewer.js`, focused test added/updated in `tests/test_workcell_studio_web_viewer_static.py`)

### Testing
- Ran `node --check workcell_studio_web/viewer/viewer.js` and static checks; result: OK.
- Ran the test harness `pytest -q tests/test_workcell_studio_web_viewer_static.py`; result: all tests passed (108 passed, 3 pre-existing Python invalid-escape warnings unrelated to the change).
- Verified focused Node/vm behavioral assertions covering nested Collada ancestry, URDF link registrations, distance-first selection competition (table/camera/UR5/Robotiq/bin), overlay visibility rules, stale registry clearing on scene reload, and empty Select-mode clicks; assertions succeeded in the test run.
- Note: display-enabled Workcell Builder click-through (real GUI acceptance) was not executed in this environment and is required to fully confirm on-screen behavior; status is PARTIALLY CONFIRMED pending that workstation validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b3cd24b2c833196c933748422c134)