### PR TITLE
Ignore local Workcell Studio dependencies and scene backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,13 @@ src/ros_industrial_cmake_boilerplate/
 scenes/*/generated/
 !scenes/*/generated/.gitkeep
 
+# Workcell Studio local authoring backups
+scenes/**/*.yaml.bak
+scenes/**/*.yml.bak
+
 # Workcell Studio Web 3D exports
 *.web_scene.json
 workcell_studio_web_scene/
+
+# Workcell Studio Web viewer dependencies
+workcell_studio_web/viewer/node_modules/


### PR DESCRIPTION
### Motivation
- Prevent local viewer dependencies and editor-created scene backup files from being committed while avoiding broad `*.bak`, `scenes/**/*.yaml`, or other mass exclusions.

### Description
- Add narrow `.gitignore` rules for `workcell_studio_web/viewer/node_modules/`, `scenes/**/*.yaml.bak`, and `scenes/**/*.yml.bak` with brief explanatory comments, and make no other source or scene edits.

### Testing
- Ran `git diff --check` which passed; confirmed each new pattern with `printf '... | git check-ignore -v --stdin'`; verified unrelated paths remain visible with negative `git check-ignore -q` checks; and confirmed the working tree is clean after applying the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c88de5aac8331943d1721ac0dae65)