### PR TITLE
Fix Save Layout success being misreported after Product View navigation

### DIFF
--- a/tests/test_embedded_web_edit_save_controller_transaction_static.py
+++ b/tests/test_embedded_web_edit_save_controller_transaction_static.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTROLLER = ROOT / "workcell_builder/workcell_builder/gui/embedded_web_edit_save_controller.hpp"
+
+
+def _section(source: str, start: str, end: str) -> str:
+    return source.split(start, 1)[1].split(end, 1)[0]
+
+
+def test_strict_prewrite_context_check_keeps_exact_viewer_identity():
+    source = CONTROLLER.read_text(encoding="utf-8")
+    strict = _section(source, "bool saveContextIsCurrent() const", "bool saveTargetContextIsActive() const")
+
+    assert "view_->url() != expected_url_" in strict
+    assert "sceneIdFromViewerUrl(view_->url()) != scene_id_" in strict
+    assert "return saveTargetContextIsActive();" in strict
+
+
+def test_postwrite_target_check_tolerates_same_scene_navigation_churn():
+    source = CONTROLLER.read_text(encoding="utf-8")
+    active = _section(source, "bool saveTargetContextIsActive() const", "void reportSceneChanged()")
+
+    assert "sceneIdFromViewerUrl(view_->url()) != scene_id_" in active
+    assert "view_->url() != expected_url_" not in active
+    assert "current.scene_id.trimmed() == scene_id_" in active
+    assert "canonicalPath(current.absolute_repo_root.trimmed()) == repo_root_" in active
+    assert "canonicalPath(current.absolute_scene_dir.trimmed()) == scene_dir_" in active
+
+
+def test_successful_write_is_classified_before_context_churn_and_starts_one_refresh():
+    source = CONTROLLER.read_text(encoding="utf-8")
+    callback = _section(
+        source,
+        "connect(process, qOverload<int, QProcess::ExitStatus>(&QProcess::finished)",
+        "process_->start();",
+    )
+
+    ok_index = callback.index("const bool ok = exit_status == QProcess::NormalExit && exit_code == 0;")
+    dry_run_context_index = callback.index(
+        "if (phase == WorkflowPhase::DryRun && !saveContextIsCurrent())"
+    )
+    failure_index = callback.index("if (!ok)")
+    write_target_index = callback.index("if (!saveTargetContextIsActive())")
+    refresh_index = callback.index("request_post_save_product_view_refresh()")
+
+    assert ok_index < dry_run_context_index < failure_index < write_target_index < refresh_index
+    assert callback.count("request_post_save_product_view_refresh()") == 1
+    assert "reportSavedButSceneChanged();" in callback
+
+
+def test_successful_write_is_never_relabelled_as_validation_failure():
+    source = CONTROLLER.read_text(encoding="utf-8")
+    report = _section(source, "void reportSavedButSceneChanged()", "bool resolveSaveContext")
+
+    assert "persisted YAML remains authoritative" in report
+    assert "The authored YAML was saved and verified" in report
+    assert "validation failed" not in report
+    assert "Web3D edits preserved" not in report

--- a/workcell_builder/workcell_builder/gui/embedded_web_edit_save_controller.hpp
+++ b/workcell_builder/workcell_builder/gui/embedded_web_edit_save_controller.hpp
@@ -213,6 +213,12 @@ private:
   {
     if (!view_ || !preview_ || view_->url() != expected_url_ ||
         sceneIdFromViewerUrl(view_->url()) != scene_id_) return false;
+    return saveTargetContextIsActive();
+  }
+
+  bool saveTargetContextIsActive() const
+  {
+    if (!view_ || !preview_ || sceneIdFromViewerUrl(view_->url()) != scene_id_) return false;
     const ScenePreviewWidget::PreviewContext current = preview_->preview_context();
     if (using_environment_fallback_) {
       return current.scene_id.trimmed().isEmpty() &&
@@ -230,6 +236,19 @@ private:
     if (save_button_) save_button_->setEnabled(false);
     setStatus(QStringLiteral("Scene changed—reload required; Web3D edits preserved"), QStringLiteral("warning"));
     logPhase(QStringLiteral("validation failed: viewer URL or PreviewContext changed; Web3D edits preserved"));
+  }
+
+  void reportSavedButSceneChanged()
+  {
+    saved_reload_pending_ = false;
+    saved_reload_revision_ = 0;
+    busy_ = false;
+    if (save_button_) save_button_->setEnabled(false);
+    setStatus(QStringLiteral("Saved; active scene changed before Product View refresh"), QStringLiteral("warning"));
+    logPhase(QStringLiteral("saved; active scene changed before reload; persisted YAML remains authoritative"));
+    QMessageBox::information(preview_, QStringLiteral("Save Product View Layout"),
+      QStringLiteral("The authored YAML was saved and verified, but the active Product View changed before the post-save refresh could start. "
+        "Reopen the saved scene to load the canonical result."));
   }
 
   bool resolveSaveContext(QString * error)
@@ -441,11 +460,11 @@ private:
         const QString output = boundedWorkflowOutput(QString::fromLocal8Bit(process->readAll()));
         if (process == process_) process_ = nullptr;
         process->deleteLater();
-        if (!saveContextIsCurrent()) {
+        const bool ok = exit_status == QProcess::NormalExit && exit_code == 0;
+        if (phase == WorkflowPhase::DryRun && !saveContextIsCurrent()) {
           reportSceneChanged();
           return;
         }
-        const bool ok = exit_status == QProcess::NormalExit && exit_code == 0;
         if (!ok) {
           busy_ = false;
           setStatus(phase == WorkflowPhase::DryRun ? QStringLiteral("Validation failed") : QStringLiteral("Save failed"),
@@ -478,6 +497,10 @@ private:
           return;
         }
 
+        if (!saveTargetContextIsActive()) {
+          reportSavedButSceneChanged();
+          return;
+        }
         setStatus(QStringLiteral("Saved; refreshing Product View…"), QStringLiteral("success"));
         logPhase(QStringLiteral("saved"));
         saved_reload_pending_ = true;


### PR DESCRIPTION
## Current goal
Make the `ur5_2f_test` edit → save → regenerate → reload authoring loop deterministic before expanding to other scenes.

## Problem
A successful `--write` workflow could persist and verify the authored YAML, while an overlapping same-scene Product View navigation changed `QWebEngineView::url()`. The save controller then ran the strict pre-write URL identity check after the subprocess had already succeeded and incorrectly logged:

`validation failed: viewer URL or PreviewContext changed; Web3D edits preserved`

The next save then correctly detected a stale patch because the first write had actually changed the authoritative YAML.

## Fix
- Keep the exact viewer URL check for patch capture, dry-run validation, confirmation, and write start.
- Add a post-write target-context check that requires the same canonical scene, repository root, and scene directory but tolerates same-scene URL/navigation-token churn.
- Classify the subprocess result before applying post-write context handling, so a successful persisted write can never be relabelled as a validation failure.
- If the user genuinely changes to another scene while the write is completing, report `Saved; active scene changed before Product View refresh` and leave the verified YAML authoritative instead of claiming validation failed.
- Preserve the existing matching post-save payload revision / `scene_ready` handshake and all fake-hardware safety defaults.

## Tests
Added `tests/test_embedded_web_edit_save_controller_transaction_static.py` covering:
- strict pre-write URL identity remains enforced;
- post-write same-scene navigation churn is accepted;
- workflow success is classified before context churn;
- exactly one forced post-save refresh is requested;
- a verified write is never labelled as validation failure.

## Workstation acceptance after merge
1. Open `ur5_2f_test`.
2. Move `support_surface_table`.
3. Save Layout and confirm.
4. Verify the log reaches `saved`, requests the forced canonical refresh, and finishes `Saved and reloaded` without `viewer URL or PreviewContext changed`.
5. Reopen the scene and verify the persisted pose.

No robot controllers, MoveIt execution, real-hardware mode, scene YAML, assets, viewer bundle, or runtime safety gates are changed.