### PR TITLE
Add headless fake-hardware launch mode for ur5_2f_test

### DIFF
--- a/scenes/ur5_2f_test/launch/demo.launch.py
+++ b/scenes/ur5_2f_test/launch/demo.launch.py
@@ -9,6 +9,7 @@ import subprocess
 from launch import LaunchDescription
 from launch.actions import OpaqueFunction
 from launch.actions import DeclareLaunchArgument
+from launch.conditions import IfCondition
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
@@ -162,6 +163,7 @@ def _write_robot_description_file(scene_name, robot_description_config):
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
+    launch_rviz = LaunchConfiguration("launch_rviz")
     joint_states_topic = f"/{scene_pkg}/joint_states"
 
     robot_description_config = load_xacro(
@@ -360,6 +362,7 @@ def _launch_setup(context):
         executable="rviz2",
         name="rviz2",
         output="screen",
+        condition=IfCondition(launch_rviz),
         arguments=["-d", rviz_config_file] if os.path.exists(rviz_config_file) else [],
         parameters=_param_list(
             validated_use_sim_time,
@@ -385,6 +388,14 @@ def _launch_setup(context):
 def generate_launch_description():
     return LaunchDescription([
         DeclareLaunchArgument("use_sim_time", default_value="false"),
+        DeclareLaunchArgument(
+            "launch_rviz",
+            default_value="true",
+            description=(
+                "Launch RViz for interactive fake-hardware visualization. "
+                "Set false for bounded headless acceptance checks."
+            ),
+        ),
         DeclareLaunchArgument(
             "use_fake_hardware",
             default_value="true",

--- a/tests/test_ur5_2f_headless_fake_hardware_launch.py
+++ b/tests/test_ur5_2f_headless_fake_hardware_launch.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from scripts import validate_rviz_moveit_simulation_launches as validator
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCENE_DIR = ROOT / "scenes" / "ur5_2f_test"
+LAUNCH_FILE = SCENE_DIR / "launch" / "demo.launch.py"
+
+
+def test_canonical_launch_declares_real_rviz_toggle():
+    source = LAUNCH_FILE.read_text(encoding="utf-8")
+
+    assert "from launch.conditions import IfCondition" in source
+    assert 'launch_rviz = LaunchConfiguration("launch_rviz")' in source
+    assert 'DeclareLaunchArgument(\n            "launch_rviz"' in source
+    assert 'default_value="true"' in source
+
+    rviz_block = source.split("rviz_node = Node(", 1)[1].split("\n    return [", 1)[0]
+    assert 'package="rviz2"' in rviz_block
+    assert "condition=IfCondition(launch_rviz)" in rviz_block
+
+    move_group_block = source.split("move_group = Node(", 1)[1].split("rviz_config_file", 1)[0]
+    assert "IfCondition(launch_rviz)" not in move_group_block
+    assert '"allow_trajectory_execution": False' in source
+    assert '"moveit_manage_controllers": False' in source
+
+
+def test_validator_headless_command_matches_declared_launch_contract():
+    source = LAUNCH_FILE.read_text(encoding="utf-8")
+    declared = validator._declared_launch_args(source)
+    assert declared["use_fake_hardware"] == "true"
+    assert declared["launch_rviz"] == "true"
+
+    entry = SimpleNamespace(
+        fake_hardware_launch_command=(
+            "ros2 launch ur5_2f_test demo.launch.py "
+            "use_fake_hardware:=true launch_rviz:=true"
+        )
+    )
+    headless = validator.command_for_scene(entry, launch_rviz=False)
+    visual = validator.command_for_scene(entry, launch_rviz=True)
+
+    assert "use_fake_hardware:=true" in headless
+    assert "launch_rviz:=false" in headless
+    assert "launch_rviz:=true" in visual
+
+    failures, evidence, metadata = validator.validate_launch_contract(
+        entry, SCENE_DIR, LAUNCH_FILE, launch_rviz=True
+    )
+    assert failures == []
+    assert "fake_hardware_default_true" in evidence
+    assert metadata["declared_launch_arguments"]["launch_rviz"] == "true"
+
+
+def test_headless_toggle_only_gates_rviz_not_fake_hardware_nodes():
+    source = LAUNCH_FILE.read_text(encoding="utf-8")
+    setup = source.split("def _launch_setup(context):", 1)[1].split(
+        "def generate_launch_description():", 1
+    )[0]
+
+    for required_node in [
+        "static_tf = Node(",
+        "robot_state_publisher = Node(",
+        "joint_state_publisher = Node(",
+        "move_group = Node(",
+    ]:
+        block = setup.split(required_node, 1)[1].split("\n    )", 1)[0]
+        assert "IfCondition(launch_rviz)" not in block
+
+    rviz_block = setup.split("rviz_node = Node(", 1)[1].split("\n    return [", 1)[0]
+    assert "condition=IfCondition(launch_rviz)" in rviz_block


### PR DESCRIPTION
## Roadmap position

The `ur5_2f_test` M1 authoring round-trip is now workstation-confirmed: edit, save, edit again, save, close, reopen, and recover the latest transform. This PR begins M2 on the canonical scene: deterministic package build and RViz/MoveIt fake-hardware launch evidence.

## Problem

The supported-scene catalog and fake-hardware validator already generate two intended launch modes:

- visual: `launch_rviz:=true`
- bounded headless acceptance: `launch_rviz:=false`

However, `scenes/ur5_2f_test/launch/demo.launch.py` did not declare `launch_rviz` and always instantiated RViz. Therefore the headless validator command was not truthful: it could still start RViz and depend on a display/GPU while attempting to collect MoveIt, robot-description, joint-state, TF, and controller evidence.

## Fix

- Declare `launch_rviz` with safe default `true`, preserving the existing interactive command.
- Resolve it with `LaunchConfiguration` inside `_launch_setup()`.
- Gate only the RViz node with `IfCondition(launch_rviz)`.
- Keep `robot_state_publisher`, `joint_state_publisher`, `move_group`, static TF, fake-hardware defaults, and trajectory-execution locks active in headless mode.
- Add focused static/contract tests proving:
  - the canonical launch accepts `launch_rviz:=true|false`;
  - the validator rewrites the catalog command to `launch_rviz:=false` for headless acceptance;
  - only RViz is conditional;
  - fake hardware remains default and MoveIt trajectory execution remains disabled.

This is deliberately limited to the `ur5_2f_test` M2 canary. After workstation acceptance, the proven launch contract can be propagated into the generator template and then the second canonical scene.

## Workstation acceptance after merge

```bash
cd ~/workcell_ws
source /opt/ros/humble/setup.bash
colcon build --symlink-install --packages-select ur5_2f_test
source install/setup.bash

cd ~/workcell_ws/src/easy_manipulation_deployment
python3 scripts/validate_rviz_moveit_simulation_launches.py \
  --scene ur5_2f_test \
  --headless \
  --timeout-sec 45 \
  --json-output /tmp/ur5_2f_m2_headless.json
```

Expected headless evidence:

- no RViz process;
- `robot_state_publisher` available;
- `move_group` available;
- `robot_description` and `robot_description_semantic` available;
- scene joint-state topic available;
- TF sample available;
- fake controllers listable;
- launched process group terminates after the bounded check.

Then verify the interactive path remains unchanged:

```bash
ros2 launch ur5_2f_test demo.launch.py \
  use_fake_hardware:=true \
  launch_rviz:=true
```

No real-hardware driver, motion execution, scene YAML, Web3D source, asset, or authored transform is changed.