### PR TITLE
M1: rebuild Web3D bundle for hierarchy selection bridge

### DIFF
--- a/workcell_studio_web/viewer/dist/viewer.bundle.js
+++ b/workcell_studio_web/viewer/dist/viewer.bundle.js
@@ -39289,6 +39289,28 @@ function pushEditorEvent(type, payload = {}) {
   if (state.editorEvents.length > 100)
     state.editorEvents.splice(0, state.editorEvents.length - 100);
 }
+var UI_SELECTION_REFERENCE_FIELDS = Object.freeze([
+  "canonical_scene_item_id",
+  "canonical_item_id",
+  "layout_item_ref",
+  "authored_item_id",
+  "scene_item_id",
+  "object_ref",
+  "support_surface_ref",
+  "camera_id"
+]);
+function explicitUiSelectionItemId(rendered) {
+  const exactId = String(rendered?.item?.id || "");
+  if (!exactId)
+    return "";
+  const activeItemIds = new Set(collectItems(state.sceneJson || {}).map((item) => String(item?.id || "")).filter(Boolean));
+  for (const field of UI_SELECTION_REFERENCE_FIELDS) {
+    const candidate = String(rendered.item?.[field] || "").trim();
+    if (candidate && activeItemIds.has(candidate))
+      return candidate;
+  }
+  return exactId;
+}
 function currentSelectionDiagnostics() {
   const id = String(state.selected || "");
   const rendered = renderedById(id);
@@ -39297,6 +39319,7 @@ function currentSelectionDiagnostics() {
   return {
     sceneId: sceneId(),
     selectedItemId: id,
+    uiSelectionItemId: explicitUiSelectionItemId(rendered),
     editOwnerItemId: editOwner?.item?.id || "",
     renderIdentity: id,
     selectedItemType: rendered ? itemType(item) : "",
@@ -39317,7 +39340,7 @@ function currentSelectionDiagnostics() {
 function editorState() {
   const rendered = renderedById(state.selected);
   const editOwner = canonicalEditOwnerRendered(rendered);
-  return { ready: Boolean(state.sceneJson && state.three?.scene), sceneId: sceneId(), selectedItemId: state.selected || "", editOwnerItemId: editOwner?.item?.id || "", selectedItemType: rendered ? itemType(rendered.item) : "", selectedEditable: selectionIsEditable(rendered), selectionDiagnostics: currentSelectionDiagnostics(), lastRaycastHitCount: state.lastRaycastHitCount, lastRaycastCandidateIds: [...state.lastRaycastCandidateIds], lastCanvasSelectedItemId: state.lastCanvasSelectedItemId, lastCanvasPickReason: state.lastCanvasPickReason, dirty: state.dirtyTransforms.size > 0, dirtyCount: state.dirtyTransforms.size, canUndo: state.undoStack.length > 0, canRedo: state.redoStack.length > 0, mode: state.editorMode, error: state.editorError || "" };
+  return { ready: Boolean(state.sceneJson && state.three?.scene), sceneId: sceneId(), selectedItemId: state.selected || "", uiSelectionItemId: explicitUiSelectionItemId(rendered), editOwnerItemId: editOwner?.item?.id || "", selectedItemType: rendered ? itemType(rendered.item) : "", selectedEditable: selectionIsEditable(rendered), selectionDiagnostics: currentSelectionDiagnostics(), lastRaycastHitCount: state.lastRaycastHitCount, lastRaycastCandidateIds: [...state.lastRaycastCandidateIds], lastCanvasSelectedItemId: state.lastCanvasSelectedItemId, lastCanvasPickReason: state.lastCanvasPickReason, dirty: state.dirtyTransforms.size > 0, dirtyCount: state.dirtyTransforms.size, canUndo: state.undoStack.length > 0, canRedo: state.redoStack.length > 0, mode: state.editorMode, error: state.editorError || "" };
 }
 function emitDirtyChanged() {
   pushEditorEvent("dirty_changed", { dirty: state.dirtyTransforms.size > 0, dirtyCount: state.dirtyTransforms.size, canUndo: state.undoStack.length > 0, canRedo: state.redoStack.length > 0 });
@@ -42205,7 +42228,7 @@ function selectObject(id) {
     removeSelectionHighlight();
   }
   if (previous !== (id || ""))
-    pushEditorEvent("selection_changed", { itemId: id || "", itemType: rendered ? itemType(rendered.item) : "", editable: Boolean(rendered && rendered.item && canEditItem(rendered["item"])) });
+    pushEditorEvent("selection_changed", { itemId: id || "", uiItemId: explicitUiSelectionItemId(rendered), itemType: rendered ? itemType(rendered.item) : "", editable: Boolean(rendered && rendered.item && canEditItem(rendered["item"])) });
 }
 function clearSelection() {
   selectObject("");


### PR DESCRIPTION
### Motivation
- Regenerate the production Web3D bundle so the viewer includes the selection-identity bridge merged in PR #2916 and ensure the production artifact matches the new source implementation.

### Description
- Regenerated only `workcell_studio_web/viewer/dist/viewer.bundle.js` by running `cd workcell_studio_web/viewer && npm ci && npm run build:web3d` and restored the source map with `git restore workcell_studio_web/viewer/dist/viewer.bundle.js.map`; the bundle now contains `UI_SELECTION_REFERENCE_FIELDS`, `explicitUiSelectionItemId`, and `uiSelectionItemId` markers and no source code, tests, C++, YAML, or generated scene files were modified.

### Testing
- Verified `npm run check:stale-bundle` reported the bundle current, ran `python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py tests/test_embedded_web3d_editor_bridge_static.py tests/test_workcell_builder_selected_item_card.py` which passed (129 tests), `git diff --check` was clean, and `git status --short` showed exactly `M workcell_studio_web/viewer/dist/viewer.bundle.js`; `git push` failed due to missing GitHub credentials in this environment and no workstation GUI acceptance was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b467a83408331892416e4c897742b)