### PR TITLE
Fix generated workbench root scale ownership

### DIFF
--- a/scripts/export_workcell_studio_web_scene.py
+++ b/scripts/export_workcell_studio_web_scene.py
@@ -1535,7 +1535,12 @@ def _annotate_owner_relative_physical_visual_transforms(
             relative_pose = _parent_to_child_pose(owner_world_pose, visual_world_pose)
             if relative_pose is None:
                 continue
-            relative_pose["scale"] = copy.deepcopy(item.get("scale") or [1.0, 1.0, 1.0])
+            # This is the transform of the generated item root in its authored
+            # owner's coordinate system.  URDF mesh/unit scale belongs below
+            # that root and is applied by the viewer's mesh-local scale path.
+            # Copying item.scale here would make reparenting apply mesh scale a
+            # second time (notably the workbench STL's millimetre conversion).
+            relative_pose["scale"] = [1.0, 1.0, 1.0]
             item["owner_relative_visual_transform"] = relative_pose
             item.setdefault("provenance", {})["owner_relative_visual_transform"] = {
                 "operation": "inverse(source_physical_owner_world_pose)_times_generated_visual_world_pose",

--- a/tests/test_workcell_builder_embedded_web3d_save_roundtrip.py
+++ b/tests/test_workcell_builder_embedded_web3d_save_roundtrip.py
@@ -24,20 +24,33 @@ def _run_production_owner_binding_assertions(web_scene: Path, owner_id: str, exp
 const fs=require('fs'),vm=require('vm'),assert=require('assert');
 let source=fs.readFileSync(process.argv[1],'utf8').replace(/boot\(\);\s*$/,'');
 const THREE_IMPL=require('./workcell_studio_web/viewer/node_modules/three/build/three.cjs');
-const payload=JSON.parse(fs.readFileSync(process.argv[2],'utf8')),ownerId=process.argv[3],expectDelta=process.argv[4]==='true';
+const payload=JSON.parse(fs.readFileSync(process.argv[2],'utf8')),ownerId=process.argv[3],expectDelta=process.argv[4]==='true',tableStl=process.argv[5];
 const element=()=>({hidden:false,checked:false,disabled:false,textContent:'',innerHTML:'',classList:{toggle(){}},querySelector(){return null},querySelectorAll(){return[]},addEventListener(){},setAttribute(){},appendChild(){},remove(){}});
-const context={console,assert,THREE_IMPL,payload,ownerId,expectDelta,window:{location:{search:''},dispatchEvent(){},parent:{postMessage(){}}},document:{getElementById(){return element()},createElement(){return element()}},URLSearchParams,CustomEvent:function(){},requestAnimationFrame(){},setTimeout(){},clearTimeout(){}};
+const context={console,assert,fs,THREE_IMPL,payload,ownerId,expectDelta,tableStl,window:{location:{search:''},dispatchEvent(){},parent:{postMessage(){}}},document:{getElementById(){return element()},createElement(){return element()}},URLSearchParams,CustomEvent:function(){},requestAnimationFrame(){},setTimeout(){},clearTimeout(){}};
 vm.createContext(context);vm.runInContext(source+`
 THREE=THREE_IMPL;createLabelElement=()=>null;state.sceneJson=payload;state.three.scene=new THREE.Scene();state.objects=[];state.physicalEditBindings=new Map();rebuildSelectionIdentityIndex(payload);
 const visual=[...asArray(payload.sensors),...asArray(payload.assets)].find(item=>(item.camera_id===ownerId||item.support_surface_ref===ownerId)&&item.owner_relative_visual_transform);
-assert(visual,'generated physical visual missing');const root=new THREE.Group();applyTransformToObject(root,transformOf(visual));state.three.scene.add(root);const rendered={item:visual,object3d:root,meshObject:new THREE.Group(),originalTransform:transformOf(visual)};root.add(rendered.meshObject);state.objects.push(rendered);
+assert(visual,'generated physical visual missing');const root=new THREE.Group();applyTransformToObject(root,transformOf(visual));state.three.scene.add(root);let meshObject=new THREE.Group();
+if(ownerId==='support_surface_table'){
+  assert.strictEqual(JSON.stringify(visual.scale),'[0.001,0.001,0.001]','production workbench must retain its URDF mesh-unit scale');
+  const bytes=fs.readFileSync(tableStl),triangles=bytes.readUInt32LE(80),positions=new Float32Array(triangles*9);
+  for(let triangle=0;triangle<triangles;triangle++)for(let vertex=0;vertex<3;vertex++)for(let axis=0;axis<3;axis++)positions[triangle*9+vertex*3+axis]=bytes.readFloatLE(84+triangle*50+12+vertex*12+axis*4);
+  const geometry=new THREE.BufferGeometry();geometry.setAttribute('position',new THREE.BufferAttribute(positions,3));geometry.computeBoundingBox();
+  meshObject=materializeLoadedMesh(visual,visual.original_mesh_uri,geometry);
+  const visualRoot=makeMeshVisualRoot(visual,meshObject);root.add(visualRoot);
+  assert.strictEqual(meshObject.scale.toArray().join(','),'0.001,0.001,0.001','loaded workbench mesh must receive 0.001 exactly once');
+}
+const rendered={item:visual,object3d:root,meshObject,originalTransform:transformOf(visual)};state.objects.push(rendered);
 const generatedWorld=root.position.clone();const bindings=bindExportedPhysicalTransformOwnership();assert.strictEqual(bindings.length,1);const binding=bindings[0];
+assert.strictEqual(binding.owner.object3d.scale.toArray().join(','),'1,1,1','authored physical owner root must remain unit scale');assert.strictEqual(root.scale.toArray().join(','),'1,1,1','generated physical visual root must remain unit scale');
 const expected=new THREE.Matrix4().compose(binding.owner.object3d.position,binding.owner.object3d.quaternion,binding.owner.object3d.scale).multiply(new THREE.Matrix4().compose(root.position,root.quaternion,root.scale));root.updateWorldMatrix(true,true);for(let i=0;i<16;i++)assert(Math.abs(root.matrixWorld.elements[i]-expected.elements[i])<1e-10,'owner world x stable local must equal visual world');const actual=new THREE.Vector3().setFromMatrixPosition(root.matrixWorld);
+if(ownerId==='support_surface_table'){const bounds=new THREE.Box3().setFromObject(root),size=bounds.getSize(new THREE.Vector3());assert(!bounds.isEmpty(),'physical workbench bounds must be non-empty');assert(size.x>0.5&&size.x<2&&size.y>0.3&&size.y<2&&size.z>0.5&&size.z<1.5,'physical workbench bounds must be realistic metres, got '+size.toArray());}
 assert.strictEqual(actual.distanceTo(generatedWorld)>1e-8,expectDelta,'reopen must move from stale generated pose iff owner was edited');const beforeAsync=root.matrixWorld.clone();visual.mesh_status='loaded';suppressOwnedAuthoredFallback(rendered);root.updateWorldMatrix(true,true);for(let i=0;i<16;i++)assert(Math.abs(root.matrixWorld.elements[i]-beforeAsync.elements[i])<1e-10,'async mesh completion changed visual pose');
 `,context);
 """
     result = subprocess.run(
-        ["node", "-e", harness, str(ROOT / "workcell_studio_web/viewer/viewer.js"), str(web_scene), owner_id, str(expect_generated_pose_delta).lower()],
+        ["node", "-e", harness, str(ROOT / "workcell_studio_web/viewer/viewer.js"), str(web_scene), owner_id, str(expect_generated_pose_delta).lower(),
+         str(ROOT / "assets/environment/workbench_description/meshes/visual/table.stl")],
         cwd=ROOT, capture_output=True, text=True,
     )
     assert result.returncode == 0, result.stderr
@@ -399,6 +412,7 @@ def test_executable_production_camera_table_save_roundtrips(tmp_path):
             if item.get("owner_relative_visual_transform")
         }
         assert set(before_visuals) == {"realsense_overhead", "support_surface_table"}
+        assert all(visual["owner_relative_visual_transform"]["scale"] == [1.0, 1.0, 1.0] for visual in before_visuals.values())
         for owner_id in before_visuals:
             _run_production_owner_binding_assertions(before_path, owner_id, False)
         assert owners["realsense_overhead"]["provenance"]["pose"] == "layout/workcell_studio_layout.yaml"

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -1550,9 +1550,11 @@ function applyExportedOwnerRelativeVisualTransform(rendered, owner) {
   const pose = poseBlockOf(relative);
   rendered.object3d.position.copy(pose.xyz);
   rendered.object3d.rotation.set(pose.rpy.x, pose.rpy.y, pose.rpy.z, 'XYZ');
-  // Scale remains generated visual metadata (not authored owner state), but it
-  // is carried with the stable local transform so reparenting cannot drop it.
-  rendered.object3d.scale.copy(vector3(relative.scale, [1, 1, 1]));
+  // The rendered root follows the item's root-scale contract.  In particular,
+  // generated URDF roots are unit scale; their mesh/unit conversion is applied
+  // exactly once below this root by applyLoadedMeshScaleHandling().  Ignoring
+  // legacy relative.scale also makes older exported payloads safe to reopen.
+  rendered.object3d.scale.copy(scaleOf(rendered.item));
   rendered.object3d.updateMatrixWorld(true);
   return true;
 }


### PR DESCRIPTION
### Motivation

- The workbench STL (0.001 mesh/unit) was being double-scaled because `owner_relative_visual_transform` carried generated URDF `item.scale`, causing the mesh-local scale to be applied twice during rendering.  This made the physical workbench visually absent in `ur5_2f_test` despite the asset resolving. 

### Description

- Treat `owner_relative_visual_transform` as the owner-local transform root and stop copying generated `item.scale` into that exported transform by emitting a unit scale (`[1,1,1]`) from the exporter in `scripts/export_workcell_studio_web_scene.py`.
- In the viewer `applyExportedOwnerRelativeVisualTransform()` (in `workcell_studio_web/viewer/viewer.js`) derive the rendered root scale from `scaleOf(rendered.item)` instead of trusting a legacy `owner_relative_visual_transform.scale`, ensuring generated URDF roots remain `1,1,1` while preserving non-URDF behavior.
- Add a focused production-path regression harness to `tests/test_workcell_builder_embedded_web3d_save_roundtrip.py` that materializes the repository workbench STL and asserts the authored owner root and generated visual root remain unit scale, the loaded mesh receives `0.001` exactly once, world bounds are realistic and non-empty, asynchronous mesh completion does not alter world transforms, and authored save/reopen ownership through `support_surface_table` is preserved.
- Changes touch only the Web3D export/viewer and test harness; scene YAML, asset files, STL files, robot/gripper/bin behavior, hardware safety defaults, and the committed dist bundle were not modified.

### Testing

- Ran the focused Python test suite with `pytest -q tests/test_export_workcell_studio_web_scene.py tests/test_embedded_web3d_editor_bridge_static.py tests/test_workcell_builder_embedded_web3d_save_roundtrip.py tests/test_workcell_web3d_visual_acceptance.py` and observed `138 passed`.
- Exercised the embedded Node/Three.js production path via the new runtime harness and verified `node --check workcell_studio_web/viewer/viewer.js` succeeded and `git diff --check` produced no problems.
- Verified the regression assertions: authored owner root scale `1,1,1`, generated visual root scale `1,1,1`, mesh-local `0.001` applied exactly once, non-empty realistic metre-scale bounds, and stable async mesh completion in the harness (all automated assertions passed).
- GUI/workstation screenshot or ROS/Humble fake-hardware build/launch were not executed in this container because they require a display-backed workstation or full ROS environment and are out of scope for this source-only Product View fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7216c7e4748331aeabbef975c51831)