### PR TITLE
M1: bind expanded URDF picks to descendant meshes

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -96,6 +96,65 @@ assert.strictEqual(state.pickRecords.length, before);
     )
 
 
+def test_expanded_urdf_descendant_mesh_picks_use_registered_link_identity():
+    js_path = VIEWER / "viewer.js"
+    harness = r"""
+const fs = require('fs'); const vm = require('vm'); const assert = require('assert');
+let source = fs.readFileSync(process.argv[1], 'utf8').replace(/boot\(\);\s*$/, '');
+const element = () => ({hidden:false,checked:false,disabled:false,textContent:'',className:'',innerHTML:'',classList:{toggle(){}},querySelector(){return null;},querySelectorAll(){return[];},addEventListener(){},setAttribute(){},appendChild(){}});
+const context={console,assert,window:{location:{search:''},dispatchEvent(){},parent:{postMessage(){}}},document:{getElementById(){return element();},querySelectorAll(){return[];},createElement(){return element();}},URLSearchParams,CustomEvent:function(){},requestAnimationFrame(){},setTimeout(){},clearTimeout(){}};
+vm.createContext(context);
+vm.runInContext(source + `
+const node = (name, children=[]) => ({name,children,visible:true,userData:{}});
+let callbacks=[];
+loadRobotPreview=(_preview,options)=>{callbacks.push(options); return {diagnostics:{},links:new Map()};};
+renderSceneSummary=()=>{}; refreshInitialPoseActionState=()=>{};
+failIfExpandedUrdfExpectedVisualSetInvalid=()=>false; completeExpandedUrdfReadiness=()=>{};
+rebuildSelectionIdentityIndex=()=>({itemById:new Map(),explicitUiIdByLink:new Map()});
+state.sceneJson={scene:{id:'urdf_descendants'},objects:[]}; state.objects=[]; state.dirtyTransforms=new Map();
+const preview={robot_instance_id:'robot',expected_robot_visual_links:['base_link','wrist_link']};
+loadExpandedUrdfRobotPreview(preview);
+const mesh=node('base-mesh');
+mesh.userData.item={id:'stale-diagnostic',diagnostic_only:true,selectable:false};
+const visualWrapper=node('base-visual',[mesh]);
+const childMesh=node('wrist-mesh');
+const childVisual=node('wrist-visual',[childMesh]);
+const childLink=node('wrist_link',[childVisual]);
+const linkRoot=node('base_link',[visualWrapper,childLink]);
+callbacks[0].onRobotLoaded({root:node('robot-root',[linkRoot]),links:new Map([['base_link',linkRoot],['wrist_link',childLink]]),diagnostics:{}});
+assert.strictEqual(state.pickRecords.length,2);
+const baseRecord=state.pickRecords.find(record=>record.item.link_name==='base_link');
+const childRecord=state.pickRecords.find(record=>record.item.link_name==='wrist_link');
+assert.strictEqual(state.pickIdentityByObject.get(linkRoot),baseRecord,'link root');
+assert.strictEqual(state.pickIdentityByObject.get(visualWrapper),baseRecord,'visual wrapper');
+assert.strictEqual(state.pickIdentityByObject.get(mesh),baseRecord,'mesh identity');
+assert.strictEqual(itemFromRaycastHit({object:mesh}),baseRecord,'mesh raycast');
+assert.strictEqual(state.pickIdentityByObject.get(childLink),childRecord,'child link');
+assert.strictEqual(state.pickIdentityByObject.get(childMesh),childRecord,'child mesh');
+assert.strictEqual(itemFromRaycastHit({object:childMesh}),childRecord,'child raycast');
+assert.strictEqual(state.pickRecords.filter(record=>record.item.link_name==='base_link').length,1);
+assert.strictEqual(state.pickRecords.filter(record=>record.item.link_name==='wrist_link').length,1);
+assert.strictEqual(state.objects.length,0);
+assert.strictEqual(state.dirtyTransforms.size,0);
+assert.strictEqual(buildEditPatch().edits.length,0);
+
+const staleCallback=callbacks[0];
+state.sceneJson={scene:{id:'replacement_scene'},objects:[]};
+loadExpandedUrdfRobotPreview(preview);
+const before=state.pickRecords.length;
+staleCallback.onRobotLoaded({root:node('stale-root'),links:new Map([['base_link',node('stale-link')]]),diagnostics:{}});
+assert.strictEqual(state.pickRecords.length,before);
+`, context);
+"""
+    subprocess.run(
+        ["node", "-e", harness, str(js_path)],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
 def test_static_viewer_files_exist():
     assert (VIEWER / "index.html").is_file()
     assert (VIEWER / "viewer.js").is_file()

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -1229,6 +1229,16 @@ function registerPickRecord(item, object3d, root = object3d, options = {}) {
   state.pickIdentityByObject.set(object3d, record);
   return record;
 }
+function bindExpandedUrdfPickRecordToSubtree(linkRoot, record, urdfLinkRoots) {
+  if (!linkRoot || !record) return;
+  const pending = [linkRoot];
+  while (pending.length) {
+    const node = pending.pop();
+    if (node !== linkRoot && urdfLinkRoots?.has(node)) continue;
+    state.pickIdentityByObject.set(node, record);
+    for (const child of node.children || []) pending.push(child);
+  }
+}
 function derivedTransformTargetId(item) {
   const targetId = String(item?.target_ref || '').trim();
   const identity = [item?.role, item?.semantic_role, item?.type, item?.category, item?.id]
@@ -3278,6 +3288,7 @@ function loadExpandedUrdfRobotPreview(preview) {
       const robotOwnerId = ownerFromExplicitContract(['selection_robot_owner_id', 'selectionRobotOwnerId', 'robot_instance_id', 'robotInstanceId', 'robot_id', 'robotId']);
       const toolOwnerId = ownerFromExplicitContract(['selection_tool_owner_id', 'selectionToolOwnerId', 'tool_instance_id', 'toolInstanceId', 'tool_id', 'toolId', 'end_effector_id', 'endEffectorId']);
       const robotInstance = String(preview?.robot_instance_id || preview?.robotInstanceId || preview?.robot_id || preview?.robotId || 'robot').trim();
+      const urdfLinkRoots = new Set(result.links.values());
       for (const [linkName, linkObject] of result?.links || []) {
         const exactLink = String(linkName || '').trim();
         const fixtureOwnerId = index.explicitUiIdByLink.get(exactLink) || '';
@@ -3290,11 +3301,13 @@ function loadExpandedUrdfRobotPreview(preview) {
         let resolution = fixtureOwnerId ? 'exact_link_explicit_ref' : 'exact_identity_fallback';
         if (toolLinks.has(exactLink) && toolOwnerId) { ownerId = toolOwnerId; resolution = 'tool_owner'; }
         else if (robotLinks.has(exactLink) && robotOwnerId) { ownerId = robotOwnerId; resolution = 'robot_owner'; }
-        registerPickRecord(item, linkObject, result.root || linkObject, {
+        if (!callbackIsCurrent()) return ignoreStaleCallback();
+        const record = registerPickRecord(item, linkObject, result.root || linkObject, {
           pickRecordSource: payloadItem ? 'payload_item' : 'expanded_urdf_inspection',
           uiSelectionOwnerId: ownerId,
           uiSelectionResolution: resolution,
         });
+        if (callbackIsCurrent()) bindExpandedUrdfPickRecordToSubtree(linkObject, record, urdfLinkRoots);
       }
       state.robotPreviewResult = result;
       state.robotUrdfPreviewDiagnostics = result.diagnostics;
@@ -3739,10 +3752,14 @@ function itemFromRaycastHit(hit) {
     if (excludedPickNode(node)) return null;
     if (!candidate) {
       const registered = state.pickIdentityByObject.get(node);
-      const item = node.userData?.item || registered?.item;
+      const registeredInspection = registered?.pickRecordSource === 'expanded_urdf_inspection' || Boolean(String(registered?.uiSelectionOwnerId || '').trim());
+      const nodeItem = node.userData?.item;
+      const nodeItemWithoutStalePickFlags = nodeItem ? { ...nodeItem, id: '', display_name: '', status: '', diagnostic_only: false, selectable: true } : null;
+      if (registeredInspection && nodeItemWithoutStalePickFlags && (isTaskOnlyHelperItem(nodeItemWithoutStalePickFlags) || isOverlayPolicyItem(nodeItemWithoutStalePickFlags) || isDebugOverlayItem(nodeItemWithoutStalePickFlags))) return null;
+      const item = registeredInspection ? registered.item : nodeItem || registered?.item;
       if (item?.id) {
         const rendered = renderedById(item.id) || registered;
-        if (!rendered || !isNormalSelectableRendered(rendered)) return null;
+        if (!rendered || (!registeredInspection && !isNormalSelectableRendered(rendered))) return null;
         candidate = rendered;
       }
     }


### PR DESCRIPTION
### Motivation
- Raycast hits on descendant visual/mesh nodes could be masked by stale `userData.item` flags (e.g. `diagnostic_only=true` / `selectable=false`), preventing traversal to the registered expanded-URDF link pick record.
- The intent is to make expanded-URDF inspection picks reliably resolve to the link-level read-only record while preserving nested-link identities and not creating extra editable objects.

### Description
- Added `bindExpandedUrdfPickRecordToSubtree(linkRoot, record, urdfLinkRoots)` which binds an existing record into `state.pickIdentityByObject` for `linkRoot` and its physical descendant visual/mesh nodes, stopping before other URDF link roots and without creating records or modifying `state.objects` or `userData.item`.
- In `loadExpandedUrdfRobotPreview()` the code now builds `const urdfLinkRoots = new Set(result.links.values());`, captures the `record` returned from `registerPickRecord(...)`, and calls the subtree-binding helper while keeping the existing `callbackIsCurrent()` guards.
- `itemFromRaycastHit()` now checks `state.pickIdentityByObject.get(node)` before `node.userData.item` and accepts a registered read-only inspection record when `pickRecordSource === 'expanded_urdf_inspection'` or the record has a non-empty `uiSelectionOwnerId`, while still rejecting invisible nodes, selection highlights, gizmos, hidden overlays and genuine helper/overlay records; ordinary scene pick behavior is preserved.
- A focused Node/vm regression test `test_expanded_urdf_descendant_mesh_picks_use_registered_link_identity` was added to `tests/test_workcell_studio_web_viewer_static.py` to validate descendant-mesh raycast resolution, nested-link isolation, single-record-per-link, and that no records enter `state.objects`, `dirtyTransforms` or edit patches.

### Testing
- `node --check workcell_studio_web/viewer/viewer.js` succeeded.
- The new Node/vm regression `test_expanded_urdf_descendant_mesh_picks_use_registered_link_identity` passed when run directly under `pytest` and as part of the test subset covering viewer logic.
- Focused run `python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py -k 'not test_selection_identity_index_and_expanded_urdf_picks_behave_end_to_end'` passed with `111 passed, 1 deselected` and `git diff --check` was clean.
- Full test run `python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py` reproduces one pre-existing baseline mismatch (one failing test: `test_selection_identity_index_and_expanded_urdf_picks_behave_end_to_end`) that also reproduces against the detached `origin/main` baseline and is therefore not caused by this change.

Note: only `workcell_studio_web/viewer/viewer.js` and `tests/test_workcell_studio_web_viewer_static.py` were changed; after merging a separate bundle-only rebuild of the browser bundle (to update `viewer.bundle.js`) will be required so the runtime bundle receives this source fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b6c2350548331bef792e2b8dcfd1f)