### PR TITLE
M1: rebuild bundle for final robot and gripper selection

### DIFF
--- a/workcell_studio_web/viewer/dist/viewer.bundle.js
+++ b/workcell_studio_web/viewer/dist/viewer.bundle.js
@@ -38528,6 +38528,21 @@ function failExpandedUrdfReadiness(err, diagnostics = {}, detail = {}) {
   });
 }
 function maybeEmitSceneReady() {
+  if (isExpandedUrdfRobotPreview(state.sceneJson?.robot_preview)) {
+    const diagnostics = state.robotUrdfPreviewDiagnostics || {};
+    const lifecycle = String(diagnostics.robot_preview_lifecycle_state || diagnostics.robotPreviewLifecycleState || "");
+    if (lifecycle === "failed") {
+      const failureReason = String(diagnostics.robot_preview_failure_reason || diagnostics.robotPreviewFailureReason || "").trim();
+      const missingMeshes = asArray(diagnostics.robot_missing_meshes || diagnostics.robotMissingMeshes);
+      const failedVisualCount = Number(diagnostics.robot_failed_visual_count ?? diagnostics.robotFailedVisualCount ?? 0) || 0;
+      if (!failureReason && missingMeshes.length === 0 && failedVisualCount === 0)
+        return;
+      failExpandedUrdfReadiness(new Error(failureReason || missingMeshes[0] || "expanded URDF preview failed"), diagnostics);
+      return;
+    }
+    if (lifecycle !== "ready")
+      return;
+  }
   if (failIfExpandedUrdfExpectedVisualSetInvalid())
     return;
   const readiness = state.web3dReadiness;
@@ -39389,7 +39404,7 @@ function currentSelectionDiagnostics() {
     editOwnerItemId: editOwner?.item?.id || "",
     renderIdentity: id,
     selectedItemType: rendered ? itemType(item) : "",
-    selectable: Boolean(rendered && isNormalSelectableRendered(rendered)),
+    selectable: Boolean(rendered && isCanvasSelectableRendered(rendered)),
     editable: Boolean(item && editOwner === rendered && !rendered?.readOnlyPick && canEditItem(item)),
     locked: Boolean(item?.locked),
     sourceLayer: String(item?.source_layer || ""),
@@ -41837,9 +41852,15 @@ function loadExpandedUrdfRobotPreview(preview) {
       };
       state.robotPreviewResult = result;
       result.diagnostics = { ...state.robotUrdfPreviewDiagnostics, ...result.diagnostics || {}, ...localDiagnostics };
+      const resultLifecycle = String(result.diagnostics.robot_preview_lifecycle_state || result.diagnostics.robotPreviewLifecycleState || "");
+      if (resultLifecycle === "ready") {
+        result.diagnostics.robot_preview_lifecycle_state = "ready";
+        result.diagnostics.robotPreviewLifecycleState = "ready";
+      }
       state.robotUrdfPreviewDiagnostics = result.diagnostics;
-      if (!failIfExpandedUrdfExpectedVisualSetInvalid())
+      if (resultLifecycle === "ready" && !failIfExpandedUrdfExpectedVisualSetInvalid())
         completeExpandedUrdfReadiness(result);
+      maybeEmitSceneReady();
       refreshInitialPoseActionState();
       renderSceneSummary();
     },
@@ -41857,7 +41878,13 @@ function loadExpandedUrdfRobotPreview(preview) {
     onRobotError: (err, diagnostics2) => {
       if (!callbackIsCurrent())
         return ignoreStaleCallback();
-      failExpandedUrdfReadiness(err, diagnostics2 || state.robotUrdfPreviewDiagnostics);
+      state.robotUrdfPreviewDiagnostics = { ...state.robotUrdfPreviewDiagnostics, ...diagnostics2 || {} };
+      state.robotUrdfPreviewDiagnostics.robot_preview_lifecycle_state = "failed";
+      state.robotUrdfPreviewDiagnostics.robotPreviewLifecycleState = "failed";
+      state.robotUrdfPreviewDiagnostics.robot_preview_failure_reason = err?.message || String(err || "expanded URDF preview failed");
+      state.robotUrdfPreviewDiagnostics.robotPreviewFailureReason = state.robotUrdfPreviewDiagnostics.robot_preview_failure_reason;
+      failExpandedUrdfReadiness(err, state.robotUrdfPreviewDiagnostics);
+      maybeEmitSceneReady();
       appendRuntimeWarning({}, preview?.urdf_url || "", `expanded_urdf_loader failed: ${err?.message || err}`, "expanded_urdf_loader_failed");
       refreshWarnings();
       renderSceneSummary();
@@ -42301,6 +42328,15 @@ function isNormalSelectableRendered(rendered) {
   const inspectionSelectable = state.debugOverlaysVisible && (isTaskOnlyHelperItem(item) || isOverlayPolicyItem(item) || isDebugOverlayItem(item));
   return Boolean(item?.id) && item.selectable !== false && !isDiagnosticOnlyItem(item) && (inspectionSelectable || !isTaskOnlyHelperItem(item) && !isOverlayPolicyItem(item) && !isDebugOverlayItem(item));
 }
+function isExpandedUrdfInspectionPick(rendered) {
+  const item = rendered?.item;
+  const registeredReadOnlyRecord = Boolean(rendered && rendered.readOnlyPick === true && state.pickRecords.includes(rendered));
+  const explicitInspectionMetadata = rendered?.pickRecordSource === "expanded_urdf_inspection" || Boolean(String(rendered?.uiSelectionOwnerId || "").trim()) || String(item?.source_layer || "").trim() === "expanded_urdf_inspection";
+  return registeredReadOnlyRecord && explicitInspectionMetadata && Boolean(item?.id) && item.selectable !== false && rendered.object3d?.visible !== false && !isTaskOnlyHelperItem(item) && !isOverlayPolicyItem(item) && !isDebugOverlayItem(item);
+}
+function isCanvasSelectableRendered(rendered) {
+  return isExpandedUrdfInspectionPick(rendered) || isNormalSelectableRendered(rendered);
+}
 function excludedPickNode(node) {
   const data = node?.userData || {};
   const name = String(node?.name || "").toLowerCase();
@@ -42314,7 +42350,7 @@ function itemFromRaycastHit(hit) {
       return null;
     if (!candidate) {
       const registered = state.pickIdentityByObject.get(node);
-      const registeredInspection = registered?.pickRecordSource === "expanded_urdf_inspection" || Boolean(String(registered?.uiSelectionOwnerId || "").trim());
+      const registeredInspection = isExpandedUrdfInspectionPick(registered);
       const nodeItem = node.userData?.item;
       const nodeItemWithoutStalePickFlags = nodeItem ? { ...nodeItem, id: "", display_name: "", status: "", diagnostic_only: false, selectable: true } : null;
       if (registeredInspection && nodeItemWithoutStalePickFlags && (isTaskOnlyHelperItem(nodeItemWithoutStalePickFlags) || isOverlayPolicyItem(nodeItemWithoutStalePickFlags) || isDebugOverlayItem(nodeItemWithoutStalePickFlags)))
@@ -42322,7 +42358,7 @@ function itemFromRaycastHit(hit) {
       const item = registeredInspection ? registered.item : nodeItem || registered?.item;
       if (item?.id) {
         const rendered = renderedById(item.id) || registered;
-        if (!rendered || !registeredInspection && !isNormalSelectableRendered(rendered))
+        if (!rendered || !isCanvasSelectableRendered(rendered))
           return null;
         candidate = rendered;
       }
@@ -42384,7 +42420,7 @@ function failedCanvasPickDiagnostic(hits) {
           firstActionableRejectionReason = "hit_node_excluded_from_picking";
         else if (registered && !registered?.item?.id)
           firstActionableRejectionReason = "registered_identity_missing_item_id";
-        else if (registered && !isNormalSelectableRendered(inspectionSelectionRendered(registered)))
+        else if (registered && !isCanvasSelectableRendered(inspectionSelectionRendered(registered)))
           firstActionableRejectionReason = "registered_identity_not_selectable";
       }
       node = node.parent;
@@ -42410,7 +42446,7 @@ function selectObject(id) {
   const rawRequested = requestedId ? renderedById(requestedId) : null;
   const requested = inspectionSelectionRendered(rawRequested);
   const selectionId = requested?.item?.id || requestedId;
-  const explicitlySelectable = requested && !isDiagnosticOnlyItem(requested.item) && requested.item.selectable !== false && (isNormalSelectableRendered(requested) || isOverlayPolicyItem(requested.item) || isTaskOnlyHelperItem(requested.item));
+  const explicitlySelectable = requested && isCanvasSelectableRendered(requested);
   if (requestedId && !explicitlySelectable) {
     const reason = requested ? "diagnostic_helper_or_non_selectable" : "missing_render_identity";
     state.ignoredSelectionKeys || (state.ignoredSelectionKeys = /* @__PURE__ */ new Set());
@@ -42463,7 +42499,7 @@ function pickObject(event) {
   const candidates = rankedPickingCandidates(hits);
   state.lastRaycastHitCount = hits.length;
   state.lastRaycastCandidateIds = candidates.map((candidate) => candidate.rendered.item.id);
-  const selectedCandidate = candidates.find((candidate) => Number.isFinite(candidate.priority) && isNormalSelectableRendered(candidate.rendered));
+  const selectedCandidate = candidates.find((candidate) => Number.isFinite(candidate.priority) && isCanvasSelectableRendered(candidate.rendered));
   if (!selectedCandidate) {
     state.lastCanvasSelectedItemId = "";
     state.lastCanvasPickReason = hits.length ? "no_eligible_candidate" : "empty_select_click";


### PR DESCRIPTION
### Motivation
- Close the M1 blocker that the production Web3D viewer bundle had not yet incorporated the merged expanded-URDF selection and lifecycle changes so the canvas selection policy and readiness gating are consistent with the new inspection features.

### Description
- Regenerated the production Web3D bundle `workcell_studio_web/viewer/dist/viewer.bundle.js` from merged PRs `#2928` and `#2930`, bringing the expanded-URDF selection and lifecycle logic into the shipped bundle.
- Bundle now includes `isExpandedUrdfInspectionPick` and `isCanvasSelectableRendered` selection gates, expanded-URDF inspection pick metadata, and lifecycle diagnostics such as `robot_preview_lifecycle_state`, so expanded-URDF inspection records pass final canvas selection gates.  
- Readiness now waits for a terminal expanded-URDF lifecycle (the bundle adds lifecycle checks in `maybeEmitSceneReady` and the robot-preview diagnostics flow).  
- Only the production bundle was changed; source JS, source maps, C++, tests, YAML, exporters, package files, generated scene files, and Node modules were not modified.

### Testing
- Ran `npm ci` and `npm run build:web3d` and restored the source map; `npm run check:stale-bundle` reported the bundle as current.  
- Verified bundle markers via `grep` for `isExpandedUrdfInspectionPick`, `isCanvasSelectableRendered`, `expanded_urdf_inspection`, `loading_urdf`, and `robot_preview_lifecycle_state` (all present).  
- Performed `node --check workcell_studio_web/viewer/viewer.js` which passed, and ran the focused tests `python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py tests/test_embedded_web3d_editor_bridge_static.py tests/test_workcell_builder_selected_item_card.py` which returned `139 passed, 3 warnings`.  
- `git status --short` and diffs before commit showed exactly one tracked file changed: `workcell_studio_web/viewer/dist/viewer.bundle.js`, and `git diff --check` reported no issues.  

Notes: the branch commit was prepared locally but pushing the branch to GitHub was blocked by missing credentials in this environment; the PR metadata is ready. Workstation UR5 and Robotiq acceptance on a display-enabled workstation remains required and was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6bb7d47094833196c7a0beb193d6ff)