### PR TITLE
M1: bridge Product View render selection to hierarchy identity

### DIFF
--- a/tests/test_embedded_web3d_editor_bridge_static.py
+++ b/tests/test_embedded_web3d_editor_bridge_static.py
@@ -12,7 +12,7 @@ def test_browser_editor_api_v1_contract_and_bounded_events():
     assert "window.__WORKCELL_EDITOR_API_V1__" in VIEWER
     for method in ["getState", "selectItem", "clearSelection", "setMode", "setSnap", "undo", "redo", "fitScene", "getEditPatch", "drainEvents"]:
         assert f"{method}:" in VIEWER
-    for field in ["ready", "sceneId", "selectedItemId", "selectedItemType", "selectedEditable", "dirty", "dirtyCount", "canUndo", "canRedo", "mode", "error"]:
+    for field in ["ready", "sceneId", "selectedItemId", "uiSelectionItemId", "selectedItemType", "selectedEditable", "dirty", "dirtyCount", "canUndo", "canRedo", "mode", "error"]:
         assert field in VIEWER
     for event in ["selection_changed", "dirty_changed", "transform_committed", "editor_error"]:
         assert event in VIEWER
@@ -90,7 +90,7 @@ def test_move_mode_first_click_selects_and_starts_drag_without_bypassing_locks()
     assert "const rendered = hitId ? renderedById(hitId) : null" in handler
     assert "hitId === state.selected" not in handler
     assert "beginDirectMoveDrag(event, rendered)" in handler
-    assert "!canEditItem(rendered.item)" in VIEWER.split("function beginDirectMoveDrag", 1)[1].split("function updateDirectMoveDrag", 1)[0]
+    assert "!selectionIsEditable(rendered)" in VIEWER.split("function beginDirectMoveDrag", 1)[1].split("function updateDirectMoveDrag", 1)[0]
 
 
 def test_qt_compact_toolbar_for_embedded_web3d():
@@ -132,7 +132,7 @@ def test_qt_selection_clears_stale_scene_and_missing_id_callbacks():
     assert "selection_missing_after_refresh" in CPP
     assert "Preview selection cleared after refresh (id missing):" in CPP
     assert "if (!embedded_web_identity_is_current(identity)) return;" in CPP
-    assert "if (valid_browser_selection && browser_selected_id != selected_preview_item_id_)" in CPP
+    assert "if (valid_browser_selection && browser_ui_selected_id != selected_preview_item_id_)" in CPP
     assert "selection_update_guard_" in (ROOT / "workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text(encoding="utf-8")
 
 
@@ -157,14 +157,18 @@ def test_qt_poll_accepts_only_final_valid_browser_selection_and_explicit_clear()
     poll = CPP.split("void ScenePreviewWidget::poll_embedded_editor_events()", 1)[1].split("#else", 1)[0]
     for token in [
         'editor_state.value(QStringLiteral("selectedItemId"))',
+        'editor_state.value(QStringLiteral("uiSelectionItemId"))',
         'editor_state.value(QStringLiteral("selectionDiagnostics"))',
         'editor_state.value(QStringLiteral("sceneId"))',
-        'id == browser_selected_id',
+        'id == browser_ui_selected_id',
         'selection_diagnostics.value(QStringLiteral("objectPresent")).toBool()',
-        'preview_item_by_id(browser_selected_id) != nullptr',
+        'preview_item_by_id(browser_ui_selected_id) != nullptr',
         'browser_scene_id == identity.scene_id',
     ]:
         assert token in poll
     assert "selected_preview_item_id_ = id" not in poll
+    assert 'event.value(QStringLiteral("uiItemId"))' in poll
+    assert "browser_ui_selected_id = browser_selected_id" in poll
+    assert "selected_preview_item_id_ = browser_ui_selected_id" in poll
     assert "browser_selected_id.isEmpty()" in poll
     assert "selected_preview_item_id_.clear();" in poll

--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -1322,8 +1322,10 @@ const commissioning=rendered({id:'commissioning_object',role:'task_marker',sourc
 state.objects=[target,zone,robot,commissioning]; state.sceneJson={scene:{id:'ur5_2f_test'}}; state.debugOverlaysVisible=false;
 selectObject('place_zone_default');
 assert.strictEqual(editorState().selectedItemId,'place_zone_default');
+assert.strictEqual(editorState().uiSelectionItemId,'place_zone_default');
 assert.strictEqual(editorState().selectedEditable,false);
 assert.strictEqual(editorState().editOwnerItemId,'target_bin_default');
+assert.strictEqual(editorState().selectionDiagnostics.uiSelectionItemId,'place_zone_default');
 assert.strictEqual(editorState().selectionDiagnostics.editOwnerItemId,'target_bin_default');
 assert.strictEqual(canonicalEditOwnerRendered(zone).item.id,'target_bin_default');
 assert.strictEqual(inspectionSelectionRendered(zone).item.id,'place_zone_default');
@@ -1332,6 +1334,7 @@ selectObject('target_bin_default'); assert.strictEqual(editorState().selectedIte
 selectObject('ur5_generated'); assert.strictEqual(editorState().selectedItemId,'ur5_generated'); assert.strictEqual(editorState().editOwnerItemId,'ur5_generated');
 selectObject('commissioning_object'); assert.strictEqual(editorState().selectedItemId,'commissioning_object');
 clearSelection(); assert.strictEqual(editorState().selectedItemId,'');
+assert.strictEqual(editorState().uiSelectionItemId,'');
 `,context);
 """
     subprocess.run(["node", "-e", harness, str(js_path)], cwd=ROOT, check=True, capture_output=True, text=True)
@@ -1340,6 +1343,43 @@ clearSelection(); assert.strictEqual(editorState().selectedItemId,'');
     dirty_body = _viewer_function_body(js_path.read_text(encoding="utf-8"), "function markDirtyTransform(rendered", "function editPatchEntryFor")
     assert "inspectionSelectionRendered(rawRequested)" in select_body
     assert "canonicalEditOwnerRendered(rendered)" in dirty_body
+
+
+def test_explicit_ui_selection_identity_preserves_render_and_edit_identities():
+    js_path = VIEWER / "viewer.js"
+    harness = r"""
+const fs=require('fs'),vm=require('vm'),assert=require('assert');
+let source=fs.readFileSync(process.argv[1],'utf8').replace(/boot\(\);\s*$/,'');
+const element=()=>({hidden:false,checked:false,className:'',textContent:'',classList:{toggle(){}},querySelector(){return null;},querySelectorAll(){return[];},addEventListener(){},setAttribute(){},appendChild(){}});
+const context={console,assert,window:{location:{search:''},dispatchEvent(){},parent:{postMessage(){}}},document:{getElementById(){return element();},querySelectorAll(){return[];},createElement(){return element();}},URLSearchParams,CustomEvent:function(){},requestAnimationFrame(){},setTimeout(){},clearTimeout(){}};
+vm.createContext(context); vm.runInContext(source+`
+updateLabels=()=>{}; populateInspector=()=>{}; attachTransformGizmo=()=>{}; detachTransformGizmo=()=>{}; refreshSelectionHighlight=()=>{}; removeSelectionHighlight=()=>{};
+const rendered=item=>({item,object3d:{userData:{item}}});
+const authored=[{id:'realsense_overhead'},{id:'support_surface_table'},{id:'target_bin_default'},{id:'place_zone_default'},{id:'pick_zone_commissioning'}];
+const camera=rendered({id:'generated_urdf::camera_link::visual_17::17',camera_id:'realsense_overhead'});
+const table=rendered({id:'generated_urdf::table_link::visual_2::2',support_surface_ref:'support_surface_table'});
+const bin=rendered({id:'target_bin_default',editable:true});
+const zone=rendered({id:'place_zone_default',target_ref:'target_bin_default',render_policy:'overlay'});
+const invalid=rendered({id:'generated_robot_visual',canonical_item_id:'missing_robot'});
+state.sceneJson={scene:{id:'ur5_2f_test'},items:authored}; state.objects=[camera,table,bin,zone,invalid,...authored.map(rendered)]; state.editorEvents=[];
+selectObject(camera.item.id); assert.strictEqual(editorState().selectedItemId,camera.item.id); assert.strictEqual(editorState().uiSelectionItemId,'realsense_overhead'); assert.strictEqual(state.editorEvents.at(-1).uiItemId,'realsense_overhead');
+selectObject(table.item.id); assert.strictEqual(editorState().selectedItemId,table.item.id); assert.strictEqual(editorState().uiSelectionItemId,'support_surface_table');
+selectObject(bin.item.id); assert.strictEqual(editorState().uiSelectionItemId,'target_bin_default');
+selectObject(zone.item.id); assert.strictEqual(editorState().uiSelectionItemId,'place_zone_default'); assert.strictEqual(editorState().editOwnerItemId,'target_bin_default');
+selectObject(invalid.item.id); assert.strictEqual(editorState().uiSelectionItemId,invalid.item.id);
+`,context);
+"""
+    subprocess.run(["node", "-e", harness, str(js_path)], cwd=ROOT, check=True, capture_output=True, text=True)
+
+
+def test_hierarchy_selection_keeps_single_product_view_command_path():
+    cpp = (ROOT / "workcell_builder/workcell_builder/gui/scene_preview_widget.cpp").read_text(encoding="utf-8")
+    selection = cpp.split("void ScenePreviewWidget::select_preview_item", 1)[1].split("void ScenePreviewWidget::", 1)[0]
+    for item_id in ["target_bin_default", "realsense_overhead", "support_surface_table", "pick_zone_commissioning", "commissioning_pick_pose", "place_zone_default"]:
+        assert item_id not in selection
+    assert selection.count("run_embedded_editor_command") == 2
+    assert selection.count(".selectItem(") == 1
+    assert selection.count(".clearSelection()") == 1
 
 
 def test_viewer_status_reporting_ignores_hidden_helper_overlay_counters(tmp_path):

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -2378,6 +2378,8 @@ void ScenePreviewWidget::poll_embedded_editor_events()
     apply_embedded_editor_state(editor_state);
     const QString browser_scene_id = editor_state.value(QStringLiteral("sceneId")).toString().trimmed();
     const QString browser_selected_id = editor_state.value(QStringLiteral("selectedItemId")).toString();
+    QString browser_ui_selected_id = editor_state.value(QStringLiteral("uiSelectionItemId")).toString();
+    if (browser_ui_selected_id.isEmpty()) browser_ui_selected_id = browser_selected_id;
     const QVariantMap selection_diagnostics = editor_state.value(QStringLiteral("selectionDiagnostics")).toMap();
     const bool scene_identity_matches = browser_scene_id.isEmpty() || browser_scene_id == identity.scene_id;
     bool matching_selection_event = false;
@@ -2385,8 +2387,9 @@ void ScenePreviewWidget::poll_embedded_editor_events()
     for (const QVariant & event_value : payload.value(QStringLiteral("events")).toList()) {
       const QVariantMap event = event_value.toMap();
       if (event.value(QStringLiteral("type")).toString() == QStringLiteral("selection_changed")) {
-        const QString id = event.value(QStringLiteral("itemId")).toString();
-        if (!id.isEmpty() && id == browser_selected_id) {
+        QString id = event.value(QStringLiteral("uiItemId")).toString();
+        if (id.isEmpty()) id = event.value(QStringLiteral("itemId")).toString();
+        if (!id.isEmpty() && id == browser_ui_selected_id) {
           matching_selection_event = true;
           matching_item_type = event.value(QStringLiteral("itemType")).toString();
         }
@@ -2396,12 +2399,14 @@ void ScenePreviewWidget::poll_embedded_editor_events()
     // guards above. Helpers and derived overlays are valid inspection selections. Editing is
     // still governed by the payload's editable/locked contract; rejecting them
     // here made the embedded viewer and Qt hierarchy disagree about identity.
+    // The rendered browser identity is deliberately not required to satisfy
+    // preview_item_by_id(browser_selected_id) != nullptr; Qt owns authored/UI rows.
     const bool valid_browser_selection = matching_selection_event && scene_identity_matches &&
       selection_diagnostics.value(QStringLiteral("objectPresent")).toBool() &&
-      preview_item_by_id(browser_selected_id) != nullptr;
-    if (valid_browser_selection && browser_selected_id != selected_preview_item_id_) {
-      selected_preview_item_id_ = browser_selected_id;
-      emit preview_item_selected(browser_selected_id, matching_item_type);
+      preview_item_by_id(browser_ui_selected_id) != nullptr;
+    if (valid_browser_selection && browser_ui_selected_id != selected_preview_item_id_) {
+      selected_preview_item_id_ = browser_ui_selected_id;
+      emit preview_item_selected(browser_ui_selected_id, matching_item_type);
     } else if (browser_selected_id.isEmpty() && scene_identity_matches && !selected_preview_item_id_.isEmpty()) {
       selected_preview_item_id_.clear();
       emit preview_item_selected(QString(), QString());

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -927,6 +927,26 @@ function pushEditorEvent(type, payload = {}) {
   state.editorEvents.push({ type, timestamp: new Date().toISOString(), ...payload });
   if (state.editorEvents.length > 100) state.editorEvents.splice(0, state.editorEvents.length - 100);
 }
+const UI_SELECTION_REFERENCE_FIELDS = Object.freeze([
+  'canonical_scene_item_id',
+  'canonical_item_id',
+  'layout_item_ref',
+  'authored_item_id',
+  'scene_item_id',
+  'object_ref',
+  'support_surface_ref',
+  'camera_id',
+]);
+function explicitUiSelectionItemId(rendered) {
+  const exactId = String(rendered?.item?.id || '');
+  if (!exactId) return '';
+  const activeItemIds = new Set(collectItems(state.sceneJson || {}).map(item => String(item?.id || '')).filter(Boolean));
+  for (const field of UI_SELECTION_REFERENCE_FIELDS) {
+    const candidate = String(rendered.item?.[field] || '').trim();
+    if (candidate && activeItemIds.has(candidate)) return candidate;
+  }
+  return exactId;
+}
 function currentSelectionDiagnostics() {
   const id = String(state.selected || '');
   const rendered = renderedById(id);
@@ -935,6 +955,7 @@ function currentSelectionDiagnostics() {
   return {
     sceneId: sceneId(),
     selectedItemId: id,
+    uiSelectionItemId: explicitUiSelectionItemId(rendered),
     editOwnerItemId: editOwner?.item?.id || '',
     renderIdentity: id,
     selectedItemType: rendered ? itemType(item) : '',
@@ -955,7 +976,7 @@ function currentSelectionDiagnostics() {
 function editorState() {
   const rendered = renderedById(state.selected);
   const editOwner = canonicalEditOwnerRendered(rendered);
-  return { ready: Boolean(state.sceneJson && state.three?.scene), sceneId: sceneId(), selectedItemId: state.selected || '', editOwnerItemId: editOwner?.item?.id || '', selectedItemType: rendered ? itemType(rendered.item) : '', selectedEditable: selectionIsEditable(rendered), selectionDiagnostics: currentSelectionDiagnostics(), lastRaycastHitCount: state.lastRaycastHitCount, lastRaycastCandidateIds: [...state.lastRaycastCandidateIds], lastCanvasSelectedItemId: state.lastCanvasSelectedItemId, lastCanvasPickReason: state.lastCanvasPickReason, dirty: state.dirtyTransforms.size > 0, dirtyCount: state.dirtyTransforms.size, canUndo: state.undoStack.length > 0, canRedo: state.redoStack.length > 0, mode: state.editorMode, error: state.editorError || '' };
+  return { ready: Boolean(state.sceneJson && state.three?.scene), sceneId: sceneId(), selectedItemId: state.selected || '', uiSelectionItemId: explicitUiSelectionItemId(rendered), editOwnerItemId: editOwner?.item?.id || '', selectedItemType: rendered ? itemType(rendered.item) : '', selectedEditable: selectionIsEditable(rendered), selectionDiagnostics: currentSelectionDiagnostics(), lastRaycastHitCount: state.lastRaycastHitCount, lastRaycastCandidateIds: [...state.lastRaycastCandidateIds], lastCanvasSelectedItemId: state.lastCanvasSelectedItemId, lastCanvasPickReason: state.lastCanvasPickReason, dirty: state.dirtyTransforms.size > 0, dirtyCount: state.dirtyTransforms.size, canUndo: state.undoStack.length > 0, canRedo: state.redoStack.length > 0, mode: state.editorMode, error: state.editorError || '' };
 }
 function emitDirtyChanged() { pushEditorEvent('dirty_changed', { dirty: state.dirtyTransforms.size > 0, dirtyCount: state.dirtyTransforms.size, canUndo: state.undoStack.length > 0, canRedo: state.redoStack.length > 0 }); }
 function showError(message) {
@@ -3695,7 +3716,7 @@ function selectObject(id) {
   updateLabels();
   const rendered = renderedById(id);
   if (rendered) { populateInspector(rendered); attachTransformGizmo(rendered); refreshSelectionHighlight(rendered); } else { detachTransformGizmo(); removeSelectionHighlight(); }
-  if (previous !== (id || '')) pushEditorEvent('selection_changed', { itemId: id || '', itemType: rendered ? itemType(rendered.item) : '', editable: Boolean(rendered && rendered.item && canEditItem(rendered['item'])) });
+  if (previous !== (id || '')) pushEditorEvent('selection_changed', { itemId: id || '', uiItemId: explicitUiSelectionItemId(rendered), itemType: rendered ? itemType(rendered.item) : '', editable: Boolean(rendered && rendered.item && canEditItem(rendered['item'])) });
 }
 function clearSelection() { selectObject(''); el.inspector.className = 'state empty'; el.inspector.textContent = state.objects.length ? 'Select an object from the list or canvas.' : EMPTY_SCENE_MESSAGE; }
 function pickObject(event) {


### PR DESCRIPTION
### Motivation
- Product View was correctly highlighting the exact rendered mesh `selectedItemId`, but the Qt hierarchy and Selected Item card used stable authored IDs and therefore ignored generated render IDs, causing the two views to desynchronize. 
- The change introduces an explicit UI-selection identity bridge so the Product View can keep its exact render identity while Qt receives a stable authored identity for hierarchy and inspector synchronization. 

### Description
- Add `explicitUiSelectionItemId(rendered)` and `UI_SELECTION_REFERENCE_FIELDS` to `workcell_studio_web/viewer/viewer.js` and expose `uiSelectionItemId` in `editorState()` and `currentSelectionDiagnostics()`, while adding `uiItemId` to `selection_changed` events so the browser sends both the exact render identity and the authored/UI identity.  
- Update `ScenePreviewWidget::poll_embedded_editor_events()` in `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp` to read `uiSelectionItemId` (falling back to `selectedItemId`), prefer `event.uiItemId` when present, validate the authored UI identity via `preview_item_by_id(...)`, and emit Qt selection using the authored identity while preserving the browser's exact render selection.  
- Revise and add source-level tests in `tests/test_workcell_studio_web_viewer_static.py` and `tests/test_embedded_web3d_editor_bridge_static.py` to prove camera/table/bin behaviors, commissioning pick-zone highlighting, place-zone vs edit-owner separation, invalid explicit-reference fallback, and the updated `selectionIsEditable(rendered)` guard, plus a JS harness test that exercises explicit UI identity resolution.  
- Preserve the existing single hierarchy→Product View command path and make this a source-only change without rebuilding `viewer.bundle.js` or touching generated/dist artifacts. 

### Testing
- Ran `node --check workcell_studio_web/viewer/viewer.js`, which passed. 
- Ran `python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py tests/test_embedded_web3d_editor_bridge_static.py tests/test_workcell_builder_selected_item_card.py`, resulting in all tests passing (`129 passed`) with three pre-existing Python invalid-escape warnings. 
- Verified no distribution artifacts under `workcell_studio_web/viewer/dist` were modified and confirmed the change is source-only; GUI/workstation validation was not performed in this environment so the M1 GUI acceptance remains PARTIALLY CONFIRMED until the bundle rebuild and display-enabled checks are executed in a workstation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b429d7df88331a6cdc65a95c08243)