### PR TITLE
Bound required physical mesh loads before readiness timeout

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -291,6 +291,104 @@ for (const [category, item, expected] of unchanged) assert.strictEqual(readiness
         text=True,
     )
 
+
+def test_required_mesh_physical_load_deadline_and_stale_camera_callbacks():
+    js_path = VIEWER / "viewer.js"
+    harness = r"""
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+let source = fs.readFileSync(process.argv[1], 'utf8')
+  .replace('const PHYSICAL_MESH_LOAD_TIMEOUT_MS = 30000;', 'const PHYSICAL_MESH_LOAD_TIMEOUT_MS = 20;')
+  .replace(/boot\(\);\s*$/, '');
+const element = () => ({hidden:false,checked:false,disabled:false,textContent:'',className:'',innerHTML:'',classList:{toggle(){}},querySelector(){return null;},appendChild(){},addEventListener(){},setAttribute(){}});
+const events = [];
+const context = {console, assert, setTimeout, clearTimeout, Promise, events, process,
+  window:{events,location:{search:''},dispatchEvent(event){events.push(event.detail);},parent:{postMessage(){}}},
+  document:{getElementById(){return element();},createElement(){return element();}}, URLSearchParams,
+  CustomEvent:function(type, init){return {type,detail:init?.detail || {}};}, requestAnimationFrame(){return 0;}};
+vm.createContext(context);
+vm.runInContext(source + `
+(async () => {
+  preflightMeshUrl = async (uri, url) => ({ok:true,url});
+  repoRootRelativeUrl = uri => uri;
+  refreshMeshLoadUi = () => {};
+  trackMeshLoadAttempt = () => {};
+  logRequiredMeshFailure = () => {};
+  styleFailedMeshDebugFallback = fallback => { if (fallback) fallback.visible = true; };
+  warnRequiredMeshFallback = () => {};
+  appendRuntimeWarning = () => {};
+  setRenderInfo = (rendered, status, uri, reason) => { rendered.renderInfo = {render_status:status,mesh_uri:uri,fallback_reason:reason}; };
+  materializeLoadedMesh = (item, uri, loaded) => loaded;
+  makeMeshVisualRoot = (item, loaded) => ({loaded,updateMatrixWorld(){}});
+  maybeApplyMeshUnitAutoscale = () => false;
+  diagnoseLoadedMeshBounds = () => true;
+  THREE = {Box3:class {setFromObject(){return this;}}};
+  const camera = {id:'generated_camera_visual',camera_id:'realsense_overhead',category:'camera',readiness_category:'configured_camera',render_policy:'primary',mesh_uri:'assets/camera.dae',mesh_load_required:true};
+  const rendered = () => ({object3d:{add(value){this.added=value;}},renderInfo:{render_status:'mesh_loading_required'}});
+  const fallback = () => ({visible:false});
+  const readiness = pending => ({state:'scene_loading',terminal:false,terminalState:'',terminalNavigationKey:'',terminalEmissionCount:0,statusSequence:0,required:{robot_arm:true,attached_tool_gripper:true,workbench_support_surface:true,configured_camera:true},pending:new Set(pending),failed:false,failure:null});
+
+  state.sceneJson={scene:{id:'timeout_scene'}}; state.sourceWebSceneFile='timeout.json'; physicalLoadToken++;
+  state.web3dReadiness=readiness(['configured_camera:realsense_overhead']);
+  ColladaLoader=class {loadAsync(){return new Promise(() => {});}};
+  const started=Date.now(); await tryLoadMesh(camera,rendered(),fallback());
+  assert(Date.now()-started < 45000);
+  const failure=events.at(-1);
+  assert.strictEqual(failure.state,'scene_failed');
+  assert.strictEqual(failure.required_category,'configured_camera');
+  assert.strictEqual(failure.readiness_identity,'realsense_overhead');
+  assert.strictEqual(failure.readiness_key,'configured_camera:realsense_overhead');
+  assert.strictEqual(failure.url,'assets/camera.dae');
+  assert.strictEqual(failure.loader,'ColladaLoader');
+  assert.match(failure.reason,/timed out/);
+  assert.strictEqual(failure.timeout_ms,20);
+  assert.deepStrictEqual(failure.pending_required_loads,['configured_camera:realsense_overhead']);
+
+  events.length=0; state.sceneJson={scene:{id:'success_scene'}}; state.sourceWebSceneFile='success.json'; physicalLoadToken++;
+  state.web3dReadiness=readiness(['configured_camera:realsense_overhead']);
+  ColladaLoader=class {loadAsync(){return Promise.resolve({mesh:true});}};
+  await tryLoadMesh(camera,rendered(),fallback());
+  assert.strictEqual(state.web3dReadiness.pending.size,0);
+  await new Promise(resolve => setTimeout(resolve,35));
+  assert.strictEqual(events.filter(event => event.state==='scene_failed').length,0);
+
+  let resolveA; events.length=0; state.sceneJson={scene:{id:'scene_a'}}; state.sourceWebSceneFile='a.json'; physicalLoadToken++;
+  state.web3dReadiness=readiness(['configured_camera:realsense_overhead']);
+  ColladaLoader=class {loadAsync(){return new Promise(resolve => {resolveA=resolve;});}};
+  const staleSuccess=tryLoadMesh(camera,rendered(),fallback()); await Promise.resolve(); await Promise.resolve();
+  state.sceneJson={scene:{id:'scene_b'}}; state.sourceWebSceneFile='b.json'; physicalLoadToken++;
+  state.web3dReadiness=readiness(['configured_camera:replacement_camera']);
+  resolveA({mesh:true}); await staleSuccess;
+  assert.deepStrictEqual(Array.from(state.web3dReadiness.pending),['configured_camera:replacement_camera']);
+
+  let rejectA; events.length=0; state.sceneJson={scene:{id:'scene_a'}}; state.sourceWebSceneFile='a.json'; physicalLoadToken++;
+  state.web3dReadiness=readiness(['configured_camera:realsense_overhead']);
+  ColladaLoader=class {loadAsync(){return new Promise((resolve,reject) => {rejectA=reject;});}};
+  const staleError=tryLoadMesh(camera,rendered(),fallback()); await Promise.resolve(); await Promise.resolve();
+  state.sceneJson={scene:{id:'scene_b'}}; state.sourceWebSceneFile='b.json'; physicalLoadToken++;
+  state.web3dReadiness=readiness(['configured_camera:replacement_camera']);
+  rejectA(new Error('scene A failed')); await staleError;
+  assert.strictEqual(events.filter(event => event.state==='scene_failed').length,0);
+
+  events.length=0; const optional={id:'optional_fixture',category:'fixture',render_policy:'primary',mesh_uri:'assets/fixture.obj'};
+  state.sceneJson={scene:{id:'optional_scene'}}; state.sourceWebSceneFile='optional.json'; physicalLoadToken++;
+  state.web3dReadiness=readiness([]); const optionalFallback=fallback();
+  OBJLoader=class {load(url,onLoad,onProgress,onError){}};
+  await tryLoadMesh(optional,rendered(),optionalFallback);
+  assert.strictEqual(optionalFallback.visible,true);
+  assert.strictEqual(events.filter(event => event.state==='scene_failed').length,0);
+})().catch(error => { console.error(error); process.exitCode=1; });
+`, context);
+"""
+    subprocess.run(
+        ["node", "-e", harness, str(js_path)],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
 def test_index_references_static_assets():
     index = (VIEWER / "index.html").read_text(encoding="utf-8")
     assert 'href="style.css"' in index
@@ -466,7 +564,7 @@ def test_viewer_includes_mesh_loader_references_and_safe_mesh_uri_logic():
         "three/addons/loaders/OBJLoader.js",
         "safeMeshUri",
         "displayMeshUri",
-        "loadAsync(loadUrl)",
+        "loadMeshWithDeadline",
         "materializeLoadedMesh",
         "appendRuntimeWarning",
         "build/workcell_studio_web_scene/assets/",
@@ -1059,7 +1157,7 @@ def test_viewer_initial_fit_not_reframed_per_mesh_load_but_manual_fit_remains():
     js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
 
     try_load_body = js.split("async function tryLoadMesh", 1)[1].split("function collectItems", 1)[0]
-    assert "loadAsync(loadUrl)" in try_load_body
+    assert "loadMeshWithDeadline(loader, loadUrl" in try_load_body
     assert "frameScene(bounds)" not in try_load_body
     assert "attemptInitialCameraFit" not in try_load_body
     assert "scheduleInitialCameraFitRetry" not in try_load_body
@@ -1169,7 +1267,7 @@ def test_viewer_mesh_preflight_surfaces_distinct_failure_reasons():
     assert "response.status" in preflight_body
     assert "!response.ok" in preflight_body
     try_load_body = js.split("async function tryLoadMesh", 1)[1].split("function collectItems", 1)[0]
-    assert try_load_body.index("await preflightMeshUrl") < try_load_body.index("new STLLoader().loadAsync")
+    assert try_load_body.index("preflightMeshUrl(uri, loadUrl)") < try_load_body.index("loadMeshWithDeadline(loader, loadUrl")
     assert "item.mesh_status = preflight.status || 'url_not_served'" in try_load_body
     assert "item.mesh_status = 'loader_failure'" in try_load_body
 
@@ -1235,8 +1333,8 @@ def test_primary_mesh_backed_target_bin_keeps_product_visibility_scale_color_and
     category = js.split("function readinessCategoryForItem(item)", 1)[1].split("function readinessKey", 1)[0]
     assert "return 'authored_physical_mesh';" in category
     load = js.split("async function tryLoadMesh", 1)[1].split("function collectItems", 1)[0]
-    assert load.index("setRenderInfo(rendered, 'mesh_loaded'") < load.rindex("requiredReadinessCompleteForItem(item)")
-    assert "failWeb3dSceneReadiness(item, loadUrl, `loaded mesh bounds validation failed" in load
+    assert load.index("setRenderInfo(rendered, 'mesh_loaded'") < load.index("completePhysicalMeshAttempt(attempt)")
+    assert "failPhysicalMeshAttempt(attempt, item, loadUrl, `loaded mesh bounds validation failed" in load
 
     material = js.split("function materialFor(item)", 1)[1].split("function materialHasUsableAppearance", 1)[0]
     assert "item?.material?.color" in material
@@ -2845,7 +2943,7 @@ def test_required_gripper_mesh_failures_transition_scene_failed_with_url_and_lin
     assert "url: url || displayMeshUri(item)" in viewer
     assert "link: item?.link || item?.link_name || item?.object_name || ''" in viewer
     assert "const eventDetail = { ...structured, ...detail, final_lifecycle_state: readinessState" in viewer
-    assert "if (required) failWeb3dSceneReadiness(item, preflight.url || loadUrl" in viewer
+    assert "if (required) failPhysicalMeshAttempt(attempt, item, preflight.url || loadUrl" in viewer
     assert "http_status: preflight.http_status || null" in viewer
     assert "onRobotMeshLoadError: (err, uri, detail) => { if (!callbackIsCurrent()) return ignoreStaleCallback(); failExpandedUrdfReadiness" in viewer
     assert "function inferMeshLinkDetail(path)" in renderer
@@ -2859,14 +2957,14 @@ def test_gripper_mesh_404_scene_failed_payload_includes_structured_url_and_link_
     viewer = (VIEWER / "viewer.js").read_text(encoding="utf-8")
     preflight_body = _viewer_function_body(viewer, "async function preflightMeshUrl", "function supportSurfaceKindOf")
     try_load_body = _viewer_function_body(viewer, "async function tryLoadMesh", "function collectItems")
-    failure_body = _viewer_function_body(viewer, "function failWeb3dSceneReadiness", "function completeExpandedUrdfReadiness")
+    failure_body = _viewer_function_body(viewer, "function failPhysicalMeshAttempt", "function failWeb3dSceneReadiness")
     assert "HTTP ${response.status}" in preflight_body
     assert "http_status: response.status" in preflight_body
-    assert "if (required) failWeb3dSceneReadiness(item, preflight.url || loadUrl" in try_load_body
+    assert "if (required) failPhysicalMeshAttempt(attempt, item, preflight.url || loadUrl" in try_load_body
     assert "http_status: preflight.http_status || null" in try_load_body
     assert "url: url || displayMeshUri(item)" in failure_body
     assert "link: item?.link || item?.link_name || item?.object_name || ''" in failure_body
-    assert "required_category: category" in failure_body
+    assert "required_category: attempt.category || 'required_physical_item'" in failure_body
     assert "scene_id: sceneId()" in viewer
 
 

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -27,6 +27,7 @@ const SUPPORTED_SCHEMA_VERSION = 'workcell_studio_web_scene/v1';
 const EDIT_PATCH_SCHEMA_VERSION = 'workcell_studio_web_scene_edit_patch/v1';
 const VIEWER_VERSION = 'static_web_viewer_edit_patch_v1';
 const READINESS_CONTRACT_VERSION = 1;
+const PHYSICAL_MESH_LOAD_TIMEOUT_MS = 30000;
 const VALID_SCENE_LIFECYCLE_STATES = Object.freeze(['booting', 'scene_loading', 'scene_ready', 'scene_failed']);
 const LOCKED_EDIT_REASON = 'Locked/generated preview item; edit source layout/environment instead.';
 const MIN_FRAME_RADIUS = 1.2;
@@ -40,6 +41,7 @@ const CAMERA_PRESET_DIRECTIONS = Object.freeze({
 });
 const state = { sceneJson: null, sourceWebSceneFile: '', diagnosticKeys: new Set(), frameLookup: new Map(), resolvedFramePoses: new Map(), objects: [], pickRecords: [], pickIdentityByObject: new WeakMap(), selectionIdentityIndex: null, assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, robotUrdfPreviewDiagnostics: {}, physicalAssemblyBounds: null, finalPhysicalFitBounds: null, selected: null, three: {}, animationId: null, lastFrameBounds: null, initialCameraFit: { sceneKey: '', done: false, attempts: 0, pendingRetry: null, userControlled: false }, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: new Map(), undoStack: [], redoStack: [], gizmoDragStart: null, directMoveDrag: null, directRotateDrag: null, editorMode: 'select', editorEvents: [], editorError: '', robotPreviewResult: null, lastRaycastHitCount: 0, lastRaycastCandidateIds: [], lastCanvasSelectedItemId: '', lastCanvasPickReason: '', lastFailedCanvasPickDiagnostic: null, initialPosePreview: { active: false, robotId: '', sceneKey: '' }, web3dReadiness: { state: 'booting', terminal: false, terminalState: '', terminalNavigationKey: '', terminalEmissionCount: 0, statusSequence: 0, required: {}, pending: new Set(), failed: false, failure: null }, builderRevision: '', sceneJsonLoaded: false, activeNavigationKey: '' };
 let robotPreviewLoadToken = 0;
+let physicalLoadToken = 0;
 const RESET_VIEW_TITLE = 'Fit Scene / Reset View: recomputes and reapplies the fitted workcell overview from renderable bounds.';
 const STAGED_MESH_ROOTS = [
   'build/workcell_studio_web_scene/assets/',
@@ -226,6 +228,43 @@ function requiredReadinessCompleteForItem(item) {
   if (!category || !state.web3dReadiness?.pending) return;
   state.web3dReadiness.pending.delete(readinessKey(category, item));
   maybeEmitSceneReady();
+}
+function physicalMeshAttempt(item) {
+  const category = readinessCategoryForItem(item);
+  const identity = category ? readinessIdentityForItem(category, item) : '';
+  return {
+    token: physicalLoadToken,
+    navigationKey: web3dNavigationKey(),
+    category,
+    identity,
+    readinessKey: category ? `${category}:${identity}` : '',
+    deadlineAt: Date.now() + PHYSICAL_MESH_LOAD_TIMEOUT_MS,
+  };
+}
+function physicalMeshAttemptIsCurrent(attempt) {
+  return attempt.token === physicalLoadToken && attempt.navigationKey === web3dNavigationKey();
+}
+function completePhysicalMeshAttempt(attempt) {
+  if (!physicalMeshAttemptIsCurrent(attempt)) return false;
+  if (attempt.readinessKey && state.web3dReadiness?.pending) state.web3dReadiness.pending.delete(attempt.readinessKey);
+  maybeEmitSceneReady();
+  return true;
+}
+function failPhysicalMeshAttempt(attempt, item, url, reason, extra = {}) {
+  if (!physicalMeshAttemptIsCurrent(attempt)) return false;
+  emitWeb3dReadinessState('scene_failed', {
+    required_category: attempt.category || 'required_physical_item',
+    readiness_identity: attempt.identity,
+    readiness_key: attempt.readinessKey,
+    item_id: item?.id || '',
+    link: item?.link || item?.link_name || item?.object_name || '',
+    url: url || displayMeshUri(item),
+    reason: reason || 'required mesh failed',
+    ...extra,
+    loader: extra.loader || extra.loader_type || '',
+    loader_type: extra.loader_type || extra.loader || '',
+  });
+  return true;
 }
 function failWeb3dSceneReadiness(item, url, reason, extra = {}) {
   const category = readinessCategoryForItem(item) || extra.category || 'required_physical_item';
@@ -2143,7 +2182,38 @@ function applyLoadedMeshScaleHandling(meshObject, item) {
   const transform = meshLocalTransformOf(item);
   meshObject.scale.set(transform.scale.x, transform.scale.y, transform.scale.z);
 }
+function promiseWithDeadline(start, timeoutMs = PHYSICAL_MESH_LOAD_TIMEOUT_MS) {
+  let timeoutId;
+  let settled = false;
+  return new Promise((resolve, reject) => {
+    const finish = (handler, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
+      handler(value);
+    };
+    timeoutId = setTimeout(() => {
+      const error = new Error(`mesh load timed out after ${timeoutMs}ms`);
+      error.code = 'mesh_load_timeout';
+      error.timeoutMs = timeoutMs;
+      finish(reject, error);
+    }, timeoutMs);
+    try {
+      start(value => finish(resolve, value), error => finish(reject, error));
+    } catch (error) {
+      finish(reject, error);
+    }
+  });
+}
+function loadMeshWithDeadline(loader, url, timeoutMs = PHYSICAL_MESH_LOAD_TIMEOUT_MS) {
+  return promiseWithDeadline((resolve, reject) => {
+    if (typeof loader?.loadAsync === 'function') Promise.resolve(loader.loadAsync(url)).then(resolve, reject);
+    else if (typeof loader?.load === 'function') loader.load(url, resolve, undefined, reject);
+    else reject(new Error('mesh loader provides neither loadAsync() nor load()'));
+  }, timeoutMs);
+}
 async function tryLoadMesh(item, rendered, fallback) {
+  const attempt = physicalMeshAttempt(item);
   const diagnostic = meshUriDiagnostic(item);
   const uri = diagnostic.uri;
   const requestedUri = displayMeshUri(item);
@@ -2168,7 +2238,18 @@ async function tryLoadMesh(item, rendered, fallback) {
   const ext = meshExtensionFromUri(uri);
   const loaderName = meshLoaderNameForExtension(ext);
   const loadUrl = repoRootRelativeUrl(uri);
-  const preflight = await preflightMeshUrl(uri, loadUrl);
+  const remainingPreflightMs = Math.max(1, attempt.deadlineAt - Date.now());
+  const preflight = await promiseWithDeadline(
+    (resolve, reject) => Promise.resolve(preflightMeshUrl(uri, loadUrl)).then(resolve, reject),
+    remainingPreflightMs,
+  ).catch(error => ({
+    ok: false,
+    status: 'loader_failure',
+    reason: error?.message || String(error),
+    url: loadUrl,
+    timeout_ms: error?.code === 'mesh_load_timeout' ? PHYSICAL_MESH_LOAD_TIMEOUT_MS : undefined,
+  }));
+  if (!physicalMeshAttemptIsCurrent(attempt)) return;
   if (!preflight.ok) {
     const required = itemRequiresMeshBackedVisual(item);
     item.mesh_status = preflight.status || 'url_not_served';
@@ -2185,15 +2266,14 @@ async function tryLoadMesh(item, rendered, fallback) {
       appendRuntimeWarning(item, uri, item.mesh_load_error, preflight.code || 'mesh_url_not_served', { mesh_url: preflight.url || loadUrl, http_status: preflight.http_status || null });
     }
     refreshMeshLoadUi(rendered);
-    if (required) failWeb3dSceneReadiness(item, preflight.url || loadUrl, item.mesh_load_error, { http_status: preflight.http_status || null, mesh_status: item.mesh_status });
+    if (required) failPhysicalMeshAttempt(attempt, item, preflight.url || loadUrl, item.mesh_load_error, { http_status: preflight.http_status || null, mesh_status: item.mesh_status, loader: loaderName, ...(preflight.timeout_ms ? { timeout_ms: preflight.timeout_ms } : {}) });
     else requiredReadinessCompleteForItem(item);
     return;
   }
   try {
-    let loaded;
-    if (ext === 'stl') loaded = await new STLLoader().loadAsync(loadUrl);
-    else if (ext === 'dae') loaded = await new ColladaLoader().loadAsync(loadUrl);
-    else loaded = await new OBJLoader().loadAsync(loadUrl);
+    const loader = ext === 'stl' ? new STLLoader() : (ext === 'dae' ? new ColladaLoader() : new OBJLoader());
+    const loaded = await loadMeshWithDeadline(loader, loadUrl, Math.max(1, attempt.deadlineAt - Date.now()));
+    if (!physicalMeshAttemptIsCurrent(attempt)) return;
     const meshObject = materializeLoadedMesh(item, uri, loaded);
     // Legacy flow was applyMeshLocalTransform(meshObject, item) followed by
     // rendered.object3d.add(meshObject); generated URDF now applies that
@@ -2215,11 +2295,12 @@ async function tryLoadMesh(item, rendered, fallback) {
     const boundsValid = diagnoseLoadedMeshBounds(item, visualRoot, rendered, validationBounds);
     refreshMeshLoadUi(rendered);
     if (!boundsValid && itemRequiresMeshBackedVisual(item)) {
-      failWeb3dSceneReadiness(item, loadUrl, `loaded mesh bounds validation failed (${item.visual_bounds_status || 'invalid'})`, { mesh_status: item.mesh_status });
+      failPhysicalMeshAttempt(attempt, item, loadUrl, `loaded mesh bounds validation failed (${item.visual_bounds_status || 'invalid'})`, { mesh_status: item.mesh_status, loader: loaderName });
       return;
     }
-    requiredReadinessCompleteForItem(item);
+    completePhysicalMeshAttempt(attempt);
   } catch (err) {
+    if (!physicalMeshAttemptIsCurrent(attempt)) return;
     const required = itemRequiresMeshBackedVisual(item);
     item.mesh_status = 'loader_failure';
     item.mesh_load_error = err?.message || String(err);
@@ -2236,7 +2317,7 @@ async function tryLoadMesh(item, rendered, fallback) {
       appendRuntimeWarning(item, uri, reason, 'mesh_loader_failure', { extension: ext, loader: loaderName, mesh_url: loadUrl });
     }
     refreshMeshLoadUi(rendered);
-    if (required) failWeb3dSceneReadiness(item, loadUrl, reason, { extension: ext, loader: loaderName, mesh_status: item.mesh_status });
+    if (required) failPhysicalMeshAttempt(attempt, item, loadUrl, reason, { extension: ext, loader: loaderName, mesh_status: item.mesh_status, ...(err?.code === 'mesh_load_timeout' ? { timeout_ms: PHYSICAL_MESH_LOAD_TIMEOUT_MS } : {}) });
     else requiredReadinessCompleteForItem(item);
   }
 }
@@ -3186,6 +3267,7 @@ function disposeOwnedObject3d(object3d, seen = new Set()) {
 }
 function resetSceneLifecycleState() {
   robotPreviewLoadToken += 1;
+  physicalLoadToken += 1;
   cancelInitialCameraFitRetry();
   state.objects = [];
   state.pickRecords = [];


### PR DESCRIPTION
### Motivation
- Close an M1 blocker by ensuring no required physical mesh load can remain pending until the outer Qt 45s timeout and prevent stale mesh callbacks from mutating replacement scenes.
- Make configured-camera and other required physical loads actionably fail (or succeed) within a bounded window and preserve optional mesh fallback behavior.

### Description
- Add a per-scene physical-load generation token (`physicalLoadToken`) and capture an attempt object with `token`, `navigationKey`, `category`, `identity`, `readinessKey`, and a `deadlineAt` to reject stale callbacks if the scene or navigation changed.
- Add a single bounded promise wrapper (`promiseWithDeadline`) and `loadMeshWithDeadline` that unify timeout handling for preflight, `loadAsync()` and callback-style loaders, with a default around 30s (`PHYSICAL_MESH_LOAD_TIMEOUT_MS`).
- Integrate the attempt token/deadline into `tryLoadMesh()` so every required-load path (missing URI, preflight failure, `loadAsync` success, callback loader rejection, bounds validation, and timeout) either clears the captured pending readiness key on current-scene success or emits a structured `scene_failed` exactly once for current-scene failures; stale attempts return early without mutating readiness.
- Preserve optional mesh behavior: optional failures still show primitive/debug fallbacks and do not emit `scene_failed`.
- Add an executable Node-backed test `test_required_mesh_physical_load_deadline_and_stale_camera_callbacks` that verifies timeout emission, payload contents, timer cancellation on success, stale-success/error isolation, and optional fallback behavior; update static expectations accordingly. Changes are confined to `workcell_studio_web/viewer/viewer.js` and `tests/test_workcell_studio_web_viewer_static.py`.

### Testing
- Ran `node --check workcell_studio_web/viewer/viewer.js` and it passed.
- Ran the focused suite: `python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py -k "required_mesh or physical_load or stale_camera"` which passed (3 passed, 114 deselected).
- Ran the full static tests: `python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py` which passed (117 passed; 3 pre-existing Python warnings unrelated to this change).
- Verified `git diff --check` and workspace status as part of the local validation workflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c8c8036648331b648a471e54a5b37)