### PR TITLE
M1: unblock expanded URDF mesh completion without LoadingManager

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -1972,6 +1972,71 @@ def test_urdf_renderer_waits_for_mesh_completion_before_ready():
     assert "collectDescendantRenderMeshDiagnostics(robot.links)" in ready_section
 
 
+def test_urdf_renderer_mesh_completion_does_not_require_loading_manager(tmp_path):
+    script = tmp_path / "mesh_completion_without_manager.mjs"
+    script.write_text(
+        f"""
+import assert from 'node:assert/strict';
+import * as THREE from {str((VIEWER / 'node_modules/three/build/three.module.js')).__repr__()};
+import URDFLoader from {str((VIEWER / 'node_modules/urdf-loader/src/URDFLoader.js')).__repr__()};
+import {{ STLLoader }} from {str((VIEWER / 'node_modules/three/examples/jsm/loaders/STLLoader.js')).__repr__()};
+
+globalThis.window = {{ setTimeout }};
+globalThis.fetch = async () => ({{ ok: true, status: 200, statusText: 'OK', text: async () => '<robot name="test"/>' }});
+const originalUrdfParse = URDFLoader.prototype.parse;
+const originalStlLoad = STLLoader.prototype.load;
+STLLoader.prototype.load = function loadStub(_url, onLoad) {{
+  onLoad(new THREE.BoxGeometry(1, 1, 1));
+  // Deliberately do not notify this.manager.onLoad().
+}};
+URDFLoader.prototype.parse = function parseStub() {{
+  const robot = new THREE.Group();
+  const base = new THREE.Group();
+  base.name = 'base_link';
+  const visual = new THREE.Group();
+  base.add(visual);
+  robot.add(base);
+  this.loadMeshCb('mesh.stl', this.manager, null, mesh => visual.add(mesh));
+  robot.links = {{ base_link: base }};
+  robot.joints = {{}};
+  robot.setJointValues = () => {{}};
+  return robot;
+}};
+
+let loaded = 0;
+let failed = 0;
+try {{
+  const {{ loadRobotPreview }} = await import({str((VIEWER / 'urdf_robot_renderer.js')).__repr__()});
+  const result = loadRobotPreview({{ urdf_url: 'robot.urdf' }}, {{
+    onRobotLoaded: () => {{ loaded += 1; }},
+    onRobotError: () => {{ failed += 1; }},
+  }});
+  await result.ready;
+  assert.equal(result.diagnostics.robot_expected_visual_count, 1);
+  assert.equal(result.diagnostics.robot_loaded_visual_count, 1);
+  assert.equal(result.diagnostics.robot_failed_visual_count, 0);
+  assert.equal(result.diagnostics.robot_loading_manager_complete, false);
+  assert.equal(result.diagnostics.robot_preview_lifecycle_state, 'ready');
+  assert.equal(loaded, 1);
+  assert.equal(failed, 0);
+}} finally {{
+  URDFLoader.prototype.parse = originalUrdfParse;
+  STLLoader.prototype.load = originalStlLoad;
+}}
+""",
+        encoding="utf-8",
+    )
+    subprocess.run(
+        ["node", str(script)],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=5,
+    )
+
+
 def test_urdf_renderer_fetches_and_validates_urdf_before_parse():
     js = (VIEWER / "urdf_robot_renderer.js").read_text(encoding="utf-8")
     body = _viewer_function_body(js, "export async function fetchValidatedUrdfRobotElement", "function collectLinkMatrixDiagnostics")

--- a/workcell_studio_web/viewer/urdf_robot_renderer.js
+++ b/workcell_studio_web/viewer/urdf_robot_renderer.js
@@ -354,23 +354,28 @@ function inferMeshLinkDetail(path) {
 
 function meshCompletionPromise(diagnostics, manager) {
   let managerComplete = false;
+  const timeoutMs = 30000;
   const waitTick = callback => (typeof window !== 'undefined' && window.setTimeout ? window.setTimeout(callback, 0) : setTimeout(callback, 0));
-  const managerDone = new Promise(resolve => {
-    const previousOnLoad = manager.onLoad;
-    manager.onLoad = () => {
-      managerComplete = true;
-      previousOnLoad?.();
-      resolve();
-    };
-  });
+  diagnostics.robot_loading_manager_complete = false;
+  diagnostics.robotLoadingManagerComplete = false;
+  const previousOnLoad = manager.onLoad;
+  manager.onLoad = () => {
+    managerComplete = true;
+    diagnostics.robot_loading_manager_complete = true;
+    diagnostics.robotLoadingManagerComplete = true;
+    previousOnLoad?.();
+  };
   const countsSettled = () => diagnostics.robot_expected_visual_count === (diagnostics.robot_loaded_visual_count + diagnostics.robot_failed_visual_count);
   return {
     async wait() {
       if (diagnostics.robot_expected_visual_count === 0) return;
-      if (!managerComplete) await managerDone;
-      await new Promise(resolve => {
+      await new Promise((resolve, reject) => {
+        const startedAt = Date.now();
         const check = () => {
           if (countsSettled()) resolve();
+          else if (Date.now() - startedAt >= timeoutMs) reject(new Error(
+            `URDF mesh callbacks timed out: expected=${diagnostics.robot_expected_visual_count} loaded=${diagnostics.robot_loaded_visual_count} failed=${diagnostics.robot_failed_visual_count} loading_manager_complete=${managerComplete}`,
+          ));
           else waitTick(check);
         };
         check();


### PR DESCRIPTION
### Motivation

- Fix a workstation-observed deadlock where all expanded-URDF mesh callbacks had settled but `LoadingManager.onLoad` did not fire, leaving the Product View stuck in `scene_loading` despite `expected_physical`/`rendered_physical` counts matching.

### Description

- Make the settled-callback condition authoritative by treating `robot_expected_visual_count === robot_loaded_visual_count + robot_failed_visual_count` as the completion signal for mesh loading. 
- Stop requiring `LoadingManager.onLoad` to gate completion while retaining its state as diagnostic fields `robot_loading_manager_complete` and `robotLoadingManagerComplete`.
- Add a bounded timeout (30s) for genuinely unsettled callbacks that rejects with an actionable error message containing expected, loaded, failed, and loading-manager state. 
- Add a focused Node-backed regression test `test_urdf_renderer_mesh_completion_does_not_require_loading_manager` that simulates a missing `LoadingManager.onLoad`, verifies mesh callbacks settle, and asserts `onRobotLoaded` is invoked exactly once with no `onRobotError`.
- Limit edits to only `workcell_studio_web/viewer/urdf_robot_renderer.js` and `tests/test_workcell_studio_web_viewer_static.py` and preserve existing transforms, Collada Z-UP handling, selection/picking, stale-load guards, and safety defaults; the production `viewer.bundle.js` was intentionally not rebuilt in this PR and will be updated in a follow-up.

### Testing

- Ran `node --check workcell_studio_web/viewer/urdf_robot_renderer.js` and it passed. 
- Ran `python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py -k "mesh_completion or urdf_renderer_waits"` which yielded `2 passed, 112 deselected` (with pre-existing `SyntaxWarning`s unrelated to the change). 
- Static repository checks (`git diff --check`) showed no trailing-whitespace or check failures for the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c6625b8748331a7b4025e33d6702e)