### PR TITLE
Normalize terminal expanded-URDF preview failures

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -3352,7 +3352,7 @@ state.robotUrdfPreviewDiagnostics = {
   robot_failed_visual_count: 0,
   robot_mesh_callbacks_complete: true,
   robot_missing_meshes: [],
-  robot_missing_required_robot_visual_links: falseMissingRobotLinks,
+  robot_missing_required_robot_visual_links: [],
   robot_missing_required_tool_visual_links: [],
   robot_visual_wrapper_world_matrices: []
 };
@@ -3376,6 +3376,59 @@ completeExpandedUrdfReadiness({ diagnostics: state.robotUrdfPreviewDiagnostics }
 assert.strictEqual(state.web3dReadiness.state, 'scene_ready');
 assert.ok(window.dispatched.includes('scene_ready'));
 assert.ok(!window.dispatched.includes('scene_failed'));
+`, context);
+"""
+    subprocess.run(["node", "-e", harness, str(js_path)], cwd=ROOT, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def test_expanded_urdf_terminal_diagnostics_emit_one_normalized_failure_or_scene_ready():
+    js_path = VIEWER / "viewer.js"
+    harness = r"""
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+let source = fs.readFileSync(process.argv[1], 'utf8').replace(/boot\(\);\s*$/, '');
+const element = () => ({ hidden: false, checked: false, disabled: false, textContent: '', className: '', innerHTML: '', classList: { toggle() {} }, setAttribute() {}, querySelector() { return { textContent: '' }; }, appendChild() {}, addEventListener() {}, getBoundingClientRect() { return { width: 800, height: 600, left: 0, top: 0 }; } });
+const context = { console, assert, window: { events: [], location: { search: '' }, dispatchEvent(event) { this.events.push(event?.detail); }, parent: { postMessage() {} } }, document: { getElementById() { return element(); }, createElement() { return element(); } }, URLSearchParams, CustomEvent: function CustomEvent(type, init) { return { type, detail: init?.detail || {} }; }, requestAnimationFrame() { return 0; }, setTimeout() { return 1; }, clearTimeout() {} };
+vm.createContext(context);
+vm.runInContext(source + `
+state.sceneJson = { scene: { id: 'ur5_2f_test' }, robot_preview: { mode: 'expanded_urdf_loader', expected_robot_visual_links: ['base_link'], expected_tool_visual_links: ['tool0'] } };
+const resetReadiness = pending => {
+  window.events = [];
+  state.web3dReadiness = { state: 'scene_loading', terminal: false, terminalState: '', terminalNavigationKey: '', terminalEmissionCount: 0, statusSequence: 0, required: { robot_arm: true, attached_tool_gripper: true, workbench_support_surface: true, configured_camera: true }, pending: new Set(pending || []), failed: false, failure: null };
+};
+const completed = { robot_preview_lifecycle_state: 'failed', robot_preview_loaded: false, robot_expected_visual_count: 3, robot_loaded_visual_count: 2, robot_completed_visual_count: 3, robot_failed_visual_count: 1, robot_loading_manager_complete: true, robot_mesh_callbacks_complete: true };
+
+resetReadiness(['robot_arm:expanded_urdf_loader', 'attached_tool_gripper:expanded_urdf_loader']);
+state.robotUrdfPreviewDiagnostics = { ...completed, robot_missing_required_tool_visual_links: ['tool0'], robot_missing_required_robot_visual_links: ['base_link'], robot_hierarchy_missing_links: ['wrist_3_link'] };
+maybeEmitSceneReady();
+maybeEmitSceneReady();
+assert.strictEqual(window.events.length, 1, 'terminal guard emits exactly one event for the navigation');
+assert.strictEqual(window.events[0].state, 'scene_failed');
+assert.strictEqual(window.events[0].required_category, 'attached_tool_gripper');
+assert.deepStrictEqual(window.events[0].robot_missing_required_tool_visual_links, ['tool0']);
+assert.strictEqual(window.events[0].robot_loading_manager_completion_state, 'complete');
+assert.match(window.events[0].reason, /tool preview.*tool0.*regenerate/i);
+
+for (const diagnostic of [
+  { ...completed, robot_missing_required_robot_visual_links: ['base_link'], robot_missing_required_tool_visual_links: [], robot_hierarchy_missing_links: [] },
+  { ...completed, robot_missing_required_robot_visual_links: [], robot_missing_required_tool_visual_links: [], robot_hierarchy_missing_links: ['wrist_3_link'] },
+]) {
+  resetReadiness(['robot_arm:expanded_urdf_loader']);
+  state.robotUrdfPreviewDiagnostics = diagnostic;
+  maybeEmitSceneReady();
+  assert.strictEqual(window.events.length, 1);
+  assert.strictEqual(window.events[0].state, 'scene_failed');
+  assert.strictEqual(window.events[0].required_category, 'robot_arm');
+  assert.ok(window.events[0].robot_missing_required_robot_visual_links.length || window.events[0].robot_hierarchy_missing_links.length);
+}
+
+resetReadiness([]);
+state.robotUrdfPreviewDiagnostics = { robot_preview_lifecycle_state: 'ready', robot_preview_loaded: true, robot_expected_visual_count: 2, robot_loaded_visual_count: 2, robot_completed_visual_count: 2, robot_failed_visual_count: 0, robot_loading_manager_complete: true, robot_mesh_callbacks_complete: true, robot_missing_required_robot_visual_links: [], robot_missing_required_tool_visual_links: [], robot_hierarchy_missing_links: [], robot_missing_meshes: [], robot_visual_wrapper_world_matrices: [] };
+maybeEmitSceneReady();
+assert.strictEqual(window.events.length, 1);
+assert.strictEqual(window.events[0].state, 'scene_ready', 'successful expanded URDF diagnostics reach scene_ready');
+assert.strictEqual(state.web3dReadiness.terminalEmissionCount, 1);
 `, context);
 """
     subprocess.run(["node", "-e", harness, str(js_path)], cwd=ROOT, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -237,10 +237,74 @@ function failExpandedUrdfReadiness(err, diagnostics = {}, detail = {}) {
     ...detail,
   });
 }
+function expandedUrdfTerminalFailure(rendererDiagnostics = {}) {
+  const list = (snakeName, camelName) => asArray(rendererDiagnostics[snakeName] || rendererDiagnostics[camelName])
+    .map(value => String(value || '').trim()).filter(Boolean);
+  const lifecycle = String(rendererDiagnostics.robot_preview_lifecycle_state || rendererDiagnostics.robotPreviewLifecycleState || '').trim();
+  const previewLoaded = rendererDiagnostics.robot_preview_loaded === true || rendererDiagnostics.robotPreviewLoaded === true;
+  const previewExplicitlyNotLoaded = rendererDiagnostics.robot_preview_loaded === false || rendererDiagnostics.robotPreviewLoaded === false;
+  const expectedVisualCount = Number(rendererDiagnostics.robot_expected_visual_count ?? rendererDiagnostics.robotExpectedVisualCount ?? 0) || 0;
+  const loadedVisualCount = Number(rendererDiagnostics.robot_loaded_visual_count ?? rendererDiagnostics.robotLoadedVisualCount ?? 0) || 0;
+  const completedVisualCount = Number(rendererDiagnostics.robot_completed_visual_count ?? rendererDiagnostics.robotCompletedVisualCount ?? 0) || 0;
+  const failedVisualCount = Number(rendererDiagnostics.robot_failed_visual_count ?? rendererDiagnostics.robotFailedVisualCount ?? 0) || 0;
+  const missingToolLinks = list('robot_missing_required_tool_visual_links', 'robotMissingRequiredToolVisualLinks');
+  const missingRobotLinks = list('robot_missing_required_robot_visual_links', 'robotMissingRequiredRobotVisualLinks');
+  const missingHierarchyLinks = list('robot_hierarchy_missing_links', 'robotHierarchyMissingLinks');
+  const loadingManagerComplete = rendererDiagnostics.robot_loading_manager_complete === true || rendererDiagnostics.robotLoadingManagerComplete === true;
+  const loadingManagerExplicitlyIncomplete = rendererDiagnostics.robot_loading_manager_complete === false || rendererDiagnostics.robotLoadingManagerComplete === false;
+  const meshCallbacksComplete = rendererDiagnostics.robot_mesh_callbacks_complete === true || rendererDiagnostics.robotMeshCallbacksComplete === true;
+  const meshCallbacksExplicitlyIncomplete = rendererDiagnostics.robot_mesh_callbacks_complete === false || rendererDiagnostics.robotMeshCallbacksComplete === false;
+
+  let requiredCategory = '';
+  let reason = '';
+  if (missingToolLinks.length) {
+    requiredCategory = 'attached_tool_gripper';
+    reason = `Expanded URDF tool preview is missing required visual links: ${missingToolLinks.join(', ')}. Check the tool URDF mesh paths and regenerate the scene.`;
+  } else if (missingRobotLinks.length) {
+    requiredCategory = 'robot_arm';
+    reason = `Expanded URDF robot preview is missing required visual links: ${missingRobotLinks.join(', ')}. Check the robot URDF mesh paths and regenerate the scene.`;
+  } else if (missingHierarchyLinks.length) {
+    requiredCategory = 'robot_arm';
+    reason = `Expanded URDF robot hierarchy is missing required links: ${missingHierarchyLinks.join(', ')}. Check the generated URDF link/joint hierarchy and regenerate the scene.`;
+  } else if (meshCallbacksExplicitlyIncomplete) {
+    requiredCategory = 'robot_arm';
+    reason = `Expanded URDF mesh callbacks did not complete (${completedVisualCount}/${expectedVisualCount} completed). Check failed mesh requests and the browser console, then regenerate or reload the scene.`;
+  } else if (lifecycle === 'failed' && previewExplicitlyNotLoaded) {
+    requiredCategory = 'robot_arm';
+    reason = String(rendererDiagnostics.robot_preview_failure_reason || rendererDiagnostics.robotPreviewFailureReason || '').trim()
+      || 'Expanded URDF preview entered the failed lifecycle without loading. Check the URDF and mesh request diagnostics, then regenerate or reload the scene.';
+  } else {
+    return null;
+  }
+
+  return {
+    required_category: requiredCategory,
+    item_id: 'expanded_urdf_loader',
+    reason,
+    robot_preview_lifecycle_state: lifecycle,
+    robot_preview_loaded: previewLoaded,
+    robot_expected_visual_count: expectedVisualCount,
+    robot_loaded_visual_count: loadedVisualCount,
+    robot_completed_visual_count: completedVisualCount,
+    robot_failed_visual_count: failedVisualCount,
+    robot_missing_required_tool_visual_links: missingToolLinks,
+    robot_missing_required_robot_visual_links: missingRobotLinks,
+    robot_hierarchy_missing_links: missingHierarchyLinks,
+    robot_loading_manager_complete: loadingManagerComplete,
+    robot_loading_manager_completion_state: loadingManagerComplete ? 'complete' : (loadingManagerExplicitlyIncomplete ? 'incomplete' : 'unknown'),
+    robot_mesh_callbacks_complete: meshCallbacksComplete,
+    robot_mesh_callback_completion_state: meshCallbacksComplete ? 'complete' : (meshCallbacksExplicitlyIncomplete ? 'incomplete' : 'unknown'),
+  };
+}
 function maybeEmitSceneReady() {
   if (isExpandedUrdfRobotPreview(state.sceneJson?.robot_preview)) {
     const diagnostics = state.robotUrdfPreviewDiagnostics || {};
     const lifecycle = String(diagnostics.robot_preview_lifecycle_state || diagnostics.robotPreviewLifecycleState || '');
+    const terminalFailure = expandedUrdfTerminalFailure(diagnostics);
+    if (terminalFailure) {
+      emitWeb3dReadinessState('scene_failed', terminalFailure);
+      return;
+    }
     if (lifecycle === 'failed') {
       const failureReason = String(diagnostics.robot_preview_failure_reason || diagnostics.robotPreviewFailureReason || '').trim();
       const missingMeshes = asArray(diagnostics.robot_missing_meshes || diagnostics.robotMissingMeshes);


### PR DESCRIPTION
### Motivation

- The expanded-URDF renderer can report multiple diagnostic shapes (missing tool links, missing robot links, hierarchy gaps, incomplete callbacks, or failed/unloaded lifecycle) but the viewer lacked a single normalized terminal failure payload to stop readiness deterministically. 
- Ensure the Web3D readiness pipeline emits a single terminal `scene_failed` per navigation with an actionable, structured payload so downstream tooling and the UI can surface precise remediation guidance.

### Description

- Added `expandedUrdfTerminalFailure(rendererDiagnostics)` in `workcell_studio_web/viewer/viewer.js` which inspects renderer diagnostics and returns either `null` or a normalized terminal failure payload containing lifecycle and preview-loaded state, expected/loaded/completed/failed visual counts, all three missing-link lists, LoadingManager completion state, mesh-callback completion state, and a human-readable `reason` string; it classifies required category as `attached_tool_gripper` or `robot_arm` per the rules.
- Called the helper from `maybeEmitSceneReady()` (before the existing failed-lifecycle early-return) and routed the result through the existing terminal readiness emission guard so `scene_failed` is emitted exactly once for the current navigation.
- Preserved existing `onRobotLoaded` processing and locked/read-only pick-record registration so visible robot/tool geometry remains selectable as a preview; the change only affects readiness emission, not pick/selection registration.
- Added Node-backed tests in `tests/test_workcell_studio_web_viewer_static.py` covering tool-link failure, robot/hierarchy-link failure, the exactly-one terminal failure emission guard, and the successful expanded-URDF path reaching `scene_ready`, and adjusted a fixture to avoid contradictory missing-link data in the successful case.

### Testing

- Ran `pytest -q tests/test_workcell_studio_web_viewer_static.py` and all tests passed (`115 passed`).
- Ran `node --check workcell_studio_web/viewer/viewer.js` to validate the bundle syntax and `git diff --check` for whitespace/checks; both passed in this environment.
- GUI/workstation edit/save/reopen manual validation and ROS 2 Humble build/fake-hardware launch were not executed because this change is a Web3D/runtime readiness normalization exercised by Node-backed viewer tests in the non-display container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c847fea408331a8dab23a6dea8003)