### PR TITLE
Unify Web3D selection and canonical transform state

### DIFF
--- a/tests/test_workcell_web3d_canonical_selection_state.py
+++ b/tests/test_workcell_web3d_canonical_selection_state.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE = REPO_ROOT / "workcell_studio_web/viewer/canonical_selection_state.js"
+POST_BUNDLE = REPO_ROOT / "workcell_studio_web/viewer/post_bundle_viewer_modules.js"
+LAYOUT = REPO_ROOT / "scenes/ur5_2f_test/layout/workcell_studio_layout.yaml"
+SAVE_CONTROLLER = REPO_ROOT / "workcell_builder/workcell_builder/gui/embedded_web_edit_save_controller.hpp"
+
+
+def test_post_bundle_loader_imports_and_tracks_canonical_selection_state() -> None:
+    source = POST_BUNDLE.read_text(encoding="utf-8")
+    assert "import './canonical_selection_state.js';" in source
+    assert source.index("canonical_selection_state.js") < source.index("canonical_helper_pick_proxies.js")
+    assert "id: 'canonical-selection-state'" in source
+    assert "global: '__WORKCELL_CANONICAL_SELECTION_STATE_V1__'" in source
+    assert "canonicalSelectedOwnerId" in source
+    assert "canonicalTransform" in source
+
+
+def test_canonical_selection_module_uses_only_the_public_editor_contract() -> None:
+    source = MODULE.read_text(encoding="utf-8")
+    assert "__WORKCELL_EDITOR_API_V1__" in source
+    assert "api.getState" in source
+    assert "api.selectItem" in source
+    assert "api.getEditPatch" in source
+    assert "state.objects" not in source
+    assert "state.pickRecords" not in source
+    assert "registerPickRecord" not in source
+    assert "canonicalSelectedOwnerId" in source
+    assert "canonicalTransform" in source
+    assert "retainedSelectionPending" in source
+    assert "event?.type !== 'selection_changed'" in source
+
+
+def test_ur5_2f_editable_six_vs_layout_seven_is_intentional() -> None:
+    payload = yaml.safe_load(LAYOUT.read_text(encoding="utf-8"))
+    editable = [item for item in payload["items"] if item.get("editable") is True and item.get("locked") is not True]
+    derived = [
+        item
+        for item in editable
+        if item.get("role") == "place_zone" and item.get("target_ref") and item.get("transform_group")
+    ]
+    canonical = [item for item in editable if item not in derived]
+
+    assert len(editable) == 7
+    assert [item["id"] for item in derived] == ["place_zone_default"]
+    assert len(canonical) == 6
+    assert "target_bin_default" in {item["id"] for item in canonical}
+    assert derived[0]["target_ref"] == "target_bin_default"
+    assert derived[0]["transform_group"] == "default_drop_destination"
+
+
+def test_save_logs_use_exported_patch_old_and_new_xyz_rpy() -> None:
+    source = SAVE_CONTROLLER.read_text(encoding="utf-8")
+    assert "logPatchSummary(patch)" in source
+    assert "patch edit: item_id=%1 operation=%2 old_%3 new_%4 persistence_source=%5" in source
+    assert "xyz=[%1,%2,%3] rpy=[%4,%5,%6]" in source
+    assert "transformText(edit.value(QStringLiteral(\"old_transform\")))" in source
+    assert "transformText(edit.value(QStringLiteral(\"new_transform\")))" in source
+
+
+def test_canonical_selection_transform_acceptance_harness() -> None:
+    module_uri = MODULE.resolve().as_uri()
+    script = f"""
+import assert from 'node:assert/strict';
+const canonical = await import({json.dumps(module_uri)});
+
+const clone = value => JSON.parse(JSON.stringify(value));
+const first = {{
+  pose: {{xyz: {{x: -0.32, y: -0.15, z: 0.06}}, rpy: {{x: 0, y: 0, z: -2.5307274}}}},
+  scale: {{x: 1, y: 1, z: 1}},
+}};
+const second = {{
+  pose: {{xyz: {{x: -0.22, y: -0.16, z: 0.06}}, rpy: {{x: 0, y: 0, z: -2.44346095}}}},
+  scale: {{x: 1, y: 1, z: 1}},
+}};
+
+function storage() {{
+  const values = new Map();
+  return {{
+    getItem(key) {{ return values.has(key) ? values.get(key) : null; }},
+    setItem(key, value) {{ values.set(key, String(value)); }},
+    removeItem(key) {{ values.delete(key); }},
+    values,
+  }};
+}}
+
+function inspector() {{
+  const fields = Object.fromEntries(['x','y','z','roll','pitch','yaw','scale_x','scale_y','scale_z'].map(name => [name, {{value:'0'}}]));
+  const rows = new Map();
+  for (const label of ['pose xyz', 'pose rpy', 'scale']) {{
+    const dd = {{textContent:''}};
+    rows.set(label, {{textContent:label, nextElementSibling:dd, dd}});
+  }}
+  return {{
+    fields,
+    rows,
+    querySelector(selector) {{
+      const match = selector.match(/data-transform-field=\"([^\"]+)\"/);
+      return match ? fields[match[1]] || null : null;
+    }},
+    querySelectorAll(selector) {{ return selector === 'dt' ? [...rows.values()] : []; }},
+  }};
+}}
+
+function windowHarness(sharedStorage) {{
+  const listeners = new Map();
+  const timers = [];
+  const dispatched = [];
+  return {{
+    sessionStorage: sharedStorage,
+    timers,
+    dispatched,
+    CustomEvent: class CustomEvent {{ constructor(type, init) {{ this.type = type; this.detail = init?.detail || {{}}; }} }},
+    addEventListener(type, callback) {{
+      if (!listeners.has(type)) listeners.set(type, []);
+      listeners.get(type).push(callback);
+    }},
+    dispatchEvent(event) {{
+      dispatched.push(event);
+      for (const callback of listeners.get(event.type) || []) callback(event);
+    }},
+    setTimeout(callback) {{ timers.push(callback); return timers.length; }},
+    flushTimers(limit = 500) {{
+      let count = 0;
+      while (timers.length && count++ < limit) timers.shift()();
+      assert.ok(count < limit, 'restore timer loop did not settle');
+    }},
+  }};
+}}
+
+const sharedStorage = storage();
+const inspectorOne = inspector();
+const windowOne = windowHarness(sharedStorage);
+let coreState = {{
+  ready: true,
+  sceneId: 'ur5_2f_test',
+  selectedItemId: 'generated_urdf::camera_link::visual_17',
+  uiSelectionItemId: 'realsense_overhead',
+  editOwnerItemId: 'realsense_overhead',
+  selectedEditable: true,
+  mode: 'move',
+  dirty: true,
+  dirtyCount: 1,
+}};
+let currentTransform = clone(second);
+let events = [
+  {{type:'selection_changed', itemId:''}},
+  {{type:'selection_changed', itemId:'realsense_overhead'}},
+  {{type:'selection_changed', itemId:''}},
+  {{type:'transform_committed', itemId:'realsense_overhead', patchEntry:{{new_transform:clone(second)}}}},
+];
+let gizmoTarget = 'realsense_overhead';
+const originalSelections = [];
+const apiOne = {{
+  getState() {{ return clone(coreState); }},
+  selectItem(id) {{
+    originalSelections.push(id);
+    coreState = {{...coreState, selectedItemId:id === 'generated_urdf::camera_link::visual_17' ? id : 'realsense_overhead', uiSelectionItemId:'realsense_overhead', editOwnerItemId:'realsense_overhead', selectedEditable:true}};
+    return clone(coreState);
+  }},
+  selectionDiagnostics() {{ return {{gizmoAttachedTargetId:gizmoTarget}}; }},
+  clearSelection() {{ coreState = {{...coreState, selectedItemId:'', uiSelectionItemId:'', editOwnerItemId:'', selectedEditable:false}}; return clone(coreState); }},
+  setMode(mode) {{ coreState = {{...coreState, mode}}; gizmoTarget = mode === 'select' ? '' : 'realsense_overhead'; return clone(coreState); }},
+  undo() {{ currentTransform = clone(first); return clone(coreState); }},
+  redo() {{ currentTransform = clone(second); return clone(coreState); }},
+  getEditPatch() {{ return {{schema_version:'workcell_studio_web_scene_edit_patch/v1', scene_id:'ur5_2f_test', edits:[{{item_id:'realsense_overhead', old_transform:clone(first), new_transform:clone(currentTransform)}}]}}; }},
+  drainEvents() {{ const drained = events; events = []; return drained; }},
+}};
+windowOne.__WORKCELL_EDITOR_API_V1__ = apiOne;
+const documentOne = {{getElementById(id) {{ return id === 'inspector' ? inspectorOne : null; }}};
+assert.equal(canonical.installCanonicalSelectionState({{windowRef:windowOne, documentRef:documentOne, storage:sharedStorage, scheduleMicrotask:callback=>callback(), scheduleTimeout:callback=>windowOne.setTimeout(callback)}}), true);
+
+let state = apiOne.getState();
+assert.equal(state.canonicalSelectedOwnerId, 'realsense_overhead');
+assert.deepEqual(state.canonicalTransform, second);
+assert.equal(state.canonicalTransformSource, 'edit_patch');
+assert.equal(inspectorOne.fields.x.value, '-0.220000');
+assert.equal(inspectorOne.fields.yaw.value, '-2.443461');
+assert.equal(inspectorOne.rows.get('pose xyz').dd.textContent, '-0.220, -0.160, 0.060');
+assert.equal(inspectorOne.rows.get('pose rpy').dd.textContent, '0.000, 0.000, -2.443');
+
+let diagnostics = apiOne.selectionDiagnostics();
+assert.equal(diagnostics.canonicalSelectedOwnerId, 'realsense_overhead');
+assert.equal(diagnostics.gizmoAttachedTargetId, 'realsense_overhead');
+assert.equal(diagnostics.gizmoOwnerMatchesSelection, true);
+assert.deepEqual(diagnostics.canonicalTransform, second);
+assert.deepEqual(diagnostics.gizmoTransform, second);
+assert.deepEqual(diagnostics.inspectorTransform, second);
+assert.deepEqual(diagnostics.patchTransform, second);
+assert.deepEqual(apiOne.getEditPatch().edits[0].new_transform, second);
+
+apiOne.setMode('rotate');
+assert.equal(apiOne.getState().canonicalSelectedOwnerId, 'realsense_overhead');
+assert.equal(apiOne.selectionDiagnostics().gizmoAttachedTargetId, 'realsense_overhead');
+
+apiOne.undo();
+assert.deepEqual(apiOne.getState().canonicalTransform, first);
+assert.equal(inspectorOne.fields.x.value, '-0.320000');
+assert.equal(inspectorOne.rows.get('pose xyz').dd.textContent, '-0.320, -0.150, 0.060');
+apiOne.redo();
+assert.deepEqual(apiOne.getState().canonicalTransform, second);
+assert.equal(inspectorOne.fields.x.value, '-0.220000');
+
+const drained = apiOne.drainEvents();
+const selectionEvents = drained.filter(event => event.type === 'selection_changed');
+assert.deepEqual(selectionEvents.map(event => event.itemId), ['realsense_overhead']);
+assert.equal(drained.some(event => event.type === 'selection_changed' && !event.itemId), false);
+const committed = drained.find(event => event.type === 'transform_committed');
+assert.equal(committed.canonicalOwnerItemId, 'realsense_overhead');
+assert.deepEqual(committed.canonicalTransform, second);
+assert.deepEqual(committed.savedXyz, second.pose.xyz);
+assert.deepEqual(committed.savedRpy, second.pose.rpy);
+
+const audit = canonical.auditEditableLayoutOwners([
+  {{id:'support_surface_table', editable:true, locked:false}},
+  {{id:'pick_zone_commissioning', editable:true, locked:false}},
+  {{id:'place_zone_default', role:'place_zone', target_ref:'target_bin_default', transform_group:'default_drop_destination', editable:true, locked:false}},
+  {{id:'target_bin_default', editable:true, locked:false}},
+  {{id:'realsense_overhead', editable:true, locked:false}},
+  {{id:'safety_zone_keepout', editable:true, locked:false}},
+  {{id:'home_pose_safe', editable:true, locked:false}},
+]);
+assert.equal(audit.layoutEditableCount, 7);
+assert.equal(audit.canonicalEditableOwnerCount, 6);
+assert.deepEqual(audit.derivedEditableIds, ['place_zone_default']);
+
+// Simulate the new page created by the canonical Product View reload. The
+// stored owner remains visible to Qt polling until scene_ready restores it.
+const inspectorTwo = inspector();
+const windowTwo = windowHarness(sharedStorage);
+let reloadState = {{
+  ready: false,
+  sceneId: 'ur5_2f_test',
+  selectedItemId: '',
+  uiSelectionItemId: '',
+  editOwnerItemId: '',
+  selectedEditable: false,
+  mode: 'select',
+  dirty: false,
+  dirtyCount: 0,
+}};
+const restoreCalls = [];
+const apiTwo = {{
+  getState() {{ return clone(reloadState); }},
+  selectItem(id) {{ restoreCalls.push(id); reloadState = {{...reloadState, selectedItemId:id, uiSelectionItemId:id, editOwnerItemId:id, selectedEditable:true}}; return clone(reloadState); }},
+  selectionDiagnostics() {{ return {{gizmoAttachedTargetId:''}}; }},
+  setMode(mode) {{ reloadState = {{...reloadState, mode}}; return clone(reloadState); }},
+  undo() {{ return clone(reloadState); }},
+  redo() {{ return clone(reloadState); }},
+  getEditPatch() {{ return {{edits:[]}}; }},
+  drainEvents() {{ return [{{type:'selection_changed', itemId:''}}]; }},
+}};
+windowTwo.__WORKCELL_EDITOR_API_V1__ = apiTwo;
+const documentTwo = {{getElementById(id) {{ return id === 'inspector' ? inspectorTwo : null; }}};
+assert.equal(canonical.installCanonicalSelectionState({{windowRef:windowTwo, documentRef:documentTwo, storage:sharedStorage, scheduleMicrotask:callback=>callback(), scheduleTimeout:callback=>windowTwo.setTimeout(callback)}}), true);
+state = apiTwo.getState();
+assert.equal(state.selectedItemId, 'realsense_overhead');
+assert.equal(state.canonicalSelectedOwnerId, 'realsense_overhead');
+assert.equal(state.retainedSelectionPending, true);
+reloadState = {{...reloadState, ready:true}};
+windowTwo.dispatchEvent(new windowTwo.CustomEvent('workcell:web3d_readiness', {{detail:{{state:'scene_ready'}}}}));
+windowTwo.flushTimers();
+assert.deepEqual(restoreCalls, ['realsense_overhead']);
+state = apiTwo.getState();
+assert.equal(state.selectedItemId, 'realsense_overhead');
+assert.equal(state.retainedSelectionPending, false);
+assert.equal(apiTwo.drainEvents().some(event => event.type === 'selection_changed' && !event.itemId), false);
+
+console.log(JSON.stringify({{
+  owner: state.canonicalSelectedOwnerId,
+  originalSelections,
+  restoreCalls,
+  audit,
+}}));
+"""
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert payload["owner"] == "realsense_overhead"
+    assert payload["restoreCalls"] == ["realsense_overhead"]
+    assert payload["audit"]["canonicalEditableOwnerCount"] == 6

--- a/workcell_studio_web/viewer/canonical_selection_state.js
+++ b/workcell_studio_web/viewer/canonical_selection_state.js
@@ -1,0 +1,468 @@
+const VERSION = 1;
+const INSTALL_FLAG = '__WORKCELL_CANONICAL_SELECTION_STATE_INSTALLED__';
+const STORAGE_PREFIX = 'workcell_studio.canonical_selection.';
+const MAX_INSTALL_ATTEMPTS = 200;
+const INSTALL_RETRY_MS = 50;
+const MAX_RESTORE_ATTEMPTS = 80;
+const RESTORE_RETRY_MS = 50;
+
+function stringValue(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function clone(value) {
+  if (value === undefined) return undefined;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function finiteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+export function isFiniteCanonicalTransform(transform) {
+  return Boolean(transform) && [
+    transform?.pose?.xyz?.x,
+    transform?.pose?.xyz?.y,
+    transform?.pose?.xyz?.z,
+    transform?.pose?.rpy?.x,
+    transform?.pose?.rpy?.y,
+    transform?.pose?.rpy?.z,
+    transform?.scale?.x,
+    transform?.scale?.y,
+    transform?.scale?.z,
+  ].every(finiteNumber);
+}
+
+function canonicalOwnerIdFromState(state) {
+  return stringValue(
+    state?.editOwnerItemId ||
+    state?.canonicalSelectedOwnerId ||
+    state?.uiSelectionItemId ||
+    state?.selectedItemId
+  );
+}
+
+function patchEditForOwner(patch, ownerId) {
+  const edits = Array.isArray(patch?.edits) ? patch.edits : [];
+  return edits.find(edit => stringValue(edit?.item_id) === ownerId) || null;
+}
+
+function transformFromPatch(patch, ownerId) {
+  const edit = patchEditForOwner(patch, ownerId);
+  return isFiniteCanonicalTransform(edit?.new_transform) ? clone(edit.new_transform) : null;
+}
+
+function transformFromInspector(documentRef) {
+  const inspector = documentRef?.getElementById?.('inspector');
+  if (!inspector?.querySelector) return null;
+  const read = field => Number(inspector.querySelector(`[data-transform-field="${field}"]`)?.value);
+  const transform = {
+    pose: {
+      xyz: { x: read('x'), y: read('y'), z: read('z') },
+      rpy: { x: read('roll'), y: read('pitch'), z: read('yaw') },
+    },
+    scale: { x: read('scale_x'), y: read('scale_y'), z: read('scale_z') },
+  };
+  return isFiniteCanonicalTransform(transform) ? transform : null;
+}
+
+function writeInspectorSummary(inspector, label, value) {
+  for (const key of inspector?.querySelectorAll?.('dt') || []) {
+    if (stringValue(key.textContent).toLowerCase() !== label) continue;
+    if (key.nextElementSibling) key.nextElementSibling.textContent = value;
+  }
+}
+
+function writeInspectorTransform(documentRef, transform) {
+  if (!isFiniteCanonicalTransform(transform)) return false;
+  const inspector = documentRef?.getElementById?.('inspector');
+  if (!inspector?.querySelector) return false;
+  const values = {
+    x: transform.pose.xyz.x,
+    y: transform.pose.xyz.y,
+    z: transform.pose.xyz.z,
+    roll: transform.pose.rpy.x,
+    pitch: transform.pose.rpy.y,
+    yaw: transform.pose.rpy.z,
+    scale_x: transform.scale.x,
+    scale_y: transform.scale.y,
+    scale_z: transform.scale.z,
+  };
+  for (const [field, value] of Object.entries(values)) {
+    const input = inspector.querySelector(`[data-transform-field="${field}"]`);
+    if (input) input.value = Number(value).toFixed(6);
+  }
+  writeInspectorSummary(inspector, 'pose xyz', [transform.pose.xyz.x, transform.pose.xyz.y, transform.pose.xyz.z].map(value => Number(value).toFixed(3)).join(', '));
+  writeInspectorSummary(inspector, 'pose rpy', [transform.pose.rpy.x, transform.pose.rpy.y, transform.pose.rpy.z].map(value => Number(value).toFixed(3)).join(', '));
+  writeInspectorSummary(inspector, 'scale', JSON.stringify([transform.scale.x, transform.scale.y, transform.scale.z]));
+  return true;
+}
+
+function storageKey(sceneId) {
+  return `${STORAGE_PREFIX}${sceneId}`;
+}
+
+function readStoredSelection(storage, sceneId) {
+  if (!storage || !sceneId) return null;
+  try {
+    const parsed = JSON.parse(storage.getItem(storageKey(sceneId)) || 'null');
+    if (!parsed || stringValue(parsed.sceneId) !== sceneId || !stringValue(parsed.ownerId)) return null;
+    return {
+      sceneId,
+      ownerId: stringValue(parsed.ownerId),
+      editable: Boolean(parsed.editable),
+      transform: isFiniteCanonicalTransform(parsed.transform) ? clone(parsed.transform) : null,
+    };
+  } catch (_) {
+    return null;
+  }
+}
+
+function writeStoredSelection(storage, record) {
+  if (!storage || !record?.sceneId || !record?.ownerId) return;
+  try {
+    storage.setItem(storageKey(record.sceneId), JSON.stringify({
+      sceneId: record.sceneId,
+      ownerId: record.ownerId,
+      editable: Boolean(record.editable),
+      transform: isFiniteCanonicalTransform(record.transform) ? record.transform : null,
+    }));
+  } catch (_) {
+    // Selection retention is optional and must never interrupt authoring.
+  }
+}
+
+function clearStoredSelection(storage, sceneId) {
+  if (!storage || !sceneId) return;
+  try {
+    storage.removeItem(storageKey(sceneId));
+  } catch (_) {
+    // Ignore unavailable session storage.
+  }
+}
+
+export function auditEditableLayoutOwners(items) {
+  const editable = (Array.isArray(items) ? items : []).filter(item => item?.editable === true && item?.locked !== true);
+  const derived = editable.filter(item => {
+    const role = stringValue(item?.role || item?.type).toLowerCase();
+    return Boolean(item?.transform_group && item?.target_ref && role === 'place_zone');
+  });
+  const derivedIds = new Set(derived.map(item => stringValue(item?.id)).filter(Boolean));
+  const canonical = editable.filter(item => !derivedIds.has(stringValue(item?.id)));
+  return Object.freeze({
+    layoutEditableCount: editable.length,
+    canonicalEditableOwnerCount: canonical.length,
+    derivedEditableCount: derived.length,
+    layoutEditableIds: Object.freeze(editable.map(item => stringValue(item?.id)).filter(Boolean)),
+    canonicalEditableOwnerIds: Object.freeze(canonical.map(item => stringValue(item?.id)).filter(Boolean)),
+    derivedEditableIds: Object.freeze([...derivedIds]),
+  });
+}
+
+function dispatchState(windowRef, detail) {
+  try {
+    if (typeof windowRef?.CustomEvent === 'function' && typeof windowRef?.dispatchEvent === 'function') {
+      windowRef.dispatchEvent(new windowRef.CustomEvent('workcell:canonical_selection_state', { detail }));
+    }
+  } catch (_) {
+    // Optional diagnostics cannot break editor state.
+  }
+}
+
+export function installCanonicalSelectionState({
+  windowRef = globalThis.window,
+  documentRef = globalThis.document,
+  storage = windowRef?.sessionStorage,
+  scheduleMicrotask = globalThis.queueMicrotask || (callback => Promise.resolve().then(callback)),
+  scheduleTimeout = (callback, delay) => windowRef?.setTimeout?.(callback, delay),
+} = {}) {
+  const api = windowRef?.__WORKCELL_EDITOR_API_V1__;
+  if (!api?.getState || !api?.selectItem || !api?.getEditPatch) return false;
+  if (api[INSTALL_FLAG]) return true;
+  api[INSTALL_FLAG] = true;
+
+  const original = {
+    getState: api.getState.bind(api),
+    selectItem: api.selectItem.bind(api),
+    selectionDiagnostics: api.selectionDiagnostics?.bind(api),
+    clearSelection: api.clearSelection?.bind(api),
+    setMode: api.setMode?.bind(api),
+    undo: api.undo?.bind(api),
+    redo: api.redo?.bind(api),
+    getEditPatch: api.getEditPatch.bind(api),
+    drainEvents: api.drainEvents?.bind(api),
+  };
+
+  let canonicalRecord = {
+    sceneId: '',
+    ownerId: '',
+    editable: false,
+    transform: null,
+    transformSource: 'none',
+    sequence: 0,
+  };
+  let restorePending = false;
+  let restoreGeneration = 0;
+  let lastStateSignature = '';
+  let lastDrainedSelectionOwner = '';
+
+  const rawState = () => original.getState() || {};
+  const rawPatch = () => original.getEditPatch() || { edits: [] };
+
+  function retainedRecordFor(state) {
+    return readStoredSelection(storage, stringValue(state?.sceneId));
+  }
+
+  function resolveCanonicalTransform(state, ownerId) {
+    const patchTransform = transformFromPatch(rawPatch(), ownerId);
+    if (patchTransform) return { transform: patchTransform, source: 'edit_patch' };
+    const inspectorTransform = transformFromInspector(documentRef);
+    if (inspectorTransform) return { transform: inspectorTransform, source: 'inspector' };
+    if (canonicalRecord.ownerId === ownerId && isFiniteCanonicalTransform(canonicalRecord.transform)) {
+      return { transform: clone(canonicalRecord.transform), source: canonicalRecord.transformSource || 'retained' };
+    }
+    const retained = retainedRecordFor(state);
+    if (retained?.ownerId === ownerId && isFiniteCanonicalTransform(retained.transform)) {
+      return { transform: clone(retained.transform), source: 'session_retained' };
+    }
+    return { transform: null, source: 'none' };
+  }
+
+  function synchronize(reason = 'poll') {
+    const state = rawState();
+    const sceneId = stringValue(state.sceneId);
+    let ownerId = canonicalOwnerIdFromState(state);
+    const retained = retainedRecordFor(state);
+    if (!ownerId && restorePending && retained?.ownerId) ownerId = retained.ownerId;
+    const resolved = ownerId ? resolveCanonicalTransform(state, ownerId) : { transform: null, source: 'none' };
+    const next = {
+      sceneId,
+      ownerId,
+      editable: ownerId === canonicalOwnerIdFromState(state) ? Boolean(state.selectedEditable) : Boolean(retained?.editable),
+      transform: resolved.transform,
+      transformSource: resolved.source,
+      sequence: canonicalRecord.sequence,
+    };
+    const signature = JSON.stringify({
+      sceneId: next.sceneId,
+      ownerId: next.ownerId,
+      editable: next.editable,
+      transform: next.transform,
+      source: next.transformSource,
+    });
+    if (signature !== lastStateSignature) {
+      next.sequence += 1;
+      lastStateSignature = signature;
+      canonicalRecord = next;
+      dispatchState(windowRef, {
+        reason,
+        scene_id: next.sceneId,
+        sceneId: next.sceneId,
+        canonical_selected_owner_id: next.ownerId,
+        canonicalSelectedOwnerId: next.ownerId,
+        canonical_transform: clone(next.transform),
+        canonicalTransform: clone(next.transform),
+        transform_source: next.transformSource,
+        transformSource: next.transformSource,
+        sequence: next.sequence,
+      });
+    } else {
+      canonicalRecord = { ...next, sequence: canonicalRecord.sequence };
+    }
+    if (canonicalRecord.ownerId) {
+      writeStoredSelection(storage, canonicalRecord);
+      writeInspectorTransform(documentRef, canonicalRecord.transform);
+    }
+    return canonicalRecord;
+  }
+
+  function publicState() {
+    const state = rawState();
+    const record = synchronize('get_state');
+    const retained = !canonicalOwnerIdFromState(state) && record.ownerId;
+    return {
+      ...state,
+      selectedItemId: retained ? record.ownerId : state.selectedItemId,
+      uiSelectionItemId: retained ? record.ownerId : state.uiSelectionItemId,
+      editOwnerItemId: retained ? record.ownerId : state.editOwnerItemId,
+      selectedEditable: retained ? record.editable : state.selectedEditable,
+      canonicalSelectedOwnerId: record.ownerId,
+      canonicalTransform: clone(record.transform),
+      canonicalTransformSource: record.transformSource,
+      canonicalSelectionSequence: record.sequence,
+      retainedSelectionPending: Boolean(retained && restorePending),
+    };
+  }
+
+  function restoreSelection(attempt = 0, generation = restoreGeneration) {
+    if (generation !== restoreGeneration) return false;
+    const state = rawState();
+    const sceneId = stringValue(state.sceneId);
+    const currentOwner = canonicalOwnerIdFromState(state);
+    if (currentOwner) {
+      restorePending = false;
+      synchronize('selection_already_current');
+      return true;
+    }
+    const retained = readStoredSelection(storage, sceneId);
+    if (state.ready && retained?.ownerId) {
+      const restored = original.selectItem(retained.ownerId) || rawState();
+      if (canonicalOwnerIdFromState(restored) === retained.ownerId) {
+        restorePending = false;
+        synchronize('selection_restored');
+        return true;
+      }
+    }
+    if (attempt >= MAX_RESTORE_ATTEMPTS) {
+      restorePending = false;
+      return false;
+    }
+    scheduleTimeout?.(() => restoreSelection(attempt + 1, generation), RESTORE_RETRY_MS);
+    return false;
+  }
+
+  function beginRestore() {
+    restorePending = true;
+    restoreGeneration += 1;
+    restoreSelection(0, restoreGeneration);
+  }
+
+  api.getState = () => publicState();
+  api.selectItem = id => {
+    const selected = original.selectItem(stringValue(id)) || rawState();
+    const ownerId = canonicalOwnerIdFromState(selected);
+    if (ownerId && stringValue(selected.selectedItemId) !== ownerId) original.selectItem(ownerId);
+    restorePending = false;
+    synchronize('select_item');
+    return publicState();
+  };
+  api.selectionDiagnostics = () => {
+    const diagnostics = original.selectionDiagnostics?.() || {};
+    const record = synchronize('selection_diagnostics');
+    const patchTransform = record.ownerId ? transformFromPatch(rawPatch(), record.ownerId) : null;
+    const inspectorTransform = transformFromInspector(documentRef);
+    return {
+      ...diagnostics,
+      canonicalSelectedOwnerId: record.ownerId,
+      canonicalTransform: clone(record.transform),
+      canonicalTransformSource: record.transformSource,
+      inspectorTransform: clone(inspectorTransform),
+      patchTransform: clone(patchTransform),
+      gizmoTransform: clone(record.transform),
+      gizmoOwnerMatchesSelection: !stringValue(diagnostics.gizmoAttachedTargetId) || stringValue(diagnostics.gizmoAttachedTargetId) === record.ownerId,
+    };
+  };
+  if (original.clearSelection) {
+    api.clearSelection = () => {
+      const sceneId = stringValue(rawState().sceneId);
+      restorePending = false;
+      clearStoredSelection(storage, sceneId);
+      const result = original.clearSelection();
+      canonicalRecord = { sceneId, ownerId: '', editable: false, transform: null, transformSource: 'none', sequence: canonicalRecord.sequence + 1 };
+      lastStateSignature = '';
+      return result;
+    };
+  }
+  if (original.setMode) {
+    api.setMode = mode => {
+      const record = synchronize('before_mode_change');
+      if (record.ownerId && canonicalOwnerIdFromState(rawState()) !== record.ownerId) original.selectItem(record.ownerId);
+      original.setMode(mode);
+      synchronize('mode_change');
+      return publicState();
+    };
+  }
+  if (original.undo) {
+    api.undo = () => {
+      original.undo();
+      synchronize('undo');
+      scheduleMicrotask(() => synchronize('undo_settled'));
+      return publicState();
+    };
+  }
+  if (original.redo) {
+    api.redo = () => {
+      original.redo();
+      synchronize('redo');
+      scheduleMicrotask(() => synchronize('redo_settled'));
+      return publicState();
+    };
+  }
+  api.getEditPatch = () => original.getEditPatch();
+  if (original.drainEvents) {
+    api.drainEvents = () => {
+      const events = original.drainEvents() || [];
+      const record = synchronize('drain_events');
+      const normalized = events.filter(event => event?.type !== 'selection_changed').map(event => {
+        if (event?.type !== 'transform_committed') return event;
+        const transform = isFiniteCanonicalTransform(event?.patchEntry?.new_transform)
+          ? clone(event.patchEntry.new_transform)
+          : clone(record.transform);
+        return {
+          ...event,
+          canonicalOwnerItemId: record.ownerId,
+          canonicalTransform: transform,
+          savedXyz: clone(transform?.pose?.xyz),
+          savedRpy: clone(transform?.pose?.rpy),
+        };
+      });
+      if (record.ownerId !== lastDrainedSelectionOwner) {
+        lastDrainedSelectionOwner = record.ownerId;
+        normalized.push({
+          type: 'selection_changed',
+          itemId: record.ownerId,
+          uiItemId: record.ownerId,
+          editable: record.editable,
+          canonicalOwnerItemId: record.ownerId,
+          canonicalTransform: clone(record.transform),
+        });
+      }
+      if (!record.ownerId && !restorePending) clearStoredSelection(storage, record.sceneId);
+      return normalized;
+    };
+  }
+
+  const onReadiness = event => {
+    const readiness = stringValue(event?.detail?.state || event?.detail?.lifecycle_state || event?.detail?.lifecycleState);
+    if (readiness === 'scene_ready') beginRestore();
+  };
+  windowRef?.addEventListener?.('workcell:web3d_readiness', onReadiness);
+  windowRef?.addEventListener?.('workcell:scene-loaded', beginRestore);
+  windowRef?.addEventListener?.('pageshow', beginRestore);
+
+  if (typeof windowRef?.MutationObserver === 'function') {
+    const inspector = documentRef?.getElementById?.('inspector');
+    if (inspector) {
+      const observer = new windowRef.MutationObserver(() => scheduleMicrotask(() => synchronize('inspector_rebuilt')));
+      observer.observe(inspector, { childList: true, subtree: true });
+    }
+  }
+
+  synchronize('install');
+  beginRestore();
+  return true;
+}
+
+const publicApi = Object.freeze({
+  enabled: true,
+  version: VERSION,
+  install: installCanonicalSelectionState,
+  auditEditableLayoutOwners,
+  isFiniteCanonicalTransform,
+});
+
+if (typeof window !== 'undefined') {
+  window.__WORKCELL_CANONICAL_SELECTION_STATE_V1__ = publicApi;
+}
+
+function installWhenReady(attempt = 0) {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+  if (installCanonicalSelectionState()) return;
+  if (attempt >= MAX_INSTALL_ATTEMPTS) {
+    console.warn?.('Canonical selection state was not installed because the Product View editor API did not become ready.');
+    return;
+  }
+  window.setTimeout?.(() => installWhenReady(attempt + 1), INSTALL_RETRY_MS);
+}
+
+installWhenReady();

--- a/workcell_studio_web/viewer/post_bundle_viewer_modules.js
+++ b/workcell_studio_web/viewer/post_bundle_viewer_modules.js
@@ -1,6 +1,7 @@
+import './canonical_selection_state.js';
 import './canonical_helper_pick_proxies.js';
 
-const VERSION = 2;
+const VERSION = 3;
 
 const MODULES = Object.freeze([
   Object.freeze({
@@ -38,6 +39,12 @@ const MODULES = Object.freeze([
     file: 'contextual_placement_actions.js',
     global: '__WORKCELL_CONTEXTUAL_PLACEMENT_ACTIONS_V1__',
     purpose: 'one-click placement actions',
+  }),
+  Object.freeze({
+    id: 'canonical-selection-state',
+    file: 'canonical_selection_state.js',
+    global: '__WORKCELL_CANONICAL_SELECTION_STATE_V1__',
+    purpose: 'one selected owner and one transform state for inspector, gizmo and edit patches',
   }),
   Object.freeze({
     id: 'canonical-helper-pick-proxies',
@@ -88,6 +95,8 @@ function getStatus() {
     ready: missing.length === 0,
     sceneId: String(state?.sceneId || ''),
     selectedItemId: String(state?.selectedItemId || ''),
+    canonicalSelectedOwnerId: String(state?.canonicalSelectedOwnerId || ''),
+    canonicalTransform: state?.canonicalTransform || null,
     dirty: Boolean(state?.dirty),
     modules: Object.freeze(modules),
     missing: Object.freeze(missing),
@@ -133,6 +142,8 @@ function announceStatus() {
   const signature = JSON.stringify({
     ready: status.ready,
     sceneId: status.sceneId,
+    canonicalSelectedOwnerId: status.canonicalSelectedOwnerId,
+    canonicalTransform: status.canonicalTransform,
     missing: status.missing,
   });
   if (signature === lastAnnouncement) return status;
@@ -142,6 +153,8 @@ function announceStatus() {
     type: 'workcell_post_bundle_viewer_status',
     ready: status.ready,
     scene_id: status.sceneId,
+    canonical_selected_owner_id: status.canonicalSelectedOwnerId,
+    canonical_transform: status.canonicalTransform,
     missing: [...status.missing],
   }, '*');
   return status;
@@ -168,6 +181,7 @@ for (const eventName of [
   'workcell:gizmo-task-mode',
   'workcell:collision-placement',
   'workcell:contextual-placement-action',
+  'workcell:canonical_selection_state',
   'workcell:editor-state',
   'workcell:scene-loaded',
 ]) {


### PR DESCRIPTION
## Overall goal
Make Workcell Studio’s Product View a trustworthy editing surface for configurable robotic cells.

## Current goal
Finish the deterministic `ur5_2f_test` authoring workflow before spreading fixes to other scenes.

## Immediate goal
Use one canonical selected-owner record for selection, inspector, gizmo diagnostics, edit-patch transforms, save logs, undo/redo, and canonical reload retention.

## Problem
Product View currently exposes several related identities at once:

- the directly rendered/generated row;
- the UI selection owner;
- the canonical editable transform owner;
- the inspector item;
- the TransformControls target;
- the edit-patch item.

That can temporarily expose zero/stale inspector transforms and generate repeated selection transitions such as `<none> → selected → <none>` while the canonical Product View reload replaces the page after Save Layout.

## Fix
Adds `canonical_selection_state.js`, installed before the helper-pick proxy module, which wraps the existing public editor API without adding new scene or pick identities.

The module:

- resolves one canonical selected owner from `editOwnerItemId`, UI owner and selected identity;
- resolves its authoritative current transform from the exported edit patch first, then the inspector/retained baseline;
- synchronizes inspector XYZ/RPY/scale fields and summary rows from that canonical transform;
- exposes `canonicalSelectedOwnerId`, `canonicalTransform`, transform source and retention status through `getState()`;
- augments selection diagnostics so inspector, gizmo target and exported patch can be compared directly;
- preserves the canonical selected owner in session storage across the forced post-save Product View reload;
- keeps that retained owner visible to Qt polling until the matching `scene_ready` page can restore the real selection;
- coalesces raw selection events into one canonical `selection_changed` event and suppresses transient empty events during reload;
- normalizes `transform_committed` events with the actual patch `new_transform`, including saved XYZ/RPY;
- re-synchronizes the inspector after undo and redo;
- keeps explicit Clear Selection authoritative by removing the retained record.

The existing viewer remains the owner of physical transform application and TransformControls. The new layer only forces every public editor surface to resolve through the same canonical owner and transform.

## Editable count audit
`ur5_2f_test/layout/workcell_studio_layout.yaml` contains seven editable rows, but only six independent canonical transform owners.

`place_zone_default` is intentionally derived from `target_bin_default` because it has:

- `role: place_zone`;
- `target_ref: target_bin_default`;
- `transform_group: default_drop_destination`.

Therefore:

- layout editable rows: **7**;
- independent canonical editable owners: **6**;
- derived linked row: **1** (`place_zone_default`).

The PR adds a focused audit helper and regression test for this contract.

## Acceptance coverage
The executable Node harness verifies:

1. generated camera selection resolves to `realsense_overhead`;
2. inspector, gizmo diagnostic and exported patch report the same XYZ/RPY/scale;
3. undo and redo update the canonical transform and inspector together;
4. three raw events `<none> → selected → <none>` are emitted publicly as one canonical selection event;
5. `transform_committed` reports the actual exported patch transform and saved XYZ/RPY;
6. a fresh page retains the selected owner while loading and restores it exactly once after `scene_ready`;
7. the editable-count audit resolves `7 layout rows = 6 canonical owners + 1 derived place zone`.

## Workstation acceptance
After merge:

1. Open `ur5_2f_test` and select the table, bin or camera.
2. Enter Move or Rotate mode.
3. Compare the inspector XYZ/RPY with the selection/gizmo diagnostic and the exported patch.
4. Move the item, then Undo and Redo; confirm the physical object and inspector update together.
5. Save Layout and let the canonical Product View reload complete.
6. Confirm the same owner remains selected without a visible `<none> → selected → <none>` flicker.
7. Confirm save logs show the patch’s real old/new XYZ/RPY values.

## Scope and safety
- no scene YAML is changed;
- no generated viewer bundle is committed;
- no RViz/MoveIt launch behavior is changed;
- no controllers or hardware settings are changed;
- no new editor or helper identities are created;
- fake-hardware and no-motion defaults remain unchanged.