### PR TITLE
M1: expose expanded URDF pick diagnostics

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -121,7 +121,7 @@ const childMesh=node('wrist-mesh');
 const childVisual=node('wrist-visual',[childMesh]);
 const childLink=node('wrist_link',[childVisual]);
 const linkRoot=node('base_link',[visualWrapper,childLink]);
-callbacks[0].onRobotLoaded({root:node('robot-root',[linkRoot]),links:new Map([['base_link',linkRoot],['wrist_link',childLink]]),diagnostics:{}});
+callbacks[0].onRobotLoaded({root:node('robot-root',[linkRoot]),links:new Map([['base_link',linkRoot],['wrist_link',childLink]]),diagnostics:{loader_value:'preserved'}});
 assert.strictEqual(state.pickRecords.length,2);
 const baseRecord=state.pickRecords.find(record=>record.item.link_name==='base_link');
 const childRecord=state.pickRecords.find(record=>record.item.link_name==='wrist_link');
@@ -134,6 +134,12 @@ assert.strictEqual(state.pickIdentityByObject.get(childMesh),childRecord,'child 
 assert.strictEqual(itemFromRaycastHit({object:childMesh}),childRecord,'child raycast');
 assert.strictEqual(state.pickRecords.filter(record=>record.item.link_name==='base_link').length,1);
 assert.strictEqual(state.pickRecords.filter(record=>record.item.link_name==='wrist_link').length,1);
+assert.strictEqual(state.robotUrdfPreviewDiagnostics.loader_value,'preserved');
+assert.strictEqual(state.robotUrdfPreviewDiagnostics.expanded_urdf_unique_link_record_count,2);
+assert.strictEqual(state.robotUrdfPreviewDiagnostics.expanded_urdf_bound_node_count,4);
+assert.strictEqual(state.robotUrdfPreviewDiagnostics.expanded_urdf_robot_pick_record_count,2);
+assert.strictEqual(state.robotUrdfPreviewDiagnostics.expanded_urdf_tool_pick_record_count,0);
+assert.strictEqual(state.robotUrdfPreviewDiagnostics.selection_robot_owner_id,'');
 assert.strictEqual(state.objects.length,0);
 assert.strictEqual(state.dirtyTransforms.size,0);
 assert.strictEqual(buildEditPatch().edits.length,0);
@@ -1415,6 +1421,18 @@ assert.strictEqual(isNormalSelectableRendered(renderedById('ur5_generated')),tru
 assert.strictEqual(editableTransformGroupMembers(bin).map(r=>r.item.id).sort().join(','),'place_zone_default,target_bin_default');
 const staleIdentity=state.pickIdentityByObject; resetSceneLifecycleState(); assert.strictEqual(state.pickRecords.length,0); assert.notStrictEqual(state.pickIdentityByObject,staleIdentity); assert.strictEqual(renderedById('ur5_generated'),undefined);
 state.editorMode='select'; state.selected='target_bin_default'; state.three.raycaster={setFromCamera(){},intersectObjects(){return[];}}; pickObject({clientX:10,clientY:10}); assert.strictEqual(state.selected,''); assert.strictEqual(state.lastCanvasPickReason,'empty_select_click');
+const rejected=node('unregistered-mesh'); const knownLink=node('known_link'); rejected.parent=knownLink; knownLink.children=[rejected];
+state.robotPreviewResult={links:new Map([['known_link',knownLink]])};
+let warnings=0; console.warn=()=>{warnings+=1;};
+state.three.raycaster={setFromCamera(){},intersectObjects(){return[{object:rejected,distance:1}];}};
+pickObject({clientX:10,clientY:10}); pickObject({clientX:10,clientY:10});
+assert.strictEqual(warnings,1);
+assert.strictEqual(state.lastFailedCanvasPickDiagnostic.raw_hit_count,1);
+assert.strictEqual(state.lastFailedCanvasPickDiagnostic.hit_object_names[0],'unregistered-mesh');
+assert.strictEqual(state.lastFailedCanvasPickDiagnostic.traversed_registered_identity,false);
+assert.strictEqual(state.lastFailedCanvasPickDiagnostic.first_actionable_rejection_reason,'no_registered_identity_in_hit_ancestry');
+assert.strictEqual(state.lastFailedCanvasPickDiagnostic.nearest_known_urdf_link_ancestor,'known_link');
+assert.strictEqual(editorState().lastFailedCanvasPickDiagnostic.rawHitCount,1);
 `, context);
 """
     subprocess.run(["node", "-e", harness, str(js_path)], cwd=ROOT, check=True, capture_output=True, text=True)

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -38,7 +38,7 @@ const CAMERA_PRESET_DIRECTIONS = Object.freeze({
   top: [0, -0.001, 1],
   robot: [1.1, -1.25, 0.72],
 });
-const state = { sceneJson: null, sourceWebSceneFile: '', diagnosticKeys: new Set(), frameLookup: new Map(), resolvedFramePoses: new Map(), objects: [], pickRecords: [], pickIdentityByObject: new WeakMap(), selectionIdentityIndex: null, assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, robotUrdfPreviewDiagnostics: {}, physicalAssemblyBounds: null, finalPhysicalFitBounds: null, selected: null, three: {}, animationId: null, lastFrameBounds: null, initialCameraFit: { sceneKey: '', done: false, attempts: 0, pendingRetry: null, userControlled: false }, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: new Map(), undoStack: [], redoStack: [], gizmoDragStart: null, directMoveDrag: null, directRotateDrag: null, editorMode: 'select', editorEvents: [], editorError: '', robotPreviewResult: null, lastRaycastHitCount: 0, lastRaycastCandidateIds: [], lastCanvasSelectedItemId: '', lastCanvasPickReason: '', initialPosePreview: { active: false, robotId: '', sceneKey: '' }, web3dReadiness: { state: 'booting', terminal: false, terminalState: '', terminalNavigationKey: '', terminalEmissionCount: 0, statusSequence: 0, required: {}, pending: new Set(), failed: false, failure: null }, builderRevision: '', sceneJsonLoaded: false, activeNavigationKey: '' };
+const state = { sceneJson: null, sourceWebSceneFile: '', diagnosticKeys: new Set(), frameLookup: new Map(), resolvedFramePoses: new Map(), objects: [], pickRecords: [], pickIdentityByObject: new WeakMap(), selectionIdentityIndex: null, assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, robotUrdfPreviewDiagnostics: {}, physicalAssemblyBounds: null, finalPhysicalFitBounds: null, selected: null, three: {}, animationId: null, lastFrameBounds: null, initialCameraFit: { sceneKey: '', done: false, attempts: 0, pendingRetry: null, userControlled: false }, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: new Map(), undoStack: [], redoStack: [], gizmoDragStart: null, directMoveDrag: null, directRotateDrag: null, editorMode: 'select', editorEvents: [], editorError: '', robotPreviewResult: null, lastRaycastHitCount: 0, lastRaycastCandidateIds: [], lastCanvasSelectedItemId: '', lastCanvasPickReason: '', lastFailedCanvasPickDiagnostic: null, initialPosePreview: { active: false, robotId: '', sceneKey: '' }, web3dReadiness: { state: 'booting', terminal: false, terminalState: '', terminalNavigationKey: '', terminalEmissionCount: 0, statusSequence: 0, required: {}, pending: new Set(), failed: false, failure: null }, builderRevision: '', sceneJsonLoaded: false, activeNavigationKey: '' };
 let robotPreviewLoadToken = 0;
 const RESET_VIEW_TITLE = 'Fit Scene / Reset View: recomputes and reapplies the fitted workcell overview from renderable bounds.';
 const STAGED_MESH_ROOTS = [
@@ -862,6 +862,8 @@ function updateViewerStatus() {
     selectedLinkName: selectionDiagnostics.selectedLinkName,
     uiSelectionResolution: selectionDiagnostics.uiSelectionResolution,
     pickRecordSource: selectionDiagnostics.pickRecordSource,
+    last_failed_canvas_pick_diagnostic: state.lastFailedCanvasPickDiagnostic,
+    lastFailedCanvasPickDiagnostic: state.lastFailedCanvasPickDiagnostic,
     renderable_count: summary.renderableCount,
     renderableCount: summary.renderableCount,
     mesh_loaded_count: summary.meshLoadedCount,
@@ -1030,12 +1032,13 @@ function currentSelectionDiagnostics() {
     lastRaycastCandidateIds: [...state.lastRaycastCandidateIds],
     lastCanvasSelectedItemId: state.lastCanvasSelectedItemId,
     lastCanvasPickReason: state.lastCanvasPickReason,
+    lastFailedCanvasPickDiagnostic: state.lastFailedCanvasPickDiagnostic,
   };
 }
 function editorState() {
   const rendered = renderedById(state.selected);
   const editOwner = canonicalEditOwnerRendered(rendered);
-  return { ready: Boolean(state.sceneJson && state.three?.scene), sceneId: sceneId(), selectedItemId: state.selected || '', uiSelectionItemId: explicitUiSelectionItemId(rendered), editOwnerItemId: editOwner?.item?.id || '', selectedItemType: rendered ? itemType(rendered.item) : '', selectedEditable: selectionIsEditable(rendered), selectionDiagnostics: currentSelectionDiagnostics(), lastRaycastHitCount: state.lastRaycastHitCount, lastRaycastCandidateIds: [...state.lastRaycastCandidateIds], lastCanvasSelectedItemId: state.lastCanvasSelectedItemId, lastCanvasPickReason: state.lastCanvasPickReason, dirty: state.dirtyTransforms.size > 0, dirtyCount: state.dirtyTransforms.size, canUndo: state.undoStack.length > 0, canRedo: state.redoStack.length > 0, mode: state.editorMode, error: state.editorError || '' };
+  return { ready: Boolean(state.sceneJson && state.three?.scene), sceneId: sceneId(), selectedItemId: state.selected || '', uiSelectionItemId: explicitUiSelectionItemId(rendered), editOwnerItemId: editOwner?.item?.id || '', selectedItemType: rendered ? itemType(rendered.item) : '', selectedEditable: selectionIsEditable(rendered), selectionDiagnostics: currentSelectionDiagnostics(), lastRaycastHitCount: state.lastRaycastHitCount, lastRaycastCandidateIds: [...state.lastRaycastCandidateIds], lastCanvasSelectedItemId: state.lastCanvasSelectedItemId, lastCanvasPickReason: state.lastCanvasPickReason, lastFailedCanvasPickDiagnostic: state.lastFailedCanvasPickDiagnostic, dirty: state.dirtyTransforms.size > 0, dirtyCount: state.dirtyTransforms.size, canUndo: state.undoStack.length > 0, canRedo: state.redoStack.length > 0, mode: state.editorMode, error: state.editorError || '' };
 }
 function emitDirtyChanged() { pushEditorEvent('dirty_changed', { dirty: state.dirtyTransforms.size > 0, dirtyCount: state.dirtyTransforms.size, canUndo: state.undoStack.length > 0, canRedo: state.redoStack.length > 0 }); }
 function showError(message) {
@@ -1230,14 +1233,17 @@ function registerPickRecord(item, object3d, root = object3d, options = {}) {
   return record;
 }
 function bindExpandedUrdfPickRecordToSubtree(linkRoot, record, urdfLinkRoots) {
-  if (!linkRoot || !record) return;
+  if (!linkRoot || !record) return 0;
+  let boundNodeCount = 0;
   const pending = [linkRoot];
   while (pending.length) {
     const node = pending.pop();
     if (node !== linkRoot && urdfLinkRoots?.has(node)) continue;
     state.pickIdentityByObject.set(node, record);
+    if (node !== linkRoot) boundNodeCount += 1;
     for (const child of node.children || []) pending.push(child);
   }
+  return boundNodeCount;
 }
 function derivedTransformTargetId(item) {
   const targetId = String(item?.target_ref || '').trim();
@@ -3089,6 +3095,7 @@ function resetSceneLifecycleState() {
   state.lastRaycastCandidateIds = [];
   state.lastCanvasSelectedItemId = '';
   state.lastCanvasPickReason = '';
+  state.lastFailedCanvasPickDiagnostic = null;
   state.assemblyRoots = [];
   state.robotAssemblyDiagnostics = [];
   state.robotAssemblyRenderDiagnostics = {};
@@ -3289,6 +3296,8 @@ function loadExpandedUrdfRobotPreview(preview) {
       const toolOwnerId = ownerFromExplicitContract(['selection_tool_owner_id', 'selectionToolOwnerId', 'tool_instance_id', 'toolInstanceId', 'tool_id', 'toolId', 'end_effector_id', 'endEffectorId']);
       const robotInstance = String(preview?.robot_instance_id || preview?.robotInstanceId || preview?.robot_id || preview?.robotId || 'robot').trim();
       const urdfLinkRoots = new Set(result.links.values());
+      const loadedPickRecords = [];
+      let boundNodeCount = 0;
       for (const [linkName, linkObject] of result?.links || []) {
         const exactLink = String(linkName || '').trim();
         const fixtureOwnerId = index.explicitUiIdByLink.get(exactLink) || '';
@@ -3307,9 +3316,41 @@ function loadExpandedUrdfRobotPreview(preview) {
           uiSelectionOwnerId: ownerId,
           uiSelectionResolution: resolution,
         });
-        if (callbackIsCurrent()) bindExpandedUrdfPickRecordToSubtree(linkObject, record, urdfLinkRoots);
+        if (record) loadedPickRecords.push(record);
+        if (callbackIsCurrent()) boundNodeCount += bindExpandedUrdfPickRecordToSubtree(linkObject, record, urdfLinkRoots);
       }
+      const robotPickRecords = loadedPickRecords.filter(record => robotLinks.has(exactSelectionLinkName(record.item)));
+      const toolPickRecords = loadedPickRecords.filter(record => toolLinks.has(exactSelectionLinkName(record.item)));
+      const localDiagnostics = {
+        robot_pick_record_count: loadedPickRecords.length,
+        robotPickRecordCount: loadedPickRecords.length,
+        expanded_urdf_pick_record_count: loadedPickRecords.length,
+        expandedUrdfPickRecordCount: loadedPickRecords.length,
+        expanded_urdf_unique_link_record_count: new Set(loadedPickRecords.map(record => exactSelectionLinkName(record.item)).filter(Boolean)).size,
+        expandedUrdfUniqueLinkRecordCount: new Set(loadedPickRecords.map(record => exactSelectionLinkName(record.item)).filter(Boolean)).size,
+        expanded_urdf_bound_node_count: boundNodeCount,
+        expandedUrdfBoundNodeCount: boundNodeCount,
+        robot_pick_bound_descendant_node_count: boundNodeCount,
+        robotPickBoundDescendantNodeCount: boundNodeCount,
+        expanded_urdf_robot_pick_record_count: robotPickRecords.length,
+        expandedUrdfRobotPickRecordCount: robotPickRecords.length,
+        robot_pick_robot_record_count: robotPickRecords.length,
+        robotPickRobotRecordCount: robotPickRecords.length,
+        expanded_urdf_tool_pick_record_count: toolPickRecords.length,
+        expandedUrdfToolPickRecordCount: toolPickRecords.length,
+        robot_pick_tool_record_count: toolPickRecords.length,
+        robotPickToolRecordCount: toolPickRecords.length,
+        expanded_urdf_robot_pick_record_links: robotPickRecords.map(record => exactSelectionLinkName(record.item)),
+        expandedUrdfRobotPickRecordLinks: robotPickRecords.map(record => exactSelectionLinkName(record.item)),
+        expanded_urdf_tool_pick_record_links: toolPickRecords.map(record => exactSelectionLinkName(record.item)),
+        expandedUrdfToolPickRecordLinks: toolPickRecords.map(record => exactSelectionLinkName(record.item)),
+        selection_robot_owner_id: robotOwnerId,
+        selectionRobotOwnerId: robotOwnerId,
+        selection_tool_owner_id: toolOwnerId,
+        selectionToolOwnerId: toolOwnerId,
+      };
       state.robotPreviewResult = result;
+      result.diagnostics = { ...state.robotUrdfPreviewDiagnostics, ...(result.diagnostics || {}), ...localDiagnostics };
       state.robotUrdfPreviewDiagnostics = result.diagnostics;
       if (!failIfExpandedUrdfExpectedVisualSetInvalid()) completeExpandedUrdfReadiness(result);
       refreshInitialPoseActionState();
@@ -3328,7 +3369,8 @@ function loadExpandedUrdfRobotPreview(preview) {
       renderSceneSummary();
     },
   });
-  state.robotUrdfPreviewDiagnostics = previewResult.diagnostics;
+  state.robotUrdfPreviewDiagnostics = { ...state.robotUrdfPreviewDiagnostics, ...(previewResult.diagnostics || {}) };
+  previewResult.diagnostics = state.robotUrdfPreviewDiagnostics;
   return previewResult;
 }
 
@@ -3793,6 +3835,43 @@ function rankedPickingCandidates(hits) {
     return Math.abs(distanceDelta) <= PICK_COINCIDENCE_TOLERANCE_M ? a.priority - b.priority || distanceDelta : distanceDelta;
   });
 }
+function failedCanvasPickDiagnostic(hits) {
+  const objectNames = [];
+  let traversedRegisteredIdentity = false;
+  let firstActionableRejectionReason = '';
+  let nearestKnownUrdfLinkAncestor = '';
+  const knownLinks = state.robotPreviewResult?.links instanceof Map ? state.robotPreviewResult.links : new Map();
+  const knownLinkByNode = new Map(Array.from(knownLinks.entries()).map(([name, node]) => [node, String(name || '')]));
+  for (const hit of hits || []) {
+    const rawName = String(hit?.object?.name || '').trim();
+    if (rawName && !objectNames.includes(rawName) && objectNames.length < 12) objectNames.push(rawName);
+    let node = hit?.object || null;
+    while (node) {
+      const registered = state.pickIdentityByObject.get(node);
+      if (registered) traversedRegisteredIdentity = true;
+      if (!nearestKnownUrdfLinkAncestor) nearestKnownUrdfLinkAncestor = knownLinkByNode.get(node) || String(registered?.item?.link_name || registered?.item?.link || '').trim();
+      if (!firstActionableRejectionReason) {
+        if (excludedPickNode(node)) firstActionableRejectionReason = 'hit_node_excluded_from_picking';
+        else if (registered && !registered?.item?.id) firstActionableRejectionReason = 'registered_identity_missing_item_id';
+        else if (registered && !isNormalSelectableRendered(inspectionSelectionRendered(registered))) firstActionableRejectionReason = 'registered_identity_not_selectable';
+      }
+      node = node.parent;
+    }
+  }
+  if (!firstActionableRejectionReason) firstActionableRejectionReason = traversedRegisteredIdentity ? 'registered_identity_rejected_by_selection_policy' : 'no_registered_identity_in_hit_ancestry';
+  return {
+    raw_hit_count: (hits || []).length,
+    rawHitCount: (hits || []).length,
+    hit_object_names: objectNames,
+    hitObjectNames: objectNames,
+    traversed_registered_identity: traversedRegisteredIdentity,
+    traversedRegisteredIdentity,
+    first_actionable_rejection_reason: firstActionableRejectionReason,
+    firstActionableRejectionReason,
+    nearest_known_urdf_link_ancestor: nearestKnownUrdfLinkAncestor,
+    nearestKnownUrdfLinkAncestor,
+  };
+}
 function selectObject(id) {
   const requestedId = String(id || '');
   const rawRequested = requestedId ? renderedById(requestedId) : null;
@@ -3842,6 +3921,15 @@ function pickObject(event) {
   if (!selectedCandidate) {
     state.lastCanvasSelectedItemId = '';
     state.lastCanvasPickReason = hits.length ? 'no_eligible_candidate' : 'empty_select_click';
+    state.lastFailedCanvasPickDiagnostic = hits.length ? failedCanvasPickDiagnostic(hits) : null;
+    if (state.lastFailedCanvasPickDiagnostic) {
+      const diagnostic = state.lastFailedCanvasPickDiagnostic;
+      const signature = ['failed_canvas_pick', sceneId(), diagnostic.raw_hit_count, diagnostic.hit_object_names.join('|'), diagnostic.first_actionable_rejection_reason, diagnostic.nearest_known_urdf_link_ancestor].join('\n');
+      if (!state.diagnosticKeys.has(signature)) {
+        state.diagnosticKeys.add(signature);
+        console.warn?.('Product View canvas pick rejected', diagnostic);
+      }
+    }
     if (state.editorMode === 'select') clearSelection();
     return '';
   }
@@ -3857,6 +3945,7 @@ function pickObject(event) {
   selectObject(selectedCandidate.rendered.item.id);
   state.lastCanvasSelectedItemId = selectedCandidate.rendered.item.id;
   state.lastCanvasPickReason = 'eligible_candidate';
+  state.lastFailedCanvasPickDiagnostic = null;
   return selectedCandidate.rendered.item.id;
 }
 


### PR DESCRIPTION
### Motivation
- Make expanded-URDF load and canvas-pick failures inspectable by exposing locally-computed pick diagnostics, selection-owner resolution, and descendant binding counts so Product View readiness/debugging is actionable for the M1 authoring round-trip.
- Preserve locally-computed diagnostic fields when the loader returns `result.diagnostics` so we do not lose ephemeral, viewer-side inspection data.

### Description
- Added diagnostic fields and tracking to the viewer `state` including `lastFailedCanvasPickDiagnostic` and preserved `state.diagnosticKeys` for de-duplicated warnings.
- When the expanded URDF preview finishes loading, collect and merge locally-computed diagnostics into the loader diagnostics instead of overwriting them; report unique link-record counts, bound descendant node counts, robot/tool record membership and selection-owner ids. (`bindExpandedUrdfPickRecordToSubtree` now returns bound descendant node count and the loader merge keeps prior fields.)
- Implemented `failedCanvasPickDiagnostic(hits)` to collect raw hit count, a bounded list of hit object names, whether any traversed node had a registered identity, the first actionable rejection reason, and the nearest registered/known URDF link ancestor, and expose it via `editorState()` and the scene summary (`__WORKCELL_VIEWER_STATUS__`).
- Emit one console warning per distinct failed-click signature using `state.diagnosticKeys` and do not emit continuous pointer-event logs; clear the failed-click diagnostic on successful eligible selection.
- Updated static Node.js harness tests to verify: diagnostics merging, unique link vs bound-node counting, robot/tool record counts, rejected-hit contents, known-link ancestry, editor exposure, and once-per-signature warning behavior.

### Testing
- Ran `node --check workcell_studio_web/viewer/viewer.js` — passed.
- Ran `git diff --check` — passed.
- Ran focused tests: `pytest -q tests/test_workcell_studio_web_viewer_static.py -k 'expanded_urdf_descendant_mesh_picks or raycast_registry_ancestry'` — 2 passed (focused diagnostics tests).
- Ran full viewer static tests: `pytest -q tests/test_workcell_studio_web_viewer_static.py` — 111 passed, 1 existing exporter-backed selection-owner test failed (the failure is unrelated to these diagnostics changes: the generated camera preview resolved to an empty UI identity rather than the expected `realsense_overhead`); the new diagnostics behavior is validated by the focused tests that passed.
- Not run here: display-enabled Workcell Builder click validation and ROS 2 Humble build/launch checks because this environment lacks a GUI workstation and those build/runtime dependencies; the changes are viewer-only and do not alter generated ROS artifacts or runtime safety defaults.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b6e0012dc8331beb723e997dd4c0a)