### PR TITLE
Repair Workcell Builder command process handling

### DIFF
--- a/tests/test_scene_preview_widget_process_failure_reporting.py
+++ b/tests/test_scene_preview_widget_process_failure_reporting.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CPP = (ROOT / "workcell_builder/workcell_builder/gui/scene_preview_widget.cpp").read_text(encoding="utf-8")
+
+
+def _between(start: str, end: str) -> str:
+    begin = CPP.index(start)
+    return CPP[begin:CPP.index(end, begin)]
+
+
+def test_product_view_prepare_uses_qprocess_with_split_arguments_and_environment():
+    prepare = _between(
+        "void ScenePreviewWidget::start_embedded_web_prepare",
+        "void ScenePreviewWidget::on_embedded_web_prepare_finished",
+    )
+    assert 'setProgram(QStringLiteral("python3"))' in prepare
+    assert "QStringList args" in prepare
+    assert '"scripts/ensure_workcell_studio_web_scene_fresh.py"' in prepare
+    assert "setArguments(args)" in prepare
+    assert "setWorkingDirectory(repo_root)" in prepare
+    assert "setProcessEnvironment(QProcessEnvironment::systemEnvironment())" in prepare
+    assert "std::system" not in prepare
+    assert '"/bin/sh"' not in prepare
+    assert '"/bin/bash"' not in prepare
+
+
+def test_process_failures_report_executable_arguments_cwd_status_stderr_and_timeout():
+    helper = _between(
+        "QString summarize_prepare_process_failure",
+        "void maybe_warn_overlay_fit_dominance",
+    )
+    for token in [
+        "executable=%1",
+        "arguments=%2",
+        "working_directory=%3",
+        "exit_status=%4",
+        "exit_code=%5",
+        "start_error=%1",
+        "stderr=%1",
+    ]:
+        assert token in helper
+
+    prepare = _between(
+        "void ScenePreviewWidget::start_embedded_web_prepare",
+        "void ScenePreviewWidget::on_embedded_web_prepare_finished",
+    )
+    assert "&QProcess::errorOccurred" in prepare
+    assert "QTimer::singleShot(120000" in prepare
+    assert 'QStringLiteral("timeout after 120000 ms")' in prepare
+    assert 'QStringLiteral("timeout")' in prepare
+    assert "process->kill()" in prepare
+
+
+def test_nonzero_exit_and_contract_failures_use_actionable_process_detail():
+    finished = _between(
+        "void ScenePreviewWidget::on_embedded_web_prepare_finished",
+        "void ScenePreviewWidget::start_embedded_web_readiness_polling",
+    )
+    assert "auto reject_prepare" in finished
+    assert "summarize_prepare_process_failure(" in finished
+    assert "diagnostic.stderr_tail" in finished
+    assert '"prepare command failed with exit code %1; old output is rejected even if present"' in finished
+    assert "show_embedded_web_preparation_failure(identity, detail)" in finished

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -89,6 +89,7 @@
 #include <QMetaObject>
 #include <QPointer>
 #include <QProgressDialog>
+#include <QProcess>
 #include <QProcessEnvironment>
 #include <QSettings>
 #include <QSizePolicy>
@@ -167,6 +168,81 @@ namespace {
   "Layout: environment_asset primitive_fallback pick_zone place_zone camera_pose camera_fov conveyor_placeholder spawn_line | "
   "Task intent: task_intent grasp_strategy top_grasp_2f suction_top approach_distance retract_distance | "
   "Generate/Validate/Plan: generated_package_path validation_output plan_simulate_handoff fake_hardware_first";
+
+
+struct WorkcellCommandResult {
+  bool started{false};
+  bool timed_out{false};
+  QProcess::ExitStatus exit_status{QProcess::NormalExit};
+  int exit_code{-1};
+  QString error_string;
+  QString stdout_text;
+  QString stderr_text;
+};
+
+static QString workcell_command_arguments_for_log(const QStringList & arguments)
+{
+  QStringList rendered;
+  for (const QString & argument : arguments) {
+    rendered << QStringLiteral("'%1'").arg(argument.left(180).replace(QStringLiteral("'"), QStringLiteral("'\\''")));
+  }
+  return rendered.join(QStringLiteral(" "));
+}
+
+static WorkcellCommandResult run_workcell_command_checked(
+  const QString & executable, const QStringList & arguments, const QString & working_directory,
+  int timeout_ms = 120000)
+{
+  WorkcellCommandResult result;
+  QProcess process;
+  process.setProgram(executable);
+  process.setArguments(arguments);
+  process.setWorkingDirectory(working_directory);
+  process.setProcessEnvironment(QProcessEnvironment::systemEnvironment());
+  process.setProcessChannelMode(QProcess::SeparateChannels);
+  process.start();
+  if (!process.waitForStarted(10000)) {
+    result.error_string = process.errorString();
+    result.stderr_text = QString::fromUtf8(process.readAllStandardError()).trimmed();
+    result.stdout_text = QString::fromUtf8(process.readAllStandardOutput()).trimmed();
+    return result;
+  }
+  result.started = true;
+  if (!process.waitForFinished(timeout_ms)) {
+    result.timed_out = true;
+    process.kill();
+    process.waitForFinished(2000);
+  }
+  result.exit_status = process.exitStatus();
+  result.exit_code = process.exitCode();
+  result.error_string = process.errorString();
+  result.stdout_text = QString::fromUtf8(process.readAllStandardOutput()).trimmed();
+  result.stderr_text = QString::fromUtf8(process.readAllStandardError()).trimmed();
+  return result;
+}
+
+static bool workcell_command_succeeded(const WorkcellCommandResult & result)
+{
+  return result.started && !result.timed_out && result.exit_status == QProcess::NormalExit && result.exit_code == 0;
+}
+
+static QString workcell_command_failure_summary(
+  const QString & executable, const QStringList & arguments, const QString & working_directory,
+  const WorkcellCommandResult & result)
+{
+  QString detail = QStringLiteral("executable=%1 arguments=%2 working_directory=%3 started=%4 timed_out=%5 exit_status=%6 exit_code=%7")
+    .arg(executable,
+         workcell_command_arguments_for_log(arguments),
+         working_directory.isEmpty() ? QStringLiteral("<unset>") : working_directory,
+         result.started ? QStringLiteral("true") : QStringLiteral("false"),
+         result.timed_out ? QStringLiteral("true") : QStringLiteral("false"),
+         result.exit_status == QProcess::NormalExit ? QStringLiteral("normal") : QStringLiteral("crash"))
+    .arg(result.exit_code);
+  if (!result.error_string.trimmed().isEmpty()) detail += QStringLiteral(" error=%1").arg(result.error_string.trimmed().left(400));
+  if (!result.stderr_text.trimmed().isEmpty()) detail += QStringLiteral(" stderr=%1").arg(result.stderr_text.trimmed().left(1200));
+  if (!result.stdout_text.trimmed().isEmpty()) detail += QStringLiteral(" stdout=%1").arg(result.stdout_text.trimmed().left(800));
+  return detail;
+}
 
 static QString scene3d_user_preview_status_summary(
   const ScenePreviewWidget::RenderDebugCounters & counters,
@@ -4615,8 +4691,13 @@ void MainWindow::open_selected_scene_artifact(const QString & artifact)
       append_studio_log("Acceptance: running safe offline layout merge first");
       workcell_builder::merge_workcell_studio_layout(s.scene_dir);
     }
-    const QString cmd = QString("python3 scripts/validate_workcell_studio_generated_scene.py '%1' --json").arg(QString::fromStdString(s.scene_dir.string()));
-    const int rc = std::system(cmd.toStdString().c_str()); append_studio_log(rc==0?"Acceptance completed":"Acceptance blocked"); refresh_scene_browser_ui(); return;
+    const QString executable = QStringLiteral("python3");
+    const QStringList arguments{QStringLiteral("scripts/validate_workcell_studio_generated_scene.py"), QString::fromStdString(s.scene_dir.string()), QStringLiteral("--json")};
+    const QString working_directory = QString::fromStdString(workcell_path.string());
+    const WorkcellCommandResult result = run_workcell_command_checked(executable, arguments, working_directory);
+    append_studio_log(workcell_command_succeeded(result) ? QStringLiteral("Acceptance completed") :
+      QStringLiteral("Acceptance blocked: %1").arg(workcell_command_failure_summary(executable, arguments, working_directory, result)));
+    refresh_scene_browser_ui(); return;
   } else if (artifact=="run_smoke") {
     QMessageBox::information(this,"Workcell Studio","Offline smoke check runner is report-only in Demo Mode. Missing artifact will be reported in demo summary."); return;
   } else if (artifact=="run_preview") {
@@ -4702,15 +4783,17 @@ void MainWindow::export_scene_bundle_for_selected_scene()
   fs::create_directories(export_root);
   const fs::path zip_out = export_root / (s.scene_name + "_workcell_studio_bundle.zip");
   const QString script = "scripts/export_workcell_scene_bundle.py";
-  const QString cmd = QString("python3 '%1' --scene-dir '%2' --output '%3' --validate --include-assets")
-    .arg(script, QString::fromStdString(s.scene_dir.string()), QString::fromStdString(zip_out.string()));
-  append_studio_log("Export Scene Bundle: running " + cmd);
-  const int rc = std::system(cmd.toStdString().c_str());
-  if (rc == 0) {
+  const QString executable = QStringLiteral("python3");
+  const QStringList arguments{script, QStringLiteral("--scene-dir"), QString::fromStdString(s.scene_dir.string()),
+    QStringLiteral("--output"), QString::fromStdString(zip_out.string()), QStringLiteral("--validate"), QStringLiteral("--include-assets")};
+  const QString working_directory = QString::fromStdString(workcell_path.string());
+  append_studio_log(QStringLiteral("Export Scene Bundle: running %1 %2").arg(executable, workcell_command_arguments_for_log(arguments)));
+  const WorkcellCommandResult result = run_workcell_command_checked(executable, arguments, working_directory);
+  if (workcell_command_succeeded(result)) {
     append_studio_log("Export Scene Bundle: completed -> " + QString::fromStdString(zip_out.string()));
     last_scene_bundle_export_folder_ = QString::fromStdString(export_root.string());
   } else {
-    append_studio_log("Export Scene Bundle: failed.");
+    append_studio_log(QStringLiteral("Export Scene Bundle: failed: %1").arg(workcell_command_failure_summary(executable, arguments, working_directory, result)));
   }
   refresh_scene_bundle_export_panel();
 }
@@ -4723,17 +4806,14 @@ void MainWindow::import_scene_bundle_into_scenes_root()
   fs::path scenes_root = scene_browser_result_.scene_root.empty() ? (workcell_path / "src" / "scenes") : scene_browser_result_.scene_root;
   fs::create_directories(scenes_root);
   const QString script = "scripts/import_workcell_scene_bundle.py";
-  QString cmd;
-  if (QFileInfo(selected).isDir()) {
-    cmd = QString("python3 '%1' --bundle '%2' --target-scenes-dir '%3' --validate --print-summary")
-      .arg(script, selected, QString::fromStdString(scenes_root.string()));
-  } else {
-    cmd = QString("python3 '%1' --bundle '%2' --target-scenes-dir '%3' --validate --print-summary")
-      .arg(script, selected, QString::fromStdString(scenes_root.string()));
-  }
-  append_studio_log("Import Scene Bundle: running " + cmd);
-  const int rc = std::system(cmd.toStdString().c_str());
-  append_studio_log(rc == 0 ? "Import Scene Bundle: completed. Imported Scene Ready." : "Import Scene Bundle: failed.");
+  const QString executable = QStringLiteral("python3");
+  const QStringList arguments{script, QStringLiteral("--bundle"), selected, QStringLiteral("--target-scenes-dir"),
+    QString::fromStdString(scenes_root.string()), QStringLiteral("--validate"), QStringLiteral("--print-summary")};
+  const QString working_directory = QString::fromStdString(workcell_path.string());
+  append_studio_log(QStringLiteral("Import Scene Bundle: running %1 %2").arg(executable, workcell_command_arguments_for_log(arguments)));
+  const WorkcellCommandResult result = run_workcell_command_checked(executable, arguments, working_directory);
+  append_studio_log(workcell_command_succeeded(result) ? QStringLiteral("Import Scene Bundle: completed. Imported Scene Ready.") :
+    QStringLiteral("Import Scene Bundle: failed: %1").arg(workcell_command_failure_summary(executable, arguments, working_directory, result)));
   refresh_scene_browser_ui();
 }
 
@@ -5180,9 +5260,13 @@ void MainWindow::copy_validation_summary() { QApplication::clipboard()->setText(
 void MainWindow::generate_readiness_pack() {
   if (!has_selected_scene()) return;
   const auto & s = scene_browser_result_.scenes[(size_t)selected_scene_index_];
-  const QString cmd = QString("python3 scripts/generate_workcell_studio_readiness_pack.py '%1'").arg(QString::fromStdString(s.scene_dir.string()));
-  append_studio_log("Generate Readiness Pack: " + cmd);
-  std::system(cmd.toStdString().c_str());
+  const QString executable = QStringLiteral("python3");
+  const QStringList arguments{QStringLiteral("scripts/generate_workcell_studio_readiness_pack.py"), QString::fromStdString(s.scene_dir.string())};
+  const QString working_directory = QString::fromStdString(workcell_path.string());
+  append_studio_log(QStringLiteral("Generate Readiness Pack: %1 %2").arg(executable, workcell_command_arguments_for_log(arguments)));
+  const WorkcellCommandResult result = run_workcell_command_checked(executable, arguments, working_directory);
+  append_studio_log(workcell_command_succeeded(result) ? QStringLiteral("Generate Readiness Pack: completed.") :
+    QStringLiteral("Generate Readiness Pack: failed: %1").arg(workcell_command_failure_summary(executable, arguments, working_directory, result)));
 }
 void MainWindow::open_readiness_dashboard() { open_selected_scene_artifact("demo_dashboard"); }
 QString MainWindow::canvas_generated_parity_state_text(CanvasGeneratedParityState state) const

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -18,6 +18,7 @@
 #include <QTimer>
 #include <QTcpServer>
 #include <QHostAddress>
+#include <QProcess>
 #include <QProcessEnvironment>
 #include <QRegularExpression>
 #include <QUrlQuery>
@@ -204,6 +205,32 @@ bool preview_item_is_raw_generated_bounds_only(const ScenePreviewWidget::Preview
   return preview_item_is_generated_or_locked_urdf(item) &&
          item.sx > 0.001 && item.sy > 0.001 && item.sz > 0.001 &&
          (preview_item_has_credible_mesh_handoff(item) || preview_item_has_valid_urdf_primitive(item));
+}
+
+
+QString summarize_process_arguments(const QStringList & arguments)
+{
+  QStringList rendered;
+  for (const QString & argument : arguments) {
+    rendered << QStringLiteral("'%1'").arg(argument.left(180).replace(QStringLiteral("'"), QStringLiteral("'\\''")));
+  }
+  return rendered.join(QStringLiteral(" "));
+}
+
+QString summarize_prepare_process_failure(
+  const QString & executable, const QStringList & arguments, const QString & working_directory,
+  QProcess::ExitStatus exit_status, int exit_code, const QString & start_error, const QByteArray & stderr_tail)
+{
+  const QString stderr_summary = QString::fromUtf8(stderr_tail).trimmed().left(1200);
+  QString detail = QStringLiteral("executable=%1 arguments=%2 working_directory=%3 exit_status=%4 exit_code=%5")
+    .arg(executable,
+         summarize_process_arguments(arguments),
+         working_directory.isEmpty() ? QStringLiteral("<unset>") : working_directory,
+         exit_status == QProcess::NormalExit ? QStringLiteral("normal") : QStringLiteral("crash"))
+    .arg(exit_code);
+  if (!start_error.trimmed().isEmpty()) detail += QStringLiteral(" start_error=%1").arg(start_error.trimmed().left(400));
+  if (!stderr_summary.isEmpty()) detail += QStringLiteral(" stderr=%1").arg(stderr_summary);
+  return detail;
 }
 
 void maybe_warn_overlay_fit_dominance(ScenePreviewWidget * self, const QRectF & physical_bounds, const QRectF & overlay_bounds)
@@ -1931,8 +1958,25 @@ void ScenePreviewWidget::start_embedded_web_prepare(const EmbeddedWebRequestIden
   });
   connect(process, &QProcess::errorOccurred, this, [this, identity, process](QProcess::ProcessError error) {
     if (!embedded_web_identity_is_current(identity)) return;
-    record_embedded_web_prepare_terminal(identity, process, QStringLiteral("process_error"), process->exitStatus(), process->exitCode(),
-      QStringLiteral("qprocess_error=%1").arg(static_cast<int>(error)));
+    const QString key = embedded_web_preparation_process_keys_.value(process);
+    const EmbeddedWebPreparationDiagnostic diagnostic = embedded_web_preparation_diagnostics_.value(key);
+    const QString detail = summarize_prepare_process_failure(
+      process->program(), process->arguments(), process->workingDirectory(), process->exitStatus(), process->exitCode(),
+      QStringLiteral("qprocess_error=%1 %2").arg(static_cast<int>(error)).arg(process->errorString()), diagnostic.stderr_tail);
+    record_embedded_web_prepare_terminal(identity, process, QStringLiteral("process_error"), process->exitStatus(), process->exitCode(), detail);
+  });
+  QTimer::singleShot(120000, this, [this, identity, process]() {
+    if (process != embedded_web_prepare_process_ || !embedded_web_identity_is_current(identity) ||
+        process->state() == QProcess::NotRunning) return;
+    append_embedded_web_prepare_output(process, false);
+    append_embedded_web_prepare_output(process, true);
+    const QString key = embedded_web_preparation_process_keys_.value(process);
+    const EmbeddedWebPreparationDiagnostic diagnostic = embedded_web_preparation_diagnostics_.value(key);
+    const QString detail = summarize_prepare_process_failure(
+      process->program(), process->arguments(), process->workingDirectory(), process->exitStatus(), process->exitCode(),
+      QStringLiteral("timeout after 120000 ms"), diagnostic.stderr_tail);
+    record_embedded_web_prepare_terminal(identity, process, QStringLiteral("timeout"), process->exitStatus(), process->exitCode(), detail);
+    process->kill();
   });
   connect(process, qOverload<int, QProcess::ExitStatus>(&QProcess::finished), this, [this, identity, process](int exit_code, QProcess::ExitStatus exit_status) {
     on_embedded_web_prepare_finished(identity, process, exit_code, exit_status);
@@ -1956,7 +2000,7 @@ void ScenePreviewWidget::on_embedded_web_prepare_finished(const EmbeddedWebReque
   // A stale process is never allowed to touch current UI state, but its
   // immutable request still receives one explicit discarded terminal record.
   if (process != embedded_web_prepare_process_) {
-    record_embedded_web_prepare_terminal(identity, process, QStringLiteral("cancelled_superseded"), exit_status, exit_code,
+    record_embedded_web_prepare_terminal(identity, process, QStringLiteral("stale_discarded"), exit_status, exit_code,
       QStringLiteral("process no longer owns the active preparation slot"));
     embedded_web_preparation_process_keys_.remove(process);
     process->deleteLater();
@@ -1967,7 +2011,7 @@ void ScenePreviewWidget::on_embedded_web_prepare_finished(const EmbeddedWebReque
   // the old process.  Retire that completion before reading output, changing
   // UI state, or loading its scene, then start the valid pending replacement.
   if (!embedded_web_identity_is_current(identity)) {
-    record_embedded_web_prepare_terminal(identity, process, QStringLiteral("cancelled_superseded"), exit_status, exit_code,
+    record_embedded_web_prepare_terminal(identity, process, QStringLiteral("stale_discarded"), exit_status, exit_code,
       QStringLiteral("request identity retired before completion"));
     process->deleteLater();
     embedded_web_preparation_process_keys_.remove(process);
@@ -1984,7 +2028,10 @@ void ScenePreviewWidget::on_embedded_web_prepare_finished(const EmbeddedWebReque
     process->deleteLater();
     embedded_web_preparation_process_keys_.remove(process);
     embedded_web_prepare_process_ = nullptr;
-    show_embedded_web_preparation_failure(identity, QStringLiteral("Product View preparation process error"));
+    const QString detail = summarize_prepare_process_failure(
+      process->program(), process->arguments(), process->workingDirectory(), process->exitStatus(), process->exitCode(),
+      QStringLiteral("process failed to start or reported a QProcess error"), existing_diagnostic.stderr_tail);
+    show_embedded_web_preparation_failure(identity, QStringLiteral("Product View preparation process error: %1").arg(detail));
     maybe_start_next_embedded_web_prepare();
     return;
   }
@@ -2000,15 +2047,16 @@ void ScenePreviewWidget::on_embedded_web_prepare_finished(const EmbeddedWebReque
   embedded_web_preparing_identity_ = EmbeddedWebRequestIdentity{};
 
   const QString absolute_output_path = QDir(embedded_web_repo_root_).filePath(output_path);
-  const bool output_is_fresh = QFileInfo::exists(QDir(embedded_web_repo_root_).filePath(output_path));  // Contract validation supersedes mtime freshness.
-  Q_UNUSED(output_is_fresh);
+  // Contract validation below supersedes mtime freshness; existence is checked when opening the expected output.
   auto reject_prepare = [&](const QString & reason) {
+    const QString detail = QStringLiteral("%1; %2").arg(reason, summarize_prepare_process_failure(
+      process->program(), process->arguments(), process->workingDirectory(), exit_status, exit_code, QString(), diagnostic.stderr_tail));
     emit studio_issue_requested(
-      QStringLiteral("Embedded Product View scene preparation failed: %1").arg(reason),
+      QStringLiteral("Embedded Product View scene preparation failed: %1").arg(detail),
       QStringLiteral("Error"), QStringLiteral("embedded_product_view_scene_preparation"));
-    show_embedded_web_preparation_failure(identity, reason);
+    show_embedded_web_preparation_failure(identity, detail);
     record_embedded_web_prepare_terminal(identity, process, QStringLiteral("command_failure"), exit_status, exit_code,
-      QStringLiteral("%1; command=%2").arg(reason, command));
+      QStringLiteral("%1; command=%2").arg(detail, command));
     maybe_start_next_embedded_web_prepare();
   };
 


### PR DESCRIPTION
### Motivation

- Fix C++ compiler/static-analysis warnings caused by unsafe shell command usage and unchecked process handling in Workcell Builder UI paths.
- Harden the embedded Product View preparation lifecycle so process start errors, timeouts, abnormal exits, and stderr are reported actionably.
- Replace fragile `std::system` shell invocations with safe `QProcess` usage that passes executable and arguments separately while preserving environment and working directory.

### Description

- Add a small checked process runner (`WorkcellCommandResult`, `run_workcell_command_checked`, helpers for argument rendering and failure summaries) and integrate it into `mainwindow.cpp` to replace `std::system` usages for acceptance, export/import, and readiness-pack commands.
- Harden `scene_preview_widget.cpp` preparation handling by summarizing executable, arguments, working directory, start errors, stderr tails, adding an explicit 120s timeout path and recording actionable terminal diagnostics, and clarifying stale/cancelled terminal labels.
- Remove an obsolete local freshness placeholder (previously `Q_UNUSED`) in the prepare/validation path and rely on the JSON contract/opening checks for output existence instead of suppressing an unused variable warning.
- Add a focused unit test `tests/test_scene_preview_widget_process_failure_reporting.py` that asserts safe `QProcess` argument usage, timeout handling, and presence of actionable failure summaries.

Files changed: `workcell_builder/workcell_builder/gui/mainwindow.cpp`, `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp`, and the new test `tests/test_scene_preview_widget_process_failure_reporting.py`.

### Testing

- Ran targeted Python unit tests: `pytest tests/test_scene_preview_widget_process_failure_reporting.py tests/test_scene_preview_widget_preparation_diagnostics.py tests/test_workcell_studio_qprocess_hardening.py`, and all tests passed (8 passed total in this run). 
- Performed static checks: `git diff --check` reported no new whitespace issues and repository `git grep` shows the replaced `std::system` usages removed from `mainwindow.cpp` (remaining legacy `std::system` occurrences are in other GUI files not in scope for this change). 
- Full `colcon build` / ROS Humble workspace build could not be completed in this execution environment because `/opt/ros/humble/setup.bash` / workspace layout is not available here, so the focused package build was not run in this container (this is an environment limitation, not a code regression).

Commit: `f19703d` (single focused commit).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7351700f8c833190278f47b6e7a52a)