### PR TITLE
Keep OrbitControls synchronized with editor mode

### DIFF
--- a/tests/test_embedded_web3d_editor_bridge_static.py
+++ b/tests/test_embedded_web3d_editor_bridge_static.py
@@ -72,9 +72,53 @@ def test_authoring_mode_round_trip_cleanup_and_selection_preservation():
     assert "cancelDirectRotateDrag('Rotation cancelled')" in mode_body
     assert "gizmo.reset?.()" in mode_body
     assert "gizmo.detach()" in mode_body
-    assert "state.three.controls.enabled = true" in mode_body
+    assert "syncOrbitControlsForEditorMode()" in mode_body
     assert "state.selected =" not in mode_body
     assert "return state.editorMode" in mode_body
+
+
+def test_orbit_controls_follow_editor_mode_across_drags_and_scene_replacement():
+    import subprocess
+
+    harness = r"""
+const fs=require('fs'),vm=require('vm'),assert=require('assert');
+let source=fs.readFileSync(process.argv[1],'utf8').replace(/boot\(\);\s*$/,'');
+const element=()=>({hidden:false,checked:false,disabled:false,textContent:'',className:'',innerHTML:'',dataset:{},classList:{add(){},remove(){},toggle(){}},querySelector(){return null},querySelectorAll(){return[]},addEventListener(){},setAttribute(){},appendChild(){},remove(){},getBoundingClientRect(){return {left:0,top:0,width:100,height:100}},setPointerCapture(){},releasePointerCapture(){}});
+const context={console,assert,process,window:{location:{search:''},dispatchEvent(){},parent:{postMessage(){}},addEventListener(){}},document:{getElementById(){return element()},querySelectorAll(){return[]},createElement(){return element()}},URLSearchParams,CustomEvent:function(){},requestAnimationFrame(){},setTimeout(){},clearTimeout(){}};
+vm.createContext(context);
+vm.runInContext(source+`
+(async()=>{
+const copy=value=>JSON.parse(JSON.stringify(value));
+const start={pose:{xyz:{x:0,y:0,z:0},rpy:{r:0,p:0,y:0}},scale:{x:1,y:1,z:1}};
+const rendered={item:{id:'editable',editable:true,locked:false,display_name:'Editable'},object3d:{}};
+state.objects=[rendered]; state.selected='editable'; state.three={controls:{enabled:true},transformControls:null,pointer:{},raycaster:{}};
+cloneTransform=copy; transformFromObject=()=>copy(start); pointerToWorldPlane=()=>({x:0,y:0,z:0}); selectionIsEditable=value=>value===rendered; renderedById=id=>id==='editable'?rendered:null; captureTransformGroup=()=>new Map([['editable',copy(start)]]); applyTransformChanges=()=>{}; syncInspectorTransformFields=()=>{}; linkedTransformChanges=()=>[]; markDirtyTransform=()=>true; emitTransformCommitted=()=>{}; pushEditorEvent=()=>{}; showError=message=>{throw new Error(message)}; updateLabels=()=>{}; attachTransformGizmo=()=>{}; canonicalTransformOwner=()=>rendered; detachTransformGizmo=()=>{}; applyTransformToObject=()=>{}; sameTransform=()=>false; snapTransform=value=>copy(value); isFiniteTransform=()=>true;
+const pointer={pointerId:7,clientX:5,clientY:5,preventDefault(){},stopPropagation(){}};
+
+setEditorMode('move'); assert.strictEqual(state.three.controls.enabled,false,'Move must disable orbit before translation');
+assert(beginDirectMoveDrag(pointer,rendered)); assert.strictEqual(state.three.controls.enabled,false,'Move must disable orbit during translation');
+finishDirectMoveDrag(pointer); assert.strictEqual(state.three.controls.enabled,false,'translation completion must preserve Move orbit state');
+beginDirectMoveDrag(pointer,rendered); cancelDirectMoveDrag(); assert.strictEqual(state.three.controls.enabled,false,'translation cancellation must preserve Move orbit state');
+beginDirectMoveDrag(pointer,rendered); onCanvasPointerCancel(); assert.strictEqual(state.three.controls.enabled,false,'pointercancel must preserve Move orbit state');
+beginDirectMoveDrag(pointer,rendered); onEditorKeyDown({key:'Escape'}); assert.strictEqual(state.three.controls.enabled,false,'Escape must preserve Move orbit state');
+
+setEditorMode('rotate'); assert.strictEqual(state.three.controls.enabled,false,'Rotate must disable orbit before rotation');
+assert(beginDirectRotateDrag(rendered)); assert.strictEqual(state.three.controls.enabled,false,'Rotate must disable orbit during rotation');
+finishDirectRotateDrag(rendered); assert.strictEqual(state.three.controls.enabled,false,'rotation completion must preserve Rotate orbit state');
+beginDirectRotateDrag(rendered); cancelDirectRotateDrag(); assert.strictEqual(state.three.controls.enabled,false,'rotation cancellation must preserve Rotate orbit state');
+
+validateSceneJson=()=>[]; renderScene=()=>{}; refreshWarnings=()=>{}; renderSceneSummary=()=>{}; beginInitialCameraFitForCurrentScene=()=>{}; emitWeb3dReadinessState=()=>{}; clearError=()=>{};
+state.three.controls={enabled:true}; await loadFile({name:'replacement.json',text:async()=>'{"scene_id":"replacement"}'}); assert.strictEqual(state.three.controls.enabled,false,'scene replacement must preserve Rotate orbit state');
+setEditorMode('move'); state.three.controls={enabled:true}; syncOrbitControlsForEditorMode(); assert.strictEqual(state.three.controls.enabled,false,'new OrbitControls must inherit Move mode');
+setEditorMode('rotate'); state.three.controls={enabled:true}; syncOrbitControlsForEditorMode(); assert.strictEqual(state.three.controls.enabled,false,'new OrbitControls must inherit Rotate mode');
+setEditorMode('select'); assert.strictEqual(state.three.controls.enabled,true,'Select must restore orbit controls');
+})().catch(error=>{console.error(error);process.exitCode=1});
+`,context);
+"""
+    subprocess.run(
+        ["node", "-e", harness, str(ROOT / "workcell_studio_web/viewer/viewer.js")],
+        cwd=ROOT, check=True, capture_output=True, text=True,
+    )
 
 
 def test_browser_mode_state_synchronizes_all_qt_controls_without_stale_callbacks():

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -2862,7 +2862,7 @@ function initThree() {
     transformControls.setMode('translate');
     transformControls.setSpace('world');
     transformControls.addEventListener('dragging-changed', event => {
-      if (state.editorMode !== 'rotate') controls.enabled = !event.value;
+      syncOrbitControlsForEditorMode();
       const rendered = canonicalTransformOwner(state.selected);
       if (!rendered || !canEditItem(rendered.item)) return;
       if (state.gizmoPivot?.owner === rendered && transformControls.object === state.gizmoPivot.group) {
@@ -2891,13 +2891,14 @@ function initThree() {
     controls.addEventListener('start', markCameraUserControlled);
     scene.add(transformControls);
     state.three = { renderer, scene, camera, controls, transformControls, raycaster: new THREE.Raycaster(), pointer: new THREE.Vector2() };
+    syncOrbitControlsForEditorMode();
     resize();
     window.addEventListener('resize', resize);
     el.canvas.addEventListener('pointerdown', onCanvasPointerDown);
     el.canvas.addEventListener('pointermove', onCanvasPointerMove);
     el.canvas.addEventListener('pointerup', onCanvasPointerUp);
-    el.canvas.addEventListener('pointercancel', () => { cancelDirectMoveDrag('Move cancelled'); cancelDirectRotateDrag('Rotation cancelled'); });
-    window.addEventListener('keydown', event => { if (event.key === 'Escape') { cancelDirectMoveDrag('Move cancelled'); cancelDirectRotateDrag('Rotation cancelled'); } });
+    el.canvas.addEventListener('pointercancel', onCanvasPointerCancel);
+    window.addEventListener('keydown', onEditorKeyDown);
     animate();
   } catch (err) {
     showError(`Bundled Three.js module load failure: ${err.message || err}`);
@@ -4543,14 +4544,17 @@ function pickObject(event) {
 
 function pointerToWorldPlane(event, z) { const rect = el.canvas.getBoundingClientRect(); if (!rect.width || !rect.height) return null; state.three.pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1; state.three.pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1; state.three.raycaster.setFromCamera(state.three.pointer, state.three.camera); const plane = new THREE.Plane(new THREE.Vector3(0, 0, 1), -z); const hit = new THREE.Vector3(); if (!state.three.raycaster.ray.intersectPlane(plane, hit)) return null; return Number.isFinite(hit.x) && Number.isFinite(hit.y) && Number.isFinite(hit.z) ? hit : null; }
 function snapHorizontalPreview(transform) { const snapped = snapTransform(transform, { translationAxes: ['x', 'y'], rotationAxes: [] }); snapped.pose.xyz.z = transform.pose.xyz.z; return snapped; }
-function beginDirectMoveDrag(event, rendered) { if (state.editorMode !== 'move' || !selectionIsEditable(rendered)) return false; const start = cloneTransform(state.dirtyTransforms.get(rendered.item.id)?.newTransform || transformFromObject(rendered.object3d)); const hit = pointerToWorldPlane(event, start.pose.xyz.z); if (!hit) return false; const controls = state.three.controls; state.directMoveDrag = { itemId: rendered.item.id, start, groupStart: captureTransformGroup(rendered), last: cloneTransform(start), offset: { x: start.pose.xyz.x - hit.x, y: start.pose.xyz.y - hit.y }, controlsWasEnabled: controls ? controls.enabled : true }; if (controls) controls.enabled = false; el.canvas.setPointerCapture?.(event.pointerId); el.canvas.classList.add('direct-move-dragging'); event.preventDefault(); event.stopPropagation(); return true; }
+function syncOrbitControlsForEditorMode() { if (state.three.controls) state.three.controls.enabled = state.editorMode === 'select'; }
+function beginDirectMoveDrag(event, rendered) { if (state.editorMode !== 'move' || !selectionIsEditable(rendered)) return false; const start = cloneTransform(state.dirtyTransforms.get(rendered.item.id)?.newTransform || transformFromObject(rendered.object3d)); const hit = pointerToWorldPlane(event, start.pose.xyz.z); if (!hit) return false; state.directMoveDrag = { itemId: rendered.item.id, start, groupStart: captureTransformGroup(rendered), last: cloneTransform(start), offset: { x: start.pose.xyz.x - hit.x, y: start.pose.xyz.y - hit.y } }; syncOrbitControlsForEditorMode(); el.canvas.setPointerCapture?.(event.pointerId); el.canvas.classList.add('direct-move-dragging'); event.preventDefault(); event.stopPropagation(); return true; }
 function updateDirectMoveDrag(event) { const drag = state.directMoveDrag; if (!drag) return false; const rendered = renderedById(drag.itemId); if (!rendered || state.selected !== drag.itemId || !selectionIsEditable(rendered)) return cancelDirectMoveDrag('Move cancelled'), true; const hit = pointerToWorldPlane(event, drag.start.pose.xyz.z); if (!hit) return true; const next = cloneTransform(drag.start); next.pose.xyz.x = hit.x + drag.offset.x; next.pose.xyz.y = hit.y + drag.offset.y; next.pose.xyz.z = drag.start.pose.xyz.z; const preview = snapHorizontalPreview(next); if (!isFiniteTransform(preview)) return true; drag.last = cloneTransform(preview); applyTransformChanges(linkedTransformChanges(rendered, drag.start, preview, drag.groupStart)); syncInspectorTransformFields(rendered); event.preventDefault(); event.stopPropagation(); return true; }
 function finishDirectMoveDrag(event) { const drag = state.directMoveDrag; if (!drag) return false; const rendered = renderedById(drag.itemId); const finalTransform = cloneTransform(drag.last); endDirectMoveDrag(event); if (!selectionIsEditable(rendered) || !isFiniteTransform(finalTransform)) return false; if (sameTransform(drag.start, finalTransform)) { applyTransformChanges([...drag.groupStart].map(([itemId, after]) => ({ rendered: renderedById(itemId), after }))); syncInspectorTransformFields(rendered); return true; } const committed = markDirtyTransform(rendered, finalTransform, { pushHistory: true, oldTransform: drag.start, memberStarts: drag.groupStart }); if (!committed) { applyTransformChanges([...drag.groupStart].map(([itemId, after]) => ({ rendered: renderedById(itemId), after }))); showError(`Move failed for ${itemLabel(rendered.item)}: final transform was rejected by the editor bridge.`); return true; } emitTransformCommitted(rendered); pushEditorEvent('status', { message: `Moved ${itemLabel(rendered.item)}` }); return true; }
-function endDirectMoveDrag(event) { const drag = state.directMoveDrag; state.directMoveDrag = null; if (state.three.controls) state.three.controls.enabled = drag ? drag.controlsWasEnabled : state.three.controls.enabled; el.canvas.classList.remove('direct-move-dragging'); if (event?.pointerId !== undefined) el.canvas.releasePointerCapture?.(event.pointerId); }
+function endDirectMoveDrag(event) { state.directMoveDrag = null; syncOrbitControlsForEditorMode(); el.canvas.classList.remove('direct-move-dragging'); if (event?.pointerId !== undefined) el.canvas.releasePointerCapture?.(event.pointerId); }
 function cancelDirectMoveDrag(message) { const drag = state.directMoveDrag; if (!drag) return false; const rendered = renderedById(drag.itemId); if (rendered) { applyTransformChanges([...drag.groupStart].map(([itemId, after]) => ({ rendered: renderedById(itemId), after }))); syncInspectorTransformFields(rendered); } endDirectMoveDrag(); pushEditorEvent('status', { message: message || 'Move cancelled' }); return true; }
 function onCanvasPointerDown(event) { const hitId = pickObject(event); const rendered = hitId ? renderedById(hitId) : null; if (beginDirectMoveDrag(event, rendered)) return; }
 function onCanvasPointerMove(event) { updateDirectMoveDrag(event); }
 function onCanvasPointerUp(event) { finishDirectMoveDrag(event); }
+function onCanvasPointerCancel() { cancelDirectMoveDrag('Move cancelled'); cancelDirectRotateDrag('Rotation cancelled'); syncOrbitControlsForEditorMode(); }
+function onEditorKeyDown(event) { if (event.key !== 'Escape') return; cancelDirectMoveDrag('Move cancelled'); cancelDirectRotateDrag('Rotation cancelled'); syncOrbitControlsForEditorMode(); }
 
 function directRotatePreviewTransform(rendered) {
   const drag = state.directRotateDrag;
@@ -4561,10 +4565,9 @@ function directRotatePreviewTransform(rendered) {
 }
 function beginDirectRotateDrag(rendered) {
   if (state.editorMode !== 'rotate' || !selectionIsEditable(rendered)) return false;
-  const controls = state.three.controls;
   const start = cloneTransform(state.dirtyTransforms.get(rendered.item.id)?.newTransform || transformFromObject(rendered.object3d));
-  state.directRotateDrag = { itemId: rendered.item.id, start, groupStart: captureTransformGroup(rendered), last: cloneTransform(start), controlsWasEnabled: controls ? controls.enabled : true };
-  if (controls) controls.enabled = false;
+  state.directRotateDrag = { itemId: rendered.item.id, start, groupStart: captureTransformGroup(rendered), last: cloneTransform(start) };
+  syncOrbitControlsForEditorMode();
   return true;
 }
 function previewDirectRotateDrag(rendered) {
@@ -4591,8 +4594,8 @@ function finishDirectRotateDrag(rendered) {
   return true;
 }
 function endDirectRotateDrag() {
-  const drag = state.directRotateDrag; state.directRotateDrag = null;
-  if (state.three.controls) state.three.controls.enabled = drag ? drag.controlsWasEnabled : state.three.controls.enabled;
+  state.directRotateDrag = null;
+  syncOrbitControlsForEditorMode();
 }
 function cancelDirectRotateDrag(message) {
   const drag = state.directRotateDrag; if (!drag) return false;
@@ -4966,6 +4969,7 @@ async function loadFile(file) {
     el.empty.hidden = true;
     if (items.length) renderScene(items);
     else renderScene([]);
+    syncOrbitControlsForEditorMode();
     refreshWarnings(json);
     renderSceneSummary();
     el.inspector.className = 'state empty';
@@ -5039,6 +5043,7 @@ async function loadSceneUrl(rawUrl) {
     detachTransformGizmo();
     el.empty.hidden = true;
     renderScene(items);
+    syncOrbitControlsForEditorMode();
     refreshWarnings(json);
     renderSceneSummary();
     el.inspector.className = 'state empty';
@@ -5074,6 +5079,7 @@ function setEditorMode(mode) {
     cancelDirectRotateDrag('Rotation cancelled');
   }
   state.editorMode = normalized;
+  syncOrbitControlsForEditorMode();
   const gizmo = state.three.transformControls;
   if (gizmo) {
     if (normalized === 'move') { gizmo.setMode('translate'); gizmo.setSpace('world'); gizmo.showX = true; gizmo.showY = true; gizmo.showZ = true; gizmo.enabled = true; }
@@ -5087,7 +5093,6 @@ function setEditorMode(mode) {
       state.gizmoDragGroupStart = null;
     }
   }
-  if (normalized === 'select' && state.three.controls) state.three.controls.enabled = true;
   if (normalized !== 'select') attachTransformGizmo(canonicalTransformOwner(state.selected), 'mode_change');
   return state.editorMode;
 }


### PR DESCRIPTION
### Motivation
- Milestone / blocker: M1 — ensure authoring UX correctness by preventing the camera orbit from being re-enabled while an operator is actively authoring Move or Rotate transforms.
- The viewer previously captured and restored `controls.enabled` per-drag which could re-enable orbit at the end of a Move/Rotate session contrary to the active `state.editorMode`.

### Description
- Introduced `syncOrbitControlsForEditorMode()` and centralized OrbitControls enablement so OrbitControls are enabled only when `state.editorMode === 'select'` and disabled for `move`/`rotate`.
- Replaced per-drag capture/restore (`controlsWasEnabled`) with calls to `syncOrbitControlsForEditorMode()` in direct-move/rotate begin/finish/cancel paths, TransformControls `dragging-changed` handling, pointer-cancel and Escape handlers, scene load/replace, and viewer initialization.
- Replaced inline `pointercancel`/Escape closures with `onCanvasPointerCancel` and `onEditorKeyDown` helpers that cancel drags and re-sync controls.
- Extended `tests/test_embedded_web3d_editor_bridge_static.py` with an executable Node-based viewer harness `test_orbit_controls_follow_editor_mode_across_drags_and_scene_replacement()` that asserts OrbitControls are disabled/enabled before, during, and after move/rotate drags, on completion/cancellation/pointercancel/Escape, across scene replacement, and that returning to `select` restores OrbitControls.

### Testing
- Ran `pytest -q tests/test_embedded_web3d_editor_bridge_static.py`, which executed the new harness and returned all tests passing (`22 passed`).
- The added assertions exercise the Node viewer harness paths for Move/Rotate lifecycle, pointercancel, Escape, scene replacement/reinitialization, and Select restoration, and they all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71c2f3bf2c833192faa7cb2bb0f5ae)