### PR TITLE
Forward helper geometry picks to canonical owners

### DIFF
--- a/tests/test_workcell_web3d_canonical_helper_pick_proxies.py
+++ b/tests/test_workcell_web3d_canonical_helper_pick_proxies.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE = REPO_ROOT / "workcell_studio_web/viewer/canonical_helper_pick_proxies.js"
+POST_BUNDLE = REPO_ROOT / "workcell_studio_web/viewer/post_bundle_viewer_modules.js"
+
+
+def test_post_bundle_loader_imports_and_tracks_canonical_helper_pick_proxies() -> None:
+    source = POST_BUNDLE.read_text(encoding="utf-8")
+    assert "import './canonical_helper_pick_proxies.js';" in source
+    assert "id: 'canonical-helper-pick-proxies'" in source
+    assert "global: '__WORKCELL_CANONICAL_HELPER_PICK_PROXIES_V1__'" in source
+
+
+def test_helper_proxy_module_does_not_create_editor_identity_records() -> None:
+    source = MODULE.read_text(encoding="utf-8")
+    assert "state.objects" not in source
+    assert "state.pickRecords" not in source
+    assert "registerPickRecord" not in source
+    assert "__WORKCELL_EDITOR_API_V1__" in source
+    assert "api.selectItem(ownerCandidate)" in source
+    assert "window.__WORKCELL_CANONICAL_HELPER_PICK_PROXIES_V1__ = publicApi" in source
+
+
+def test_canonical_helper_proxy_acceptance_harness() -> None:
+    module_uri = MODULE.resolve().as_uri()
+    script = f"""
+import assert from 'node:assert/strict';
+const proxy = await import({json.dumps(module_uri)});
+
+const listeners = {{ capture: [], bubble: [] }};
+const canvas = {{
+  addEventListener(type, callback, options) {{
+    if (type !== 'pointerdown') return;
+    (options === true ? listeners.capture : listeners.bubble).push(callback);
+  }},
+}};
+
+let state = {{
+  selectedItemId: '',
+  selectedEditable: false,
+  lastCanvasPickReason: '',
+  lastFailedCanvasPickDiagnostic: null,
+  selectionDiagnostics: {{ gizmoAttachedTargetId: '' }},
+}};
+const forwarded = [];
+const dispatched = [];
+const canonicalOwners = new Map([
+  ['target_bin_default', {{ id: 'target_bin_default', editable: true }}],
+  ['support_surface_table', {{ id: 'support_surface_table', editable: true }}],
+  ['urdf_visual_17_camera_link_visual_17_package_realsense2_description_meshes_d435_dae', {{ id: 'realsense_overhead', editable: true }}],
+  ['ur5', {{ id: 'ur5', editable: false }}],
+  ['robotiq_85_gripper', {{ id: 'robotiq_85_gripper', editable: false }}],
+]);
+const api = {{
+  getState() {{ return state; }},
+  selectItem(candidate) {{
+    const owner = canonicalOwners.get(candidate) || {{ id: candidate, editable: false }};
+    forwarded.push(candidate);
+    state = {{
+      ...state,
+      selectedItemId: owner.id,
+      selectedEditable: owner.editable,
+      selectionDiagnostics: {{
+        gizmoAttachedTargetId: owner.editable ? owner.id : '',
+      }},
+    }};
+    return state;
+  }},
+  selectionDiagnostics() {{ return state.selectionDiagnostics; }},
+}};
+const windowRef = {{
+  __WORKCELL_EDITOR_API_V1__: api,
+  CustomEvent: class CustomEvent {{ constructor(type, init) {{ this.type = type; this.detail = init.detail; }} }},
+  dispatchEvent(event) {{ dispatched.push(event); }},
+}};
+const documentRef = {{ getElementById(id) {{ return id === 'scene-canvas' ? canvas : null; }} }};
+const microtasks = [];
+assert.equal(proxy.installCanonicalHelperPickProxies({{
+  windowRef,
+  documentRef,
+  scheduleMicrotask: callback => microtasks.push(callback),
+}}), true);
+
+function helperDiagnostic(name, selectionOwnerId = '') {{
+  return {{
+    hit_object_names: [name],
+    hit_resolutions: [{{
+      hit_node_name: name,
+      selection_owner_id: selectionOwnerId,
+      rejection_stage_reason: 'hit_node_intrinsically_excluded',
+    }}],
+  }};
+}}
+function clickHelper(name, selectionOwnerId = '') {{
+  for (const callback of listeners.capture) callback({{}});
+  state = {{
+    ...state,
+    selectedItemId: '',
+    selectedEditable: false,
+    lastCanvasPickReason: 'no_eligible_candidate',
+    lastFailedCanvasPickDiagnostic: helperDiagnostic(name, selectionOwnerId),
+    selectionDiagnostics: {{ gizmoAttachedTargetId: '' }},
+  }};
+  for (const callback of listeners.bubble) callback({{}});
+  while (microtasks.length) microtasks.shift()();
+  return state;
+}}
+function clickNormal(selectedItemId, selectedEditable) {{
+  for (const callback of listeners.capture) callback({{}});
+  state = {{
+    ...state,
+    selectedItemId,
+    selectedEditable,
+    lastCanvasPickReason: 'eligible_candidate',
+    lastFailedCanvasPickDiagnostic: null,
+    selectionDiagnostics: {{ gizmoAttachedTargetId: selectedEditable ? selectedItemId : '' }},
+  }};
+  for (const callback of listeners.bubble) callback({{}});
+  while (microtasks.length) microtasks.shift()();
+  return state;
+}}
+
+for (let i = 0; i < 20; ++i) {{
+  const selected = clickHelper('target_bin_default_fallback_edges');
+  assert.equal(selected.selectedItemId, 'target_bin_default');
+  assert.equal(selected.selectedEditable, true);
+  assert.equal(selected.selectionDiagnostics.gizmoAttachedTargetId, 'target_bin_default');
+}}
+
+const cameraVisual = 'urdf_visual_17_camera_link_visual_17_package_realsense2_description_meshes_d435_dae';
+for (let i = 0; i < 20; ++i) {{
+  const selected = i % 2 === 0
+    ? clickHelper(`${{cameraVisual}}_fallback_sensor_frustum`)
+    : clickNormal('realsense_overhead', true);
+  assert.equal(selected.selectedItemId, 'realsense_overhead');
+  assert.equal(selected.selectedEditable, true);
+  assert.notEqual(selected.selectionDiagnostics.gizmoAttachedTargetId, `${{cameraVisual}}_fallback_sensor_frustum`);
+}}
+
+let selected = clickHelper('support_surface_table_fallback_edges');
+assert.equal(selected.selectedItemId, 'support_surface_table');
+assert.equal(selected.selectedEditable, true);
+assert.equal(selected.selectionDiagnostics.gizmoAttachedTargetId, 'support_surface_table');
+
+selected = clickHelper('ur5_fallback_edges');
+assert.equal(selected.selectedItemId, 'ur5');
+assert.equal(selected.selectedEditable, false);
+assert.equal(selected.selectionDiagnostics.gizmoAttachedTargetId, '');
+
+selected = clickHelper('robotiq_85_gripper_fallback_edges');
+assert.equal(selected.selectedItemId, 'robotiq_85_gripper');
+assert.equal(selected.selectedEditable, false);
+assert.equal(selected.selectionDiagnostics.gizmoAttachedTargetId, '');
+
+state = {{
+  ...state,
+  selectedItemId: 'target_bin_default',
+  selectedEditable: true,
+  lastCanvasPickReason: 'eligible_candidate',
+  lastFailedCanvasPickDiagnostic: null,
+  selectionDiagnostics: {{ gizmoAttachedTargetId: 'target_bin_default' }},
+}};
+selected = clickHelper('selection_subtle_bounds_highlight');
+assert.equal(selected.selectedItemId, 'target_bin_default');
+assert.equal(selected.selectionDiagnostics.gizmoAttachedTargetId, 'target_bin_default');
+
+const forwardedBeforeOrdinaryFailure = forwarded.length;
+clickHelper('unrelated_debug_helper');
+assert.equal(forwarded.length, forwardedBeforeOrdinaryFailure);
+assert.ok(forwarded.every(id => !proxy.isCanonicalOwnerHelperName(id)));
+assert.ok(dispatched.length >= 34);
+assert.ok(dispatched.every(event => event.detail.gizmo_attached_to_helper === false));
+console.log(JSON.stringify({{ forwardedCount: forwarded.length, dispatchedCount: dispatched.length }}));
+"""
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert payload["forwardedCount"] >= 34

--- a/workcell_studio_web/viewer/canonical_helper_pick_proxies.js
+++ b/workcell_studio_web/viewer/canonical_helper_pick_proxies.js
@@ -1,0 +1,184 @@
+const VERSION = 1;
+const INSTALL_FLAG = '__WORKCELL_CANONICAL_HELPER_PICK_PROXIES_V1__';
+const MAX_INSTALL_ATTEMPTS = 200;
+const INSTALL_RETRY_MS = 50;
+
+const OWNER_SUFFIXES = Object.freeze([
+  '_fallback_sensor_frustum',
+  '_fallback_edges',
+  '_selection_outline',
+  '_visual_outline',
+  '_owner_outline',
+  '_bounds_highlight',
+]);
+
+const OWNERLESS_SELECTION_HELPERS = Object.freeze(new Set([
+  'selection_subtle_bounds_highlight',
+  'selection_bounds_highlight',
+  'selection_outline',
+]));
+
+function stringValue(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export function isCanonicalOwnerHelperName(value) {
+  const name = stringValue(value).toLowerCase();
+  if (!name || /transformcontrols|transform_controls|gizmo|transient_gizmo/.test(name)) return false;
+  if (OWNERLESS_SELECTION_HELPERS.has(name)) return true;
+  return OWNER_SUFFIXES.some(suffix => name.endsWith(suffix));
+}
+
+export function ownerIdFromHelperName(value, previousSelectedItemId = '') {
+  const originalName = stringValue(value);
+  const name = originalName.toLowerCase();
+  if (!isCanonicalOwnerHelperName(name)) return '';
+  if (OWNERLESS_SELECTION_HELPERS.has(name)) return stringValue(previousSelectedItemId);
+  const suffix = OWNER_SUFFIXES.find(candidate => name.endsWith(candidate));
+  return suffix ? originalName.slice(0, originalName.length - suffix.length) : '';
+}
+
+function diagnosticHitResolutions(diagnostic) {
+  const values = diagnostic?.hit_resolutions || diagnostic?.hitResolutions;
+  return Array.isArray(values) ? values : [];
+}
+
+function diagnosticHitObjectNames(diagnostic) {
+  const values = diagnostic?.hit_object_names || diagnostic?.hitObjectNames;
+  return Array.isArray(values) ? values.map(stringValue).filter(Boolean) : [];
+}
+
+function resolutionNodeName(resolution) {
+  return stringValue(resolution?.hit_node_name || resolution?.hitNodeName);
+}
+
+function resolutionSelectionOwnerId(resolution) {
+  return stringValue(
+    resolution?.selection_owner_id ||
+    resolution?.selectionOwnerId ||
+    resolution?.edit_owner_id ||
+    resolution?.editOwnerId
+  );
+}
+
+function resolutionRegisteredRecordId(resolution) {
+  return stringValue(resolution?.registered_record_id || resolution?.registeredRecordId);
+}
+
+export function helperProxyOwnerCandidate(diagnostic, previousSelectedItemId = '') {
+  if (!diagnostic || typeof diagnostic !== 'object') return '';
+
+  for (const resolution of diagnosticHitResolutions(diagnostic)) {
+    const nodeName = resolutionNodeName(resolution);
+    if (!isCanonicalOwnerHelperName(nodeName)) continue;
+    const explicitOwner = resolutionSelectionOwnerId(resolution);
+    if (explicitOwner) return explicitOwner;
+    const registeredOwner = resolutionRegisteredRecordId(resolution);
+    if (registeredOwner) return registeredOwner;
+    const inferredOwner = ownerIdFromHelperName(nodeName, previousSelectedItemId);
+    if (inferredOwner) return inferredOwner;
+  }
+
+  for (const nodeName of diagnosticHitObjectNames(diagnostic)) {
+    const inferredOwner = ownerIdFromHelperName(nodeName, previousSelectedItemId);
+    if (inferredOwner) return inferredOwner;
+  }
+  return '';
+}
+
+export function shouldForwardCanonicalHelperPick(editorState) {
+  return Boolean(
+    editorState &&
+    editorState.lastCanvasPickReason === 'no_eligible_candidate' &&
+    editorState.lastFailedCanvasPickDiagnostic
+  );
+}
+
+function dispatchForwardedEvent(windowRef, detail) {
+  try {
+    const EventConstructor = windowRef?.CustomEvent;
+    if (typeof EventConstructor === 'function' && typeof windowRef.dispatchEvent === 'function') {
+      windowRef.dispatchEvent(new EventConstructor('workcell:canonical_helper_pick_forwarded', { detail }));
+    }
+  } catch (_) {
+    // Selection forwarding must not fail because optional diagnostics are unavailable.
+  }
+}
+
+export function installCanonicalHelperPickProxies({
+  windowRef = globalThis.window,
+  documentRef = globalThis.document,
+  scheduleMicrotask = globalThis.queueMicrotask || (callback => Promise.resolve().then(callback)),
+} = {}) {
+  const canvas = documentRef?.getElementById?.('scene-canvas');
+  const api = windowRef?.__WORKCELL_EDITOR_API_V1__;
+  if (!canvas || typeof canvas.addEventListener !== 'function' || !api?.getState || !api?.selectItem) return false;
+  if (canvas[INSTALL_FLAG]) return true;
+  canvas[INSTALL_FLAG] = true;
+
+  let pointerContext = { previousSelectedItemId: '' };
+  canvas.addEventListener('pointerdown', () => {
+    const before = api.getState?.() || {};
+    pointerContext = { previousSelectedItemId: stringValue(before.selectedItemId) };
+  }, true);
+
+  canvas.addEventListener('pointerdown', () => {
+    const context = pointerContext;
+    scheduleMicrotask(() => {
+      const afterPick = api.getState?.() || {};
+      if (!shouldForwardCanonicalHelperPick(afterPick)) return;
+      const ownerCandidate = helperProxyOwnerCandidate(
+        afterPick.lastFailedCanvasPickDiagnostic,
+        context.previousSelectedItemId,
+      );
+      if (!ownerCandidate) return;
+
+      const forwardedState = api.selectItem(ownerCandidate) || api.getState?.() || {};
+      const selectedItemId = stringValue(forwardedState.selectedItemId);
+      if (!selectedItemId) return;
+      const selectionDiagnostics = api.selectionDiagnostics?.() || forwardedState.selectionDiagnostics || {};
+      const gizmoTargetId = stringValue(selectionDiagnostics.gizmoAttachedTargetId);
+      const helperNodeNames = diagnosticHitObjectNames(afterPick.lastFailedCanvasPickDiagnostic);
+      dispatchForwardedEvent(windowRef, {
+        helper_node_names: helperNodeNames,
+        helperNodeNames,
+        forwarded_candidate_id: ownerCandidate,
+        forwardedCandidateId: ownerCandidate,
+        selected_item_id: selectedItemId,
+        selectedItemId,
+        selected_editable: Boolean(forwardedState.selectedEditable),
+        selectedEditable: Boolean(forwardedState.selectedEditable),
+        gizmo_attached_target_id: gizmoTargetId,
+        gizmoAttachedTargetId: gizmoTargetId,
+        gizmo_attached_to_helper: isCanonicalOwnerHelperName(gizmoTargetId),
+        gizmoAttachedToHelper: isCanonicalOwnerHelperName(gizmoTargetId),
+      });
+    });
+  });
+  return true;
+}
+
+const publicApi = Object.freeze({
+  enabled: true,
+  version: VERSION,
+  install: installCanonicalHelperPickProxies,
+  isCanonicalOwnerHelperName,
+  ownerIdFromHelperName,
+  helperProxyOwnerCandidate,
+});
+
+if (typeof window !== 'undefined') {
+  window.__WORKCELL_CANONICAL_HELPER_PICK_PROXIES_V1__ = publicApi;
+}
+
+function installWhenReady(attempt = 0) {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+  if (installCanonicalHelperPickProxies()) return;
+  if (attempt >= MAX_INSTALL_ATTEMPTS) {
+    console.warn?.('Canonical helper pick proxies were not installed because the Product View editor API did not become ready.');
+    return;
+  }
+  window.setTimeout?.(() => installWhenReady(attempt + 1), INSTALL_RETRY_MS);
+}
+
+installWhenReady();

--- a/workcell_studio_web/viewer/post_bundle_viewer_modules.js
+++ b/workcell_studio_web/viewer/post_bundle_viewer_modules.js
@@ -1,4 +1,6 @@
-const VERSION = 1;
+import './canonical_helper_pick_proxies.js';
+
+const VERSION = 2;
 
 const MODULES = Object.freeze([
   Object.freeze({
@@ -36,6 +38,12 @@ const MODULES = Object.freeze([
     file: 'contextual_placement_actions.js',
     global: '__WORKCELL_CONTEXTUAL_PLACEMENT_ACTIONS_V1__',
     purpose: 'one-click placement actions',
+  }),
+  Object.freeze({
+    id: 'canonical-helper-pick-proxies',
+    file: 'canonical_helper_pick_proxies.js',
+    global: '__WORKCELL_CANONICAL_HELPER_PICK_PROXIES_V1__',
+    purpose: 'canonical owner forwarding for helper-only canvas hits',
   }),
 ]);
 


### PR DESCRIPTION
## Roadmap position

This is **PR 3** from the current `ur5_2f_test` authoring roadmap. PR 1 fixed the save/navigation transaction race and PR 2 rebased the live edit baseline after persistence. This PR fixes the next confirmed blocker: visible helper geometry intercepting canvas clicks without selecting the physical item it represents.

## Problem

Real Workcell Builder logs show helper-only ray hits such as:

- `target_bin_default_fallback_edges`
- `...d435_dae_fallback_sensor_frustum`

The bundled viewer correctly refuses to treat those helper nodes as independent editor identities, but the click then ends as `hit_node_intrinsically_excluded` / `no_eligible_candidate`. This makes visible bin edges and camera frustums feel unclickable.

## Fix

Add a post-bundle canonical helper-pick proxy module that:

- observes helper-only failed canvas picks through the existing editor diagnostics contract;
- recognizes owner-representing helper names for fallback edges, sensor frustums, selection/visual/owner outlines, and bounds highlights;
- forwards the click through `__WORKCELL_EDITOR_API_V1__.selectItem(...)` to the existing canonical owner resolution path;
- uses the previously selected canonical item for the ownerless selection-bounds highlight;
- emits one bounded `workcell:canonical_helper_pick_forwarded` diagnostic;
- explicitly excludes TransformControls/gizmo/transient-pivot names and unrelated generic helpers.

The proxy does **not** append helper nodes to `state.objects`, `state.pickRecords`, or any editor identity registry. The existing selection/edit-owner logic remains authoritative, so generated camera rows still resolve to `realsense_overhead`, editable helpers never become persisted IDs, and robot/tool ownership remains read-only.

The module is registered in the existing post-bundle module status surface as `canonical-helper-pick-proxies`.

## Automated acceptance

Added an executable Node harness covering:

- 20 consecutive bin fallback-edge clicks → `target_bin_default`;
- 20 camera clicks alternating body and frustum → `realsense_overhead`;
- table fallback-edge click → `support_surface_table`;
- robot helper click → `ur5`, read-only;
- gripper helper click → `robotiq_85_gripper`, read-only;
- selection outline → previously selected canonical owner;
- unrelated helper → no forwarding;
- every forwarded event reports that the gizmo target is not a helper node.

Local focused result:

```text
3 passed
```

Both JavaScript modules also pass `node --check`.

## Workstation acceptance after merge

```bash
cd ~/workcell_ws/src/easy_manipulation_deployment
git checkout main
git pull

cd ~/workcell_ws
source /opt/ros/humble/setup.bash
colcon build --symlink-install --packages-select workcell_builder
source install/setup.bash
workcell_builder
```

Open `ur5_2f_test`, then verify:

1. Click the visible bin/edge region 20 times; every click selects `target_bin_default`.
2. Click the camera body and frustum region 20 times; every click selects `realsense_overhead`.
3. Click the table; it selects `support_surface_table`.
4. Click the robot and gripper; they remain selectable for inspection but read-only.
5. Switch to Move/Rotate on editable owners and confirm TransformControls attach only to the canonical owner or canonical physical pivot—never to an edge, frustum, outline, highlight, or helper node.

No scene YAML, authored transforms, generated Web3D bundle, robot controllers, RViz/MoveIt behavior, real-hardware setting, or safety gate is changed.