### PR TITLE
Automate Web3D bundle freshness in Workcell Builder builds

### DIFF
--- a/scripts/ensure_workcell_studio_web_bundle_fresh.py
+++ b/scripts/ensure_workcell_studio_web_bundle_fresh.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Ensure the committed Workcell Studio Web3D bundle matches its sources."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+def _run(command: list[str], viewer_root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, cwd=viewer_root, text=True, check=False)
+
+
+def _require_tool(name: str) -> None:
+    if shutil.which(name) is None:
+        raise RuntimeError(
+            f"Required Web3D build tool '{name}' was not found on PATH. "
+            "Install Node.js and npm, then rebuild workcell_builder."
+        )
+
+
+def ensure_bundle(viewer_root: Path, stamp: Path | None = None) -> bool:
+    """Return True when a stale bundle was rebuilt, otherwise False."""
+    _require_tool("node")
+    _require_tool("npm")
+
+    lock_id = hashlib.sha256(str(viewer_root.resolve()).encode()).hexdigest()[:16]
+    lock_path = Path(tempfile.gettempdir()) / f"workcell-web3d-bundle-{lock_id}.lock"
+    with lock_path.open("w", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+
+        # npm ls catches an absent, incomplete, or lockfile-inconsistent install.
+        dependencies = _run(["npm", "ls", "--ignore-scripts", "--depth=0"], viewer_root)
+        if dependencies.returncode != 0:
+            print("Web3D npm dependencies are unavailable or inconsistent; running npm ci.")
+            installed = _run(["npm", "ci"], viewer_root)
+            if installed.returncode != 0:
+                raise RuntimeError("npm ci failed while preparing the Web3D bundle build.")
+
+        current = _run(["npm", "run", "check:stale-bundle"], viewer_root)
+        rebuilt = current.returncode != 0
+        if rebuilt:
+            print("Web3D production bundle is stale; rebuilding it now.")
+            build = _run(["npm", "run", "build:web3d"], viewer_root)
+            if build.returncode != 0:
+                raise RuntimeError("npm run build:web3d failed; the production bundle was not refreshed.")
+            verified = _run(["npm", "run", "check:stale-bundle"], viewer_root)
+            if verified.returncode != 0:
+                raise RuntimeError("Web3D bundle remained stale after npm run build:web3d.")
+        else:
+            print("Web3D production bundle is already current; no rebuild needed.")
+
+        if stamp is not None:
+            stamp.parent.mkdir(parents=True, exist_ok=True)
+            stamp.touch()
+        return rebuilt
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--viewer-root",
+        type=Path,
+        default=repo_root / "workcell_studio_web" / "viewer",
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument("--stamp", type=Path, help="touch this build stamp after verification")
+    args = parser.parse_args()
+    try:
+        ensure_bundle(args.viewer_root.resolve(), args.stamp)
+    except RuntimeError as error:
+        print(f"Web3D bundle freshness failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_workcell_web3d_bundle_freshness.py
+++ b/tests/test_workcell_web3d_bundle_freshness.py
@@ -1,0 +1,93 @@
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / "scripts/ensure_workcell_studio_web_bundle_fresh.py"
+CMAKE = ROOT / "workcell_builder/workcell_builder/CMakeLists.txt"
+
+
+def _fake_tools(tmp_path: Path, *, stale: bool = False) -> tuple[Path, Path]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    (bin_dir / "node").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    log = tmp_path / "npm.log"
+    state = tmp_path / "stale"
+    if stale:
+        state.touch()
+    npm = bin_dir / "npm"
+    npm.write_text(
+        "#!/bin/sh\n"
+        'echo "$*" >> "$NPM_LOG"\n'
+        'if [ "$1 $2" = "run check:stale-bundle" ] && [ -f "$STALE_STATE" ]; then exit 1; fi\n'
+        'if [ "$1 $2" = "run build:web3d" ]; then /bin/rm -f "$STALE_STATE"; fi\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    npm.chmod(0o755)
+    (bin_dir / "node").chmod(0o755)
+    return bin_dir, log
+
+
+def _run(tmp_path: Path, *, stale: bool = False) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    viewer = tmp_path / "viewer"
+    viewer.mkdir()
+    bin_dir, log = _fake_tools(tmp_path, stale=stale)
+    env = {**os.environ, "PATH": str(bin_dir), "NPM_LOG": str(log), "STALE_STATE": str(tmp_path / "stale")}
+    result = subprocess.run(
+        [sys.executable, str(HELPER), "--viewer-root", str(viewer)],
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+    return result, log.read_text(encoding="utf-8").splitlines()
+
+
+def test_current_bundle_is_a_no_op(tmp_path):
+    result, calls = _run(tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert calls == ["ls --ignore-scripts --depth=0", "run check:stale-bundle"]
+    assert "already current" in result.stdout
+
+
+def test_stale_bundle_is_built_and_verified(tmp_path):
+    result, calls = _run(tmp_path, stale=True)
+    assert result.returncode == 0, result.stderr
+    assert calls == [
+        "ls --ignore-scripts --depth=0",
+        "run check:stale-bundle",
+        "run build:web3d",
+        "run check:stale-bundle",
+    ]
+
+
+def test_missing_npm_has_actionable_error(tmp_path):
+    viewer = tmp_path / "viewer"
+    viewer.mkdir()
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    node = bin_dir / "node"
+    node.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    node.chmod(0o755)
+    result = subprocess.run(
+        [sys.executable, str(HELPER), "--viewer-root", str(viewer)],
+        text=True,
+        capture_output=True,
+        env={**os.environ, "PATH": str(bin_dir)},
+        check=False,
+    )
+    assert result.returncode == 1
+    assert "'npm' was not found on PATH" in result.stderr
+    assert "Install Node.js and npm" in result.stderr
+
+
+def test_cmake_wires_freshness_without_tracking_node_modules():
+    cmake = CMAKE.read_text(encoding="utf-8")
+    assert "add_custom_target(ensure_workcell_web3d_bundle_fresh" in cmake
+    assert "add_dependencies(workcell_builder ensure_workcell_web3d_bundle_fresh)" in cmake
+    target_block = cmake.split("add_custom_command(", 1)[1].split("add_custom_target", 1)[0]
+    assert "node_modules" not in target_block
+    assert "workcell_web3d_bundle_fresh.stamp" in cmake

--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -41,6 +41,7 @@ find_package(pluginlib REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system filesystem)
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
 option(WORKCELL_BUILDER_ALLOW_NATIVE_3D_FALLBACK "Allow the legacy native Scene3DViewportWidget Product View when Qt WebEngine is unavailable" OFF)
 
 find_package(Qt5 COMPONENTS Widgets Concurrent Svg OpenGL Network REQUIRED)
@@ -267,6 +268,33 @@ add_custom_target(generate_workcell_builder_secondary_assets ALL
   COMMENT "Generating secondary default-asset tree from canonical package assets")
 
 add_dependencies(workcell_builder generate_workcell_builder_secondary_assets)
+
+# The checked-in bundle remains the runtime/offline asset.  Refresh it at build
+# time only when one of its frontend inputs changes; node_modules is deliberately
+# neither an input nor an output of this target.
+set(WORKCELL_WEB3D_VIEWER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../workcell_studio_web/viewer")
+set(WORKCELL_WEB3D_FRESHNESS_SCRIPT
+  "${CMAKE_CURRENT_SOURCE_DIR}/../../scripts/ensure_workcell_studio_web_bundle_fresh.py")
+file(GLOB WORKCELL_WEB3D_SOURCE_DEPENDENCIES CONFIGURE_DEPENDS
+  "${WORKCELL_WEB3D_VIEWER_DIR}/*.js"
+  "${WORKCELL_WEB3D_VIEWER_DIR}/src/*.js"
+  "${WORKCELL_WEB3D_VIEWER_DIR}/scripts/*.mjs")
+set(WORKCELL_WEB3D_BUNDLE_STAMP "${CMAKE_CURRENT_BINARY_DIR}/workcell_web3d_bundle_fresh.stamp")
+add_custom_command(
+  OUTPUT "${WORKCELL_WEB3D_BUNDLE_STAMP}"
+  COMMAND "${Python3_EXECUTABLE}" "${WORKCELL_WEB3D_FRESHNESS_SCRIPT}"
+    --stamp "${WORKCELL_WEB3D_BUNDLE_STAMP}"
+  DEPENDS
+    ${WORKCELL_WEB3D_SOURCE_DEPENDENCIES}
+    "${WORKCELL_WEB3D_VIEWER_DIR}/package.json"
+    "${WORKCELL_WEB3D_VIEWER_DIR}/package-lock.json"
+    "${WORKCELL_WEB3D_VIEWER_DIR}/dist/viewer.bundle.js"
+    "${WORKCELL_WEB3D_FRESHNESS_SCRIPT}"
+  COMMENT "Ensuring the Workcell Studio Web3D production bundle is current"
+  VERBATIM)
+add_custom_target(ensure_workcell_web3d_bundle_fresh
+  DEPENDS "${WORKCELL_WEB3D_BUNDLE_STAMP}")
+add_dependencies(workcell_builder ensure_workcell_web3d_bundle_fresh)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/workcell_studio_web/viewer/README.md
+++ b/workcell_studio_web/viewer/README.md
@@ -41,14 +41,20 @@ URL: `http://localhost:8765/workcell_studio_web/viewer/index.html?scene=build%2F
 
 Expected result: when source meshes exist and are supported by the exporter/viewer, the robot, table/workbench, camera, and gripper/tool should be recognizable mesh-backed visuals rather than only generic boxes.
 
-The checked-in bundle contains the pinned Three.js and URDF loader modules, so the served viewer does not depend on CDN import maps at runtime. Regenerate it after source or dependency changes with:
+The checked-in bundle contains the pinned Three.js and URDF loader modules, so the served viewer does not depend on CDN import maps or Node.js at runtime. A normal Workcell Builder build automatically checks and, when necessary, refreshes this bundle:
+
+```bash
+colcon build --symlink-install --packages-select workcell_builder
+```
+
+An unchanged subsequent build uses the CMake freshness stamp and does not rerun esbuild or `npm ci`. For direct frontend development, the explicit build remains available:
 
 ```bash
 cd workcell_studio_web/viewer
 npm ci && npm run build:web3d
 ```
 
-Check that the committed bundle is not stale with:
+CI still rejects a committed stale bundle. Check the same condition locally with:
 
 ```bash
 cd workcell_studio_web/viewer


### PR DESCRIPTION
### Motivation

- Developers must no longer remember to run `npm run build:web3d` after editing Web3D source files so Product View updates automatically during normal `workcell_builder` builds. 

### Description

- Add `scripts/ensure_workcell_studio_web_bundle_fresh.py`, a deterministic, lock-protected helper that locates `workcell_studio_web/viewer`, checks Node/npm availability with actionable errors, runs the existing `check:stale-bundle`, runs `npm ci` only when npm reports inconsistent/missing dependencies, rebuilds with `npm run build:web3d` when stale, re-verifies freshness, and touches an optional stamp file. 【F:scripts/ensure_workcell_studio_web_bundle_fresh.py†L21-L63】【F:scripts/ensure_workcell_studio_web_bundle_fresh.py†L66-L86】
- Wire a narrowly scoped CMake custom command/target into `workcell_builder` so `colcon build --symlink-install --packages-select workcell_builder` depends on a freshness stamp and will refresh the bundle only when inputs change; `node_modules` is not tracked as a build output. 【F:workcell_builder/workcell_builder/CMakeLists.txt†L272-L297】
- Add focused unit tests `tests/test_workcell_web3d_bundle_freshness.py` covering: no-op when bundle is current, stale-bundle rebuild and verification, actionable error when `npm` is missing, and that the CMake wiring does not track `node_modules`. 【F:tests/test_workcell_web3d_bundle_freshness.py†L49-L93】
- Update viewer README to document that normal `workcell_builder` builds check and refresh the production bundle when required and that direct frontend commands (`npm ci && npm run build:web3d`) remain available for frontend development. 【F:workcell_studio_web/viewer/README.md†L44-L62]

### Testing

- ✅ `python3 -m pytest -q tests/ -k "bundle_fresh or stale_bundle"` — focused tests passed (5 passed, 2710 deselected). 
- ✅ `npm --prefix workcell_studio_web/viewer run check:stale-bundle` — committed bundle reported current. 
- ✅ `python3 scripts/ensure_workcell_studio_web_bundle_fresh.py` — helper run in-place detected current bundle and performed no rebuild. 
- ✅ Repository hygiene checks (`git diff --check`, staged diff checks) — no modifications to `dist/viewer.bundle.js` or its source map were introduced. 
- ⚠️ `colcon build --symlink-install --packages-select workcell_builder` — not executed in this environment because `colcon` is not installed in the container; the CMake integration was added and verified in source.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c7280a65483319c595afd110e8de5)