### PR TITLE
M1: preserve explicit Qt preview selection owners

### DIFF
--- a/tests/test_embedded_web3d_editor_bridge_static.py
+++ b/tests/test_embedded_web3d_editor_bridge_static.py
@@ -187,12 +187,32 @@ def test_qt_poll_treats_current_browser_state_as_authoritative_without_same_cycl
     assert "emitted_scene_diagnostic_keys_.contains(rejection_key)" in poll
 
 
-def test_qt_inventory_preserves_unique_locked_robot_and_tool_owner_rows():
+def test_qt_inventory_preserves_explicit_locked_robot_and_tool_owner_rows():
     main = (ROOT / "workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text(encoding="utf-8")
-    body = main.split("auto preserve_unique_inspection_owner", 1)[1].split("const bool filtered_payload_changed", 1)[0]
+    body = main.split("QString selection_robot_owner_id", 1)[1].split("const bool filtered_payload_changed", 1)[0]
+    assert 'value(QStringLiteral("selection_robot_owner_id"))' in body
+    assert 'value(QStringLiteral("selection_tool_owner_id"))' in body
+    assert "item.id.trimmed() == owner_id" in body
+    assert "filtered_items.push_back(*owner)" in body
+    assert "selection_robot_owner_id.isEmpty() && !explicit_robot_owner" in body
+    assert "selection_tool_owner_id.isEmpty() && !explicit_tool_owner" in body
+    assert "used unique category fallback" in body
     assert "item.locked && !item.editable" in body
     assert 'source_layer != QStringLiteral("locked_generated_urdf_visual")' in body
     assert "if (candidates.size() != 1) return;" in body
     assert 'QStringLiteral("robot_arm")' in body
     assert 'QStringLiteral("end_effector")' in body
     assert "filtered_items.push_back(candidates.front())" in body
+
+
+def test_qt_exact_ur5_and_robotiq_owner_ids_remain_selectable_in_preview_inventory():
+    main = (ROOT / "workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text(encoding="utf-8")
+    environment = (ROOT / "scenes/ur5_2f_test/environment.yaml").read_text(encoding="utf-8")
+    owner_body = main.split("auto preserve_explicit_inspection_owner", 1)[1].split("// Compatibility fallback", 1)[0]
+    poll = CPP.split("void ScenePreviewWidget::poll_embedded_editor_events()", 1)[1].split("#else", 1)[0]
+    assert "all_scene_preview_items_.cbegin()" in owner_body
+    assert "item.id.trimmed() == owner_id" in owner_body
+    assert "filtered_items.push_back(*owner)" in owner_body
+    for owner_id in ("ur5", "robotiq_85_gripper"):
+        assert f"id: {owner_id}" in environment
+    assert "preview_item_by_id(browser_ui_selected_id) != nullptr" in poll

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -8708,10 +8708,45 @@ void MainWindow::apply_scene3d_preview_layer_filters(bool log_change)
   if (filtered_items.isEmpty() && !all_scene_preview_items_.isEmpty()) {
     append_studio_log("Scene3D blocker: current layer filters hide all items. Re-enable editable layout, mesh preview, primitive fallback, or locked generated URDF visuals.");
   }
-  // Keep the single configured robot and end-effector inspection owners in the
-  // Qt identity inventory even when their generated per-link render rows are
-  // suppressed. These are existing payload records, not renderable URDF-link
-  // rows, and remain locked/read-only hierarchy and Selected Item owners.
+  // Keep the explicitly exported robot and end-effector inspection owners in
+  // the Qt identity inventory even when filtering suppresses them.  The web
+  // preview has already ingested this contract from the same exported payload;
+  // only re-use matching locked/read-only records from the Qt inventory here.
+  QString selection_robot_owner_id;
+  QString selection_tool_owner_id;
+  bool owner_contract_loaded = false;
+  const auto preview_context = scene_preview_widget_->preview_context();
+  const QString owner_contract_path = QDir(preview_context.absolute_repo_root).filePath(
+    QStringLiteral("build/workcell_studio_web_scene/%1.web_scene.json").arg(preview_context.scene_id));
+  QFile owner_contract_file(owner_contract_path);
+  if (owner_contract_file.open(QIODevice::ReadOnly)) {
+    const QJsonDocument owner_contract_document = QJsonDocument::fromJson(owner_contract_file.readAll());
+    const QJsonObject robot_preview = owner_contract_document.object().value(QStringLiteral("robot_preview")).toObject();
+    owner_contract_loaded = owner_contract_document.isObject() && !robot_preview.isEmpty();
+    selection_robot_owner_id = robot_preview.value(QStringLiteral("selection_robot_owner_id")).toString().trimmed();
+    selection_tool_owner_id = robot_preview.value(QStringLiteral("selection_tool_owner_id")).toString().trimmed();
+  }
+  auto preserve_explicit_inspection_owner = [&](const QString & owner_id, const QString & owner_type) {
+    if (owner_id.isEmpty()) return false;
+    const auto owner = std::find_if(all_scene_preview_items_.cbegin(), all_scene_preview_items_.cend(),
+      [&](const auto & item) { return item.id.trimmed() == owner_id; });
+    if (owner == all_scene_preview_items_.cend() || !owner->locked || owner->editable) {
+      append_studio_log(QStringLiteral(
+        "Scene3D selection-owner contract mismatch: type=%1 id=%2 is absent from the locked/read-only Qt preview inventory.")
+        .arg(owner_type, owner_id));
+      return true;
+    }
+    const bool already_present = std::any_of(filtered_items.cbegin(), filtered_items.cend(), [&](const auto & item) {
+      return item.id.trimmed() == owner_id;
+    });
+    if (!already_present) filtered_items.push_back(*owner);
+    return true;
+  };
+  const bool explicit_robot_owner = preserve_explicit_inspection_owner(selection_robot_owner_id, QStringLiteral("robot"));
+  const bool explicit_tool_owner = preserve_explicit_inspection_owner(selection_tool_owner_id, QStringLiteral("tool"));
+
+  // Compatibility fallback is intentionally category-based only when the
+  // exported robot-preview payload truly has no explicit ID for that owner.
   auto preserve_unique_inspection_owner = [&](const QSet<QString> & categories) {
     QVector<ScenePreviewWidget::PreviewItem> candidates;
     for (const auto & item : all_scene_preview_items_) {
@@ -8730,8 +8765,19 @@ void MainWindow::apply_scene3d_preview_layer_filters(bool log_change)
     });
     if (!already_present) filtered_items.push_back(candidates.front());
   };
-  preserve_unique_inspection_owner({QStringLiteral("robot"), QStringLiteral("robot_arm")});
-  preserve_unique_inspection_owner({QStringLiteral("tool"), QStringLiteral("end_effector"), QStringLiteral("gripper")});
+  if (owner_contract_loaded && selection_robot_owner_id.isEmpty() && !explicit_robot_owner) {
+    preserve_unique_inspection_owner({QStringLiteral("robot"), QStringLiteral("robot_arm")});
+    append_studio_log(QStringLiteral("Scene3D diagnostic: selection_robot_owner_id missing; used unique category fallback."));
+  }
+  if (owner_contract_loaded && selection_tool_owner_id.isEmpty() && !explicit_tool_owner) {
+    preserve_unique_inspection_owner({QStringLiteral("tool"), QStringLiteral("end_effector"), QStringLiteral("gripper")});
+    append_studio_log(QStringLiteral("Scene3D diagnostic: selection_tool_owner_id missing; used unique category fallback."));
+  }
+  if (!owner_contract_loaded) {
+    append_studio_log(QStringLiteral(
+      "Scene3D diagnostic: active robot-preview selection-owner contract unavailable; category fallback was not used: %1")
+      .arg(owner_contract_path));
+  }
   const bool filtered_payload_changed = !scene_preview_widget_->preview_payload_matches(filtered_items);
   if (filtered_payload_changed) {
     scene_preview_widget_->set_preview_items(filtered_items);


### PR DESCRIPTION
### Motivation
- Prevent category-only fallback from dropping exact selection-owner records used by the Web3D preview, which can cause canonical robot/tool selections to be rejected. This aligns the preview inventory behavior with the exported robot-preview contract.

### Description
- Read `selection_robot_owner_id` and `selection_tool_owner_id` from the active exported robot-preview payload at `build/workcell_studio_web_scene/<scene>.web_scene.json` using the active `preview_context()` and attempt to load the contract at runtime.
- Locate the exact owner IDs in `all_scene_preview_items_` and, when present as existing locked/read-only records, append those records to `filtered_items` instead of synthesizing rows or per-link hierarchy entries. Emit a diagnostic when the contract references an owner ID that is not present as a locked/read-only inventory item.
- Preserve the existing category-only unique-owner fallback only when the exported contract is available and explicitly omits an owner ID, and log diagnostics for both fallback and unavailable/ malformed contract cases.
- Add focused static assertions in `tests/test_embedded_web3d_editor_bridge_static.py` that verify ingestion of explicit owner IDs, that the code searches `all_scene_preview_items_` for exact IDs, and that canonical `ur5` and `robotiq_85_gripper` IDs remain discoverable and accepted by the `preview_item_by_id()` gate.
- Files changed: `workcell_builder/workcell_builder/gui/mainwindow.cpp` and `tests/test_embedded_web3d_editor_bridge_static.py`.

### Testing
- Ran `pytest -q tests/test_embedded_web3d_editor_bridge_static.py`; all tests passed (17 passed).
- Performed repository static checks (`git diff --check`) as part of validation; no diff-check errors observed.
- GUI/workstation validation and ROS 2 Humble build/launch were not executed in this environment because a display-enabled Workcell Builder session and ROS runtime were not available; those manual/runtime checks remain recommended for full M1 evidence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b6f7d096c8331810c54e545ad7053)