### PR TITLE
M1: synchronize fixture and robot link selection end to end

### DIFF
--- a/tests/test_embedded_web3d_editor_bridge_static.py
+++ b/tests/test_embedded_web3d_editor_bridge_static.py
@@ -160,7 +160,6 @@ def test_qt_poll_accepts_only_final_valid_browser_selection_and_explicit_clear()
         'editor_state.value(QStringLiteral("uiSelectionItemId"))',
         'editor_state.value(QStringLiteral("selectionDiagnostics"))',
         'editor_state.value(QStringLiteral("sceneId"))',
-        'id == browser_ui_selected_id',
         'selection_diagnostics.value(QStringLiteral("objectPresent")).toBool()',
         'preview_item_by_id(browser_ui_selected_id) != nullptr',
         'browser_scene_id == identity.scene_id',
@@ -172,3 +171,28 @@ def test_qt_poll_accepts_only_final_valid_browser_selection_and_explicit_clear()
     assert "selected_preview_item_id_ = browser_ui_selected_id" in poll
     assert "browser_selected_id.isEmpty()" in poll
     assert "selected_preview_item_id_.clear();" in poll
+
+
+def test_qt_poll_treats_current_browser_state_as_authoritative_without_same_cycle_event():
+    poll = CPP.split("void ScenePreviewWidget::poll_embedded_editor_events()", 1)[1].split("#else", 1)[0]
+    assert "matching_selection_event" not in poll
+    assert "const bool valid_browser_selection = scene_identity_matches && !browser_ui_selected_id.isEmpty()" in poll
+    assert 'editor_state.value(QStringLiteral("selectedItemType"))' in poll
+    assert "browser_ui_selected_id != selected_preview_item_id_" in poll
+    assert "emit preview_item_selected(browser_ui_selected_id, matching_item_type);" in poll
+    assert "browser_selected_id.isEmpty() && scene_identity_matches" in poll
+    assert "state_request_token != embedded_editor_state_request_token_" in poll
+    assert "preview_item_by_id(browser_ui_selected_id) != nullptr" in poll
+    assert "Embedded Product View selection rejected:" in poll
+    assert "emitted_scene_diagnostic_keys_.contains(rejection_key)" in poll
+
+
+def test_qt_inventory_preserves_unique_locked_robot_and_tool_owner_rows():
+    main = (ROOT / "workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text(encoding="utf-8")
+    body = main.split("auto preserve_unique_inspection_owner", 1)[1].split("const bool filtered_payload_changed", 1)[0]
+    assert "item.locked && !item.editable" in body
+    assert 'source_layer != QStringLiteral("locked_generated_urdf_visual")' in body
+    assert "if (candidates.size() != 1) return;" in body
+    assert 'QStringLiteral("robot_arm")' in body
+    assert 'QStringLiteral("end_effector")' in body
+    assert "filtered_items.push_back(candidates.front())" in body

--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -6,6 +6,85 @@ ROOT = Path(__file__).resolve().parents[1]
 VIEWER = ROOT / "workcell_studio_web" / "viewer"
 
 
+def test_selection_identity_index_and_expanded_urdf_picks_behave_end_to_end(tmp_path):
+    harness = r"""
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+let source = fs.readFileSync(process.argv[1], 'utf8').replace(/boot\(\);\s*$/, '');
+const element = () => ({ hidden:false, checked:false, disabled:false, textContent:'', className:'', innerHTML:'', classList:{toggle(){}}, querySelector(){return {textContent:''}}, appendChild(){}, addEventListener(){}, setAttribute(){} });
+const context = { console, assert, window:{location:{search:''},dispatchEvent(){},parent:{postMessage(){}}}, document:{getElementById(){return element()},createElement(){return element()}}, URLSearchParams, CustomEvent:function(){}, requestAnimationFrame(){return 0}, setTimeout(){return 0}, clearTimeout(){} };
+vm.createContext(context);
+vm.runInContext(source + `
+const cameraOwner = { id:'camera_owner', category:'camera' };
+const tableOwner = { id:'table_owner', category:'table' };
+const robotOwner = { id:'configured_robot', category:'robot', readiness_category:'robot_arm', locked:true, editable:false };
+const toolOwner = { id:'configured_tool', category:'tool', readiness_category:'attached_tool_gripper', locked:true, editable:false };
+const cameraMapped = { id:'camera_payload_visual', link_name:'fixture_camera_link', canonical_scene_item_id:'camera_owner' };
+const cameraClicked = { id:'generated_urdf::fixture_camera_link::visual_17::17', link_name:'fixture_camera_link' };
+const tableMapped = { id:'table_payload_visual', final_render_link:'fixture_table_link', support_surface_ref:'table_owner' };
+const tableClicked = { id:'generated_urdf::fixture_table_link::visual_4::4', canonical_link_name:'fixture_table_link' };
+state.sceneJson = { scene:{id:'selection_scene'}, objects:[cameraOwner, tableOwner, robotOwner, toolOwner, cameraMapped, cameraClicked, tableMapped, tableClicked], robot_preview:{ mode:'expanded_urdf_loader', robot_instance_id:'configured_robot', tool_id:'configured_tool', expected_robot_visual_links:['arm_link'], expected_tool_visual_links:['finger_link'] } };
+rebuildSelectionIdentityIndex();
+let camera = uiSelectionIdentity({item:cameraClicked, pickRecordSource:'payload_item'});
+assert.deepStrictEqual(JSON.parse(JSON.stringify(camera)), {id:'camera_owner', resolution:'exact_link_explicit_ref', linkName:'fixture_camera_link', pickRecordSource:'payload_item'});
+let table = uiSelectionIdentity({item:tableClicked, pickRecordSource:'payload_item'});
+assert.strictEqual(table.id, 'table_owner');
+assert.strictEqual(table.resolution, 'exact_link_explicit_ref');
+
+state.sceneJson.objects.push({id:'other_owner'}, {id:'ambiguous_mapping', link_name:'fixture_camera_link', canonical_item_id:'other_owner'});
+rebuildSelectionIdentityIndex();
+assert.strictEqual(explicitUiSelectionItemId({item:cameraClicked}), cameraClicked.id);
+state.sceneJson.objects.splice(-2);
+rebuildSelectionIdentityIndex();
+
+let callbacks = [];
+loadRobotPreview = (_preview, options) => { callbacks.push(options); return {diagnostics:{}, links:new Map()}; };
+state.three = {scene:{add(){}}};
+state.web3dReadiness = {state:'scene_loading', required:{}, pending:new Set(), failed:false};
+renderSceneSummary = () => {};
+refreshInitialPoseActionState = () => {};
+failIfExpandedUrdfExpectedVisualSetInvalid = () => false;
+completeExpandedUrdfReadiness = () => {};
+loadExpandedUrdfRobotPreview(state.sceneJson.robot_preview);
+const armObject = {visible:true};
+const fingerObject = {visible:true};
+callbacks[0].onRobotLoaded({root:{}, links:new Map([['arm_link',armObject],['finger_link',fingerObject]]), diagnostics:{}});
+assert.strictEqual(state.pickRecords.length, 2);
+const armPick = state.pickRecords.find(record => record.item.link_name === 'arm_link');
+const fingerPick = state.pickRecords.find(record => record.item.link_name === 'finger_link');
+assert.strictEqual(armPick.pickRecordSource, 'expanded_urdf_inspection');
+assert.strictEqual(uiSelectionIdentity(armPick).id, 'configured_robot');
+assert.strictEqual(uiSelectionIdentity(armPick).resolution, 'robot_owner');
+assert.strictEqual(uiSelectionIdentity(fingerPick).id, 'configured_tool');
+assert.strictEqual(uiSelectionIdentity(fingerPick).resolution, 'tool_owner');
+state.selected = armPick.item.id;
+let diagnostic = currentSelectionDiagnostics();
+assert.strictEqual(diagnostic.selectedItemId, armPick.item.id);
+assert.strictEqual(diagnostic.uiSelectionItemId, 'configured_robot');
+assert.strictEqual(diagnostic.pickRecordSource, 'expanded_urdf_inspection');
+assert.strictEqual(state.objects.some(record => record.item.id === armPick.item.id), false);
+assert.strictEqual(state.dirtyTransforms.has(armPick.item.id), false);
+assert.strictEqual(buildEditPatch().edits.some(edit => edit.id === armPick.item.id), false);
+
+const stale = callbacks[0];
+state.sceneJson = {scene:{id:'next_scene'}, objects:[]};
+resetSceneLifecycleState();
+const before = state.pickRecords.length;
+stale.onRobotLoaded({root:{}, links:new Map([['arm_link',{visible:true}]]), diagnostics:{}});
+assert.strictEqual(state.pickRecords.length, before);
+`, context);
+"""
+    subprocess.run(
+        ["node", "-e", harness, str(VIEWER / "viewer.js")],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
 def test_static_viewer_files_exist():
     assert (VIEWER / "index.html").is_file()
     assert (VIEWER / "viewer.js").is_file()

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -8708,6 +8708,30 @@ void MainWindow::apply_scene3d_preview_layer_filters(bool log_change)
   if (filtered_items.isEmpty() && !all_scene_preview_items_.isEmpty()) {
     append_studio_log("Scene3D blocker: current layer filters hide all items. Re-enable editable layout, mesh preview, primitive fallback, or locked generated URDF visuals.");
   }
+  // Keep the single configured robot and end-effector inspection owners in the
+  // Qt identity inventory even when their generated per-link render rows are
+  // suppressed. These are existing payload records, not renderable URDF-link
+  // rows, and remain locked/read-only hierarchy and Selected Item owners.
+  auto preserve_unique_inspection_owner = [&](const QSet<QString> & categories) {
+    QVector<ScenePreviewWidget::PreviewItem> candidates;
+    for (const auto & item : all_scene_preview_items_) {
+      const QString category = item.category.trimmed().toLower();
+      const QString source_layer = item.source_layer.trimmed().toLower();
+      if (categories.contains(category) && item.locked && !item.editable &&
+          source_layer != QStringLiteral("locked_generated_urdf_visual") &&
+          source_layer != QStringLiteral("generated_urdf_visual")) {
+        candidates.push_back(item);
+      }
+    }
+    if (candidates.size() != 1) return;
+    const QString owner_id = candidates.front().id.trimmed();
+    const bool already_present = std::any_of(filtered_items.cbegin(), filtered_items.cend(), [&](const auto & item) {
+      return item.id.trimmed() == owner_id;
+    });
+    if (!already_present) filtered_items.push_back(candidates.front());
+  };
+  preserve_unique_inspection_owner({QStringLiteral("robot"), QStringLiteral("robot_arm")});
+  preserve_unique_inspection_owner({QStringLiteral("tool"), QStringLiteral("end_effector"), QStringLiteral("gripper")});
   const bool filtered_payload_changed = !scene_preview_widget_->preview_payload_matches(filtered_items);
   if (filtered_payload_changed) {
     scene_preview_widget_->set_preview_items(filtered_items);

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -2381,8 +2381,7 @@ void ScenePreviewWidget::poll_embedded_editor_events()
     QString browser_ui_selected_id = editor_state.value(QStringLiteral("uiSelectionItemId")).toString();
     if (browser_ui_selected_id.isEmpty()) browser_ui_selected_id = browser_selected_id;
     const QVariantMap selection_diagnostics = editor_state.value(QStringLiteral("selectionDiagnostics")).toMap();
-    const bool scene_identity_matches = browser_scene_id.isEmpty() || browser_scene_id == identity.scene_id;
-    bool matching_selection_event = false;
+    const bool scene_identity_matches = !browser_scene_id.isEmpty() && browser_scene_id == identity.scene_id;
     QString matching_item_type;
     for (const QVariant & event_value : payload.value(QStringLiteral("events")).toList()) {
       const QVariantMap event = event_value.toMap();
@@ -2390,7 +2389,6 @@ void ScenePreviewWidget::poll_embedded_editor_events()
         QString id = event.value(QStringLiteral("uiItemId")).toString();
         if (id.isEmpty()) id = event.value(QStringLiteral("itemId")).toString();
         if (!id.isEmpty() && id == browser_ui_selected_id) {
-          matching_selection_event = true;
           matching_item_type = event.value(QStringLiteral("itemType")).toString();
         }
       }
@@ -2401,9 +2399,30 @@ void ScenePreviewWidget::poll_embedded_editor_events()
     // here made the embedded viewer and Qt hierarchy disagree about identity.
     // The rendered browser identity is deliberately not required to satisfy
     // preview_item_by_id(browser_selected_id) != nullptr; Qt owns authored/UI rows.
-    const bool valid_browser_selection = matching_selection_event && scene_identity_matches &&
-      selection_diagnostics.value(QStringLiteral("objectPresent")).toBool() &&
-      preview_item_by_id(browser_ui_selected_id) != nullptr;
+    if (matching_item_type.isEmpty()) {
+      matching_item_type = editor_state.value(QStringLiteral("selectedItemType")).toString();
+    }
+    const bool object_present = selection_diagnostics.value(QStringLiteral("objectPresent")).toBool();
+    const bool preview_item_found = preview_item_by_id(browser_ui_selected_id) != nullptr;
+    const bool valid_browser_selection = scene_identity_matches && !browser_ui_selected_id.isEmpty() &&
+      object_present && preview_item_found;
+    if (!browser_selected_id.isEmpty() && !valid_browser_selection) {
+      QString rejection_reason;
+      if (!scene_identity_matches) rejection_reason = QStringLiteral("scene_identity_mismatch");
+      else if (browser_ui_selected_id.isEmpty()) rejection_reason = QStringLiteral("empty_ui_identity");
+      else if (!object_present) rejection_reason = QStringLiteral("browser_object_absent");
+      else rejection_reason = QStringLiteral("preview_item_absent");
+      const QString rejection_key = QStringLiteral("embedded_selection_rejected|%1|%2|%3|%4")
+        .arg(identity.scene_id, browser_selected_id, browser_ui_selected_id, rejection_reason);
+      if (!emitted_scene_diagnostic_keys_.contains(rejection_key)) {
+        emitted_scene_diagnostic_keys_.insert(rejection_key);
+        emit studio_log_requested(QStringLiteral(
+          "Embedded Product View selection rejected: browser_exact_id=%1 browser_ui_id=%2 scene_id=%3 objectPresent=%4 preview_item_found=%5 reason=%6")
+          .arg(browser_selected_id, browser_ui_selected_id, identity.scene_id,
+               object_present ? QStringLiteral("true") : QStringLiteral("false"),
+               preview_item_found ? QStringLiteral("true") : QStringLiteral("false"), rejection_reason));
+      }
+    }
     if (valid_browser_selection && browser_ui_selected_id != selected_preview_item_id_) {
       selected_preview_item_id_ = browser_ui_selected_id;
       emit preview_item_selected(browser_ui_selected_id, matching_item_type);

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -38,7 +38,7 @@ const CAMERA_PRESET_DIRECTIONS = Object.freeze({
   top: [0, -0.001, 1],
   robot: [1.1, -1.25, 0.72],
 });
-const state = { sceneJson: null, sourceWebSceneFile: '', diagnosticKeys: new Set(), frameLookup: new Map(), resolvedFramePoses: new Map(), objects: [], pickRecords: [], pickIdentityByObject: new WeakMap(), assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, robotUrdfPreviewDiagnostics: {}, physicalAssemblyBounds: null, finalPhysicalFitBounds: null, selected: null, three: {}, animationId: null, lastFrameBounds: null, initialCameraFit: { sceneKey: '', done: false, attempts: 0, pendingRetry: null, userControlled: false }, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: new Map(), undoStack: [], redoStack: [], gizmoDragStart: null, directMoveDrag: null, directRotateDrag: null, editorMode: 'select', editorEvents: [], editorError: '', robotPreviewResult: null, lastRaycastHitCount: 0, lastRaycastCandidateIds: [], lastCanvasSelectedItemId: '', lastCanvasPickReason: '', initialPosePreview: { active: false, robotId: '', sceneKey: '' }, web3dReadiness: { state: 'booting', terminal: false, terminalState: '', terminalNavigationKey: '', terminalEmissionCount: 0, statusSequence: 0, required: {}, pending: new Set(), failed: false, failure: null }, builderRevision: '', sceneJsonLoaded: false, activeNavigationKey: '' };
+const state = { sceneJson: null, sourceWebSceneFile: '', diagnosticKeys: new Set(), frameLookup: new Map(), resolvedFramePoses: new Map(), objects: [], pickRecords: [], pickIdentityByObject: new WeakMap(), selectionIdentityIndex: null, assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, robotUrdfPreviewDiagnostics: {}, physicalAssemblyBounds: null, finalPhysicalFitBounds: null, selected: null, three: {}, animationId: null, lastFrameBounds: null, initialCameraFit: { sceneKey: '', done: false, attempts: 0, pendingRetry: null, userControlled: false }, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: new Map(), undoStack: [], redoStack: [], gizmoDragStart: null, directMoveDrag: null, directRotateDrag: null, editorMode: 'select', editorEvents: [], editorError: '', robotPreviewResult: null, lastRaycastHitCount: 0, lastRaycastCandidateIds: [], lastCanvasSelectedItemId: '', lastCanvasPickReason: '', initialPosePreview: { active: false, robotId: '', sceneKey: '' }, web3dReadiness: { state: 'booting', terminal: false, terminalState: '', terminalNavigationKey: '', terminalEmissionCount: 0, statusSequence: 0, required: {}, pending: new Set(), failed: false, failure: null }, builderRevision: '', sceneJsonLoaded: false, activeNavigationKey: '' };
 let robotPreviewLoadToken = 0;
 const RESET_VIEW_TITLE = 'Fit Scene / Reset View: recomputes and reapplies the fitted workcell overview from renderable bounds.';
 const STAGED_MESH_ROOTS = [
@@ -937,25 +937,69 @@ const UI_SELECTION_REFERENCE_FIELDS = Object.freeze([
   'support_surface_ref',
   'camera_id',
 ]);
-function explicitUiSelectionItemId(rendered) {
+const SELECTION_LINK_IDENTITY_FIELDS = Object.freeze([
+  'link_name', 'link', 'canonical_link_name', 'object_name', 'final_render_link',
+]);
+function exactSelectionLinkName(item) {
+  for (const field of SELECTION_LINK_IDENTITY_FIELDS) {
+    const value = String(item?.[field] || '').trim();
+    if (value) return value;
+  }
+  return '';
+}
+function rebuildSelectionIdentityIndex(sceneJson = state.sceneJson || {}) {
+  const items = collectItems(sceneJson);
+  const itemById = new Map(items.map(item => [String(item?.id || '').trim(), item]).filter(([id]) => id));
+  const recordsByLink = new Map();
+  for (const item of items) {
+    const link = exactSelectionLinkName(item);
+    if (!link) continue;
+    if (!recordsByLink.has(link)) recordsByLink.set(link, []);
+    recordsByLink.get(link).push(item);
+  }
+  const explicitUiIdByLink = new Map();
+  for (const [link, records] of recordsByLink) {
+    const candidates = new Set();
+    for (const record of records) {
+      for (const field of UI_SELECTION_REFERENCE_FIELDS) {
+        const candidate = String(record?.[field] || '').trim();
+        if (candidate && itemById.has(candidate)) candidates.add(candidate);
+      }
+    }
+    if (candidates.size === 1) explicitUiIdByLink.set(link, [...candidates][0]);
+  }
+  state.selectionIdentityIndex = { itemById, recordsByLink, explicitUiIdByLink };
+  return state.selectionIdentityIndex;
+}
+function uiSelectionIdentity(rendered) {
   const exactId = String(rendered?.item?.id || '');
-  if (!exactId) return '';
-  const activeItemIds = new Set(collectItems(state.sceneJson || {}).map(item => String(item?.id || '')).filter(Boolean));
+  if (!exactId) return { id: '', resolution: 'exact_identity_fallback', linkName: '', pickRecordSource: '' };
+  const index = state.selectionIdentityIndex || rebuildSelectionIdentityIndex();
   for (const field of UI_SELECTION_REFERENCE_FIELDS) {
     const candidate = String(rendered.item?.[field] || '').trim();
-    if (candidate && activeItemIds.has(candidate)) return candidate;
+    if (candidate && index.itemById.has(candidate)) return { id: candidate, resolution: 'direct_explicit_ref', linkName: exactSelectionLinkName(rendered.item), pickRecordSource: rendered.pickRecordSource || 'payload_item' };
   }
-  return exactId;
+  const linkName = exactSelectionLinkName(rendered.item);
+  const linkedId = linkName ? index.explicitUiIdByLink.get(linkName) : '';
+  if (linkedId) return { id: linkedId, resolution: 'exact_link_explicit_ref', linkName, pickRecordSource: rendered.pickRecordSource || 'payload_item' };
+  if (rendered.uiSelectionOwnerId && index.itemById.has(rendered.uiSelectionOwnerId)) {
+    return { id: rendered.uiSelectionOwnerId, resolution: rendered.uiSelectionResolution || 'exact_identity_fallback', linkName, pickRecordSource: rendered.pickRecordSource || 'expanded_urdf_inspection' };
+  }
+  return { id: exactId, resolution: 'exact_identity_fallback', linkName, pickRecordSource: rendered.pickRecordSource || 'payload_item' };
+}
+function explicitUiSelectionItemId(rendered) {
+  return uiSelectionIdentity(rendered).id;
 }
 function currentSelectionDiagnostics() {
   const id = String(state.selected || '');
   const rendered = renderedById(id);
   const editOwner = canonicalEditOwnerRendered(rendered);
   const item = rendered?.item || null;
+  const selectionIdentity = uiSelectionIdentity(rendered);
   return {
     sceneId: sceneId(),
     selectedItemId: id,
-    uiSelectionItemId: explicitUiSelectionItemId(rendered),
+    uiSelectionItemId: selectionIdentity.id,
     editOwnerItemId: editOwner?.item?.id || '',
     renderIdentity: id,
     selectedItemType: rendered ? itemType(item) : '',
@@ -967,6 +1011,9 @@ function currentSelectionDiagnostics() {
     diagnosticOnly: Boolean(item && isDiagnosticOnlyItem(item)),
     helperOrOverlay: Boolean(item && isDebugOverlayItem(item)),
     objectPresent: Boolean(rendered),
+    selectedLinkName: selectionIdentity.linkName,
+    uiSelectionResolution: selectionIdentity.resolution,
+    pickRecordSource: selectionIdentity.pickRecordSource,
     lastRaycastHitCount: state.lastRaycastHitCount,
     lastRaycastCandidateIds: [...state.lastRaycastCandidateIds],
     lastCanvasSelectedItemId: state.lastCanvasSelectedItemId,
@@ -1163,9 +1210,9 @@ function meshLocalTransformOf(item) {
 function cloneTransform(transform) { return JSON.parse(JSON.stringify(transform)); }
 function sameTransform(a, b) { return JSON.stringify(a) === JSON.stringify(b); }
 function renderedById(id) { return state.objects.find(obj => obj.item.id === id) || state.pickRecords.find(obj => obj.item.id === id); }
-function registerPickRecord(item, object3d, root = object3d) {
+function registerPickRecord(item, object3d, root = object3d, options = {}) {
   if (!item?.id || !object3d) return null;
-  const record = { item, object3d, pickRoot: root, readOnlyPick: true };
+  const record = { item, object3d, pickRoot: root, readOnlyPick: true, ...options };
   state.pickRecords.push(record);
   state.pickIdentityByObject.set(object3d, record);
   return record;
@@ -3015,6 +3062,7 @@ function resetSceneLifecycleState() {
   state.objects = [];
   state.pickRecords = [];
   state.pickIdentityByObject = new WeakMap();
+  state.selectionIdentityIndex = null;
   state.lastRaycastHitCount = 0;
   state.lastRaycastCandidateIds = [];
   state.lastCanvasSelectedItemId = '';
@@ -3063,6 +3111,7 @@ function clearSceneObjects() {
 }
 function renderScene(items) {
   clearSceneObjects();
+  rebuildSelectionIdentityIndex(state.sceneJson || {});
   state.frameLookup = parseSceneFrames(state.sceneJson || {});
   state.resolvedFramePoses.clear();
   beginWeb3dSceneReadiness(items);
@@ -3198,12 +3247,42 @@ function loadExpandedUrdfRobotPreview(preview) {
       const itemsByLink = new Map();
       for (const item of collectItems(state.sceneJson || {})) {
         if (!isGeneratedUrdfItem(item)) continue;
-        const explicitLink = String(item?.link_name || item?.link || '').trim();
+        const explicitLink = exactSelectionLinkName(item);
         if (explicitLink && !itemsByLink.has(explicitLink)) itemsByLink.set(explicitLink, item);
       }
+      const robotLinks = new Set(asArray(preview?.expected_robot_visual_links || preview?.expectedRobotVisualLinks).map(value => String(value || '').trim()).filter(Boolean));
+      const toolLinks = new Set(asArray(preview?.expected_tool_visual_links || preview?.expectedToolVisualLinks).map(value => String(value || '').trim()).filter(Boolean));
+      const index = state.selectionIdentityIndex || rebuildSelectionIdentityIndex();
+      const ownerFromExplicitContract = (fields, readinessCategory) => {
+        for (const field of fields) {
+          const id = String(preview?.[field] || '').trim();
+          if (id && index.itemById.has(id)) return id;
+        }
+        const candidates = [...index.itemById.values()].filter(item =>
+          String(item?.readiness_category || item?.readinessCategory || '').trim() === readinessCategory &&
+          !isGeneratedUrdfItem(item));
+        return candidates.length === 1 ? String(candidates[0].id) : '';
+      };
+      const robotOwnerId = ownerFromExplicitContract(['robot_instance_id', 'robotInstanceId', 'robot_id', 'robotId'], 'robot_arm');
+      const toolOwnerId = ownerFromExplicitContract(['tool_instance_id', 'toolInstanceId', 'tool_id', 'toolId', 'end_effector_id', 'endEffectorId'], 'attached_tool_gripper');
+      const robotInstance = String(preview?.robot_instance_id || preview?.robotInstanceId || preview?.robot_id || preview?.robotId || 'robot').trim();
       for (const [linkName, linkObject] of result?.links || []) {
-        const item = itemsByLink.get(String(linkName));
-        if (item) registerPickRecord(item, linkObject, result.root || linkObject);
+        const exactLink = String(linkName || '').trim();
+        const fixtureOwnerId = index.explicitUiIdByLink.get(exactLink) || '';
+        const eligible = toolLinks.has(exactLink) || robotLinks.has(exactLink) || Boolean(fixtureOwnerId);
+        if (!eligible || !linkObject || linkObject.visible === false) continue;
+        const payloadItem = itemsByLink.get(exactLink);
+        const inspectionId = `${loadSceneId}::expanded_urdf_inspection::${robotInstance}::${exactLink}`;
+        const item = payloadItem || { id: inspectionId, link_name: exactLink, locked: true, editable: false, selectable: true, source_layer: 'expanded_urdf_inspection' };
+        let ownerId = fixtureOwnerId;
+        let resolution = fixtureOwnerId ? 'exact_link_explicit_ref' : 'exact_identity_fallback';
+        if (toolLinks.has(exactLink) && toolOwnerId) { ownerId = toolOwnerId; resolution = 'tool_owner'; }
+        else if (robotLinks.has(exactLink) && robotOwnerId) { ownerId = robotOwnerId; resolution = 'robot_owner'; }
+        registerPickRecord(item, linkObject, result.root || linkObject, {
+          pickRecordSource: payloadItem ? 'payload_item' : 'expanded_urdf_inspection',
+          uiSelectionOwnerId: ownerId,
+          uiSelectionResolution: resolution,
+        });
       }
       state.robotPreviewResult = result;
       state.robotUrdfPreviewDiagnostics = result.diagnostics;


### PR DESCRIPTION
### Motivation
- Product View clicks for cameras/tables or expanded-URDF robot links were not mapping to the stable Scene Hierarchy/UI owner because UI identity resolution only inspected the exact clicked payload record. 
- Expanded-URDF links often have no generated payload visual rows, so `loadExpandedUrdfRobotPreview()` did not create pick records for UR5/Robotiq links and they could not be selected. 
- The Qt bridge required a same-cycle `selection_changed` event in the drained event batch to accept a selection, making `getState()` non-authoritative and fragile across 200 ms polls. 
- The Scene Hierarchy inventory (`preview_items`) could lose the stable robot/tool owner rows when generated-per-link rows were filtered, removing valid UI IDs Qt would accept.

### Description
- Build a deterministic per-scene selection identity index on scene load that maps exact item IDs, exact normalized link names, and a single unambiguous explicit UI item ID per link using only explicit fields (e.g. `canonical_scene_item_id`, `camera_id`), implemented as `rebuildSelectionIdentityIndex()` and stored on `state.selectionIdentityIndex`. 
- Resolve UI identity via `uiSelectionIdentity(rendered)` (used by `explicitUiSelectionItemId`) by first honoring explicit UI fields on the clicked record, then consulting the link index for an exact-link explicit UI candidate and finally falling back to the exact clicked identity; diagnostics now expose `selectedItemId`, `uiSelectionItemId`, `selectedLinkName`, `uiSelectionResolution`, and `pickRecordSource`. 
- During non-stale `onRobotLoaded` calls register pick records for every eligible expanded-URDF link (even when no generated payload visual row exists) by creating deterministic, locked, browser-only inspection records and attaching `uiSelectionOwnerId`/`uiSelectionResolution` metadata so robot links map to a top-level configured robot owner and tool links to the configured tool owner (via `expected_robot_visual_links`/`expected_tool_visual_links`). 
- Make Qt polling treat the current `getState()` result as authoritative by validating scene/request identity, `selectionDiagnostics.objectPresent`, and presence of the stable UI ID in `preview_items`, remove dependence on same-cycle `selection_changed`, deduplicate rejection diagnostics, and emit `preview_item_selected` only when the stable Qt ID changes. 
- Preserve a single locked/read-only robot owner and single locked tool/end-effector owner in the Qt `preview_items` inventory even when per-link generated rows are filtered, and ensure these preserved rows are not editable, included in edit patches, or counted in editable/dirty state. 
- Files changed: `workcell_studio_web/viewer/viewer.js`, `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp`, `workcell_builder/workcell_builder/gui/mainwindow.cpp`, `tests/test_workcell_studio_web_viewer_static.py`, and `tests/test_embedded_web3d_editor_bridge_static.py`; the PR is source-only and does not modify `viewer.bundle.js`. 
- Identity contract: `selectedItemId` remains the exact clicked render/link identity (browser highlight), `uiSelectionItemId` is the stable authored fixture or configured robot/tool hierarchy/card owner, and `editOwnerItemId` (transform owner) is unchanged by these browser-only inspection records.

### Testing
- Ran `node --check workcell_studio_web/viewer/viewer.js` which passed. 
- Ran `python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py tests/test_embedded_web3d_editor_bridge_static.py tests/test_workcell_builder_selected_item_card.py tests/test_export_workcell_studio_web_scene.py` and all tests passed (`168 passed`). 
- Ran `git diff --check` and `git status --short` with no check failures; ROS 2 Humble is unavailable in this container so full workstation compilation/visual acceptance on the real `ur5_2f_test` remains required. 
- Confirmed root cause and why PRs `#2916`–`#2918` did not fully solve runtime selection because they did not index equivalent records by exact link, did not synthesize browser-only expanded-URDF pick records when generated rows were absent, did not preserve stable owner rows through filtering, and left Qt tied to same-cycle events. 
- Note: this is a source-only fix; a separate one-file `viewer.bundle.js` rebuild PR will be required after merging to exercise these viewer source changes in the deployed embedded viewer.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b5afbf514833191d14bee2837c152)