### PR TITLE
M1: gate scene readiness on expanded URDF lifecycle

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -467,7 +467,7 @@ def test_expanded_urdf_robot_preview_callbacks_are_scene_current_guarded():
         "onRobotLoaded: result => {": "state.robotPreviewResult = result;",
         "onRobotMeshLoaded: () => {": "renderSceneSummary();",
         "onRobotMeshLoadError: (err, uri, detail) => {": "failExpandedUrdfReadiness(err, state.robotUrdfPreviewDiagnostics, detail || { uri });",
-        "onRobotError: (err, diagnostics) => {": "failExpandedUrdfReadiness(err, diagnostics || state.robotUrdfPreviewDiagnostics);",
+        "onRobotError: (err, diagnostics) => {": "state.robotUrdfPreviewDiagnostics.robot_preview_lifecycle_state = 'failed';",
     }
     for callback, mutation in callback_mutations.items():
         section = load_body.split(callback, 1)[1].split("},", 1)[0]
@@ -532,6 +532,7 @@ function assertOldCallbacksRejected(targetSceneId) {
   assert.deepStrictEqual(Array.from(state.frameLookup.keys()), []);
   assert.deepStrictEqual(state.assemblyRoots, []);
   assert.deepStrictEqual(state.objects, []);
+  assert.deepStrictEqual(state.pickRecords, []);
   assert.strictEqual(state.web3dReadiness.state, 'scene_loading');
   assert.strictEqual(state.web3dReadiness.failed, false);
   assert.strictEqual(state.web3dReadiness.terminal, false);
@@ -564,6 +565,58 @@ clearSceneObjects();
 fireOldCallbacks(oldWithoutScene);
 assert.strictEqual(state.three.scene, null);
 assertOldCallbacksRejected('suction_test');
+`, context);
+'''
+    result = subprocess.run(["node", "-e", harness, str(js_path)], cwd=ROOT, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert result.stderr == ""
+
+
+def test_expanded_urdf_readiness_waits_for_current_terminal_loader_callback():
+    js_path = VIEWER / "viewer.js"
+    harness = r'''
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+let source = fs.readFileSync(process.argv[1], 'utf8').replace(/boot\(\);\s*$/, '');
+const element = () => ({ hidden:false, checked:false, disabled:false, textContent:'', className:'', innerHTML:'', classList:{toggle(){}}, setAttribute(){}, querySelector(){return {textContent:''}}, appendChild(){}, addEventListener(){} });
+const context = { console, assert, window:{dispatched:[],location:{search:''},dispatchEvent(event){this.dispatched.push(event.detail.state)},parent:{postMessage(){}}}, document:{getElementById(){return element()},createElement(){return element()}}, URLSearchParams, CustomEvent:function(type,init){return {type,detail:init.detail}}, requestAnimationFrame(){return 0}, setTimeout(){return 1}, clearTimeout(){} };
+vm.createContext(context);
+vm.runInContext(source + `
+renderSceneSummary = () => {};
+refreshInitialPoseActionState = () => {};
+refreshWarnings = () => {};
+appendRuntimeWarning = () => {};
+rebuildSelectionIdentityIndex = () => ({ itemById:new Map(), explicitUiIdByLink:new Map() });
+let callback;
+loadRobotPreview = (preview, rendererContext) => { callback = rendererContext; return { diagnostics:{ robot_preview_lifecycle_state:'loading_urdf', robotPreviewLifecycleState:'loading_urdf' } }; };
+const required = { robot_arm:true, attached_tool_gripper:true, workbench_support_surface:true, configured_camera:true };
+function beginExpanded() {
+  window.dispatched.length = 0;
+  state.sceneJson = { scene:{id:'ur5_2f_test'}, robot_preview:{mode:'expanded_urdf_loader', expected_robot_visual_links:[], expected_tool_visual_links:[]} };
+  state.web3dReadiness = { state:'scene_loading', terminal:false, required, pending:new Set(['robot_arm:expanded_urdf_loader','attached_tool_gripper:expanded_urdf_loader']), failed:false, failure:null };
+  loadExpandedUrdfRobotPreview(state.sceneJson.robot_preview);
+}
+beginExpanded();
+maybeEmitSceneReady();
+assert.strictEqual(window.dispatched.length, 0, 'loading_urdf must not become terminal');
+callback.onRobotLoaded({ root:{}, links:new Map(), diagnostics:{robot_preview_lifecycle_state:'ready',robot_preview_loaded:true} });
+assert.strictEqual(window.dispatched.join(','), 'scene_ready', 'current successful callback becomes ready');
+assert.strictEqual(state.robotUrdfPreviewDiagnostics.robot_preview_lifecycle_state, 'ready');
+
+beginExpanded();
+state.robotUrdfPreviewDiagnostics = {robot_preview_lifecycle_state:'failed'};
+maybeEmitSceneReady();
+assert.strictEqual(window.dispatched.length, 0, 'failed without diagnostics is not terminal');
+callback.onRobotError(new Error('URDF parse failed'), {robot_preview_lifecycle_state:'failed'});
+assert.strictEqual(window.dispatched.join(','), 'scene_failed', 'explicit current failure becomes terminal');
+assert.strictEqual(state.web3dReadiness.failure.reason, 'URDF parse failed');
+
+window.dispatched.length = 0;
+state.sceneJson = { scene:{id:'legacy'}, robot_preview:{mode:'flattened_rows'} };
+state.web3dReadiness = { state:'scene_loading', terminal:false, required, pending:new Set(), failed:false, failure:null };
+state.robotUrdfPreviewDiagnostics = {robot_preview_lifecycle_state:'loading_urdf'};
+maybeEmitSceneReady();
+assert.strictEqual(window.dispatched.join(','), 'scene_ready', 'non-expanded scenes retain existing readiness behavior');
 `, context);
 '''
     result = subprocess.run(["node", "-e", harness, str(js_path)], cwd=ROOT, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -3226,8 +3279,8 @@ vm.runInContext(source + `
 const falseMissingRobotLinks = ['base_link_inertia', 'shoulder_link', 'upper_arm_link', 'forearm_link', 'wrist_1_link', 'wrist_2_link', 'wrist_3_link'];
 state.sceneJson = { scene: { id: 'ur5_2f_test' }, robot_preview: { mode: 'expanded_urdf_loader', robot_instance_id: 'ur5_2f', expected_robot_visual_links: falseMissingRobotLinks, expected_tool_visual_links: ['robotiq_85_base_link'] } };
 state.robotUrdfPreviewDiagnostics = {
-  robot_preview_lifecycle_state: 'failed',
-  robot_preview_loaded: false,
+  robot_preview_lifecycle_state: 'ready',
+  robot_preview_loaded: true,
   robot_expected_visual_count: 16,
   robot_completed_visual_count: 16,
   robot_loaded_visual_count: 16,

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -238,6 +238,19 @@ function failExpandedUrdfReadiness(err, diagnostics = {}, detail = {}) {
   });
 }
 function maybeEmitSceneReady() {
+  if (isExpandedUrdfRobotPreview(state.sceneJson?.robot_preview)) {
+    const diagnostics = state.robotUrdfPreviewDiagnostics || {};
+    const lifecycle = String(diagnostics.robot_preview_lifecycle_state || diagnostics.robotPreviewLifecycleState || '');
+    if (lifecycle === 'failed') {
+      const failureReason = String(diagnostics.robot_preview_failure_reason || diagnostics.robotPreviewFailureReason || '').trim();
+      const missingMeshes = asArray(diagnostics.robot_missing_meshes || diagnostics.robotMissingMeshes);
+      const failedVisualCount = Number(diagnostics.robot_failed_visual_count ?? diagnostics.robotFailedVisualCount ?? 0) || 0;
+      if (!failureReason && missingMeshes.length === 0 && failedVisualCount === 0) return;
+      failExpandedUrdfReadiness(new Error(failureReason || missingMeshes[0] || 'expanded URDF preview failed'), diagnostics);
+      return;
+    }
+    if (lifecycle !== 'ready') return;
+  }
   if (failIfExpandedUrdfExpectedVisualSetInvalid()) return;
   const readiness = state.web3dReadiness;
   if (!readiness || readiness.failed || readiness.state === 'scene_failed') return;
@@ -3351,8 +3364,14 @@ function loadExpandedUrdfRobotPreview(preview) {
       };
       state.robotPreviewResult = result;
       result.diagnostics = { ...state.robotUrdfPreviewDiagnostics, ...(result.diagnostics || {}), ...localDiagnostics };
+      const resultLifecycle = String(result.diagnostics.robot_preview_lifecycle_state || result.diagnostics.robotPreviewLifecycleState || '');
+      if (resultLifecycle === 'ready') {
+        result.diagnostics.robot_preview_lifecycle_state = 'ready';
+        result.diagnostics.robotPreviewLifecycleState = 'ready';
+      }
       state.robotUrdfPreviewDiagnostics = result.diagnostics;
-      if (!failIfExpandedUrdfExpectedVisualSetInvalid()) completeExpandedUrdfReadiness(result);
+      if (resultLifecycle === 'ready' && !failIfExpandedUrdfExpectedVisualSetInvalid()) completeExpandedUrdfReadiness(result);
+      maybeEmitSceneReady();
       refreshInitialPoseActionState();
       renderSceneSummary();
     },
@@ -3363,7 +3382,13 @@ function loadExpandedUrdfRobotPreview(preview) {
     onRobotMeshLoadError: (err, uri, detail) => { if (!callbackIsCurrent()) return ignoreStaleCallback(); failExpandedUrdfReadiness(err, state.robotUrdfPreviewDiagnostics, detail || { uri }); renderSceneSummary(); },
     onRobotError: (err, diagnostics) => {
       if (!callbackIsCurrent()) return ignoreStaleCallback();
-      failExpandedUrdfReadiness(err, diagnostics || state.robotUrdfPreviewDiagnostics);
+      state.robotUrdfPreviewDiagnostics = { ...state.robotUrdfPreviewDiagnostics, ...(diagnostics || {}) };
+      state.robotUrdfPreviewDiagnostics.robot_preview_lifecycle_state = 'failed';
+      state.robotUrdfPreviewDiagnostics.robotPreviewLifecycleState = 'failed';
+      state.robotUrdfPreviewDiagnostics.robot_preview_failure_reason = err?.message || String(err || 'expanded URDF preview failed');
+      state.robotUrdfPreviewDiagnostics.robotPreviewFailureReason = state.robotUrdfPreviewDiagnostics.robot_preview_failure_reason;
+      failExpandedUrdfReadiness(err, state.robotUrdfPreviewDiagnostics);
+      maybeEmitSceneReady();
       appendRuntimeWarning({}, preview?.urdf_url || '', `expanded_urdf_loader failed: ${err?.message || err}`, 'expanded_urdf_loader_failed');
       refreshWarnings();
       renderSceneSummary();


### PR DESCRIPTION
### Motivation

- Prevent expanded-URDF scenes from emitting a terminal `scene_ready` while the robot preview is still in `loading_urdf` to avoid readiness races and stale pick/materialization from out-of-date loader callbacks. 
- Treat the expanded-URDF loader `ready` lifecycle as the authoritative success and treat `failed` as terminal only when explicit failure diagnostics exist to avoid false-negative readiness signals.

### Description

- Update `maybeEmitSceneReady()` to short-circuit for scenes using `expanded_urdf_loader`, allowing completion only when the preview lifecycle is `ready` or when `failed` is accompanied by explicit diagnostics, otherwise returning early. (workcell_studio_web/viewer/viewer.js)
- On the current non-stale `onRobotLoaded` path, record `ready` in the preview diagnostics, run the existing expanded-URDF completion accounting, and call `maybeEmitSceneReady()` to re-evaluate readiness. (workcell_studio_web/viewer/viewer.js)
- On the current non-stale `onRobotError` path, record failure diagnostics and lifecycle `failed`, call the expanded-URDF failure handler, and then call `maybeEmitSceneReady()` so the terminal failure emission is based on recorded diagnostics. (workcell_studio_web/viewer/viewer.js)
- Add executable Node-backed test cases that exercise: no terminal readiness while `loading_urdf`, readiness when a current successful loader callback finishes, explicit terminal failure only when diagnostics are present, and that stale loader callbacks cannot mutate new scene state or emit readiness events. (tests/test_workcell_studio_web_viewer_static.py)

### Testing

- Ran the repository static test suite for the viewer harness with `pytest -q tests/test_workcell_studio_web_viewer_static.py` and the suite passed (`113 passed`).
- Executable Node-backed cases covering loading suppression, current successful completion, diagnostic-backed terminal failure, and stale-callback protections were exercised as part of the test run and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6bb369a954833186382cd26af9e509)