### PR TITLE
M1: stabilize configured-camera readiness identity

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -242,6 +242,55 @@ def test_static_viewer_files_exist():
     assert (VIEWER / "README.md").is_file()
 
 
+def test_configured_camera_readiness_identity_is_shared_across_authored_and_generated_rows():
+    js_path = VIEWER / "viewer.js"
+    harness = r"""
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+let source = fs.readFileSync(process.argv[1], 'utf8').replace(/boot\(\);\s*$/, '');
+const element = () => ({ hidden:false, checked:false, disabled:false, textContent:'', className:'', innerHTML:'', classList:{toggle(){}}, querySelector(){return null;}, appendChild(){}, addEventListener(){}, setAttribute(){} });
+const context = { console, assert, window:{events:[], location:{search:''}, dispatchEvent(event){this.events.push(event.detail);}, parent:{postMessage(){}}}, document:{getElementById(){return element();},createElement(){return element();}}, URLSearchParams, CustomEvent:function(type, init){return {type, detail:init?.detail || {}};}, requestAnimationFrame(){return 0;}, setTimeout(){return 0;}, clearTimeout(){} };
+vm.createContext(context);
+vm.runInContext(source + `
+const authoredCamera = { id:'realsense_overhead', category:'camera', readiness_category:'configured_camera', render_policy:'primary', mesh_uri:'camera.dae' };
+const generatedCamera = { id:'generated_urdf::camera_link::visual_17', camera_id:'realsense_overhead', category:'camera', readiness_category:'configured_camera', render_policy:'primary', mesh_uri:'camera.dae' };
+assert.strictEqual(readinessIdentityForItem('configured_camera', authoredCamera), 'realsense_overhead');
+assert.strictEqual(readinessIdentityForItem('configured_camera', generatedCamera), 'realsense_overhead');
+assert.strictEqual(readinessKey('configured_camera', authoredCamera), readinessKey('configured_camera', generatedCamera));
+
+state.sceneJson = {scene:{id:'ur5_2f_test'}};
+beginWeb3dSceneReadiness([authoredCamera, generatedCamera]);
+assert.deepStrictEqual(Array.from(state.web3dReadiness.pending), ['configured_camera:realsense_overhead']);
+assert.deepStrictEqual(window.events.at(-1).pending_required_loads, ['configured_camera:realsense_overhead']);
+requiredReadinessCompleteForItem(generatedCamera);
+assert.strictEqual(state.web3dReadiness.pending.size, 0);
+
+state.web3dReadiness = {state:'scene_loading', terminal:false, terminalState:'', terminalNavigationKey:'', terminalEmissionCount:0, statusSequence:0, required:{configured_camera:true}, pending:new Set(['configured_camera:realsense_overhead']), failed:false, failure:null};
+failWeb3dSceneReadiness(generatedCamera, 'camera.dae', 'camera mesh failed');
+const failure = window.events.at(-1);
+assert.strictEqual(failure.required_category, 'configured_camera');
+assert.strictEqual(failure.readiness_identity, 'realsense_overhead');
+assert.strictEqual(failure.readiness_key, 'configured_camera:realsense_overhead');
+assert.deepStrictEqual(failure.pending_required_loads, ['configured_camera:realsense_overhead']);
+
+const unchanged = [
+  ['robot_arm', {id:'ur5'}, 'robot_arm:ur5'],
+  ['attached_tool_gripper', {id:'robotiq_85'}, 'attached_tool_gripper:robotiq_85'],
+  ['workbench_support_surface', {id:'support_surface_table'}, 'workbench_support_surface:support_surface_table'],
+  ['authored_physical_mesh', {id:'target_bin'}, 'authored_physical_mesh:target_bin'],
+];
+for (const [category, item, expected] of unchanged) assert.strictEqual(readinessKey(category, item), expected);
+`, context);
+"""
+    subprocess.run(
+        ["node", "-e", harness, str(js_path)],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
 def test_index_references_static_assets():
     index = (VIEWER / "index.html").read_text(encoding="utf-8")
     assert 'href="style.css"' in index

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -69,7 +69,7 @@ function emitWeb3dReadinessState(readinessState, detail = {}) {
     state.web3dReadiness.terminalEmissionCount = Number(state.web3dReadiness.terminalEmissionCount || 0) + 1;
   }
   const structured = structuredWeb3dReadinessFields(readinessState);
-  const eventDetail = { ...structured, ...detail, final_lifecycle_state: readinessState, finalLifecycleState: readinessState };
+  const eventDetail = { ...structured, ...detail, final_lifecycle_state: readinessState, finalLifecycleState: readinessState, pending_required_loads: pendingRequiredLoads() };
   if (readinessState === 'scene_failed') {
     state.web3dReadiness.failed = true;
     state.web3dReadiness.failure = eventDetail;
@@ -121,7 +121,24 @@ function readinessCategoryForItem(item) {
   if (itemRequiresMeshBackedVisual(item) && (category === 'object' || viewerGroupFor(item) === 'environment/layout')) return 'authored_physical_mesh';
   return '';
 }
-function readinessKey(category, item) { return `${category}:${item?.id || item?.link || itemLabel(item || {})}`; }
+function readinessIdentityForItem(category, item) {
+  if (category === 'configured_camera') {
+    const cameraIdentityFields = [
+      'configured_camera_id', 'configuredCameraId', 'camera_id', 'cameraId',
+      'canonical_scene_item_id', 'canonicalSceneItemId', 'canonical_item_id', 'canonicalItemId',
+      'authored_item_id', 'authoredItemId', 'layout_item_ref', 'layoutItemRef',
+      'scene_item_id', 'sceneItemId', 'selection_owner_id', 'selectionOwnerId',
+      'owner_id', 'ownerId', 'object_ref', 'objectRef',
+    ];
+    for (const field of cameraIdentityFields) {
+      const value = String(item?.[field] || '').trim();
+      if (value) return value;
+    }
+  }
+  return String(item?.id || item?.link || itemLabel(item || {}));
+}
+function readinessKey(category, item) { return `${category}:${readinessIdentityForItem(category, item)}`; }
+function pendingRequiredLoads() { return Array.from(state.web3dReadiness?.pending || []); }
 
 function physicalReadinessItems() {
   return collectItems(state.sceneJson || {}).filter(item => isPrimaryRenderableItem(item) && !isDebugOverlayItem(item) && readinessCategoryForItem(item));
@@ -142,13 +159,14 @@ function failedRequiredItemCount() {
 function readinessCategoryStatus(category) {
   const readiness = state.web3dReadiness || {};
   if (!readiness.required?.[category]) return 'missing';
-  const pending = Array.from(readiness.pending || []).some(key => String(key).startsWith(`${category}:`));
+  const pending = pendingRequiredLoads().some(key => String(key).startsWith(`${category}:`));
   if (readiness.state === 'scene_failed' && (readiness.failure?.required_category === category || pending)) return 'failed';
   if (pending) return 'pending';
   return readiness.state === 'scene_ready' ? 'ready' : 'loading';
 }
 function structuredWeb3dReadinessFields(lifecycleState) {
   const finalState = lifecycleState || state.web3dReadiness?.state || 'booting';
+  const pendingLoads = pendingRequiredLoads();
   return {
     scene_id: sceneId(),
     sceneId: sceneId(),
@@ -168,6 +186,8 @@ function structuredWeb3dReadinessFields(lifecycleState) {
     environmentStatus: readinessCategoryStatus('workbench_support_surface'),
     camera_status: readinessCategoryStatus('configured_camera'),
     cameraStatus: readinessCategoryStatus('configured_camera'),
+    pending_required_loads: pendingLoads,
+    pendingRequiredLoads: pendingLoads,
     readiness_contract_version: READINESS_CONTRACT_VERSION,
     readinessContractVersion: READINESS_CONTRACT_VERSION,
     lifecycle_state: finalState,
@@ -199,7 +219,7 @@ function beginWeb3dSceneReadiness(items) {
     pending.add('attached_tool_gripper:expanded_urdf_loader');
   }
   state.web3dReadiness = { state: 'scene_loading', terminal: false, terminalState: '', terminalNavigationKey: web3dNavigationKey(), terminalEmissionCount: 0, statusSequence: 0, required, pending, failed: false, failure: null };
-  emitWeb3dReadinessState('scene_loading', { required_categories: required, pending_required_loads: Array.from(pending) });
+  emitWeb3dReadinessState('scene_loading', { required_categories: required });
 }
 function requiredReadinessCompleteForItem(item) {
   const category = readinessCategoryForItem(item);
@@ -209,8 +229,11 @@ function requiredReadinessCompleteForItem(item) {
 }
 function failWeb3dSceneReadiness(item, url, reason, extra = {}) {
   const category = readinessCategoryForItem(item) || extra.category || 'required_physical_item';
+  const readinessIdentity = readinessIdentityForItem(category, item);
   emitWeb3dReadinessState('scene_failed', {
     required_category: category,
+    readiness_identity: readinessIdentity,
+    readiness_key: `${category}:${readinessIdentity}`,
     item_id: item?.id || '',
     link: item?.link || item?.link_name || item?.object_name || '',
     url: url || displayMeshUri(item),
@@ -978,8 +1001,8 @@ function updateViewerStatus() {
     ...expandedUrdfVisualDiagnostics,
     required_physical_categories: state.web3dReadiness?.required || {},
     requiredPhysicalCategories: state.web3dReadiness?.required || {},
-    pending_required_loads: Array.from(state.web3dReadiness?.pending || []),
-    pendingRequiredLoads: Array.from(state.web3dReadiness?.pending || []),
+    pending_required_loads: pendingRequiredLoads(),
+    pendingRequiredLoads: pendingRequiredLoads(),
     ...structuredWeb3dReadinessFields(state.web3dReadiness?.state || 'booting'),
     final_failed_url: state.web3dReadiness?.failure?.url || state.web3dReadiness?.failure?.final_failed_url || '',
     finalFailedUrl: state.web3dReadiness?.failure?.url || state.web3dReadiness?.failure?.finalFailedUrl || '',


### PR DESCRIPTION
### Motivation
- Prevent the configured-camera authored row and its generated visual row from creating distinct readiness keys that can leave Product View stuck in `scene_loading`.
- Ensure readiness events and diagnostics consistently reference one stable identity for configured cameras so success and failure clear or report the same pending key.

### Description
- Added `readinessIdentityForItem(category, item)` helper in `workcell_studio_web/viewer/viewer.js` that derives a stable identity for required items and prefers configured/authored/canonical/reference camera metadata for `configured_camera` entries.
- Replaced ad-hoc readiness key derivation with a single `readinessKey(category, item)` that uses the new helper, and used it consistently in `beginWeb3dSceneReadiness()`, `requiredReadinessCompleteForItem()`, `failWeb3dSceneReadiness()`, and readiness diagnostics.
- Centralized pending-load serialization via `pendingRequiredLoads()` and included `pending_required_loads` in every emitted readiness payload and diagnostic view to avoid duplicated array construction across emit points.
- Kept existing behavior for other readiness categories (`robot_arm`, `attached_tool_gripper`, `workbench_support_surface`, `authored_physical_mesh`) unchanged and limited changes to `viewer.js` and the focused test file; `viewer.bundle.js` and its source map were not regenerated.

### Testing
- Added a Node-backed test in `tests/test_workcell_studio_web_viewer_static.py` that verifies authored and generated camera rows share the same configured-camera readiness key, that initialization produces only one pending entry, that completing the generated visual removes the shared key, and that failures report `required_category`, the shared `readiness_identity`, and `pending_required_loads` as required.
- Ran `node --check workcell_studio_web/viewer/viewer.js` which passed.
- Ran the focused tests: `python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py -k "configured_camera or readiness_identity"` which passed (1 passed, 115 deselected).
- Ran the full static viewer test file: `python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py` which passed (116 passed).
- `git diff --check` and repository status checks were clean after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c8a03fec48331969c4c8e3ed3f31c)