### PR TITLE
Fix expanded-URDF descendant canvas picking

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -127,6 +127,7 @@ const childVisual=node('wrist-visual',[childMesh]);
 const childLink=node('wrist_link',[childVisual]);
 const linkRoot=node('base_link',[visualWrapper,childLink]); // link root -> visual wrapper -> descendant mesh
 const toolMesh=node('robotiq-mesh');
+toolMesh.userData.item={id:'stale_tool_visual',diagnostic_only:true,selectable:false};
 const toolLink=node('robotiq_85_base_link',[toolMesh]);
 const robotRoot=node('robot-root',[linkRoot,toolLink]);
 callbacks[0].onRobotLoaded({root:robotRoot,links:new Map([['base_link',linkRoot],['wrist_link',childLink],['robotiq_85_base_link',toolLink]]),diagnostics:{loader_value:'preserved'}});
@@ -144,11 +145,14 @@ assert.strictEqual(state.pickIdentityByObject.get(childLink),childRecord,'child 
 assert.strictEqual(state.pickIdentityByObject.get(childVisual),childRecord,'child visual wrapper');
 assert.strictEqual(state.pickIdentityByObject.get(childMesh),childRecord,'child mesh');
 assert.strictEqual(itemFromRaycastHit({object:childMesh}),childRecord,'child raycast');
+state.pickIdentityByObject.delete(childMesh); state.pickIdentityByObject.delete(childVisual);
+assert.strictEqual(itemFromRaycastHit({object:childMesh}),childRecord,'nested traversal stops at the child URDF link root instead of crossing to the base link');
 assert.strictEqual(state.pickRecords.filter(record=>record.item.link_name==='base_link').length,1);
 assert.strictEqual(state.pickRecords.filter(record=>record.item.link_name==='wrist_link').length,1);
 assert.strictEqual(baseRecord.uiSelectionOwnerId,'ur5');
 assert.strictEqual(childRecord.uiSelectionOwnerId,'ur5');
 assert.strictEqual(toolRecord.uiSelectionOwnerId,'robotiq_85_gripper');
+assert.strictEqual(itemFromRaycastHit({object:toolMesh}),toolRecord,'stale tool descendant flags do not override its explicit registration');
 for (const record of [baseRecord,childRecord,toolRecord]) {
   assert.strictEqual(isExpandedUrdfInspectionPick(record),true);
   assert.strictEqual(isCanvasSelectableRendered(record),true);
@@ -160,6 +164,25 @@ assert.strictEqual(isExpandedUrdfInspectionPick(nameSpoof),false,'names and link
 const ordinaryDiagnostic={item:{id:'ordinary_diagnostic',diagnostic_only:true},object3d:{visible:true},readOnlyPick:true};
 state.pickRecords.push(ordinaryDiagnostic);
 assert.strictEqual(isCanvasSelectableRendered(ordinaryDiagnostic),false);
+
+const physicalItem={id:'editable_fixture',role:'table',editable:true,locked:false,render_policy:'primary',source_layer:'editable_layout'};
+const physicalRoot=node('editable_fixture'); physicalRoot.userData.item=physicalItem;
+const physicalRecord={item:physicalItem,object3d:physicalRoot}; state.objects.push(physicalRecord);
+const edge=node('fixture_fallback_edges'); edge.userData.selectable=false; edge.parent=physicalRoot;
+const frustum=node('camera_fallback_sensor_frustum'); frustum.userData.non_selectable=true; frustum.parent=physicalRoot;
+assert.strictEqual(itemFromRaycastHit({object:edge}),physicalRecord,'non-selectable edge passes through to its physical parent');
+assert.strictEqual(itemFromRaycastHit({object:frustum}),physicalRecord,'non-selectable frustum passes through to its physical parent');
+const hiddenFallback=node('hidden_fallback_edges'); hiddenFallback.visible=false; hiddenFallback.parent=physicalRoot;
+assert.strictEqual(rankedPickingCandidates([{object:hiddenFallback,distance:1},{object:physicalRoot,distance:2}])[0].rendered,physicalRecord,'a hidden fallback hit does not suppress a later physical hit');
+const taskOverlay=node('task-overlay'); taskOverlay.userData.item={id:'task_overlay',role:'task_marker',source_layer:'task_preview'};
+const debugOverlay=node('debug-overlay'); debugOverlay.userData.item={id:'debug_overlay',diagnostic_only:true,role:'debug_overlay'};
+const gizmo=node('TransformControls_gizmo');
+const highlight=node('selection_subtle_bounds_highlight'); highlight.userData.selection_highlight=true;
+const hiddenHelper=node('hidden-helper'); hiddenHelper.userData.helper_hidden=true;
+for (const excluded of [taskOverlay,debugOverlay,gizmo,highlight,hiddenHelper]) assert.strictEqual(itemFromRaycastHit({object:excluded}),null,excluded.name+' remains intrinsically excluded');
+assert.strictEqual(rankedPickingCandidates([{object:mesh,distance:1},{object:physicalRoot,distance:1}])[0].rendered,physicalRecord,'editable primary physical items retain priority over generated inspection records');
+assert.strictEqual(pickingPriority(physicalRecord),1);
+state.objects=[];
 
 selectObject(baseRecord.item.id);
 assert.strictEqual(editorState().selectedItemId,baseRecord.item.id);

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -4028,25 +4028,53 @@ function isExpandedUrdfInspectionPick(rendered) {
 function isCanvasSelectableRendered(rendered) {
   return isExpandedUrdfInspectionPick(rendered) || isNormalSelectableRendered(rendered);
 }
-function excludedPickNode(node) {
+function intrinsicallyExcludedPickNode(node) {
   const data = node?.userData || {};
   const name = String(node?.name || '').toLowerCase();
-  return node?.visible === false || data.selection_outline || data.selection_highlight || data.diagnostic_only ||
-    data.hidden_overlay || data.helper_hidden || data.non_selectable || data.selectable === false ||
+  return node?.visible === false || data.selection_outline || data.selection_highlight ||
+    data.hidden_overlay || data.helper_hidden ||
     /transformcontrols|transform_controls|gizmo|selection_.*highlight/.test(name);
+}
+function passThroughPickNode(node) {
+  const data = node?.userData || {};
+  const name = String(node?.name || '').toLowerCase();
+  return data.diagnostic_only || data.non_selectable || data.selectable === false ||
+    /(?:^|[_-])(?:edges?|frustum|helper)(?:$|[_-])/.test(name);
+}
+function excludedPickNode(node) {
+  return intrinsicallyExcludedPickNode(node) || passThroughPickNode(node);
+}
+function intrinsicallyExcludedPickItem(item) {
+  const sourceLayer = String(item?.source_layer || '').toLowerCase();
+  const identity = [item?.role, item?.category, item?.id].map(value => String(value || '').toLowerCase()).join(' ');
+  const explicitDebug = isDebugOverlayItem(item) && (item?.diagnostic_only === true || /debug|diagnostic/.test(`${sourceLayer} ${identity}`));
+  return explicitDebug || (isTaskOnlyHelperItem(item) && /task|debug/.test(sourceLayer));
 }
 function itemFromRaycastHit(hit) {
   let node = hit?.object || null;
   let candidate = null;
   while (node) {
-    if (excludedPickNode(node)) return null;
+    // Registration is authoritative for expanded-URDF inspection descendants.
+    // Loader-provided Collada/URDF userData can contain stale diagnostic flags,
+    // so consult the registry before interpreting those descendant flags.
+    const registered = state.pickIdentityByObject.get(node);
+    if (intrinsicallyExcludedPickNode(node)) return null;
+    if (isExpandedUrdfInspectionPick(registered)) {
+      const descendantItem = node.userData?.item;
+      const identityFreeDescendant = descendantItem ? { ...descendantItem, id: '', display_name: '', status: '', diagnostic_only: false, selectable: true } : null;
+      if (identityFreeDescendant && intrinsicallyExcludedPickItem(identityFreeDescendant)) return null;
+      return registered;
+    }
+    // A different registered root is a nested URDF-link ownership boundary.
+    if (candidate && registered && registered !== candidate) return candidate;
+    if (passThroughPickNode(node)) {
+      node = node.parent;
+      continue;
+    }
     if (!candidate) {
-      const registered = state.pickIdentityByObject.get(node);
-      const registeredInspection = isExpandedUrdfInspectionPick(registered);
       const nodeItem = node.userData?.item;
-      const nodeItemWithoutStalePickFlags = nodeItem ? { ...nodeItem, id: '', display_name: '', status: '', diagnostic_only: false, selectable: true } : null;
-      if (registeredInspection && nodeItemWithoutStalePickFlags && (isTaskOnlyHelperItem(nodeItemWithoutStalePickFlags) || isOverlayPolicyItem(nodeItemWithoutStalePickFlags) || isDebugOverlayItem(nodeItemWithoutStalePickFlags))) return null;
-      const item = registeredInspection ? registered.item : nodeItem || registered?.item;
+      if (nodeItem && intrinsicallyExcludedPickItem(nodeItem)) return null;
+      const item = nodeItem || registered?.item;
       if (item?.id) {
         const rendered = renderedById(item.id) || registered;
         if (!rendered || !isCanvasSelectableRendered(rendered)) return null;


### PR DESCRIPTION
### Motivation
- Close an M1 blocker: expanded-URDF robot and tool descendants could be rejected by stale Collada/URDF descendant metadata before an explicit expanded-URDF registration was consulted, breaking deterministic canvas selection for generated robots/tools.
- Ensure the registry-backed read-only inspection identities remain authoritative while preserving existing intrinsic exclusions and nested URDF-link ownership boundaries.

### Description
- Update `itemFromRaycastHit()` to consult `state.pickIdentityByObject` at every traversed node and treat an explicit `isExpandedUrdfInspectionPick()` registration as authoritative even when descendants carry `diagnostic_only: true` or `selectable: false` flags. 
- Split intrinsic, terminal exclusions from pass-through descendant metadata by adding `intrinsicallyExcludedPickNode`, `passThroughPickNode`, and `intrinsicallyExcludedPickItem` helpers so hidden overlays/gizmos/highlights remain terminally excluded while edges/frustum/helper fallback geometry and diagnostic flags may pass through to a legitimate selectable parent.
- Preserve nested URDF-link boundaries by treating a different registered root encountered in ancestry as a terminal ownership boundary and by returning a registered read-only record immediately when appropriate.
- Keep original `pickingPriority()` semantics unchanged so editable primary physical items retain their ranking; add focused static regression tests for expanded-URDF and fallback/overlay/helper traversal behaviors in `tests/test_workcell_studio_web_viewer_static.py`.

### Testing
- Ran static JS check: `node --check workcell_studio_web/viewer/viewer.js` (passed).
- Ran focused unit harnesses: `python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py -k "pick or raycast or expanded_urdf or fallback or helper"` (30 passed, 87 deselected) and `python3 -m pytest -q tests/test_embedded_web3d_editor_bridge_static.py` (20 passed).
- Did not rebuild the committed generated bundle; follow-up local bundle rebuild commands are: `cd workcell_studio_web/viewer` and `npm ci && npm run build:web3d`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f967d5f9483319ed289aa87e19d82)