### PR TITLE
Rebuild Web3D bundle for expanded-URDF mesh completion

### DIFF
--- a/workcell_studio_web/viewer/dist/viewer.bundle.js
+++ b/workcell_studio_web/viewer/dist/viewer.bundle.js
@@ -37741,26 +37741,31 @@ function inferMeshLinkDetail(path) {
 }
 function meshCompletionPromise(diagnostics, manager) {
   let managerComplete = false;
+  const timeoutMs = 3e4;
   const waitTick = (callback) => typeof window !== "undefined" && window.setTimeout ? window.setTimeout(callback, 0) : setTimeout(callback, 0);
-  const managerDone = new Promise((resolve) => {
-    const previousOnLoad = manager.onLoad;
-    manager.onLoad = () => {
-      managerComplete = true;
-      previousOnLoad?.();
-      resolve();
-    };
-  });
+  diagnostics.robot_loading_manager_complete = false;
+  diagnostics.robotLoadingManagerComplete = false;
+  const previousOnLoad = manager.onLoad;
+  manager.onLoad = () => {
+    managerComplete = true;
+    diagnostics.robot_loading_manager_complete = true;
+    diagnostics.robotLoadingManagerComplete = true;
+    previousOnLoad?.();
+  };
   const countsSettled = () => diagnostics.robot_expected_visual_count === diagnostics.robot_loaded_visual_count + diagnostics.robot_failed_visual_count;
   return {
     async wait() {
       if (diagnostics.robot_expected_visual_count === 0)
         return;
-      if (!managerComplete)
-        await managerDone;
-      await new Promise((resolve) => {
+      await new Promise((resolve, reject) => {
+        const startedAt = Date.now();
         const check = () => {
           if (countsSettled())
             resolve();
+          else if (Date.now() - startedAt >= timeoutMs)
+            reject(new Error(
+              `URDF mesh callbacks timed out: expected=${diagnostics.robot_expected_visual_count} loaded=${diagnostics.robot_loaded_visual_count} failed=${diagnostics.robot_failed_visual_count} loading_manager_complete=${managerComplete}`
+            ));
           else
             waitTick(check);
         };


### PR DESCRIPTION
### Motivation

- The production Product View still served the pre-built bundle and did not include the merged expanded-URDF mesh-completion fix, so the new callback-count-based completion logic needed to be activated in the deployed bundle.

### Description

- Rebuilt the Web3D viewer and committed only the generated production bundle `workcell_studio_web/viewer/dist/viewer.bundle.js` (commit `afc8c4d`).
- The bundle now records `robot_loading_manager_complete` / `robotLoadingManagerComplete` diagnostics and resolves mesh completion by comparing expected visual count to loaded plus failed visuals instead of requiring `LoadingManager.onLoad`.
- The bundle includes the timeout/failure message `URDF mesh callbacks timed out` with expected/loaded/failed/manager-completion diagnostics; manager completion remains available as diagnostic state.
- Restored the source map locally and removed `node_modules`; only the single tracked generated bundle file was committed as requested.

### Testing

- `cd workcell_studio_web/viewer && npm ci` — passed.
- `cd workcell_studio_web/viewer && npm run build:web3d` — passed and produced `dist/viewer.bundle.js`.
- `cd workcell_studio_web/viewer && npm run check:stale-bundle` — passed (bundle reported current).
- `node --check workcell_studio_web/viewer/viewer.js` — passed.
- `python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py -k "mesh_completion or urdf_renderer_waits"` — passed (2 passed, 112 deselected).
- `git diff --check` — passed and exactly one tracked file changed: `workcell_studio_web/viewer/dist/viewer.bundle.js`.

Note: runtime Product View acceptance on a display-enabled `ur5_2f_test` workstation was not executed in this environment and remains required before claiming M1 complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c6b397f048331a3847bd6265d784f)