### PR TITLE
M1: declare non-renderable selection owners in Web3D payload

### DIFF
--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -1382,6 +1382,88 @@ def _annotate_generated_ui_selection_refs(
                 "support_surface_ref": "web_export_authored_ui_identity",
             })
 
+
+def _selection_owner_registry(
+    top_robots: Sequence[Mapping[str, Any]],
+    top_tools: Sequence[Mapping[str, Any]],
+    authored_sensors: Sequence[Mapping[str, Any]],
+    authored_assets: Sequence[Mapping[str, Any]],
+) -> Tuple[List[Json], str, str]:
+    """Declare stable Qt hierarchy identities without restoring shadowed visuals."""
+
+    def unique_owner_id(records: Sequence[Mapping[str, Any]], kind: str) -> str:
+        environment_records = [
+            record for record in records
+            if "environment.yaml" in {str(value) for value in _as_map(record.get("provenance")).values()}
+        ]
+        if environment_records:
+            records = environment_records
+        ids = {str(record.get("id") or "").strip() for record in records}
+        ids.discard("")
+        if len(ids) > 1:
+            raise BlockingExportError(
+                f"selection owner contract requires one unambiguous {kind} owner; candidates={sorted(ids)}"
+            )
+        return next(iter(ids), "")
+
+    robot_id = unique_owner_id(top_robots, "robot")
+    tool_id = unique_owner_id(top_tools, "end_effector")
+    camera_ids = sorted({
+        str(item.get("id") or "").strip()
+        for item in authored_sensors
+        if item.get("source_kind") == "user_authored"
+        and any(token in _identity_text(item) for token in ("camera", "realsense", "d435"))
+    } | {
+        str(item.get("camera_id") or "").strip()
+        for item in authored_sensors
+        if str(item.get("camera_id") or "").strip()
+        and not str(item.get("camera_id") or "").startswith("UNKNOWN_")
+    } - {""})
+    support_surface_ids = sorted({
+        str(item.get("id") or "").strip()
+        for item in authored_assets
+        if item.get("source_kind") == "user_authored"
+        and (
+            str(item.get("id") or "").startswith("support_surface")
+            or {str(item.get(field) or "").lower().replace(" ", "_") for field in ("type", "role", "category")}
+            & {"support_surface", "table", "workbench", "work_surface"}
+        )
+    } - {""})
+    owners = [
+        *({"id": value, "type": "camera", "locked": True, "editable": False} for value in camera_ids),
+        *({"id": value, "type": "support_surface", "locked": True, "editable": False} for value in support_surface_ids),
+    ]
+    if robot_id:
+        owners.append({"id": robot_id, "type": "robot", "locked": True, "editable": False})
+    if tool_id:
+        owners.append({"id": tool_id, "type": "end_effector", "locked": True, "editable": False})
+    return sorted(owners, key=lambda owner: (owner["type"], owner["id"])), robot_id, tool_id
+
+
+def _validate_selection_owner_contract(payload: Json) -> None:
+    owner_ids = {str(owner.get("id") or "").strip() for owner in payload.get("ui_selection_owners", [])}
+    reference_fields = (
+        "canonical_scene_item_id", "camera_id", "support_surface_ref",
+    )
+    for section in RENDERABLE_OUTPUT_SECTIONS:
+        for item in payload.get(section, []):
+            if item.get("source_kind") != "generated_preview":
+                continue
+            for field in reference_fields:
+                value = str(item.get(field) or "").strip()
+                if value.startswith("UNKNOWN_"):
+                    continue
+                if value and value not in owner_ids:
+                    raise BlockingExportError(
+                        f"undeclared selection owner reference: section={section} id={item.get('id', '')} "
+                        f"field={field} owner={value}"
+                    )
+    preview = _as_map(payload.get("robot_preview"))
+    for field in ("selection_robot_owner_id", "selection_tool_owner_id"):
+        value = str(preview.get(field) or "").strip()
+        if value and value not in owner_ids:
+            raise BlockingExportError(f"robot_preview {field} is undeclared: {value}")
+
 def _supplement_missing_tool_meshes(data: Dict[str, Any], generated: Dict[str, List[Json]]) -> None:
     """Add capability-described tool visuals when the flattened index omitted them.
 
@@ -2887,6 +2969,12 @@ def build_web_scene(
         top_sensors + authored["sensors"],
         authored["assets"],
     )
+    selection_owners, robot_owner_id, tool_owner_id = _selection_owner_registry(
+        top_robots,
+        top_tools,
+        top_sensors + authored["sensors"],
+        authored["assets"],
+    )
 
     robots = _drop_shadowed_metadata_primitives(top_robots + generated["robots"], generated["robots"], ("robot", "ur5", "ur3", "ur10"))
     tools = _drop_shadowed_metadata_primitives(top_tools + generated["tools"], generated["tools"], ("tool", "gripper", "robotiq", "end_effector"))
@@ -2924,6 +3012,7 @@ def build_web_scene(
         "sensors": _sort_items(sensors),
         "zones": _sort_items(zones),
         "frames": _sort_items(generated["frames"]),
+        "ui_selection_owners": selection_owners,
         "warnings": sorted(warnings, key=lambda w: (str(w.get("source", "")), str(w.get("code", "")), str(w.get("message", "")))),
         "backend_actions": [
             {
@@ -2977,6 +3066,12 @@ def build_web_scene(
     if stage_assets:
         _stage_visual_meshes(output, scene_dir, output_path or Path("build/workcell_studio_web_scene/scene.web_scene.json"))
         _stage_expanded_robot_urdf(output, scene_dir, output_path or Path("build/workcell_studio_web_scene/scene.web_scene.json"), warnings)
+        if output.get("robot_preview"):
+            output["robot_preview"].update({
+                "selection_robot_owner_id": robot_owner_id,
+                "selection_tool_owner_id": tool_owner_id,
+            })
+    _validate_selection_owner_contract(output)
     _apply_render_ownership_contract(output, expanded_urdf_active=_as_map(output.get("robot_preview")).get("mode") == "expanded_urdf_loader")
     output.pop("_visual_mesh_index_source", None)
     _populate_visual_bounds_item_fields(output, data)

--- a/tests/test_workcell_studio_web_ui_selection_refs.py
+++ b/tests/test_workcell_studio_web_ui_selection_refs.py
@@ -1,3 +1,5 @@
+import pytest
+
 from scripts import export_workcell_studio_web_scene as exporter
 
 
@@ -10,6 +12,16 @@ def empty_generated():
         "zones": [],
         "frames": [],
     }
+
+
+def test_selection_owner_registry_rejects_ambiguous_configured_robot():
+    with pytest.raises(exporter.BlockingExportError, match="unambiguous robot owner"):
+        exporter._selection_owner_registry(
+            [{"id": "robot_a"}, {"id": "robot_b"}],
+            [{"id": "tool"}],
+            [],
+            [],
+        )
 
 
 def test_generated_camera_and_table_receive_authored_ui_identity():

--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -1,5 +1,8 @@
+import json
 import subprocess
 from pathlib import Path
+
+from scripts import export_workcell_studio_web_scene as exporter
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -7,36 +10,38 @@ VIEWER = ROOT / "workcell_studio_web" / "viewer"
 
 
 def test_selection_identity_index_and_expanded_urdf_picks_behave_end_to_end(tmp_path):
+    payload = exporter.build_web_scene(
+        ROOT / "scenes" / "ur5_2f_test",
+        stage_assets=True,
+        output_path=tmp_path / "ur5_2f_test.web_scene.json",
+    )
+    payload_path = tmp_path / "ur5_2f_test.web_scene.json"
+    payload_path.write_text(json.dumps(payload), encoding="utf-8")
     harness = r"""
 const fs = require('fs');
 const vm = require('vm');
 const assert = require('assert');
 let source = fs.readFileSync(process.argv[1], 'utf8').replace(/boot\(\);\s*$/, '');
 const element = () => ({ hidden:false, checked:false, disabled:false, textContent:'', className:'', innerHTML:'', classList:{toggle(){}}, querySelector(){return {textContent:''}}, appendChild(){}, addEventListener(){}, setAttribute(){} });
-const context = { console, assert, window:{location:{search:''},dispatchEvent(){},parent:{postMessage(){}}}, document:{getElementById(){return element()},createElement(){return element()}}, URLSearchParams, CustomEvent:function(){}, requestAnimationFrame(){return 0}, setTimeout(){return 0}, clearTimeout(){} };
+const payload = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+const context = { console, assert, payload, window:{location:{search:''},dispatchEvent(){},parent:{postMessage(){}}}, document:{getElementById(){return element()},createElement(){return element()}}, URLSearchParams, CustomEvent:function(){}, requestAnimationFrame(){return 0}, setTimeout(){return 0}, clearTimeout(){} };
 vm.createContext(context);
 vm.runInContext(source + `
-const cameraOwner = { id:'camera_owner', category:'camera' };
-const tableOwner = { id:'table_owner', category:'table' };
-const robotOwner = { id:'configured_robot', category:'robot', readiness_category:'robot_arm', locked:true, editable:false };
-const toolOwner = { id:'configured_tool', category:'tool', readiness_category:'attached_tool_gripper', locked:true, editable:false };
-const cameraMapped = { id:'camera_payload_visual', link_name:'fixture_camera_link', canonical_scene_item_id:'camera_owner' };
-const cameraClicked = { id:'generated_urdf::fixture_camera_link::visual_17::17', link_name:'fixture_camera_link' };
-const tableMapped = { id:'table_payload_visual', final_render_link:'fixture_table_link', support_surface_ref:'table_owner' };
-const tableClicked = { id:'generated_urdf::fixture_table_link::visual_4::4', canonical_link_name:'fixture_table_link' };
-state.sceneJson = { scene:{id:'selection_scene'}, objects:[cameraOwner, tableOwner, robotOwner, toolOwner, cameraMapped, cameraClicked, tableMapped, tableClicked], robot_preview:{ mode:'expanded_urdf_loader', robot_instance_id:'configured_robot', tool_id:'configured_tool', expected_robot_visual_links:['arm_link'], expected_tool_visual_links:['finger_link'] } };
+state.sceneJson = payload;
 rebuildSelectionIdentityIndex();
-let camera = uiSelectionIdentity({item:cameraClicked, pickRecordSource:'payload_item'});
-assert.deepStrictEqual(JSON.parse(JSON.stringify(camera)), {id:'camera_owner', resolution:'exact_link_explicit_ref', linkName:'fixture_camera_link', pickRecordSource:'payload_item'});
-let table = uiSelectionIdentity({item:tableClicked, pickRecordSource:'payload_item'});
-assert.strictEqual(table.id, 'table_owner');
-assert.strictEqual(table.resolution, 'exact_link_explicit_ref');
-
-state.sceneJson.objects.push({id:'other_owner'}, {id:'ambiguous_mapping', link_name:'fixture_camera_link', canonical_item_id:'other_owner'});
-rebuildSelectionIdentityIndex();
-assert.strictEqual(explicitUiSelectionItemId({item:cameraClicked}), cameraClicked.id);
-state.sceneJson.objects.splice(-2);
-rebuildSelectionIdentityIndex();
+const owners = state.sceneJson.ui_selection_owners;
+assert(owners.some(owner => owner.id === 'realsense_overhead'));
+assert(owners.some(owner => owner.id === 'support_surface_table'));
+const cameraClicked = state.sceneJson.sensors.find(item => item.camera_id === 'realsense_overhead' && item.source_kind === 'generated_preview');
+const tableClicked = state.sceneJson.assets.find(item => item.support_surface_ref === 'support_surface_table' && item.source_kind === 'generated_preview');
+assert.strictEqual(uiSelectionIdentity({item:cameraClicked, pickRecordSource:'payload_item'}).id, 'realsense_overhead');
+assert.strictEqual(uiSelectionIdentity({item:tableClicked, pickRecordSource:'payload_item'}).id, 'support_surface_table');
+assert(!collectItems(state.sceneJson).some(item => owners.some(owner => owner.id === item.id)));
+assert(!state.objects.some(record => owners.some(owner => owner.id === record.item?.id)));
+assert.strictEqual(state.dirtyTransforms.size, 0);
+assert.strictEqual(buildEditPatch().edits.length, 0);
+const invalid = {id:'invalid_visual', canonical_scene_item_id:'undeclared_owner'};
+assert.strictEqual(uiSelectionIdentity({item:invalid}).id, 'invalid_visual');
 
 let callbacks = [];
 loadRobotPreview = (_preview, options) => { callbacks.push(options); return {diagnostics:{}, links:new Map()}; };
@@ -47,36 +52,42 @@ refreshInitialPoseActionState = () => {};
 failIfExpandedUrdfExpectedVisualSetInvalid = () => false;
 completeExpandedUrdfReadiness = () => {};
 loadExpandedUrdfRobotPreview(state.sceneJson.robot_preview);
+const robotOwner = state.sceneJson.robot_preview.selection_robot_owner_id;
+const toolOwner = state.sceneJson.robot_preview.selection_tool_owner_id;
+assert(owners.some(owner => owner.id === robotOwner));
+assert(owners.some(owner => owner.id === toolOwner));
+const armLink = state.sceneJson.robot_preview.expected_robot_visual_links[0];
+const toolLink = state.sceneJson.robot_preview.expected_tool_visual_links[0];
 const armObject = {visible:true};
 const fingerObject = {visible:true};
-callbacks[0].onRobotLoaded({root:{}, links:new Map([['arm_link',armObject],['finger_link',fingerObject]]), diagnostics:{}});
+callbacks[0].onRobotLoaded({root:{}, links:new Map([[armLink,armObject],[toolLink,fingerObject]]), diagnostics:{}});
 assert.strictEqual(state.pickRecords.length, 2);
-const armPick = state.pickRecords.find(record => record.item.link_name === 'arm_link');
-const fingerPick = state.pickRecords.find(record => record.item.link_name === 'finger_link');
-assert.strictEqual(armPick.pickRecordSource, 'expanded_urdf_inspection');
-assert.strictEqual(uiSelectionIdentity(armPick).id, 'configured_robot');
+const armPick = state.pickRecords.find(record => record.item.link_name === armLink);
+const fingerPick = state.pickRecords.find(record => record.item.link_name === toolLink);
+assert.strictEqual(armPick.pickRecordSource, 'payload_item');
+assert.strictEqual(uiSelectionIdentity(armPick).id, robotOwner);
 assert.strictEqual(uiSelectionIdentity(armPick).resolution, 'robot_owner');
-assert.strictEqual(uiSelectionIdentity(fingerPick).id, 'configured_tool');
+assert.strictEqual(uiSelectionIdentity(fingerPick).id, toolOwner);
 assert.strictEqual(uiSelectionIdentity(fingerPick).resolution, 'tool_owner');
 state.selected = armPick.item.id;
 let diagnostic = currentSelectionDiagnostics();
 assert.strictEqual(diagnostic.selectedItemId, armPick.item.id);
-assert.strictEqual(diagnostic.uiSelectionItemId, 'configured_robot');
-assert.strictEqual(diagnostic.pickRecordSource, 'expanded_urdf_inspection');
+assert.strictEqual(diagnostic.uiSelectionItemId, robotOwner);
+assert.strictEqual(diagnostic.pickRecordSource, 'payload_item');
 assert.strictEqual(state.objects.some(record => record.item.id === armPick.item.id), false);
 assert.strictEqual(state.dirtyTransforms.has(armPick.item.id), false);
 assert.strictEqual(buildEditPatch().edits.some(edit => edit.id === armPick.item.id), false);
 
 const stale = callbacks[0];
-state.sceneJson = {scene:{id:'next_scene'}, objects:[]};
+state.sceneJson = {scene:{id:'next_scene'}, objects:[], ui_selection_owners:[]};
 resetSceneLifecycleState();
 const before = state.pickRecords.length;
-stale.onRobotLoaded({root:{}, links:new Map([['arm_link',{visible:true}]]), diagnostics:{}});
+stale.onRobotLoaded({root:{}, links:new Map([[armLink,{visible:true}]]), diagnostics:{}});
 assert.strictEqual(state.pickRecords.length, before);
 `, context);
 """
     subprocess.run(
-        ["node", "-e", harness, str(VIEWER / "viewer.js")],
+        ["node", "-e", harness, str(VIEWER / "viewer.js"), str(payload_path)],
         cwd=ROOT,
         check=True,
         text=True,

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -802,6 +802,7 @@ function collectRenderedMeshDiagnostics() {
 
 function updateViewerStatus() {
   const summary = computeSceneSummary();
+  const selectionDiagnostics = currentSelectionDiagnostics();
   const warnings = asArray(state.sceneJson?.warnings).concat(asArray(state.sceneJson?.notes_warnings), asArray(state.runtimeWarnings));
   const resolvedFrameStatus = buildResolvedFrameStatus();
   const renderedMeshDiagnostics = collectRenderedMeshDiagnostics();
@@ -854,6 +855,13 @@ function updateViewerStatus() {
     sceneJsonLoaded: Boolean(state.sceneJsonLoaded),
     scene_name: summary.sceneName,
     sceneName: summary.sceneName,
+    selectionOwnerRegistryCount: selectionDiagnostics.selectionOwnerRegistryCount,
+    selectionOwnerIds: selectionDiagnostics.selectionOwnerIds,
+    selectedItemId: selectionDiagnostics.selectedItemId,
+    uiSelectionItemId: selectionDiagnostics.uiSelectionItemId,
+    selectedLinkName: selectionDiagnostics.selectedLinkName,
+    uiSelectionResolution: selectionDiagnostics.uiSelectionResolution,
+    pickRecordSource: selectionDiagnostics.pickRecordSource,
     renderable_count: summary.renderableCount,
     renderableCount: summary.renderableCount,
     mesh_loaded_count: summary.meshLoadedCount,
@@ -949,7 +957,8 @@ function exactSelectionLinkName(item) {
 }
 function rebuildSelectionIdentityIndex(sceneJson = state.sceneJson || {}) {
   const items = collectItems(sceneJson);
-  const itemById = new Map(items.map(item => [String(item?.id || '').trim(), item]).filter(([id]) => id));
+  const selectionOwners = asArray(sceneJson.ui_selection_owners).filter(owner => owner && typeof owner === 'object');
+  const itemById = new Map(items.concat(selectionOwners).map(item => [String(item?.id || '').trim(), item]).filter(([id]) => id));
   const recordsByLink = new Map();
   for (const item of items) {
     const link = exactSelectionLinkName(item);
@@ -968,7 +977,7 @@ function rebuildSelectionIdentityIndex(sceneJson = state.sceneJson || {}) {
     }
     if (candidates.size === 1) explicitUiIdByLink.set(link, [...candidates][0]);
   }
-  state.selectionIdentityIndex = { itemById, recordsByLink, explicitUiIdByLink };
+  state.selectionIdentityIndex = { itemById, recordsByLink, explicitUiIdByLink, selectionOwners };
   return state.selectionIdentityIndex;
 }
 function uiSelectionIdentity(rendered) {
@@ -996,6 +1005,7 @@ function currentSelectionDiagnostics() {
   const editOwner = canonicalEditOwnerRendered(rendered);
   const item = rendered?.item || null;
   const selectionIdentity = uiSelectionIdentity(rendered);
+  const selectionOwners = state.selectionIdentityIndex?.selectionOwners || [];
   return {
     sceneId: sceneId(),
     selectedItemId: id,
@@ -1014,6 +1024,8 @@ function currentSelectionDiagnostics() {
     selectedLinkName: selectionIdentity.linkName,
     uiSelectionResolution: selectionIdentity.resolution,
     pickRecordSource: selectionIdentity.pickRecordSource,
+    selectionOwnerRegistryCount: selectionOwners.length,
+    selectionOwnerIds: selectionOwners.map(owner => String(owner.id || '')).filter(Boolean),
     lastRaycastHitCount: state.lastRaycastHitCount,
     lastRaycastCandidateIds: [...state.lastRaycastCandidateIds],
     lastCanvasSelectedItemId: state.lastCanvasSelectedItemId,
@@ -3111,7 +3123,10 @@ function clearSceneObjects() {
 }
 function renderScene(items) {
   clearSceneObjects();
-  rebuildSelectionIdentityIndex(state.sceneJson || {});
+  const selectionIndex = rebuildSelectionIdentityIndex(state.sceneJson || {});
+  const ownersByType = type => selectionIndex.selectionOwners.filter(owner => owner.type === type).map(owner => owner.id);
+  const preview = state.sceneJson?.robot_preview || {};
+  console.info?.(`Product View selection owners: count=${selectionIndex.selectionOwners.length} robot=${preview.selection_robot_owner_id || 'missing'} tool=${preview.selection_tool_owner_id || 'missing'} camera=${ownersByType('camera').join(',') || 'missing'} support_surface=${ownersByType('support_surface').join(',') || 'missing'}`);
   state.frameLookup = parseSceneFrames(state.sceneJson || {});
   state.resolvedFramePoses.clear();
   beginWeb3dSceneReadiness(items);
@@ -3253,18 +3268,15 @@ function loadExpandedUrdfRobotPreview(preview) {
       const robotLinks = new Set(asArray(preview?.expected_robot_visual_links || preview?.expectedRobotVisualLinks).map(value => String(value || '').trim()).filter(Boolean));
       const toolLinks = new Set(asArray(preview?.expected_tool_visual_links || preview?.expectedToolVisualLinks).map(value => String(value || '').trim()).filter(Boolean));
       const index = state.selectionIdentityIndex || rebuildSelectionIdentityIndex();
-      const ownerFromExplicitContract = (fields, readinessCategory) => {
+      const ownerFromExplicitContract = fields => {
         for (const field of fields) {
           const id = String(preview?.[field] || '').trim();
           if (id && index.itemById.has(id)) return id;
         }
-        const candidates = [...index.itemById.values()].filter(item =>
-          String(item?.readiness_category || item?.readinessCategory || '').trim() === readinessCategory &&
-          !isGeneratedUrdfItem(item));
-        return candidates.length === 1 ? String(candidates[0].id) : '';
+        return '';
       };
-      const robotOwnerId = ownerFromExplicitContract(['robot_instance_id', 'robotInstanceId', 'robot_id', 'robotId'], 'robot_arm');
-      const toolOwnerId = ownerFromExplicitContract(['tool_instance_id', 'toolInstanceId', 'tool_id', 'toolId', 'end_effector_id', 'endEffectorId'], 'attached_tool_gripper');
+      const robotOwnerId = ownerFromExplicitContract(['selection_robot_owner_id', 'selectionRobotOwnerId', 'robot_instance_id', 'robotInstanceId', 'robot_id', 'robotId']);
+      const toolOwnerId = ownerFromExplicitContract(['selection_tool_owner_id', 'selectionToolOwnerId', 'tool_instance_id', 'toolInstanceId', 'tool_id', 'toolId', 'end_effector_id', 'endEffectorId']);
       const robotInstance = String(preview?.robot_instance_id || preview?.robotInstanceId || preview?.robot_id || preview?.robotId || 'robot').trim();
       for (const [linkName, linkObject] of result?.links || []) {
         const exactLink = String(linkName || '').trim();


### PR DESCRIPTION
### Motivation
- A real ur5_2f_test exported payload contained generated visual IDs for camera/table/robot/tool but the browser selection lookup discarded them because their authored owner rows were shadowed from the rendered sections. 
- The previous synthetic Node test passed because it manually injected authored owner rows into `sceneJson.objects`, which hid the real-payload mismatch where authored owners are removed or shadowed by generated preview rows. 
- The change introduces an explicit, deterministic, non-renderable registry so the viewer and expanded-URDF inspection can resolve stable Qt owner identities without reintroducing duplicate physical visuals. 

### Description
- Added an exporter-side `ui_selection_owners` registry produced by `scripts/export_workcell_studio_web_scene.py` that declares authored camera, support-surface, robot, and tool/end-effector owner IDs without restoring duplicate renderable rows, and added `robot_preview.selection_robot_owner_id` and `selection_tool_owner_id` fields. 
- Implemented validation in the exporter so generated references (`canonical_scene_item_id`, `camera_id`, `support_surface_ref`, and `robot_preview` owner fields) are checked against the declared registry and `UNKNOWN_*` placeholders are allowed in diagnostic preview mode. 
- Extended the viewer index in `workcell_studio_web/viewer/viewer.js` to build `selectionIdentityIndex` from both normal scene items and the non-renderable `ui_selection_owners` but kept registry entries out of rendering, editor state, readiness counts, dirty transforms, undo/redo, edit patches, and renderable counts. 
- Replaced the synthetic selection test with an end-to-end test that exports the real `ur5_2f_test` payload and verifies camera/table resolve to authored owners, expanded-URDF links resolve to configured robot/tool owners, invalid/undeclared references fall back to the exact clicked identity, and registry entries do not appear in `state.objects` or edit patches (changes in `tests/test_workcell_studio_web_viewer_static.py` and `tests/test_workcell_studio_web_ui_selection_refs.py`). 

### Testing
- Generated a fresh web scene with `python3 scripts/ensure_workcell_studio_web_scene_fresh.py --scene scenes/ur5_2f_test --output build/workcell_studio_web_scene/ur5_2f_test.web_scene.json --stage-assets --force` and confirmed `ui_selection_owners` contains `realsense_overhead` and `support_surface_table` and that `robot_preview` exposes `ur5` and `robotiq_85_gripper`. 
- Linted the viewer with `node --check workcell_studio_web/viewer/viewer.js` and ran the focused Python test set with `python3 -m pytest -q tests/test_workcell_studio_web_ui_selection_refs.py tests/test_workcell_studio_web_viewer_static.py tests/test_embedded_web3d_editor_bridge_static.py tests/test_workcell_builder_selected_item_card.py tests/test_export_workcell_studio_web_scene.py`, which produced all tests passing (173 passed). 
- Verified the generated-payload assertions via a small Python inspection that printed the owner registry and resolved camera/table/robot/tool owner IDs. 
- This is a source-only change; `viewer.bundle.js` and other built/minified assets were intentionally not modified and a separate bundle rebuild is required after merging to propagate runtime changes into the shipped bundle.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b6222a90883318b0cb83359601e1b)