### PR TITLE
Initialize CanvasEditCommand fields explicitly

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -7777,7 +7777,7 @@ void MainWindow::apply_inspector_pose_to_item()
   refreshed_state.linked_to_editable_layout_state = true;
   selected_item_state_ = refreshed_state;
 
-  undo_stack_.push_back({"pose_edit", item_id, old, updated, false, false});
+  undo_stack_.push_back({"pose_edit", item_id, old, updated, false, false, {}});
   redo_stack_.clear();
   mark_layout_dirty("Inspector Pose/Dimensions Edit");
   if (metadata_changed) {
@@ -8018,8 +8018,11 @@ void MainWindow::duplicate_selected_item()
   item->position_filter = [this](const QPointF & p){ return snap_canvas_position(p); };
   digital_twin_scene_->addItem(item);
   all_scene_preview_items_.push_back(copy);
-  CanvasEditCommand command{"duplicate", new_id, QPointF(copy.x * 100.0, copy.y * 100.0), QPointF(copy.x * 100.0, copy.y * 100.0), true, false};
-  command.preview_items.push_back(copy);
+  CanvasEditCommand command{
+    "duplicate", new_id,
+    QPointF(copy.x * 100.0, copy.y * 100.0),
+    QPointF(copy.x * 100.0, copy.y * 100.0),
+    true, false, {copy}};
   undo_stack_.push_back(command); redo_stack_.clear();
   apply_scene3d_preview_layer_filters(false);
   refresh_scene_builder_left_explorer();
@@ -8048,14 +8051,17 @@ void MainWindow::delete_selected_item(){
     return;
   }
   const QString id = target.state.id.trimmed();
-  CanvasEditCommand command{"delete", id, target.fallback_item ? target.fallback_item->pos() : QPointF(), target.fallback_item ? target.fallback_item->pos() : QPointF(), false, true};
-  for (const auto & p : all_scene_preview_items_) if (p.id == id) command.preview_items.push_back(p);
-  if (command.preview_items.isEmpty()) {
+  QVector<ScenePreviewWidget::PreviewItem> deleted_preview_items;
+  for (const auto & p : all_scene_preview_items_) if (p.id == id) deleted_preview_items.push_back(p);
+  if (deleted_preview_items.isEmpty()) {
     append_studio_log("Selected item cannot be deleted");
     statusBar()->showMessage("Selected item cannot be deleted", 4000);
     refresh_delete_selected_action();
     return;
   }
+  const QPointF item_position = target.fallback_item ? target.fallback_item->pos() : QPointF();
+  CanvasEditCommand command{
+    "delete", id, item_position, item_position, false, true, deleted_preview_items};
   deleted_layout_item_ids_.insert(id);
   for (int i = all_scene_preview_items_.size() - 1; i >= 0; --i) if (all_scene_preview_items_[i].id == id) all_scene_preview_items_.removeAt(i);
   if (target.fallback_item) delete target.fallback_item;
@@ -8119,7 +8125,7 @@ void MainWindow::keyPressEvent(QKeyEvent * event)
   item->setPos(snap_canvas_position(old_pos + delta));
   item->setData(RolePoseZ, item->data(RolePoseZ).toDouble() + dz);
   if (snap_step_label_) snap_step_label_->setText(QString("Nudge step: %1 m").arg(step_m, 0, 'f', 3));
-  undo_stack_.push_back({"nudge", item->data(RoleId).toString(), old_pos, item->pos(), false, false});
+  undo_stack_.push_back({"nudge", item->data(RoleId).toString(), old_pos, item->pos(), false, false, {}});
   redo_stack_.clear();
   mark_layout_dirty("Nudge Move");
   rebuild_canvas_inspector();
@@ -8382,7 +8388,7 @@ void MainWindow::commit_armed_asset_placement(const QPointF & canvas_pos_px)
   digital_twin_scene_->clearSelection();
   item->setSelected(true);
   select_canvas_item(item);
-  undo_stack_.push_back({"add", new_id, item->pos(), item->pos(), true, false});
+  undo_stack_.push_back({"add", new_id, item->pos(), item->pos(), true, false, {}});
   redo_stack_.clear();
   set_canvas_interaction_mode(CanvasInteractionMode::Place);
   mark_layout_dirty("Place Asset Mode: Add to 3D Canvas");

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -671,7 +671,34 @@ private:
   SelectedSceneState selected_scene_state_;
   SelectedSceneItemState selected_item_state_;
   QString current_selected_scene_item_id_;
-  struct CanvasEditCommand { QString kind; QString item_id; QPointF old_pos; QPointF new_pos; bool created{false}; bool deleted{false}; QVector<ScenePreviewWidget::PreviewItem> preview_items; };
+  struct CanvasEditCommand
+  {
+    CanvasEditCommand(
+      const QString & kind,
+      const QString & item_id,
+      const QPointF & old_pos,
+      const QPointF & new_pos,
+      bool created,
+      bool deleted,
+      const QVector<ScenePreviewWidget::PreviewItem> & preview_items)
+    : kind(kind),
+      item_id(item_id),
+      old_pos(old_pos),
+      new_pos(new_pos),
+      created(created),
+      deleted(deleted),
+      preview_items(preview_items)
+    {
+    }
+
+    QString kind;
+    QString item_id;
+    QPointF old_pos;
+    QPointF new_pos;
+    bool created;
+    bool deleted;
+    QVector<ScenePreviewWidget::PreviewItem> preview_items;
+  };
   QSet<QString> deleted_layout_item_ids_;
   std::vector<CanvasEditCommand> undo_stack_;
   std::vector<CanvasEditCommand> redo_stack_;

--- a/workcell_builder/workcell_builder/test/layout_serialization_contract_test.cpp
+++ b/workcell_builder/workcell_builder/test/layout_serialization_contract_test.cpp
@@ -137,10 +137,21 @@ TEST(LayoutSerializationContractTest, DuplicateSelectedUsesSharedEditableSelecti
   EXPECT_NE(src.find("selected_item_can_be_duplicated()"), std::string::npos);
   EXPECT_NE(src.find("resolve_selected_editable_layout_target()"), std::string::npos);
   EXPECT_NE(src.find("Selected item cannot be duplicated"), std::string::npos);
-  EXPECT_NE(src.find("CanvasEditCommand command{\"duplicate\""), std::string::npos);
+  EXPECT_NE(src.find("true, false, {copy}}"), std::string::npos);
   EXPECT_NE(src.find("undo_stack_.push_back(command); redo_stack_.clear();"), std::string::npos);
   EXPECT_NE(src.find("Removed duplicate %1"), std::string::npos);
   EXPECT_NE(hdr.find("refresh_duplicate_selected_action"), std::string::npos);
+}
+
+TEST(LayoutSerializationContractTest, CanvasEditCommandsInitializePreviewItemsExplicitly)
+{
+  const std::string src = load_file("gui/mainwindow.cpp");
+  const std::string hdr = load_file("gui/mainwindow.h");
+  EXPECT_NE(hdr.find("CanvasEditCommand("), std::string::npos);
+  EXPECT_NE(hdr.find("preview_items(preview_items)"), std::string::npos);
+  EXPECT_NE(src.find("true, false, {copy}}"), std::string::npos);
+  EXPECT_NE(src.find("false, true, deleted_preview_items}"), std::string::npos);
+  EXPECT_NE(src.find("false, false, {}}"), std::string::npos);
 }
 
 TEST(LayoutSerializationContractTest, DuplicateSelectedCopiesAuthoredRecordWithStableOffsetIdentity)


### PR DESCRIPTION
### Motivation

- Ensure every `CanvasEditCommand` is fully initialized (including `preview_items`) to avoid warning-producing partial aggregate initialization and to make undo/redo preview semantics explicit.

### Description

- Add a stable constructor for `CanvasEditCommand` in `workcell_builder/workcell_builder/gui/mainwindow.h` that initializes every field including `preview_items`.
- Update command creation sites in `mainwindow.cpp` so `duplicate` constructs the command with `{copy}`, `delete` collects matching preview records into `deleted_preview_items` and constructs the command with that vector, and `pose_edit`, `nudge`, and `add` explicitly construct commands with an empty preview collection `{}`.
- Update `workcell_builder/workcell_builder/test/layout_serialization_contract_test.cpp` to assert the presence of the new constructor and the explicit preview-items initialization rather than relying on the old aggregate-initializer text.

### Testing

- Ran focused static source assertions via a Python inspection that loads the modified files and confirms the constructor and explicit `preview_items` usages, and all assertions passed.
- Ran repository whitespace/check validation (`git diff --check`) and source diff inspection to ensure no check warnings were introduced, and the validation passed.
- The ament/`gtest` test target was not executed because a ROS Humble environment (`/opt/ros/humble`) is not available in this container, so full C++ test execution is pending on a proper ROS/Humble workstation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7431933ea88331a1bf43ac9eb0b889)