### PR TITLE
Fix authoritative physical canvas pick resolution and diagnostics

### DIFF
--- a/tests/test_embedded_web3d_editor_bridge_static.py
+++ b/tests/test_embedded_web3d_editor_bridge_static.py
@@ -117,7 +117,7 @@ def test_product_view_selection_uses_stable_identity_and_filters_helpers():
     assert "function isExpandedUrdfInspectionPick(rendered)" in VIEWER
     assert "function isCanvasSelectableRendered(rendered)" in VIEWER
     assert "state.pickRecords.includes(rendered)" in VIEWER
-    assert "rendered.readOnlyPick === true" in VIEWER
+    assert "rendered?.authoritativePhysicalPick === true" in VIEWER
     assert "function isNormalSelectableRendered(rendered)" in VIEWER
     assert "item.selectable !== false" in VIEWER
     assert "state.debugOverlaysVisible && (isTaskOnlyHelperItem(item)" in VIEWER

--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -230,12 +230,12 @@ assert.ok(!warning.includes('[object Object]'));
 const serializedDiagnostic=JSON.parse(warning.slice('Product View canvas pick rejected: '.length));
 assert.strictEqual(serializedDiagnostic.raw_hit_count,1);
 assert.deepStrictEqual(serializedDiagnostic.hit_object_names,['rejected-stale-mesh']);
-assert.strictEqual(serializedDiagnostic.first_actionable_rejection_reason,'hit_node_excluded_from_picking');
+assert.strictEqual(serializedDiagnostic.first_actionable_rejection_reason,'hit_node_non_selectable_metadata');
 const failed=state.lastFailedCanvasPickDiagnostic;
 assert.strictEqual(failed.raw_hit_count,1);
 assert.deepStrictEqual(Array.from(failed.hit_object_names),['rejected-stale-mesh']);
 assert.strictEqual(failed.traversed_registered_identity,false);
-assert.strictEqual(failed.first_actionable_rejection_reason,'hit_node_excluded_from_picking');
+assert.strictEqual(failed.first_actionable_rejection_reason,'hit_node_non_selectable_metadata');
 assert.strictEqual(failed.nearest_known_urdf_link_ancestor,'');
 
 const staleCallback=callbacks[0];
@@ -290,8 +290,8 @@ state.objects=[ur5Owner,toolOwner,camera,table,bin];state.sceneJson={scene:{id:'
 const generatedParent=new THREE.Group();generatedParent.name='generated_robot_parent';generatedParent.userData={diagnostic_only:true,selectable:false,item:{id:'stale_generated_parent',diagnostic_only:true,selectable:false,render_policy:'diagnostic_only'}};
 const ur5Link=new THREE.Group();ur5Link.name='wrist_3_link';const ur5Mesh=new THREE.Mesh(new THREE.BoxGeometry(1,1,1));ur5Mesh.name='wrist_visual_mesh';ur5Mesh.userData={diagnostic_only:true,selectable:false,item:{id:'stale_ur5_visual',diagnostic_only:true,selectable:false,render_policy:'diagnostic_only'}};ur5Link.add(ur5Mesh);generatedParent.add(ur5Link);
 const toolLink=new THREE.Group();toolLink.name='robotiq_85_base_link';const toolMesh=new THREE.Mesh(new THREE.BoxGeometry(1,1,1));toolMesh.name='robotiq_visual_mesh';toolMesh.userData={diagnostic_only:true,selectable:false,item:{id:'stale_tool_visual',diagnostic_only:true,selectable:false,render_policy:'diagnostic_only'}};toolLink.add(toolMesh);generatedParent.add(toolLink);
-const ur5Record=registerPickRecord({id:'generated::wrist',link_name:'wrist_3_link',diagnostic_only:true,selectable:false,render_policy:'diagnostic_only'},ur5Link,generatedParent,{pickRecordSource:'payload_item',uiSelectionOwnerId:'ur5'});
-const toolRecord=registerPickRecord({id:'generated::tool',link_name:'robotiq_85_base_link',diagnostic_only:true,selectable:false,render_policy:'diagnostic_only'},toolLink,generatedParent,{pickRecordSource:'payload_item',uiSelectionOwnerId:'robotiq_85_gripper'});
+const ur5Record=registerPickRecord({id:'generated::wrist',link_name:'wrist_3_link',diagnostic_only:true,selectable:false,render_policy:'diagnostic_only'},ur5Link,generatedParent,{pickRecordSource:'payload_item',authoritativePhysicalPick:true,uiSelectionOwnerId:'ur5'});
+const toolRecord=registerPickRecord({id:'generated::tool',link_name:'robotiq_85_base_link',diagnostic_only:true,selectable:false,render_policy:'diagnostic_only'},toolLink,generatedParent,{pickRecordSource:'payload_item',authoritativePhysicalPick:true,uiSelectionOwnerId:'robotiq_85_gripper'});
 bindExpandedUrdfPickRecordToSubtree(ur5Link,ur5Record,new Set([ur5Link,toolLink]));bindExpandedUrdfPickRecordToSubtree(toolLink,toolRecord,new Set([ur5Link,toolLink]));
 const fallbackEdge=new THREE.LineSegments();fallbackEdge.name='robot_fallback_edges';
 const frustum=new THREE.LineSegments();frustum.name='realsense_overhead_fallback_sensor_frustum';frustum.userData={non_selectable:true,item:camera.item};camera.object3d.add(frustum);
@@ -1798,7 +1798,10 @@ def test_viewer_load_contract_keeps_selection_empty_until_manual_pick():
     assert "rankedPickingCandidates(hits)" in pick_body
     assert "candidates.find(candidate => Number.isFinite(candidate.priority)" in pick_body
     ranking_body = _viewer_function_body(js, "function rankedPickingCandidates(hits)", "function selectObject(id)")
-    assert "inspectionSelectionRendered" in ranking_body
+    assert "resolveCanvasPickHit(hit)" in ranking_body
+    resolution_body = _viewer_function_body(js, "function resolveCanvasPickHit(hit)", "function itemFromRaycastHit(hit)")
+    for identity in ["renderIdentity", "selectionOwner", "editOwner", "eligible", "rejectionReason"]:
+        assert identity in resolution_body
     assert "canonicalEditOwnerRendered" not in ranking_body
     assert "inspectionSelectionRendered" in select_body
     assert "selectObjectFromRender(canonicalId, selectedCandidate.rendered);" in pick_body
@@ -1863,7 +1866,7 @@ assert.strictEqual(JSON.parse(warnings[0][0].slice('Product View canvas pick rej
 assert.strictEqual(state.lastFailedCanvasPickDiagnostic.raw_hit_count,1);
 assert.strictEqual(state.lastFailedCanvasPickDiagnostic.hit_object_names[0],'unregistered-mesh');
 assert.strictEqual(state.lastFailedCanvasPickDiagnostic.traversed_registered_identity,false);
-assert.strictEqual(state.lastFailedCanvasPickDiagnostic.first_actionable_rejection_reason,'no_registered_identity_in_hit_ancestry');
+assert.strictEqual(state.lastFailedCanvasPickDiagnostic.first_actionable_rejection_reason,'no_registered_or_rendered_identity');
 assert.strictEqual(state.lastFailedCanvasPickDiagnostic.nearest_known_urdf_link_ancestor,'known_link');
 assert.strictEqual(editorState().lastFailedCanvasPickDiagnostic.rawHitCount,1);
 `, context);

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -1416,7 +1416,16 @@ function meshLocalTransformOf(item) {
 function cloneTransform(transform) { return JSON.parse(JSON.stringify(transform)); }
 function sameTransform(a, b) { return JSON.stringify(a) === JSON.stringify(b); }
 function renderedById(id) { return state.objects.find(obj => obj.item.id === id) || state.pickRecords.find(obj => obj.item.id === id); }
-function selectedRenderIdentity() { return renderedById(state.selectedRenderIdentityId) || renderedById(state.selected); }
+function selectionOwnerRenderedById(id) {
+  const matches = state.objects.filter(record => record?.item?.id === id);
+  return matches.find(record => canEditItem(record.item) && !isGeneratedUrdfItem(record.item)) ||
+    matches.find(record => !isGeneratedUrdfItem(record.item)) || matches[0] ||
+    state.pickRecords.find(record => record?.item?.id === id);
+}
+function selectedRenderIdentity() {
+  return state.pickRecords.find(record => record.authoritativePhysicalPick === true && record.item?.id === state.selectedRenderIdentityId) ||
+    renderedById(state.selectedRenderIdentityId) || renderedById(state.selected);
+}
 function registerPickRecord(item, object3d, root = object3d, options = {}) {
   if (!item?.id || !object3d) return null;
   const record = { item, object3d, pickRoot: root, readOnlyPick: true, ...options };
@@ -1448,7 +1457,7 @@ function inspectionSelectionRendered(rendered) {
   return rendered?.item?.id ? rendered : null;
 }
 function canonicalEditOwnerRendered(rendered) {
-  const selectionOwner = renderedById(explicitUiSelectionItemId(rendered));
+  const selectionOwner = selectionOwnerRenderedById(explicitUiSelectionItemId(rendered));
   if (selectionOwner && selectionOwner !== rendered && canEditItem(selectionOwner.item)) return selectionOwner;
   const derivedTarget = renderedById(derivedTransformTargetId(rendered?.item));
   return derivedTarget && canEditItem(derivedTarget.item) ? derivedTarget : inspectionSelectionRendered(rendered);
@@ -3596,6 +3605,7 @@ function loadExpandedUrdfRobotPreview(preview) {
         if (!callbackIsCurrent()) return ignoreStaleCallback();
         const record = registerPickRecord(item, linkObject, result.root || linkObject, {
           pickRecordSource: payloadItem ? 'payload_item' : 'expanded_urdf_inspection',
+          authoritativePhysicalPick: true,
           uiSelectionOwnerId: ownerId,
           uiSelectionResolution: resolution,
         });
@@ -4104,14 +4114,8 @@ function isNormalSelectableRendered(rendered) {
   return Boolean(item?.id) && item.selectable !== false && !isDiagnosticOnlyItem(item) && (inspectionSelectable || (!isTaskOnlyHelperItem(item) && !isOverlayPolicyItem(item) && !isDebugOverlayItem(item)));
 }
 function isExpandedUrdfInspectionPick(rendered) {
-  const item = rendered?.item;
-  const registeredReadOnlyRecord = Boolean(rendered && rendered.readOnlyPick === true && state.pickRecords.includes(rendered));
-  const explicitInspectionMetadata = rendered?.pickRecordSource === 'expanded_urdf_inspection' ||
-    rendered?.pickRecordSource === 'payload_item' ||
-    Boolean(String(rendered?.uiSelectionOwnerId || '').trim()) ||
-    String(item?.source_layer || '').trim() === 'expanded_urdf_inspection';
-  return registeredReadOnlyRecord && explicitInspectionMetadata && Boolean(item?.id) &&
-    rendered.object3d?.visible !== false;
+  return Boolean(rendered?.authoritativePhysicalPick === true && state.pickRecords.includes(rendered) &&
+    rendered?.item?.id && rendered.object3d?.visible !== false);
 }
 function isCanvasSelectableRendered(rendered) {
   return isExpandedUrdfInspectionPick(rendered) || isNormalSelectableRendered(rendered);
@@ -4138,38 +4142,63 @@ function intrinsicallyExcludedPickItem(item) {
   const explicitDebug = isDebugOverlayItem(item) && (item?.diagnostic_only === true || /debug|diagnostic/.test(`${sourceLayer} ${identity}`));
   return explicitDebug || (isTaskOnlyHelperItem(item) && /task|debug/.test(sourceLayer));
 }
-function itemFromRaycastHit(hit) {
+function resolveCanvasPickHit(hit) {
   let node = hit?.object || null;
   let candidate = null;
+  let registeredRecord = null;
+  let rejectionReason = 'no_registered_or_rendered_identity';
   while (node) {
     // Registration is authoritative for expanded-URDF inspection descendants.
     // Loader-provided Collada/URDF userData can contain stale diagnostic flags,
     // so consult the registry before interpreting those descendant flags.
     const registered = state.pickIdentityByObject.get(node);
-    if (intrinsicallyExcludedPickNode(node)) return null;
+    if (intrinsicallyExcludedPickNode(node)) {
+      rejectionReason = 'hit_node_intrinsically_excluded';
+      return { renderIdentity: null, selectionOwner: null, editOwner: null, eligible: false, rejectionReason, registeredRecord, hit };
+    }
     if (isExpandedUrdfInspectionPick(registered)) {
-      return registered;
+      registeredRecord = registered;
+      candidate = registered;
+      break;
     }
     // A different registered root is a nested URDF-link ownership boundary.
-    if (candidate && registered && registered !== candidate) return candidate;
+    if (candidate && registered && registered !== candidate) break;
     // Edges, frustums, and other helpers are transparent to the ordered hit
     // list, not aliases for a physical ancestor. Reject this intersection and
     // let the caller evaluate the next raycast hit (for example the camera
     // body behind its frustum).
-    if (passThroughPickNode(node)) return null;
+    if (passThroughPickNode(node)) {
+      rejectionReason = 'hit_node_non_selectable_metadata';
+      return { renderIdentity: null, selectionOwner: null, editOwner: null, eligible: false, rejectionReason, registeredRecord, hit };
+    }
     if (!candidate) {
       const nodeItem = node.userData?.item;
-      if (nodeItem && intrinsicallyExcludedPickItem(nodeItem)) return null;
+      if (nodeItem && intrinsicallyExcludedPickItem(nodeItem)) {
+        rejectionReason = 'render_item_intrinsically_excluded';
+        return { renderIdentity: null, selectionOwner: null, editOwner: null, eligible: false, rejectionReason, registeredRecord, hit };
+      }
       const item = nodeItem || registered?.item;
       if (item?.id) {
-        const rendered = renderedById(item.id) || registered;
-        if (!rendered || !isCanvasSelectableRendered(rendered)) return null;
+        const rendered = registered?.authoritativePhysicalPick === true ? registered : (renderedById(item.id) || registered);
+        if (!rendered) break;
         candidate = rendered;
       }
     }
     node = node.parent;
   }
-  return candidate;
+  const renderIdentity = candidate;
+  const ownerId = renderIdentity ? explicitUiSelectionItemId(renderIdentity) : '';
+  const selectionOwner = ownerId ? selectionOwnerRenderedById(ownerId) : null;
+  const editOwner = selectionOwner && canEditItem(selectionOwner.item) ? selectionOwner : null;
+  const explicitlyPhysical = renderIdentity?.authoritativePhysicalPick === true;
+  const eligible = Boolean(renderIdentity && (explicitlyPhysical || isCanvasSelectableRendered(selectionOwner || renderIdentity)));
+  if (!eligible) rejectionReason = renderIdentity ? 'resolved_owner_not_canvas_selectable' : rejectionReason;
+  else rejectionReason = '';
+  return { renderIdentity, selectionOwner, editOwner, eligible, rejectionReason, registeredRecord: registeredRecord || (explicitlyPhysical ? renderIdentity : null), hit };
+}
+function itemFromRaycastHit(hit) {
+  const resolved = resolveCanvasPickHit(hit);
+  return resolved.eligible ? resolved.renderIdentity : null;
 }
 function pickingPriority(rendered) {
   const item = rendered?.item;
@@ -4184,10 +4213,12 @@ function rankedPickingCandidates(hits) {
   const candidates = [];
   const seen = new Set();
   for (const hit of hits || []) {
-    const rendered = inspectionSelectionRendered(itemFromRaycastHit(hit));
-    if (!rendered?.item?.id || seen.has(rendered.item.id)) continue;
-    seen.add(rendered.item.id);
-    candidates.push({ rendered, hit, priority: pickingPriority(rendered) });
+    const resolved = resolveCanvasPickHit(hit);
+    const rendered = resolved.renderIdentity;
+    const identityKey = `${rendered?.item?.id || ''}|${resolved.selectionOwner?.item?.id || ''}`;
+    if (!rendered?.item?.id || seen.has(identityKey)) continue;
+    seen.add(identityKey);
+    candidates.push({ ...resolved, rendered, priority: pickingPriority(resolved.editOwner || resolved.selectionOwner || rendered) });
   }
   // Coincident transparent surfaces can report tiny ordering noise. Semantic
   // priority is only a tie-break within one millimetre; distance wins otherwise.
@@ -4201,10 +4232,12 @@ function failedCanvasPickDiagnostic(hits) {
   const objectNames = [];
   let traversedRegisteredIdentity = false;
   let firstActionableRejectionReason = '';
+  const hitResolutions = [];
   let nearestKnownUrdfLinkAncestor = '';
   const knownLinks = state.robotPreviewResult?.links instanceof Map ? state.robotPreviewResult.links : new Map();
   const knownLinkByNode = new Map(Array.from(knownLinks.entries()).map(([name, node]) => [node, String(name || '')]));
   for (const hit of hits || []) {
+    const resolution = resolveCanvasPickHit(hit);
     const rawName = String(hit?.object?.name || '').trim();
     if (rawName && !objectNames.includes(rawName) && objectNames.length < 12) objectNames.push(rawName);
     let node = hit?.object || null;
@@ -4212,13 +4245,19 @@ function failedCanvasPickDiagnostic(hits) {
       const registered = state.pickIdentityByObject.get(node);
       if (registered) traversedRegisteredIdentity = true;
       if (!nearestKnownUrdfLinkAncestor) nearestKnownUrdfLinkAncestor = knownLinkByNode.get(node) || String(registered?.item?.link_name || registered?.item?.link || '').trim();
-      if (!firstActionableRejectionReason) {
-        if (excludedPickNode(node)) firstActionableRejectionReason = 'hit_node_excluded_from_picking';
-        else if (registered && !registered?.item?.id) firstActionableRejectionReason = 'registered_identity_missing_item_id';
-        else if (registered && !isCanvasSelectableRendered(inspectionSelectionRendered(registered))) firstActionableRejectionReason = 'registered_identity_not_selectable';
-      }
       node = node.parent;
     }
+    if (!firstActionableRejectionReason && resolution.rejectionReason) firstActionableRejectionReason = resolution.rejectionReason;
+    hitResolutions.push({
+      hit_node_name: rawName,
+      registered_record_id: resolution.registeredRecord?.item?.id || '',
+      pick_source: resolution.registeredRecord?.pickRecordSource || '',
+      authoritative_physical_pick: resolution.registeredRecord?.authoritativePhysicalPick === true,
+      selection_owner_id: resolution.selectionOwner?.item?.id || '',
+      edit_owner_id: resolution.editOwner?.item?.id || '',
+      rejection_stage_reason: resolution.rejectionReason || '',
+      candidate_priority: pickingPriority(resolution.editOwner || resolution.selectionOwner || resolution.renderIdentity),
+    });
   }
   if (!firstActionableRejectionReason) firstActionableRejectionReason = traversedRegisteredIdentity ? 'registered_identity_rejected_by_selection_policy' : 'no_registered_identity_in_hit_ancestry';
   return {
@@ -4232,6 +4271,8 @@ function failedCanvasPickDiagnostic(hits) {
     firstActionableRejectionReason,
     nearest_known_urdf_link_ancestor: nearestKnownUrdfLinkAncestor,
     nearestKnownUrdfLinkAncestor,
+    hit_resolutions: hitResolutions,
+    hitResolutions,
   };
 }
 function selectObject(id) { return selectObjectFromRender(id, null); }
@@ -4267,7 +4308,7 @@ function selectObjectFromRender(id, renderIdentity = null) {
   const rendered = requested || renderedById(id);
   const editOwner = canonicalEditOwnerRendered(rendered);
   if (rendered) { populateInspector(editOwner || rendered); attachTransformGizmo(editOwner || rendered); refreshSelectionHighlight(rendered); } else { detachTransformGizmo(); removeSelectionHighlight(); }
-  if (previous !== (id || '')) pushEditorEvent('selection_changed', { itemId: id || '', uiItemId: explicitUiSelectionItemId(rendered), itemType: rendered ? itemType(rendered.item) : '', editable: Boolean(rendered && rendered.item && canEditItem(rendered['item'])) });
+  if (previous !== (id || '')) pushEditorEvent('selection_changed', { itemId: id || '', uiItemId: explicitUiSelectionItemId(rendered), itemType: (editOwner || rendered) ? itemType((editOwner || rendered).item) : '', editable: Boolean(editOwner && selectionIsEditable(editOwner)) });
 }
 function clearSelection() { selectObject(''); el.inspector.className = 'state empty'; el.inspector.textContent = state.objects.length ? 'Select an object from the list or canvas.' : EMPTY_SCENE_MESSAGE; }
 function pickObject(event) {
@@ -4281,7 +4322,7 @@ function pickObject(event) {
   const candidates = rankedPickingCandidates(hits);
   state.lastRaycastHitCount = hits.length;
   state.lastRaycastCandidateIds = candidates.map(candidate => candidate.rendered.item.id);
-  const selectedCandidate = candidates.find(candidate => Number.isFinite(candidate.priority) && isCanvasSelectableRendered(candidate.rendered));
+  const selectedCandidate = candidates.find(candidate => Number.isFinite(candidate.priority) && candidate.eligible);
   if (!selectedCandidate) {
     state.lastCanvasSelectedItemId = '';
     state.lastCanvasPickReason = hits.length ? 'no_eligible_candidate' : 'empty_select_click';
@@ -4306,7 +4347,7 @@ function pickObject(event) {
       pushEditorEvent('helper_pick_skipped', { helperItemId: skippedHelper.rendered.item.id, selectedItemId: selectedCandidate.rendered.item.id, sceneId: sceneId() });
     }
   }
-  const canonicalId = explicitUiSelectionItemId(selectedCandidate.rendered);
+  const canonicalId = selectedCandidate.selectionOwner?.item?.id || explicitUiSelectionItemId(selectedCandidate.rendered);
   selectObjectFromRender(canonicalId, selectedCandidate.rendered);
   state.lastCanvasSelectedItemId = canonicalId;
   state.lastCanvasPickReason = 'eligible_candidate';


### PR DESCRIPTION
### Motivation
- Resolve a production Product View bug where UR5/Robotiq/camera/table hits produced `no_eligible_candidate` despite explicit registered owners. 
- Make canvas pick eligibility and gizmo/edit ownership depend on the canonical owner registration rather than incidental rendered/generated row metadata. 
- Preserve explicit per-URDF-link physical registrations when generated `state.objects` rows share the same IDs and avoid overwriting authoritative pick records. 

### Description
- Introduced an explicit per-hit resolution API (`renderIdentity`, `selectionOwner`, `editOwner`, `eligible`, `rejectionReason`) implemented by `resolveCanvasPickHit` and used by `rankedPickingCandidates` to drive picking decisions. 
- Added `authoritativePhysicalPick` marker on expanded-URDF pick records and preserved registered records when generated `state.objects` contain same-ID rows, while keeping renderIdentity for highlighting. 
- Implemented `selectionOwnerRenderedById` to prefer authored/editable owners over same-ID generated rows and updated `selectedRenderIdentity`/selection payloads to prioritize authoritative physical registrations and canonical edit owners. 
- Expanded failed-click diagnostics to include per-hit details (node name, registered record id and source, `authoritativePhysicalPick`, resolved `selectionOwner` and `editOwner`, rejection stage/reason, and candidate priority). 
- Updated focused unit tests to exercise the real expanded-URDF registration + production `pickObject()` path and adjusted assertions to the new five-part hit-resolution contract; only source/tests were changed. 

### Testing
- Ran `pytest -q tests/test_workcell_studio_web_viewer_static.py` and received 119 passed with three pre-existing Python invalid-escape `SyntaxWarning`s. 
- Ran `pytest -q tests/test_embedded_web3d_editor_bridge_static.py` and received 20 passed. 
- Ran repository checks including `git diff --check` which reported no check failures against the working tree. 
- Not run in this PR: real display-enabled Workcell Builder click acceptance for `ur5_2f_test` because a GUI workstation was not available; bundle rebuild was intentionally not performed in this source/tests-only change and should be done after merge using `cd workcell_studio_web/viewer && npm run build:web3d` followed by `cd workcell_studio_web/viewer && npm run check:stale-bundle`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a706eb6a3a883318297ba5f2ec7f91d)