### PR TITLE
M1: rebuild Web3D bundle for selection owner registry

### DIFF
--- a/workcell_studio_web/viewer/dist/viewer.bundle.js
+++ b/workcell_studio_web/viewer/dist/viewer.bundle.js
@@ -39162,6 +39162,7 @@ function collectRenderedMeshDiagnostics() {
 }
 function updateViewerStatus() {
   const summary = computeSceneSummary();
+  const selectionDiagnostics = currentSelectionDiagnostics();
   const warnings = asArray(state.sceneJson?.warnings).concat(asArray(state.sceneJson?.notes_warnings), asArray(state.runtimeWarnings));
   const resolvedFrameStatus = buildResolvedFrameStatus();
   const renderedMeshDiagnostics = collectRenderedMeshDiagnostics();
@@ -39214,6 +39215,13 @@ function updateViewerStatus() {
     sceneJsonLoaded: Boolean(state.sceneJsonLoaded),
     scene_name: summary.sceneName,
     sceneName: summary.sceneName,
+    selectionOwnerRegistryCount: selectionDiagnostics.selectionOwnerRegistryCount,
+    selectionOwnerIds: selectionDiagnostics.selectionOwnerIds,
+    selectedItemId: selectionDiagnostics.selectedItemId,
+    uiSelectionItemId: selectionDiagnostics.uiSelectionItemId,
+    selectedLinkName: selectionDiagnostics.selectedLinkName,
+    uiSelectionResolution: selectionDiagnostics.uiSelectionResolution,
+    pickRecordSource: selectionDiagnostics.pickRecordSource,
     renderable_count: summary.renderableCount,
     renderableCount: summary.renderableCount,
     mesh_loaded_count: summary.meshLoadedCount,
@@ -39316,7 +39324,8 @@ function exactSelectionLinkName(item) {
 }
 function rebuildSelectionIdentityIndex(sceneJson = state.sceneJson || {}) {
   const items = collectItems(sceneJson);
-  const itemById = new Map(items.map((item) => [String(item?.id || "").trim(), item]).filter(([id]) => id));
+  const selectionOwners = asArray(sceneJson.ui_selection_owners).filter((owner) => owner && typeof owner === "object");
+  const itemById = new Map(items.concat(selectionOwners).map((item) => [String(item?.id || "").trim(), item]).filter(([id]) => id));
   const recordsByLink = /* @__PURE__ */ new Map();
   for (const item of items) {
     const link = exactSelectionLinkName(item);
@@ -39339,7 +39348,7 @@ function rebuildSelectionIdentityIndex(sceneJson = state.sceneJson || {}) {
     if (candidates.size === 1)
       explicitUiIdByLink.set(link, [...candidates][0]);
   }
-  state.selectionIdentityIndex = { itemById, recordsByLink, explicitUiIdByLink };
+  state.selectionIdentityIndex = { itemById, recordsByLink, explicitUiIdByLink, selectionOwners };
   return state.selectionIdentityIndex;
 }
 function uiSelectionIdentity(rendered) {
@@ -39370,6 +39379,7 @@ function currentSelectionDiagnostics() {
   const editOwner = canonicalEditOwnerRendered(rendered);
   const item = rendered?.item || null;
   const selectionIdentity = uiSelectionIdentity(rendered);
+  const selectionOwners = state.selectionIdentityIndex?.selectionOwners || [];
   return {
     sceneId: sceneId(),
     selectedItemId: id,
@@ -39388,6 +39398,8 @@ function currentSelectionDiagnostics() {
     selectedLinkName: selectionIdentity.linkName,
     uiSelectionResolution: selectionIdentity.resolution,
     pickRecordSource: selectionIdentity.pickRecordSource,
+    selectionOwnerRegistryCount: selectionOwners.length,
+    selectionOwnerIds: selectionOwners.map((owner) => String(owner.id || "")).filter(Boolean),
     lastRaycastHitCount: state.lastRaycastHitCount,
     lastRaycastCandidateIds: [...state.lastRaycastCandidateIds],
     lastCanvasSelectedItemId: state.lastCanvasSelectedItemId,
@@ -41576,7 +41588,10 @@ function clearSceneObjects() {
 }
 function renderScene(items) {
   clearSceneObjects();
-  rebuildSelectionIdentityIndex(state.sceneJson || {});
+  const selectionIndex = rebuildSelectionIdentityIndex(state.sceneJson || {});
+  const ownersByType = (type) => selectionIndex.selectionOwners.filter((owner) => owner.type === type).map((owner) => owner.id);
+  const preview = state.sceneJson?.robot_preview || {};
+  console.info?.(`Product View selection owners: count=${selectionIndex.selectionOwners.length} robot=${preview.selection_robot_owner_id || "missing"} tool=${preview.selection_tool_owner_id || "missing"} camera=${ownersByType("camera").join(",") || "missing"} support_surface=${ownersByType("support_surface").join(",") || "missing"}`);
   state.frameLookup = parseSceneFrames(state.sceneJson || {});
   state.resolvedFramePoses.clear();
   beginWeb3dSceneReadiness(items);
@@ -41725,17 +41740,16 @@ function loadExpandedUrdfRobotPreview(preview) {
       const robotLinks = new Set(asArray(preview?.expected_robot_visual_links || preview?.expectedRobotVisualLinks).map((value) => String(value || "").trim()).filter(Boolean));
       const toolLinks = new Set(asArray(preview?.expected_tool_visual_links || preview?.expectedToolVisualLinks).map((value) => String(value || "").trim()).filter(Boolean));
       const index = state.selectionIdentityIndex || rebuildSelectionIdentityIndex();
-      const ownerFromExplicitContract = (fields, readinessCategory) => {
+      const ownerFromExplicitContract = (fields) => {
         for (const field of fields) {
           const id = String(preview?.[field] || "").trim();
           if (id && index.itemById.has(id))
             return id;
         }
-        const candidates = [...index.itemById.values()].filter((item) => String(item?.readiness_category || item?.readinessCategory || "").trim() === readinessCategory && !isGeneratedUrdfItem(item));
-        return candidates.length === 1 ? String(candidates[0].id) : "";
+        return "";
       };
-      const robotOwnerId = ownerFromExplicitContract(["robot_instance_id", "robotInstanceId", "robot_id", "robotId"], "robot_arm");
-      const toolOwnerId = ownerFromExplicitContract(["tool_instance_id", "toolInstanceId", "tool_id", "toolId", "end_effector_id", "endEffectorId"], "attached_tool_gripper");
+      const robotOwnerId = ownerFromExplicitContract(["selection_robot_owner_id", "selectionRobotOwnerId", "robot_instance_id", "robotInstanceId", "robot_id", "robotId"]);
+      const toolOwnerId = ownerFromExplicitContract(["selection_tool_owner_id", "selectionToolOwnerId", "tool_instance_id", "toolInstanceId", "tool_id", "toolId", "end_effector_id", "endEffectorId"]);
       const robotInstance = String(preview?.robot_instance_id || preview?.robotInstanceId || preview?.robot_id || preview?.robotId || "robot").trim();
       for (const [linkName, linkObject] of result?.links || []) {
         const exactLink = String(linkName || "").trim();


### PR DESCRIPTION
### Motivation
- Close a deployment gap where the source implementation from merged PR #2921 (non-renderable Product View selection-owner registry) was present in source but the production Web3D bundle had not been regenerated. 
- This is scoped to the M1 goal of making Product View selection behavior deterministic and available in the production bundle without changing source code or tests.

### Description
- Regenerated the production Web3D bundle at `workcell_studio_web/viewer/dist/viewer.bundle.js` using `npm ci` and `npm run build:web3d` and restored the source map. 
- The new bundle includes the selection-owner registry and diagnostics (identifiers and counters such as `ui_selection_owners`, `selectionOwnerRegistryCount`, `selection_robot_owner_id`, `selection_tool_owner_id`, and the `Product View selection owners` diagnostic message). 
- Only the derived runtime artifact `workcell_studio_web/viewer/dist/viewer.bundle.js` was modified and committed in this change, with no edits to source JS, Python, tests, or package manifests. 
- Do not merge automatically; workstation GUI acceptance remains required to complete the M1 acceptance criteria. 

### Testing
- Ran `npm ci` and `npm run build:web3d` and verified marker checks with `grep` for `ui_selection_owners`, `selectionOwnerRegistryCount`, `selection_robot_owner_id`, `selection_tool_owner_id`, and `Product View selection owners`, all of which were found. 
- Ran `cd workcell_studio_web/viewer && npm run check:stale-bundle` which reported the bundle current (hash `e186b384af2790004d046ce6a417e67231c7e969d7802cc8f6892c3b1c3af8d8`). 
- Executed focused tests with `python3 -m pytest -q tests/test_workcell_studio_web_ui_selection_refs.py tests/test_workcell_studio_web_viewer_static.py tests/test_embedded_web3d_editor_bridge_static.py tests/test_workcell_builder_selected_item_card.py tests/test_export_workcell_studio_web_scene.py` which resulted in `173 passed`. 
- Ran `git diff --check` (no issues) and `git status` to confirm that `workcell_studio_web/viewer/dist/viewer.bundle.js` was the only tracked file changed; workstation GUI acceptance was not performed in this non-display environment and remains required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b65306d648331a3ffd8a4e9776fc7)