### PR TITLE
M1: rebuild Web3D bundle for end-to-end selection

### DIFF
--- a/workcell_studio_web/viewer/dist/viewer.bundle.js
+++ b/workcell_studio_web/viewer/dist/viewer.bundle.js
@@ -38302,7 +38302,7 @@ var CAMERA_PRESET_DIRECTIONS = Object.freeze({
   top: [0, -1e-3, 1],
   robot: [1.1, -1.25, 0.72]
 });
-var state = { sceneJson: null, sourceWebSceneFile: "", diagnosticKeys: /* @__PURE__ */ new Set(), frameLookup: /* @__PURE__ */ new Map(), resolvedFramePoses: /* @__PURE__ */ new Map(), objects: [], pickRecords: [], pickIdentityByObject: /* @__PURE__ */ new WeakMap(), assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, robotUrdfPreviewDiagnostics: {}, physicalAssemblyBounds: null, finalPhysicalFitBounds: null, selected: null, three: {}, animationId: null, lastFrameBounds: null, initialCameraFit: { sceneKey: "", done: false, attempts: 0, pendingRetry: null, userControlled: false }, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: /* @__PURE__ */ new Map(), undoStack: [], redoStack: [], gizmoDragStart: null, directMoveDrag: null, directRotateDrag: null, editorMode: "select", editorEvents: [], editorError: "", robotPreviewResult: null, lastRaycastHitCount: 0, lastRaycastCandidateIds: [], lastCanvasSelectedItemId: "", lastCanvasPickReason: "", initialPosePreview: { active: false, robotId: "", sceneKey: "" }, web3dReadiness: { state: "booting", terminal: false, terminalState: "", terminalNavigationKey: "", terminalEmissionCount: 0, statusSequence: 0, required: {}, pending: /* @__PURE__ */ new Set(), failed: false, failure: null }, builderRevision: "", sceneJsonLoaded: false, activeNavigationKey: "" };
+var state = { sceneJson: null, sourceWebSceneFile: "", diagnosticKeys: /* @__PURE__ */ new Set(), frameLookup: /* @__PURE__ */ new Map(), resolvedFramePoses: /* @__PURE__ */ new Map(), objects: [], pickRecords: [], pickIdentityByObject: /* @__PURE__ */ new WeakMap(), selectionIdentityIndex: null, assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, robotUrdfPreviewDiagnostics: {}, physicalAssemblyBounds: null, finalPhysicalFitBounds: null, selected: null, three: {}, animationId: null, lastFrameBounds: null, initialCameraFit: { sceneKey: "", done: false, attempts: 0, pendingRetry: null, userControlled: false }, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: /* @__PURE__ */ new Map(), undoStack: [], redoStack: [], gizmoDragStart: null, directMoveDrag: null, directRotateDrag: null, editorMode: "select", editorEvents: [], editorError: "", robotPreviewResult: null, lastRaycastHitCount: 0, lastRaycastCandidateIds: [], lastCanvasSelectedItemId: "", lastCanvasPickReason: "", initialPosePreview: { active: false, robotId: "", sceneKey: "" }, web3dReadiness: { state: "booting", terminal: false, terminalState: "", terminalNavigationKey: "", terminalEmissionCount: 0, statusSequence: 0, required: {}, pending: /* @__PURE__ */ new Set(), failed: false, failure: null }, builderRevision: "", sceneJsonLoaded: false, activeNavigationKey: "" };
 var robotPreviewLoadToken = 0;
 var RESET_VIEW_TITLE = "Fit Scene / Reset View: recomputes and reapplies the fitted workcell overview from renderable bounds.";
 var STAGED_MESH_ROOTS = [
@@ -39299,27 +39299,81 @@ var UI_SELECTION_REFERENCE_FIELDS = Object.freeze([
   "support_surface_ref",
   "camera_id"
 ]);
-function explicitUiSelectionItemId(rendered) {
+var SELECTION_LINK_IDENTITY_FIELDS = Object.freeze([
+  "link_name",
+  "link",
+  "canonical_link_name",
+  "object_name",
+  "final_render_link"
+]);
+function exactSelectionLinkName(item) {
+  for (const field of SELECTION_LINK_IDENTITY_FIELDS) {
+    const value = String(item?.[field] || "").trim();
+    if (value)
+      return value;
+  }
+  return "";
+}
+function rebuildSelectionIdentityIndex(sceneJson = state.sceneJson || {}) {
+  const items = collectItems(sceneJson);
+  const itemById = new Map(items.map((item) => [String(item?.id || "").trim(), item]).filter(([id]) => id));
+  const recordsByLink = /* @__PURE__ */ new Map();
+  for (const item of items) {
+    const link = exactSelectionLinkName(item);
+    if (!link)
+      continue;
+    if (!recordsByLink.has(link))
+      recordsByLink.set(link, []);
+    recordsByLink.get(link).push(item);
+  }
+  const explicitUiIdByLink = /* @__PURE__ */ new Map();
+  for (const [link, records] of recordsByLink) {
+    const candidates = /* @__PURE__ */ new Set();
+    for (const record of records) {
+      for (const field of UI_SELECTION_REFERENCE_FIELDS) {
+        const candidate = String(record?.[field] || "").trim();
+        if (candidate && itemById.has(candidate))
+          candidates.add(candidate);
+      }
+    }
+    if (candidates.size === 1)
+      explicitUiIdByLink.set(link, [...candidates][0]);
+  }
+  state.selectionIdentityIndex = { itemById, recordsByLink, explicitUiIdByLink };
+  return state.selectionIdentityIndex;
+}
+function uiSelectionIdentity(rendered) {
   const exactId = String(rendered?.item?.id || "");
   if (!exactId)
-    return "";
-  const activeItemIds = new Set(collectItems(state.sceneJson || {}).map((item) => String(item?.id || "")).filter(Boolean));
+    return { id: "", resolution: "exact_identity_fallback", linkName: "", pickRecordSource: "" };
+  const index = state.selectionIdentityIndex || rebuildSelectionIdentityIndex();
   for (const field of UI_SELECTION_REFERENCE_FIELDS) {
     const candidate = String(rendered.item?.[field] || "").trim();
-    if (candidate && activeItemIds.has(candidate))
-      return candidate;
+    if (candidate && index.itemById.has(candidate))
+      return { id: candidate, resolution: "direct_explicit_ref", linkName: exactSelectionLinkName(rendered.item), pickRecordSource: rendered.pickRecordSource || "payload_item" };
   }
-  return exactId;
+  const linkName = exactSelectionLinkName(rendered.item);
+  const linkedId = linkName ? index.explicitUiIdByLink.get(linkName) : "";
+  if (linkedId)
+    return { id: linkedId, resolution: "exact_link_explicit_ref", linkName, pickRecordSource: rendered.pickRecordSource || "payload_item" };
+  if (rendered.uiSelectionOwnerId && index.itemById.has(rendered.uiSelectionOwnerId)) {
+    return { id: rendered.uiSelectionOwnerId, resolution: rendered.uiSelectionResolution || "exact_identity_fallback", linkName, pickRecordSource: rendered.pickRecordSource || "expanded_urdf_inspection" };
+  }
+  return { id: exactId, resolution: "exact_identity_fallback", linkName, pickRecordSource: rendered.pickRecordSource || "payload_item" };
+}
+function explicitUiSelectionItemId(rendered) {
+  return uiSelectionIdentity(rendered).id;
 }
 function currentSelectionDiagnostics() {
   const id = String(state.selected || "");
   const rendered = renderedById(id);
   const editOwner = canonicalEditOwnerRendered(rendered);
   const item = rendered?.item || null;
+  const selectionIdentity = uiSelectionIdentity(rendered);
   return {
     sceneId: sceneId(),
     selectedItemId: id,
-    uiSelectionItemId: explicitUiSelectionItemId(rendered),
+    uiSelectionItemId: selectionIdentity.id,
     editOwnerItemId: editOwner?.item?.id || "",
     renderIdentity: id,
     selectedItemType: rendered ? itemType(item) : "",
@@ -39331,6 +39385,9 @@ function currentSelectionDiagnostics() {
     diagnosticOnly: Boolean(item && isDiagnosticOnlyItem(item)),
     helperOrOverlay: Boolean(item && isDebugOverlayItem(item)),
     objectPresent: Boolean(rendered),
+    selectedLinkName: selectionIdentity.linkName,
+    uiSelectionResolution: selectionIdentity.resolution,
+    pickRecordSource: selectionIdentity.pickRecordSource,
     lastRaycastHitCount: state.lastRaycastHitCount,
     lastRaycastCandidateIds: [...state.lastRaycastCandidateIds],
     lastCanvasSelectedItemId: state.lastCanvasSelectedItemId,
@@ -39548,10 +39605,10 @@ function sameTransform(a, b) {
 function renderedById(id) {
   return state.objects.find((obj) => obj.item.id === id) || state.pickRecords.find((obj) => obj.item.id === id);
 }
-function registerPickRecord(item, object3d, root = object3d) {
+function registerPickRecord(item, object3d, root = object3d, options = {}) {
   if (!item?.id || !object3d)
     return null;
-  const record = { item, object3d, pickRoot: root, readOnlyPick: true };
+  const record = { item, object3d, pickRoot: root, readOnlyPick: true, ...options };
   state.pickRecords.push(record);
   state.pickIdentityByObject.set(object3d, record);
   return record;
@@ -41468,6 +41525,7 @@ function resetSceneLifecycleState() {
   state.objects = [];
   state.pickRecords = [];
   state.pickIdentityByObject = /* @__PURE__ */ new WeakMap();
+  state.selectionIdentityIndex = null;
   state.lastRaycastHitCount = 0;
   state.lastRaycastCandidateIds = [];
   state.lastCanvasSelectedItemId = "";
@@ -41518,6 +41576,7 @@ function clearSceneObjects() {
 }
 function renderScene(items) {
   clearSceneObjects();
+  rebuildSelectionIdentityIndex(state.sceneJson || {});
   state.frameLookup = parseSceneFrames(state.sceneJson || {});
   state.resolvedFramePoses.clear();
   beginWeb3dSceneReadiness(items);
@@ -41659,14 +41718,48 @@ function loadExpandedUrdfRobotPreview(preview) {
       for (const item of collectItems(state.sceneJson || {})) {
         if (!isGeneratedUrdfItem(item))
           continue;
-        const explicitLink = String(item?.link_name || item?.link || "").trim();
+        const explicitLink = exactSelectionLinkName(item);
         if (explicitLink && !itemsByLink.has(explicitLink))
           itemsByLink.set(explicitLink, item);
       }
+      const robotLinks = new Set(asArray(preview?.expected_robot_visual_links || preview?.expectedRobotVisualLinks).map((value) => String(value || "").trim()).filter(Boolean));
+      const toolLinks = new Set(asArray(preview?.expected_tool_visual_links || preview?.expectedToolVisualLinks).map((value) => String(value || "").trim()).filter(Boolean));
+      const index = state.selectionIdentityIndex || rebuildSelectionIdentityIndex();
+      const ownerFromExplicitContract = (fields, readinessCategory) => {
+        for (const field of fields) {
+          const id = String(preview?.[field] || "").trim();
+          if (id && index.itemById.has(id))
+            return id;
+        }
+        const candidates = [...index.itemById.values()].filter((item) => String(item?.readiness_category || item?.readinessCategory || "").trim() === readinessCategory && !isGeneratedUrdfItem(item));
+        return candidates.length === 1 ? String(candidates[0].id) : "";
+      };
+      const robotOwnerId = ownerFromExplicitContract(["robot_instance_id", "robotInstanceId", "robot_id", "robotId"], "robot_arm");
+      const toolOwnerId = ownerFromExplicitContract(["tool_instance_id", "toolInstanceId", "tool_id", "toolId", "end_effector_id", "endEffectorId"], "attached_tool_gripper");
+      const robotInstance = String(preview?.robot_instance_id || preview?.robotInstanceId || preview?.robot_id || preview?.robotId || "robot").trim();
       for (const [linkName, linkObject] of result?.links || []) {
-        const item = itemsByLink.get(String(linkName));
-        if (item)
-          registerPickRecord(item, linkObject, result.root || linkObject);
+        const exactLink = String(linkName || "").trim();
+        const fixtureOwnerId = index.explicitUiIdByLink.get(exactLink) || "";
+        const eligible = toolLinks.has(exactLink) || robotLinks.has(exactLink) || Boolean(fixtureOwnerId);
+        if (!eligible || !linkObject || linkObject.visible === false)
+          continue;
+        const payloadItem = itemsByLink.get(exactLink);
+        const inspectionId = `${loadSceneId}::expanded_urdf_inspection::${robotInstance}::${exactLink}`;
+        const item = payloadItem || { id: inspectionId, link_name: exactLink, locked: true, editable: false, selectable: true, source_layer: "expanded_urdf_inspection" };
+        let ownerId = fixtureOwnerId;
+        let resolution = fixtureOwnerId ? "exact_link_explicit_ref" : "exact_identity_fallback";
+        if (toolLinks.has(exactLink) && toolOwnerId) {
+          ownerId = toolOwnerId;
+          resolution = "tool_owner";
+        } else if (robotLinks.has(exactLink) && robotOwnerId) {
+          ownerId = robotOwnerId;
+          resolution = "robot_owner";
+        }
+        registerPickRecord(item, linkObject, result.root || linkObject, {
+          pickRecordSource: payloadItem ? "payload_item" : "expanded_urdf_inspection",
+          uiSelectionOwnerId: ownerId,
+          uiSelectionResolution: resolution
+        });
       }
       state.robotPreviewResult = result;
       state.robotUrdfPreviewDiagnostics = result.diagnostics;


### PR DESCRIPTION
### Motivation
- The production Web3D bundle must reflect the end-to-end Product View selection synchronization implemented in the merged source from PR #2919 so the viewer can resolve UI selection identities consistently. 

### Description
- Regenerated the production Web3D bundle at `workcell_studio_web/viewer/dist/viewer.bundle.js` from the updated source and restored the generated source map `workcell_studio_web/viewer/dist/viewer.bundle.js.map` so only the bundle file is changed. 
- The rebuild brings in the selection identity index and reconstruction logic plus helper APIs (`selectionIdentityIndex`, `rebuildSelectionIdentityIndex`, `uiSelectionIdentity`, `expanded_urdf_inspection`, `robot_owner`, `tool_owner`) used by the end-to-end selection sync. 
- This change is limited to the generated/production Web3D bundle and does not modify `viewer.js`, C++ files, tests, package metadata, scene YAML, generated scene files, `node_modules`, or other sources. 

### Testing
- Regeneration commands used: `npm ci` and `npm run build:web3d` in `workcell_studio_web/viewer`, and the generated source map was restored with `git restore`. 
- Stale-bundle check: `npm run check:stale-bundle` reported the bundle is current (`viewer.bundle.js is current`). 
- Focused automated tests: `python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py tests/test_embedded_web3d_editor_bridge_static.py tests/test_workcell_builder_selected_item_card.py` passed (132 passed, 3 pre-existing `SyntaxWarning`s). 
- Verified the expected implementation markers are present by searching the bundle for `selectionIdentityIndex`, `rebuildSelectionIdentityIndex`, `uiSelectionIdentity`, `expanded_urdf_inspection`, `robot_owner`, and `tool_owner`, and ran `git diff --check` to validate no whitespace/merge issues; `workcell_studio_web/viewer/dist/viewer.bundle.js` was the only changed file. 
- Display-enabled workstation GUI acceptance remains required to validate the full scene hierarchy ↔ Product View ↔ inspector selection workflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b5d932e948331a38a20222496bdfa)