### PR TITLE
Report detailed required-mesh bounds failure payload in web viewer

### DIFF
--- a/tests/test_workcell_studio_web_viewer_static.py
+++ b/tests/test_workcell_studio_web_viewer_static.py
@@ -3142,6 +3142,60 @@ def test_gripper_mesh_404_scene_failed_payload_includes_structured_url_and_link_
     assert "scene_id: sceneId()" in viewer
 
 
+def test_oversized_required_mesh_terminal_payload_preserves_identity_and_numerical_bounds():
+    js_path = VIEWER / "viewer.js"
+    harness = r"""
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+let source = fs.readFileSync(process.argv[1], 'utf8').replace(/boot\(\);\s*$/, '');
+const element = () => ({ hidden: false, checked: false, disabled: false, textContent: '', className: '', innerHTML: '', classList: { toggle() {} }, setAttribute() {}, querySelector() { return null; }, appendChild() {}, addEventListener() {} });
+const events = [];
+const context = { console, assert, window: { events, location: { search: '' }, dispatchEvent(event) { this.events.push(event.detail); }, parent: { postMessage() {} } }, document: { getElementById() { return element(); }, createElement() { return element(); } }, URLSearchParams, CustomEvent: function CustomEvent(type, init) { return { type, detail: init?.detail || {} }; }, requestAnimationFrame() { return 0; }, setTimeout() { return 1; }, clearTimeout() {} };
+vm.createContext(context);
+vm.runInContext(source + `
+THREE = { Vector3: class Vector3 { constructor(x, y, z) { this.x = x; this.y = y; this.z = z; } } };
+state.sceneJson = { scene: { id: 'ur5_2f_test' } };
+state.sourceWebSceneFile = 'ur5_2f_test/web_scene.json';
+state.sceneJsonLoaded = true;
+state.web3dReadiness = { state: 'scene_loading', terminal: false, terminalState: '', terminalNavigationKey: '', terminalEmissionCount: 0, statusSequence: 0, required: { workbench_support_surface: true }, pending: new Set(['workbench_support_surface:oversized_table']), failed: false, failure: null };
+const item = {
+  id: 'oversized_table', display_name: 'Oversized Workbench', category: 'table', mesh_uri: 'package://cell/meshes/table.stl', expected_dimensions_m: [1, 0.5, 0.2],
+  loaded_mesh_bounds: { min: {x:0,y:0,z:0}, max: {x:4,y:1,z:0.4}, center: {x:2,y:0.5,z:0.2}, dimensions: {x:4,y:1,z:0.4} },
+  loaded_mesh_world_bounds: { min: {x:10,y:20,z:0}, max: {x:14,y:21,z:0.4}, center: {x:12,y:20.5,z:0.2}, dimensions: {x:4,y:1,z:0.4} },
+  loaded_mesh_axis_ratios: {x:4,y:2,z:2}, loaded_mesh_maximum_ratio: 4, loaded_mesh_uniform_ratio: 2,
+  loaded_mesh_bounds_reason_code: 'loaded_mesh_oversized', mesh_unit_correction: { scale: 1, confidence: 'rejected_non_uniform_or_unclear_ratio' }
+};
+const attempt = { token: physicalLoadToken, navigationKey: web3dNavigationKey(), category: 'workbench_support_surface', identity: item.id, readinessKey: 'workbench_support_surface:oversized_table', operation: registerReadinessOperation(['workbench_support_surface:oversized_table']) };
+const extra = physicalMeshBoundsFailurePayload(item, '/assets/table.stl', 'STLLoader');
+assert.strictEqual(failPhysicalMeshAttempt(attempt, item, '/assets/table.stl', 'loaded mesh bounds validation failed (oversized)', extra), true);
+const failure = window.events.at(-1);
+assert.strictEqual(failure.state, 'scene_failed');
+assert.strictEqual(failure.scene_id, 'ur5_2f_test');
+assert.strictEqual(failure.item_id, 'oversized_table');
+assert.strictEqual(failure.item_display_name, 'Oversized Workbench');
+assert.strictEqual(failure.category, 'table');
+assert.strictEqual(failure.mesh_uri, 'package://cell/meshes/table.stl');
+assert.strictEqual(failure.mesh_load_url, '/assets/table.stl');
+assert.strictEqual(failure.loader, 'STLLoader');
+assert.deepStrictEqual(failure.expected_dimensions, {x:1,y:0.5,z:0.2});
+assert.deepStrictEqual(failure.loaded_local_dimensions, {x:4,y:1,z:0.4});
+assert.deepStrictEqual(failure.loaded_world_bounds.max, {x:14,y:21,z:0.4});
+assert.deepStrictEqual(failure.axis_ratios, {x:4,y:2,z:2});
+assert.strictEqual(failure.maximum_ratio, 4);
+assert.strictEqual(failure.uniform_ratio, 2);
+assert.strictEqual(failure.applied_mesh_scale, 1);
+assert.strictEqual(failure.unit_correction_decision, 'rejected_non_uniform_or_unclear_ratio');
+assert.strictEqual(failure.bounds_reason_code, 'loaded_mesh_oversized');
+const statusFailure = window.__WORKCELL_VIEWER_STATUS__.readiness_failure;
+for (const field of ['scene_id', 'item_id', 'item_display_name', 'category', 'mesh_uri', 'mesh_load_url', 'loader', 'expected_dimensions', 'loaded_local_dimensions', 'loaded_local_bounds', 'loaded_world_dimensions', 'loaded_world_bounds', 'axis_ratios', 'maximum_ratio', 'uniform_ratio', 'applied_mesh_scale', 'unit_correction_decision', 'bounds_reason_code']) {
+  assert.deepStrictEqual(statusFailure[field], failure[field], field + ' must survive viewer status normalization');
+}
+`, context);
+"""
+    subprocess.run(["node", "-e", harness, str(js_path)], cwd=ROOT, check=True, capture_output=True, text=True)
+
+
 def test_successful_required_loads_emit_scene_ready_exactly_once_after_completion():
     js = (VIEWER / "viewer.js").read_text(encoding="utf-8")
     body = _viewer_function_body(js, "function emitWeb3dReadinessState", "function readinessCategoryForItem")

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -315,6 +315,31 @@ function failPhysicalMeshAttempt(attempt, item, url, reason, extra = {}) {
   });
   return true;
 }
+function physicalMeshBoundsFailurePayload(item, loadUrl, loader) {
+  const expected = expectedDimensionsOf(item);
+  const localBounds = item?.loaded_mesh_bounds || null;
+  const worldBounds = item?.loaded_mesh_world_bounds || null;
+  return {
+    scene_id: sceneId(),
+    item_id: item?.id || '',
+    item_display_name: item?.display_name || item?.label || item?.name || item?.object_name || item?.link || item?.id || '',
+    category: meshContractCategoryOf(item),
+    mesh_uri: displayMeshUri(item),
+    mesh_load_url: loadUrl || '',
+    loader: loader || '',
+    expected_dimensions: expected ? { x: expected.x, y: expected.y, z: expected.z } : null,
+    loaded_local_dimensions: localBounds?.dimensions || null,
+    loaded_local_bounds: localBounds,
+    loaded_world_dimensions: worldBounds?.dimensions || null,
+    loaded_world_bounds: worldBounds,
+    axis_ratios: item?.loaded_mesh_axis_ratios || null,
+    maximum_ratio: item?.loaded_mesh_maximum_ratio ?? null,
+    uniform_ratio: item?.loaded_mesh_uniform_ratio ?? null,
+    applied_mesh_scale: item?.mesh_unit_correction?.scale ?? 1.0,
+    unit_correction_decision: item?.mesh_unit_correction?.confidence || 'not_requested_or_not_applicable',
+    bounds_reason_code: item?.loaded_mesh_bounds_reason_code || 'loaded_mesh_bounds_invalid',
+  };
+}
 function failWeb3dSceneReadiness(item, url, reason, extra = {}) {
   const category = readinessCategoryForItem(item) || extra.category || 'required_physical_item';
   const readinessIdentity = readinessIdentityForItem(category, item);
@@ -2510,7 +2535,10 @@ async function tryLoadMesh(item, rendered, fallback, readinessOperation) {
     refreshMeshLoadUi(rendered);
     if (!boundsValid && itemRequiresMeshBackedVisual(item)) {
       detachTransientPivotForFailedPhysicalVisual(rendered);
-      failPhysicalMeshAttempt(attempt, item, loadUrl, `loaded mesh bounds validation failed (${item.visual_bounds_status || 'invalid'})`, { mesh_status: item.mesh_status, loader: loaderName });
+      failPhysicalMeshAttempt(attempt, item, loadUrl, `loaded mesh bounds validation failed (${item.visual_bounds_status || 'invalid'})`, {
+        mesh_status: item.mesh_status,
+        ...physicalMeshBoundsFailurePayload(item, loadUrl, loaderName),
+      });
       return;
     }
     completePhysicalMeshAttempt(attempt);
@@ -3281,6 +3309,7 @@ function isCoreMeshContractItem(item) {
 }
 function warnLoadedMeshBounds(item, code, reason, extra = {}) {
   item.visual_bounds_status = code === 'loaded_mesh_oversized' ? 'oversized' : code === 'loaded_mesh_collapsed' ? 'collapsed' : 'invalid';
+  item.loaded_mesh_bounds_reason_code = code;
   appendViewerDiagnosticWarning(item, code, reason, {
     mesh_uri: displayMeshUri(item),
     loaded_mesh_bounds: item.loaded_mesh_bounds,
@@ -3317,6 +3346,9 @@ function diagnoseLoadedMeshBounds(item, meshObject, rendered, nativeBounds = nul
   const maxRatio = Math.max(...Object.values(axisRatios));
   const minRatio = Math.min(...Object.values(axisRatios));
   const uniformRatio = minRatio > 0 ? maxRatio / minRatio : Infinity;
+  item.loaded_mesh_axis_ratios = axisRatios;
+  item.loaded_mesh_maximum_ratio = maxRatio;
+  item.loaded_mesh_uniform_ratio = uniformRatio;
   const category = meshContractCategoryOf(item);
   if (maxRatio > 3 || uniformRatio > 3) {
     if (['table', 'camera', 'object'].includes(category)) warnLoadedMeshBounds(item, 'loaded_mesh_oversized', `loaded mesh dimensions exceed expected_dimensions_m by more than 3x (max_axis_ratio=${maxRatio.toFixed(3)}, uniform_ratio=${uniformRatio.toFixed(3)})`, {


### PR DESCRIPTION
### Motivation
- Provide actionable, canonical failure evidence when a required physical mesh rejects bounds validation so operators and CI can quickly identify the offending identity and numerical dimensions. 
- Preserve the terminal `scene_failed` semantics while ensuring the readiness payload includes a single snake_case representation of the relevant mesh/bounds diagnostics.

### Description
- Add a canonical snake_case failure payload builder `physicalMeshBoundsFailurePayload()` that includes `scene_id`, `item_id`, `item_display_name`, `category`, `mesh_uri`, `mesh_load_url`, `loader`, `expected_dimensions`, `loaded_local_dimensions`, `loaded_local_bounds`, `loaded_world_dimensions`, `loaded_world_bounds`, `axis_ratios`, `maximum_ratio`, `uniform_ratio`, `applied_mesh_scale`, `unit_correction_decision`, and `bounds_reason_code`, and attach it to required-mesh failures. (modified `workcell_studio_web/viewer/viewer.js`)
- Wire the structured payload into the terminal failure path so `failPhysicalMeshAttempt()` emits the detailed payload in the `workcell:web3d_readiness` terminal event and it is preserved on `window.__WORKCELL_VIEWER_STATUS__.readiness_failure` without changing the `scene_failed` lifecycle state.
- Persist numerical evidence produced during diagnosis (axis ratios, max/uniform ratios, and a bounds reason code) into the item so the terminal event contains the original offending numbers. (modified `workcell_studio_web/viewer/viewer.js`)
- Add a focused Node-backed static test that asserts an oversized required mesh produces the identity and numerical bounds fields in the terminal event and that those fields survive viewer status normalization. (modified `tests/test_workcell_studio_web_viewer_static.py`)

### Testing
- Ran the focused tests via `pytest -q tests/test_workcell_studio_web_viewer_static.py -k 'oversized_required_mesh_terminal_payload or gripper_mesh_404_scene_failed_payload or primary_mesh_backed_target_bin'` and verified the new assertions passed. 
- Ran the full static viewer test suite via `pytest -q tests/test_workcell_studio_web_viewer_static.py` and observed all tests passed (`120 passed`).
- Confirmed `window.__WORKCELL_VIEWER_STATUS__` contains the structured `readiness_failure` and that `workcell:web3d_readiness` events emit the terminal payload with the new snake_case fields.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7434952d28833196c3a0fecfdeec7b)