### PR TITLE
Fix live expanded-URDF readiness diagnostics

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -823,7 +823,7 @@ let source=fs.readFileSync(process.argv[1],'utf8').replace(/boot\(\);\s*$/,'');
 const payload=JSON.parse(fs.readFileSync(process.argv[2],'utf8'));
 const element=()=>({hidden:false,checked:false,disabled:false,textContent:'',className:'',innerHTML:'',classList:{toggle(){}},setAttribute(){},querySelector(){return {textContent:''}},appendChild(){},addEventListener(){}});
 const timers=[]; const events=[]; const debug=[];
-const context={assert,payload,console:{...console,debug(...args){debug.push(args)}},window:{location:{search:''},dispatchEvent(e){events.push(e.detail)},parent:{postMessage(){}}},document:{getElementById(){return element()},createElement(){return element()}},URLSearchParams,CustomEvent:function(type,init){return {type,detail:init.detail}},requestAnimationFrame(){return 0},setTimeout(fn,ms){timers.push({fn,ms,cleared:false});return timers.length},clearTimeout(id){if(timers[id-1])timers[id-1].cleared=true}};
+const context={assert,payload,events,debug,timers,console:{...console,debug(...args){debug.push(args)}},window:{location:{search:''},dispatchEvent(e){events.push(e.detail)},parent:{postMessage(){}}},document:{getElementById(){return element()},createElement(){return element()}},URLSearchParams,CustomEvent:function(type,init){return {type,detail:init.detail}},requestAnimationFrame(){return 0},setTimeout(fn,ms){timers.push({fn,ms,cleared:false});return timers.length},clearTimeout(id){if(timers[id-1])timers[id-1].cleared=true}};
 vm.createContext(context);
 vm.runInContext(source+`
 (async()=>{
@@ -834,21 +834,25 @@ state.sceneJson=payload; state.sourceWebSceneFile='ur5_2f_test.web_scene.json';
 const rows=physicalReadinessItems();
 const camera=rows.find(item=>readinessCategoryForItem(item)==='configured_camera');
 const table=rows.find(item=>readinessCategoryForItem(item)==='workbench_support_surface');
-assert(camera && table); assert.strictEqual(truthyFlag(camera.mesh_load_required),true); assert.strictEqual(truthyFlag(table.mesh_load_required),true);
+assert(camera && table);
 let controls=[];
 loadRobotPreview=(_preview,callbacks)=>{let resolve,reject;const result={diagnostics:{robot_preview_lifecycle_state:'loading_urdf'},links:new Map()};result.ready=new Promise((ok,bad)=>{resolve=ok;reject=bad});controls.push({callbacks,result,resolve,reject});return result};
 const required={robot_arm:true,attached_tool_gripper:true,workbench_support_surface:true,configured_camera:true};
 function begin(){events.length=0;state.web3dReadiness={state:'scene_loading',terminal:false,terminalState:'',terminalNavigationKey:web3dNavigationKey(),terminalEmissionCount:0,statusSequence:0,required,pending:new Set(),failed:false,failure:null};const cameraOp=registerReadinessOperation([readinessKey('configured_camera',camera)]);const tableOp=registerReadinessOperation([readinessKey('workbench_support_surface',table)]);loadExpandedUrdfRobotPreview(payload.robot_preview);return {cameraOp,tableOp,control:controls.at(-1)}}
 let run=begin();
 assert.deepStrictEqual(Array.from(run.cameraOp.pendingKeys),['configured_camera:realsense_overhead']);
+const liveDiagnostics=run.control.result.diagnostics;
+assert.strictEqual(state.robotUrdfPreviewDiagnostics,liveDiagnostics,'viewer must retain renderer diagnostics identity immediately after registration');
 completeReadinessOperation(run.tableOp); completeReadinessOperation(run.cameraOp);
-run.control.result.diagnostics.robot_preview_lifecycle_state='ready';run.control.result.diagnostics.robot_preview_loaded=true;run.control.resolve(run.control.result);await Promise.resolve();await Promise.resolve();
+await Promise.resolve().then(()=>{liveDiagnostics.robot_preview_lifecycle_state='ready';liveDiagnostics.robotPreviewLifecycleState='ready';liveDiagnostics.robot_preview_loaded=true;liveDiagnostics.robot_expected_visual_count=2;liveDiagnostics.robot_loaded_visual_count=2;liveDiagnostics.robot_failed_visual_count=0;run.control.resolve(run.control.result)});await Promise.resolve();await Promise.resolve();
+assert.strictEqual(run.control.result.diagnostics,liveDiagnostics);assert.strictEqual(state.robotUrdfPreviewDiagnostics,liveDiagnostics,'ready completion must still expose the renderer-owned diagnostics');
 assert.deepStrictEqual(pendingRequiredLoads(),[]);assert.strictEqual(events.filter(e=>e.state==='scene_ready').length,1);assert.strictEqual(state.web3dReadiness.terminalEmissionCount,1);
-run.control.callbacks.onRobotLoaded({root:{},links:new Map(),diagnostics:{robot_preview_lifecycle_state:'ready',robot_preview_loaded:true}});
+run.control.callbacks.onRobotLoaded(run.control.result);
 assert.strictEqual(events.filter(e=>e.state==='scene_ready').length,1,'duplicate callback cannot emit again');
 
 run=begin();completeReadinessOperation(run.tableOp);completeReadinessOperation(run.cameraOp);run.control.reject(new Error('preview ready rejected'));await Promise.resolve();await Promise.resolve();
 assert.strictEqual(state.web3dReadiness.state,'scene_failed');assert.deepStrictEqual(pendingRequiredLoads(),[]);assert.match(state.web3dReadiness.failure.reason,/preview ready rejected/);assert.match(state.web3dReadiness.failure.operation_id,/expanded_urdf:ur5_2f_test/);
+assert.strictEqual(state.web3dReadiness.failure.robot_preview_lifecycle_state,'loading_urdf');assert.strictEqual(state.web3dReadiness.failure.robot_loaded_visual_count,0);assert.strictEqual(state.web3dReadiness.failure.robot_expected_visual_count,0);assert.strictEqual(state.web3dReadiness.failure.robot_failed_visual_count,0);assert.deepStrictEqual(state.web3dReadiness.failure.pending_required_loads,[]);
 
 run=begin();completeReadinessOperation(run.tableOp);completeReadinessOperation(run.cameraOp);const deadline=timers.filter(t=>t.ms===REQUIRED_LOAD_DEADLINE_MS&&!t.cleared).at(-1);assert(deadline);deadline.fn();
 assert.strictEqual(state.web3dReadiness.state,'scene_failed');assert.deepStrictEqual(pendingRequiredLoads(),[]);assert.strictEqual(state.web3dReadiness.failure.timeout_ms,REQUIRED_LOAD_DEADLINE_MS);assert.deepStrictEqual(state.web3dReadiness.failure.pending_required_loads,[]);
@@ -3039,7 +3043,7 @@ def test_required_gripper_mesh_failures_transition_scene_failed_with_url_and_lin
     assert "const eventDetail = { ...structured, ...detail, final_lifecycle_state: readinessState" in viewer
     assert "if (required) failPhysicalMeshAttempt(attempt, item, preflight.url || loadUrl" in viewer
     assert "http_status: preflight.http_status || null" in viewer
-    assert "onRobotMeshLoadError: (err, uri, detail) => { if (!callbackIsCurrent()) return ignoreStaleCallback(); failExpandedUrdfReadiness" in viewer
+    assert "onRobotMeshLoadError: (err, uri, detail) => { if (!callbackIsCurrent()) return ignoreStaleCallback(); finalizeRequiredLoad('failure'" in viewer
     assert "function inferMeshLinkDetail(path)" in renderer
     assert "'gripper_base_link'" in renderer
     assert "context?.onRobotMeshLoadError?.(err, uri, { url, uri, path, source_url: path, sourceUrl: path, policy_reason:" in renderer
@@ -3071,7 +3075,7 @@ def test_successful_required_loads_emit_scene_ready_exactly_once_after_completio
     assert "readiness.pending?.size === 0" in maybe_body
     assert "emitWeb3dReadinessState('scene_ready'" in maybe_body
     assert "requiredReadinessCompleteForItem(item);" in js
-    assert "completeExpandedUrdfReadiness(readinessOperation);" in js
+    assert "finalizeRequiredLoad('success'" in js
 
 
 

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -341,6 +341,10 @@ function failExpandedUrdfReadiness(operation, err, diagnostics = {}, detail = {}
     link,
     url: detail.url || detail.uri || diagnostics.robot_urdf_url || '',
     reason: err?.message || String(err || 'expanded URDF required mesh failed'),
+    robot_preview_lifecycle_state: diagnostics.robot_preview_lifecycle_state || diagnostics.robotPreviewLifecycleState || '',
+    robot_loaded_visual_count: Number(diagnostics.robot_loaded_visual_count ?? diagnostics.robotLoadedVisualCount ?? 0) || 0,
+    robot_expected_visual_count: Number(diagnostics.robot_expected_visual_count ?? diagnostics.robotExpectedVisualCount ?? 0) || 0,
+    robot_failed_visual_count: Number(diagnostics.robot_failed_visual_count ?? diagnostics.robotFailedVisualCount ?? 0) || 0,
     robot_missing_meshes: diagnostics.robot_missing_meshes || [],
     ...detail,
     pending_required_loads: pendingRequiredLoads(),
@@ -3518,6 +3522,18 @@ function loadExpandedUrdfRobotPreview(preview) {
     robotPreviewCanonicalFallbackUsed: false,
     skipped_legacy_generated_urdf_visual_count: state.robotAssemblyRenderDiagnostics?.skipped_legacy_generated_urdf_visual_count || state.robotAssemblyRenderDiagnostics?.skipped_legacy_generated_urdf_count || 0,
   };
+  const mergeMissingDiagnosticsInPlace = (target, additions) => {
+    if (!target || typeof target !== 'object') return target;
+    for (const [key, value] of Object.entries(additions || {})) {
+      if (target[key] === undefined) target[key] = value;
+    }
+    return target;
+  };
+  const rendererReady = rendererDiagnostics => {
+    const lifecycle = String(rendererDiagnostics?.robot_preview_lifecycle_state || rendererDiagnostics?.robotPreviewLifecycleState || '');
+    const loaded = rendererDiagnostics?.robot_preview_loaded === true || rendererDiagnostics?.robotPreviewLoaded === true;
+    return lifecycle === 'ready' && loaded;
+  };
   if (typeof loadRobotPreview !== 'function') {
     diagnostics.robot_preview_lifecycle_state = 'failed';
     diagnostics.robotPreviewLifecycleState = 'failed';
@@ -3613,14 +3629,11 @@ function loadExpandedUrdfRobotPreview(preview) {
         selectionToolOwnerId: toolOwnerId,
       };
       state.robotPreviewResult = result;
-      result.diagnostics = { ...state.robotUrdfPreviewDiagnostics, ...(result.diagnostics || {}), ...localDiagnostics };
-      const resultLifecycle = String(result.diagnostics.robot_preview_lifecycle_state || result.diagnostics.robotPreviewLifecycleState || '');
-      if (resultLifecycle === 'ready') {
-        result.diagnostics.robot_preview_lifecycle_state = 'ready';
-        result.diagnostics.robotPreviewLifecycleState = 'ready';
-      }
-      state.robotUrdfPreviewDiagnostics = result.diagnostics;
-      if (resultLifecycle === 'ready' && !failIfExpandedUrdfExpectedVisualSetInvalid()) finalizeRequiredLoad('success', { completion_source: 'onRobotLoaded' });
+      const authoritativeDiagnostics = result.diagnostics || previewResult.diagnostics;
+      mergeMissingDiagnosticsInPlace(authoritativeDiagnostics, diagnostics);
+      Object.assign(authoritativeDiagnostics, localDiagnostics);
+      state.robotUrdfPreviewDiagnostics = authoritativeDiagnostics;
+      if (rendererReady(authoritativeDiagnostics) && !failIfExpandedUrdfExpectedVisualSetInvalid()) finalizeRequiredLoad('success', { completion_source: 'onRobotLoaded' });
       maybeEmitSceneReady();
       refreshInitialPoseActionState();
       renderSceneSummary();
@@ -3632,7 +3645,9 @@ function loadExpandedUrdfRobotPreview(preview) {
     onRobotMeshLoadError: (err, uri, detail) => { if (!callbackIsCurrent()) return ignoreStaleCallback(); finalizeRequiredLoad('failure', { ...(detail || { uri }), error: err, completion_source: 'onRobotMeshLoadError' }); renderSceneSummary(); },
     onRobotError: (err, diagnostics) => {
       if (!callbackIsCurrent()) return ignoreStaleCallback();
-      state.robotUrdfPreviewDiagnostics = { ...state.robotUrdfPreviewDiagnostics, ...(diagnostics || {}) };
+      const authoritativeDiagnostics = diagnostics || previewResult.diagnostics || state.robotUrdfPreviewDiagnostics;
+      mergeMissingDiagnosticsInPlace(authoritativeDiagnostics, state.robotUrdfPreviewDiagnostics);
+      state.robotUrdfPreviewDiagnostics = authoritativeDiagnostics;
       state.robotUrdfPreviewDiagnostics.robot_preview_lifecycle_state = 'failed';
       state.robotUrdfPreviewDiagnostics.robotPreviewLifecycleState = 'failed';
       state.robotUrdfPreviewDiagnostics.robot_preview_failure_reason = err?.message || String(err || 'expanded URDF preview failed');
@@ -3644,8 +3659,10 @@ function loadExpandedUrdfRobotPreview(preview) {
       renderSceneSummary();
     },
   });
-  state.robotUrdfPreviewDiagnostics = { ...state.robotUrdfPreviewDiagnostics, ...(previewResult.diagnostics || {}) };
-  previewResult.diagnostics = state.robotUrdfPreviewDiagnostics;
+  if (previewResult.diagnostics && typeof previewResult.diagnostics === 'object') {
+    mergeMissingDiagnosticsInPlace(previewResult.diagnostics, diagnostics);
+    state.robotUrdfPreviewDiagnostics = previewResult.diagnostics;
+  }
   if (!previewResult.ready || typeof previewResult.ready.then !== 'function') {
     finalizeRequiredLoad('failure', {
       completion_source: 'previewResult.ready',
@@ -3655,12 +3672,13 @@ function loadExpandedUrdfRobotPreview(preview) {
     previewResult.ready.then(readyResult => {
       if (!callbackIsCurrent()) return ignoreStaleCallback('previewResult.ready');
       const terminalResult = readyResult || previewResult;
-      const terminalDiagnostics = terminalResult?.diagnostics || previewResult.diagnostics || {};
+      const terminalDiagnostics = terminalResult?.diagnostics || previewResult.diagnostics;
       state.robotPreviewResult = terminalResult;
-      state.robotUrdfPreviewDiagnostics = { ...state.robotUrdfPreviewDiagnostics, ...terminalDiagnostics };
-      const lifecycle = String(state.robotUrdfPreviewDiagnostics.robot_preview_lifecycle_state || state.robotUrdfPreviewDiagnostics.robotPreviewLifecycleState || '');
-      const ready = state.robotUrdfPreviewDiagnostics.robot_preview_loaded === true || state.robotUrdfPreviewDiagnostics.robotPreviewLoaded === true || lifecycle === 'ready';
-      if (ready && !failIfExpandedUrdfExpectedVisualSetInvalid()) {
+      if (terminalDiagnostics && typeof terminalDiagnostics === 'object') {
+        mergeMissingDiagnosticsInPlace(terminalDiagnostics, diagnostics);
+        state.robotUrdfPreviewDiagnostics = terminalDiagnostics;
+      }
+      if (rendererReady(state.robotUrdfPreviewDiagnostics) && !failIfExpandedUrdfExpectedVisualSetInvalid()) {
         finalizeRequiredLoad('success', { completion_source: 'previewResult.ready' });
       } else {
         finalizeRequiredLoad('failure', {


### PR DESCRIPTION
### Motivation
- A readiness regression occurred when `loadRobotPreview()` returned a diagnostics object that the renderer mutated asynchronously while the viewer replaced that object with a copy, causing `previewResult.ready` to resolve against a stale diagnostics snapshot and emit a spurious `scene_failed` message.
- The change preserves the renderer-owned diagnostics identity and ensures readiness finalization only when the authoritative renderer lifecycle/count state indicates a true ready condition.

### Description
- Preserve the renderer-owned diagnostics object identity by never replacing `previewResult.diagnostics` or `state.robotUrdfPreviewDiagnostics` while the renderer may still update it, and make `state.robotUrdfPreviewDiagnostics` reference the authoritative live object in-place (`workcell_studio_web/viewer/viewer.js`).
- Merge viewer-only diagnostic fields into the authoritative diagnostics object in-place via `mergeMissingDiagnosticsInPlace` instead of overwriting lifecycle or visual-count values that the renderer may update.
- Require both the renderer lifecycle (`robot_preview_lifecycle_state === 'ready'`) and `robot_preview_loaded === true` (plus the existing expected-visual validation) before finalizing required expanded-URDF readiness with `finalizeRequiredLoad('success', ...)`, and keep the idempotent finalizer, deadline, pending-key clearing and stale-callback guards intact.
- Emit richer actionable failure diagnostics (including `robot_preview_lifecycle_state`, `robot_loaded_visual_count`, `robot_expected_visual_count`, `robot_failed_visual_count`, and `pending_required_loads`) when the renderer rejects, times out, or genuinely fails required loads.
- Add/update a focused regression test that reproduces the real registration order where the renderer returns a loading result, asynchronously mutates its diagnostics, then resolves `ready`, and asserts diagnostics identity, cleared `pending_required_loads`, single `scene_ready` emission, proper rejection/timeout handling, duplicate completion protection, and stale-replacement guards (`tests/test_workcell_studio_web_viewer_static.py`).

### Testing
- Ran the focused viewer/readiness unit suite with `python3 -m pytest -q tests/test_workcell_studio_web_viewer_static.py`, which passed (`118 passed`, with three unrelated Python `SyntaxWarning` notices). 
- Ran related policy tests with `python3 -m pytest -q tests/test_workcell_builder_embedded_web3d_readiness_policy.py`, which passed (`14 passed`).
- Performed `git diff --check` and repository status verification locally; working tree clean after the change and commit message `Fix live URDF readiness diagnostics` created.
- Did not rebuild the viewer bundle in this PR; to produce the distributable bundle run: `cd workcell_studio_web/viewer && npm ci && npm run build:web3d && npm run check:stale-bundle`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a705ad3f2108331a031820c6dbf3d22)