### PR TITLE
Fix authored camera and table transform gizmos

### DIFF
--- a/tests/test_embedded_web3d_editor_bridge_static.py
+++ b/tests/test_embedded_web3d_editor_bridge_static.py
@@ -25,8 +25,10 @@ def test_browser_api_reuses_existing_editor_functions_and_preserves_locks():
     for token in ["selectObject(String(id || ''))", "refreshGizmoSnap()", "undoPreviewEdit()", "redoPreviewEdit()", "resetView()", "buildEditPatch()"]:
         assert token in VIEWER
     assert "function canEditItem(item)" in VIEWER
-    assert "source.includes('generated')" in VIEWER
-    assert "item?.locked || item?.editable !== true" in VIEWER
+    assert "function editAuthorityForItem(item)" in VIEWER
+    assert "item.locked === true" in VIEWER
+    assert "item.editable !== true" in VIEWER
+    assert "active_visual_source and renderer/mesh provenance deliberately do not" in VIEWER
     assert "emitTransformCommitted(rendered)" in VIEWER
     assert "dragging-changed" in VIEWER
 
@@ -188,8 +190,45 @@ def test_selection_diagnostics_are_exposed_to_qt_bridge():
     assert "function currentSelectionDiagnostics()" in VIEWER
     assert "selectionDiagnostics: currentSelectionDiagnostics()" in VIEWER
     assert "selectionDiagnostics: () => currentSelectionDiagnostics()" in VIEWER
-    for field in ["renderIdentity", "sourceLayer", "activeVisualSource", "diagnosticOnly", "helperOrOverlay", "objectPresent"]:
+    for field in ["renderIdentity", "sourceLayer", "activeVisualSource", "diagnosticOnly", "helperOrOverlay", "objectPresent", "canonicalSelectedId", "editAuthoritySource", "gizmoAttachedTargetId", "gizmoVisible", "gizmoEnabled", "gizmoAttachmentReason"]:
         assert field in VIEWER
+
+
+def test_authored_camera_and_table_generated_visuals_attach_to_canonical_edit_owners(tmp_path):
+    harness = r"""
+const fs=require('fs'),vm=require('vm'),assert=require('assert');
+let source=fs.readFileSync(process.argv[1],'utf8').replace(/boot\(\);\s*$/,'');
+const element=()=>({hidden:false,checked:false,disabled:false,textContent:'',className:'',innerHTML:'',classList:{toggle(){}},querySelector(){return null;},querySelectorAll(){return[];},addEventListener(){},setAttribute(){},appendChild(){},getBoundingClientRect(){return {left:0,top:0,width:100,height:100}}});
+const context={console,assert,window:{location:{search:''},dispatchEvent(){},parent:{postMessage(){}}},document:{getElementById(){return element()},querySelectorAll(){return[]},createElement(){return element()}},URLSearchParams,CustomEvent:function(){},requestAnimationFrame(){},setTimeout(){},clearTimeout(){}};
+vm.createContext(context); vm.runInContext(source+`
+updateLabels=()=>{}; populateInspector=()=>{}; refreshSelectionHighlight=()=>{}; removeSelectionHighlight=()=>{}; updateDirtyState=()=>{};
+const vector=(x,y,z)=>({x,y,z,set(nx,ny,nz){this.x=nx;this.y=ny;this.z=nz}});
+const object=(name,item=null)=>({name,visible:true,userData:item?{item}:{},children:[],parent:null,position:vector(0,0,0),rotation:vector(0,0,0),scale:vector(1,1,1)});
+const owner=item=>({item,object3d:object(item.id,item),originalTransform:{pose:{xyz:{x:0,y:0,z:0},rpy:{x:0,y:0,z:0}},scale:{x:1,y:1,z:1}}});
+const camera=owner({id:'realsense_overhead',type:'realsense',role:'camera',category:'camera',editable:true,locked:false,source_layer:'editable_layout',active_visual_source:'generated_preview',render_policy:'primary'});
+const table=owner({id:'support_surface_table',type:'support_surface',role:'support_surface',category:'work_surface',editable:true,locked:false,source_layer:'editable_layout',active_visual_source:'mesh_preview',render_policy:'primary'});
+const bin=owner({id:'target_bin_default',type:'bin',role:'target_bin',editable:true,locked:false,source_layer:'editable_layout',active_visual_source:'declared_mesh',render_policy:'primary'});
+const robot=owner({id:'ur5',role:'robot',editable:false,locked:true,source_layer:'selection_owner_registry'});
+const gripper=owner({id:'robotiq_85_gripper',role:'tool',editable:false,locked:true,source_layer:'selection_owner_registry'});
+const generated=(id,refs,parent)=>{const item={id,editable:false,locked:true,source_layer:'locked_generated_urdf_visual',active_visual_source:'generated_urdf_visual',render_policy:'primary',...refs};const mesh=object(id,item);mesh.parent=parent.object3d;parent.object3d.children.push(mesh);return {item,object3d:mesh,readOnlyPick:true};};
+const cameraVisual=generated('generated_urdf::camera_link::visual_17::17',{camera_id:'realsense_overhead',type:'camera',role:'sensor'},camera);
+const tableVisual=generated('generated_urdf::table_link::visual_2::2',{support_surface_ref:'support_surface_table',type:'table',role:'support_surface'},table);
+const robotVisual=generated('generated_urdf::wrist_3_link::visual_1',{canonical_item_id:'ur5',role:'robot'},robot);
+const gripperVisual=generated('generated_urdf::robotiq_link::visual_1',{canonical_item_id:'robotiq_85_gripper',role:'tool'},gripper);
+state.objects=[camera,table,bin,robot,gripper,cameraVisual,tableVisual,robotVisual,gripperVisual];state.sceneJson={scene:{id:'ur5_2f_test'},items:state.objects.map(r=>r.item)};rebuildSelectionIdentityIndex();
+const gizmo={object:null,visible:false,enabled:false,showX:false,showY:false,showZ:false,attach(o){this.object=o},detach(){this.object=null},setMode(){},setSpace(){},setTranslationSnap(){},setRotationSnap(){},reset(){}};
+let hits=[];state.three={transformControls:gizmo,pointer:{},camera:{},controls:{enabled:true},raycaster:{setFromCamera(){},intersectObjects(){return hits}}};state.editorMode='move';
+const pick=(visual,canonical,editableObject)=>{hits=[{object:visual.object3d,distance:1}];assert.strictEqual(pickObject({clientX:5,clientY:5}),canonical);assert.strictEqual(state.selected,canonical);assert.strictEqual(editorState().selectedEditable,true);assert.strictEqual(gizmo.object,editableObject);assert.strictEqual(gizmo.visible,true);assert.strictEqual(gizmo.enabled,true);assert.strictEqual(gizmo.showX&&gizmo.showY&&gizmo.showZ,true);assert.strictEqual(currentSelectionDiagnostics().gizmoAttachedTargetId,canonical);};
+pick(cameraVisual,'realsense_overhead',camera.object3d);pick(tableVisual,'support_surface_table',table.object3d);hits=[{object:bin.object3d,distance:1}];assert.strictEqual(pickObject({clientX:5,clientY:5}),'target_bin_default');assert.strictEqual(gizmo.object,bin.object3d);
+for(const [visual,id] of [[robotVisual,'ur5'],[gripperVisual,'robotiq_85_gripper']]){hits=[{object:visual.object3d,distance:1}];assert.strictEqual(pickObject({clientX:5,clientY:5}),id);assert.strictEqual(editorState().selectedEditable,false);assert.strictEqual(gizmo.object,null);assert.strictEqual(gizmo.visible,false);}
+setEditorMode('rotate');hits=[{object:cameraVisual.object3d,distance:1}];pickObject({clientX:5,clientY:5});assert.strictEqual(gizmo.object,camera.object3d);setEditorMode('move');assert.strictEqual(gizmo.object,camera.object3d);
+const before=cloneTransform(transformFromObject(camera.object3d));camera.object3d.position.x=.04;const after=transformFromObject(camera.object3d);assert.strictEqual(markDirtyTransform(camera,after,{pushHistory:true,oldTransform:before}),true);assert.deepStrictEqual([...state.dirtyTransforms.keys()],['realsense_overhead']);assert.strictEqual(cameraVisual.object3d.parent.position.x,.04);undoPreviewEdit();assert.strictEqual(camera.object3d.position.x,0);redoPreviewEdit();assert.strictEqual(camera.object3d.position.x,.04);
+const tableBefore=cloneTransform(transformFromObject(table.object3d));table.object3d.position.y=-.03;assert.strictEqual(markDirtyTransform(table,transformFromObject(table.object3d),{pushHistory:true,oldTransform:tableBefore}),true);assert.strictEqual(tableVisual.object3d.parent.position.y,-.03);assert.strictEqual(state.dirtyTransforms.has('support_surface_table'),true);undoPreviewEdit();assert.strictEqual(table.object3d.position.y,0);redoPreviewEdit();assert.strictEqual(table.object3d.position.y,-.03);
+assert.strictEqual(state.dirtyTransforms.has(cameraVisual.item.id),false);assert.strictEqual(state.dirtyTransforms.has(tableVisual.item.id),false);
+`,context);
+"""
+    import subprocess
+    subprocess.run(["node", "-e", harness, str(ROOT / "workcell_studio_web/viewer/viewer.js")], cwd=ROOT, check=True, capture_output=True, text=True)
 
 
 def test_qt_poll_accepts_only_final_valid_browser_selection_and_explicit_clear():

--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -1973,7 +1973,7 @@ const rendered=item=>({item,object3d:{userData:{item}}});
 const authored=[{id:'realsense_overhead'},{id:'support_surface_table'},{id:'target_bin_default'},{id:'place_zone_default'},{id:'pick_zone_commissioning'}];
 const camera=rendered({id:'generated_urdf::camera_link::visual_17::17',camera_id:'realsense_overhead'});
 const table=rendered({id:'generated_urdf::table_link::visual_2::2',support_surface_ref:'support_surface_table'});
-const bin=rendered({id:'target_bin_default',editable:true});
+const bin=rendered({id:'target_bin_default',editable:true,locked:false,source_layer:'editable_layout'});
 const zone=rendered({id:'place_zone_default',target_ref:'target_bin_default',render_policy:'overlay'});
 const invalid=rendered({id:'generated_robot_visual',canonical_item_id:'missing_robot'});
 state.sceneJson={scene:{id:'ur5_2f_test'},items:authored}; state.objects=[camera,table,bin,zone,invalid,...authored.map(rendered)]; state.editorEvents=[]; state.debugOverlaysVisible=true;

--- a/tests/test_workcell_studio_web_viewer_transform_ux.py
+++ b/tests/test_workcell_studio_web_viewer_transform_ux.py
@@ -18,10 +18,10 @@ def _index_text():
 def test_viewer_has_edit_mode_guard_for_editable_and_unlocked_items():
     viewer = _viewer_text()
     assert "function canEditItem" in viewer
-    assert "item?.locked" in viewer
-    assert "item?.editable !== true" in viewer
-    assert "source.includes('generated')" in viewer
-    assert "sourceIdentity" in viewer
+    assert "item.locked === true" in viewer
+    assert "item.editable !== true" in viewer
+    assert "generated_authority_layer" in viewer
+    assert "editAuthoritySource" in viewer
     assert "active_visual_source" in viewer
     assert "Edit mode active for editable/unlocked item" in viewer
 
@@ -70,8 +70,8 @@ def test_patch_export_still_exists_and_remains_preview_only():
     assert "schema_version: EDIT_PATCH_SCHEMA_VERSION" in viewer
     assert "Preview-only browser transform edit. Source scene files were not modified." in viewer
     assert "canEditItem" in viewer
-    assert "item?.editable !== true" in viewer
-    assert "item?.locked" in viewer
+    assert "item.editable !== true" in viewer
+    assert "item.locked === true" in viewer
 
 
 def test_no_direct_yaml_write_or_browser_apply_logic_added():

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -40,7 +40,7 @@ const CAMERA_PRESET_DIRECTIONS = Object.freeze({
   top: [0, -0.001, 1],
   robot: [1.1, -1.25, 0.72],
 });
-const state = { sceneJson: null, sourceWebSceneFile: '', diagnosticKeys: new Set(), frameLookup: new Map(), resolvedFramePoses: new Map(), objects: [], pickRecords: [], pickIdentityByObject: new WeakMap(), selectionIdentityIndex: null, assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, robotUrdfPreviewDiagnostics: {}, physicalAssemblyBounds: null, finalPhysicalFitBounds: null, selected: null, selectedRenderIdentityId: '', three: {}, animationId: null, lastFrameBounds: null, initialCameraFit: { sceneKey: '', done: false, attempts: 0, pendingRetry: null, userControlled: false }, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: new Map(), undoStack: [], redoStack: [], gizmoDragStart: null, directMoveDrag: null, directRotateDrag: null, editorMode: 'select', editorEvents: [], editorError: '', robotPreviewResult: null, lastRaycastHitCount: 0, lastRaycastCandidateIds: [], lastCanvasSelectedItemId: '', lastCanvasPickReason: '', lastFailedCanvasPickDiagnostic: null, initialPosePreview: { active: false, robotId: '', sceneKey: '' }, web3dReadiness: { state: 'booting', terminal: false, terminalState: '', terminalNavigationKey: '', terminalEmissionCount: 0, statusSequence: 0, required: {}, pending: new Set(), failed: false, failure: null }, builderRevision: '', sceneJsonLoaded: false, activeNavigationKey: '' };
+const state = { sceneJson: null, sourceWebSceneFile: '', diagnosticKeys: new Set(), frameLookup: new Map(), resolvedFramePoses: new Map(), objects: [], pickRecords: [], pickIdentityByObject: new WeakMap(), selectionIdentityIndex: null, assemblyRoots: [], robotAssemblyDiagnostics: [], robotAssemblyRenderDiagnostics: {}, robotUrdfPreviewDiagnostics: {}, physicalAssemblyBounds: null, finalPhysicalFitBounds: null, selected: null, selectedRenderIdentityId: '', three: {}, animationId: null, lastFrameBounds: null, initialCameraFit: { sceneKey: '', done: false, attempts: 0, pendingRetry: null, userControlled: false }, runtimeWarnings: [], labelsVisible: false, debugOverlaysVisible: false, dirtyTransforms: new Map(), undoStack: [], redoStack: [], gizmoDragStart: null, gizmoAttachmentDiagnostic: { targetId: '', reason: 'not_evaluated' }, directMoveDrag: null, directRotateDrag: null, editorMode: 'select', editorEvents: [], editorError: '', robotPreviewResult: null, lastRaycastHitCount: 0, lastRaycastCandidateIds: [], lastCanvasSelectedItemId: '', lastCanvasPickReason: '', lastFailedCanvasPickDiagnostic: null, initialPosePreview: { active: false, robotId: '', sceneKey: '' }, web3dReadiness: { state: 'booting', terminal: false, terminalState: '', terminalNavigationKey: '', terminalEmissionCount: 0, statusSequence: 0, required: {}, pending: new Set(), failed: false, failure: null }, builderRevision: '', sceneJsonLoaded: false, activeNavigationKey: '' };
 let robotPreviewLoadToken = 0;
 let physicalLoadToken = 0;
 const RESET_VIEW_TITLE = 'Fit Scene / Reset View: recomputes and reapplies the fitted workcell overview from renderable bounds.';
@@ -1227,6 +1227,12 @@ function currentSelectionDiagnostics() {
     selectedItemId: id,
     uiSelectionItemId: selectionIdentity.id,
     editOwnerItemId: editOwner?.item?.id || '',
+    canonicalSelectedId: id,
+    editAuthoritySource: editAuthoritySource(editOwner?.item),
+    gizmoAttachedTargetId: state.three?.transformControls?.object === editOwner?.object3d ? (editOwner?.item?.id || '') : (state.gizmoAttachmentDiagnostic?.targetId || ''),
+    gizmoVisible: Boolean(state.three?.transformControls?.visible),
+    gizmoEnabled: Boolean(state.three?.transformControls?.enabled),
+    gizmoAttachmentReason: state.gizmoAttachmentDiagnostic?.reason || 'not_evaluated',
     renderIdentity: rendered?.item?.id || '',
     selectedItemType: rendered ? itemType(item) : '',
     selectable: Boolean(rendered && isCanvasSelectableRendered(rendered)),
@@ -1501,7 +1507,7 @@ function canonicalEditOwnerRendered(rendered) {
 // canonicalSelectionRendered intentionally retired: inspection identity must
 // never be rewritten to the transform owner.
 function selectionIsEditable(rendered) {
-  return Boolean(rendered && !rendered.readOnlyPick && canonicalEditOwnerRendered(rendered) === rendered && canEditItem(rendered.item));
+  return Boolean(rendered && !rendered.readOnlyPick && !isTaskOnlyHelperItem(rendered.item) && !isDebugOverlayItem(rendered.item) && canonicalEditOwnerRendered(rendered) === rendered && canEditItem(rendered.item));
 }
 function transformFromObject(object) {
   return { pose: { xyz: { x: object.position.x, y: object.position.y, z: object.position.z }, rpy: { x: object.rotation.x, y: object.rotation.y, z: object.rotation.z } }, scale: { x: object.scale.x, y: object.scale.y, z: object.scale.z } };
@@ -4477,7 +4483,7 @@ function cancelDirectRotateDrag(message) {
 
 function attachTransformGizmo(rendered) {
   const gizmo = state.three.transformControls;
-  if (!gizmo) return;
+  if (!gizmo) { state.gizmoAttachmentDiagnostic = { targetId: '', reason: 'transform_controls_unavailable' }; return; }
   if (selectionIsEditable(rendered)) {
     gizmo.attach(rendered.object3d);
     gizmo.visible = true;
@@ -4487,10 +4493,18 @@ function attachTransformGizmo(rendered) {
     gizmo.enabled = state.editorMode !== 'select';
     gizmo.setTranslationSnap(el.snapToggle?.checked ? translationSnapValue() : null);
     gizmo.setRotationSnap(el.snapToggle?.checked ? rotationSnapRadians() : null);
-  } else detachTransformGizmo();
+    state.gizmoAttachmentDiagnostic = { targetId: rendered.item.id, reason: 'attached_to_canonical_edit_owner' };
+  } else {
+    const authority = editAuthorityForItem(rendered?.item);
+    const refusal = rendered && (isTaskOnlyHelperItem(rendered.item) || isDebugOverlayItem(rendered.item))
+      ? 'helper_or_overlay_record'
+      : (rendered?.readOnlyPick ? 'read_only_render_identity' : (authority.eligible ? 'not_canonical_edit_owner' : authority.reason));
+    detachTransformGizmo(refusal);
+  }
 }
-function detachTransformGizmo() {
+function detachTransformGizmo(reason = 'detached') {
   const gizmo = state.three.transformControls;
+  state.gizmoAttachmentDiagnostic = { targetId: '', reason };
   if (!gizmo) return;
   gizmo.detach();
   gizmo.visible = false;
@@ -4502,14 +4516,25 @@ function refreshGizmoSnap() {
   gizmo.setTranslationSnap(el.snapToggle?.checked ? translationSnapValue() : null);
   gizmo.setRotationSnap(el.snapToggle?.checked ? rotationSnapRadians() : null);
 }
+function editAuthoritySource(item) {
+  return String(item?.source_layer || item?.authoring_source_layer || item?.render_owner || item?.source_kind || '').trim();
+}
+function editAuthorityForItem(item) {
+  if (!item) return { eligible: false, source: '', reason: 'missing_item' };
+  if (item.locked === true) return { eligible: false, source: editAuthoritySource(item), reason: 'owner_locked' };
+  if (item.editable !== true) return { eligible: false, source: editAuthoritySource(item), reason: 'owner_not_editable' };
+  if (isDiagnosticOnlyItem(item)) return { eligible: false, source: editAuthoritySource(item), reason: 'diagnostic_record' };
+  const source = editAuthoritySource(item);
+  const normalizedSource = source.toLowerCase();
+  const authoredSource = /(?:^|[_\s-])(?:editable|authored|authoring|layout)(?:$|[_\s-])/.test(normalizedSource);
+  if (!authoredSource) return { eligible: false, source, reason: normalizedSource.includes('generated') ? 'generated_authority_layer' : 'non_authored_authority_layer' };
+  // active_visual_source and renderer/mesh provenance deliberately do not
+  // participate here: they describe how an authored owner is drawn, not who
+  // owns its transform.
+  return { eligible: true, source, reason: 'authored_edit_authority' };
+}
 function canEditItem(item) {
-  if (isDiagnosticOnlyItem(item)) return false;
-  const sourceIdentity = [item?.source_kind, item?.source_layer, item?.active_visual_source, item?.role, item?.category]
-    .map(value => String(value || '').toLowerCase())
-    .join(' ');
-  const source = sourceIdentity;
-  if (item?.locked || item?.editable !== true || source.includes('generated')) return false;
-  return true;
+  return editAuthorityForItem(item).eligible;
 }
 function currentTransformFromInputs(container) {
   const get = name => Number(container.querySelector(`[data-transform-field="${name}"]`)?.value);


### PR DESCRIPTION
### Motivation
- Restore edit/gizmo eligibility for authored camera and support table items in `ur5_2f_test` by separating authoring/edit authority from visual provenance so authored owners with generated visuals remain editable. 
- Ensure canonical transform ownership, dirty tracking, and undo/redo operate on authored owners while preserving protections for generated visuals, diagnostic overlays, and robot/tool read-only owners. 
- Close the PR2 blocker for the M1 authoring round-trip: let overhead camera and support table resolve to their authored editable owners and attach TransformControls consistently.

### Description
- Implement an explicit edit-authority check (`editAuthorityForItem` / `editAuthoritySource`) that uses authored source layers (`source_layer`, `authoring_source_layer`, `render_owner`, fallback `source_kind`) and does not treat `active_visual_source`/renderer/mesh provenance as authority. 
- Replace the old `canEditItem` content-based test with `editAuthorityForItem(...).eligible` and update `selectionIsEditable` to exclude helper/overlay/diagnostic records before evaluating canonical edit ownership. 
- Change `attachTransformGizmo`/`detachTransformGizmo` to attach `TransformControls` to the canonical authored edit owner (when eligible) and record a machine-readable attach/refusal diagnostic (`state.gizmoAttachmentDiagnostic`) with `targetId` and `reason`. 
- Add selection diagnostics fields exposed to the embedded API: `canonicalSelectedId`, `editAuthoritySource`, `gizmoAttachedTargetId`, `gizmoVisible`, `gizmoEnabled`, and `gizmoAttachmentReason`. 
- Add / update focused browser harness tests that exercise production-shaped `ur5_2f_test` cases so generated camera/table visuals resolve to `realsense_overhead` and `support_surface_table` authored owners, verify gizmo attach/detach, assert UR5 and Robotiq remain read-only, and confirm transform application, dirty ownership, undo and redo operate on the authored owners. 
- Only viewer source and tests were modified; no YAML/exporter/Qt/C++/runtime/launch/build artifacts were changed.

### Testing
- Ran focused viewer test suites in CI: `pytest -q tests/test_embedded_web3d_editor_bridge_static.py` — 21 passed. 
- Ran full viewer static tests: `pytest -q tests/test_workcell_studio_web_viewer_static.py` — 119 passed (3 pre-existing Python invalid-escape warnings only). 
- Ran UX/static transform tests: `pytest -q tests/test_workcell_studio_web_viewer_transform_ux.py` — all relevant assertions passed. 
- Ran `git diff --check` with no errors. 
- Ran `cd workcell_studio_web/viewer && npm run check:stale-bundle` which correctly reports the committed dist bundle is stale because this PR intentionally updates readable source and tests only; a bundle rebuild is expected after merge. 

Bundle rebuild commands (post-merge):
- `cd workcell_studio_web/viewer && npm ci && npm run build:web3d && npm run check:stale-bundle`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7086b7f5dc833185614c0116188f89)