### PR TITLE
Remove unused selected-scene variable in MainWindow::refresh_scene_builder_selected_scene_ui

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -5861,7 +5861,6 @@ void MainWindow::refresh_scene_builder_selected_scene_ui()
     refresh_create_starter_layout_action();
     return;
   }
-  const auto & s = scene_browser_result_.scenes[static_cast<size_t>(selected_scene_state_.index)];
   if (scene_builder_title_) scene_builder_title_->setText(QString("<h2>Scene Builder: %1</h2>").arg(selected_scene_state_.name));
   update_scene_builder_path_header(selected_scene_state_.name, selected_scene_path());
   refresh_scene_builder_view_chips();


### PR DESCRIPTION
### Motivation
- Remove an unused local `const auto & s = scene_browser_result_.scenes[...]` declaration in `MainWindow::refresh_scene_builder_selected_scene_ui()` to eliminate an unused-variable compiler warning and keep the codebase clean without adding any diagnostic suppressions.

### Description
- Deleted the unused local variable from `workcell_builder/workcell_builder/gui/mainwindow.cpp` in `MainWindow::refresh_scene_builder_selected_scene_ui()` with no functional changes to the UI logic.

### Testing
- Verified the removal with `git diff --check` and a targeted search (`sed`/`rg`) which shows the `const auto & s` declaration is no longer present in the function, and committed the change; attempted to rebuild with `colcon build --packages-select workcell_builder --cmake-args -DCMAKE_CXX_FLAGS='-Wall -Wextra -Wpedantic'` but `colcon` is not available in this environment (exit code 127), so the runtime compiler-warning disappearance could not be confirmed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7430218c0c8331bb4123e1093c3b37)