### PR TITLE
Fix Web3D mesh bounds coordinate spaces

### DIFF
--- a/tests/fixtures/web3d_mesh_coordinate_space_cases.json
+++ b/tests/fixtures/web3d_mesh_coordinate_space_cases.json
@@ -1,0 +1,112 @@
+{
+  "schema_version": "workcell_web3d_mesh_coordinate_space_fixture/v1",
+  "cases": [
+    {
+      "id": "ur5_2f_test_realsense_overhead_rotated_visual",
+      "description": "Canonical failing ur5_2f_test camera visual: local body dimensions are valid but a 90-degree visual rotation swaps world AABB axes.",
+      "item": {
+        "id": "generated_urdf::camera_link::visual_17::17",
+        "canonical_owner_id": "realsense_overhead",
+        "category": "camera",
+        "render_policy": "primary",
+        "mesh_load_required": true,
+        "expected_dimensions_m": [
+          0.09,
+          0.025,
+          0.025
+        ]
+      },
+      "geometry_dimensions": [
+        0.09,
+        0.025,
+        0.025
+      ],
+      "visual_rotation_rpy": [
+        0.0,
+        1.5707963267948966,
+        0.0
+      ],
+      "expected_outcome": "valid"
+    },
+    {
+      "id": "rotated_authored_object",
+      "description": "Rotation may enlarge or permute world-axis AABB dimensions but must not alter authored-local validation dimensions.",
+      "item": {
+        "id": "rotated_fixture",
+        "category": "object",
+        "render_policy": "primary",
+        "mesh_load_required": true,
+        "expected_dimensions_m": [
+          2.0,
+          1.0,
+          0.5
+        ]
+      },
+      "geometry_dimensions": [
+        2.0,
+        1.0,
+        0.5
+      ],
+      "visual_rotation_rpy": [
+        0.0,
+        0.0,
+        0.7853981633974483
+      ],
+      "expected_outcome": "valid"
+    },
+    {
+      "id": "millimetre_authored_object",
+      "description": "A clear uniform 1000x mesh-unit mismatch is corrected exactly once at the loaded mesh node.",
+      "item": {
+        "id": "millimetre_fixture",
+        "category": "object",
+        "render_policy": "primary",
+        "mesh_load_required": true,
+        "allow_mesh_unit_autoscale": true,
+        "expected_dimensions_m": [
+          0.9,
+          0.25,
+          0.25
+        ]
+      },
+      "geometry_dimensions": [
+        900.0,
+        250.0,
+        250.0
+      ],
+      "visual_rotation_rpy": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "expected_unit_scale": 0.001,
+      "expected_outcome": "valid"
+    },
+    {
+      "id": "genuine_oversized_object",
+      "description": "A genuinely greater-than-3x authored-local mismatch remains a strict terminal failure.",
+      "item": {
+        "id": "oversized_fixture",
+        "category": "object",
+        "render_policy": "primary",
+        "mesh_load_required": true,
+        "expected_dimensions_m": [
+          0.1,
+          0.1,
+          0.1
+        ]
+      },
+      "geometry_dimensions": [
+        0.31,
+        0.1,
+        0.1
+      ],
+      "visual_rotation_rpy": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "expected_outcome": "scene_failed"
+    }
+  ]
+}

--- a/tests/test_workcell_web3d_mesh_coordinate_space_contract.py
+++ b/tests/test_workcell_web3d_mesh_coordinate_space_contract.py
@@ -1,0 +1,191 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VIEWER = ROOT / "workcell_studio_web" / "viewer"
+SOURCE = (VIEWER / "viewer.js").read_text(encoding="utf-8")
+FIXTURE = ROOT / "tests" / "fixtures" / "web3d_mesh_coordinate_space_cases.json"
+
+
+def test_mesh_bounds_coordinate_space_contract_is_documented_and_used():
+    assert "const MESH_BOUNDS_COORDINATE_SPACE_CONTRACT" in SOURCE
+    assert "mesh_local_before_visual_origin_or_world_transform" in SOURCE
+    assert "authored_visual_local_after_unit_correction" in SOURCE
+    assert "scene_world_after_visual_origin_and_item_pose" in SOURCE
+    assert "function measureLoadedMeshBoundsInAuthoredLocalSpace" in SOURCE
+    assert "const rawAuthoredLocalBounds = measureLoadedMeshBoundsInAuthoredLocalSpace(visualRoot);" in SOURCE
+    assert "maybeApplyMeshUnitAutoscale(item, meshObject, visualRoot, rawAuthoredLocalBounds, uri);" in SOURCE
+    assert "const validationLocalBounds = measureLoadedMeshBoundsInAuthoredLocalSpace(visualRoot);" in SOURCE
+    assert "diagnoseLoadedMeshBounds(item, visualRoot, rendered, validationLocalBounds)" in SOURCE
+    assert "const nativeBounds = new THREE.Box3().setFromObject(visualRoot);" not in SOURCE
+    assert "loaded_mesh_local_bounds" in SOURCE
+    assert "loaded_mesh_world_bounds" in SOURCE
+    assert "MESH_OVERSIZED_RATIO_THRESHOLD = 3" in SOURCE
+
+
+def test_coordinate_space_regression_fixture_covers_canonical_rotation_units_and_failure(tmp_path):
+    payload = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "workcell_web3d_mesh_coordinate_space_fixture/v1"
+    case_ids = {case["id"] for case in payload["cases"]}
+    assert {
+        "ur5_2f_test_realsense_overhead_rotated_visual",
+        "rotated_authored_object",
+        "millimetre_authored_object",
+        "genuine_oversized_object",
+    } <= case_ids
+
+    script = tmp_path / "mesh_coordinate_space_contract.mjs"
+    script.write_text(r'''
+import fs from 'node:fs';
+import vm from 'node:vm';
+import assert from 'node:assert/strict';
+import { pathToFileURL } from 'node:url';
+
+const viewerPath = process.argv[2];
+const fixturePath = process.argv[3];
+const threePath = process.argv[4];
+const injectedThree = await import(pathToFileURL(threePath).href);
+let source = fs.readFileSync(viewerPath, 'utf8').replace(/boot\(\);\s*$/, '');
+const fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+const events = [];
+const warnings = [];
+const element = () => ({
+  hidden: false, checked: false, disabled: false, textContent: '', className: '',
+  innerHTML: '', value: '', style: {}, dataset: {},
+  classList: { toggle() {}, add() {}, remove() {} },
+  querySelector() { return null; }, querySelectorAll() { return []; },
+  appendChild() {}, addEventListener() {}, setAttribute() {},
+  getBoundingClientRect() { return { left: 0, top: 0, width: 800, height: 600 }; },
+});
+const context = {
+  console,
+  assert,
+  injectedThree,
+  fixture,
+  events,
+  warnings,
+  window: {
+    location: { search: '' },
+    dispatchEvent(event) { events.push(event?.detail || null); },
+    parent: { postMessage() {} },
+    addEventListener() {},
+  },
+  document: {
+    getElementById() { return element(); },
+    createElement() { return element(); },
+    querySelectorAll() { return []; },
+    addEventListener() {},
+    body: element(),
+  },
+  URL,
+  URLSearchParams,
+  CustomEvent: function CustomEvent(type, init) { return { type, detail: init?.detail || {} }; },
+  requestAnimationFrame() { return 0; },
+  cancelAnimationFrame() {},
+  setTimeout() { return 1; },
+  clearTimeout() {},
+  performance: { now() { return 0; } },
+};
+vm.createContext(context);
+vm.runInContext(source + `
+THREE = injectedThree;
+appendViewerDiagnosticWarning = (...args) => warnings.push(args);
+appendRuntimeWarning = (...args) => warnings.push(args);
+updateViewerStatus = () => ({ readiness_failure: state.web3dReadiness?.failure || null });
+
+const close = (actual, expected, tolerance = 1e-8) => Math.abs(actual - expected) <= tolerance;
+const dimensions = box => {
+  const size = new THREE.Vector3();
+  box.getSize(size);
+  return [size.x, size.y, size.z];
+};
+const makeCase = testCase => {
+  const item = JSON.parse(JSON.stringify(testCase.item));
+  const root = new THREE.Group();
+  const rpy = testCase.visual_rotation_rpy || [0, 0, 0];
+  root.rotation.set(rpy[0], rpy[1], rpy[2], 'XYZ');
+  const geometry = new THREE.BoxGeometry(...testCase.geometry_dimensions);
+  const mesh = new THREE.Mesh(geometry, new THREE.MeshBasicMaterial());
+  root.add(mesh);
+  const object3d = new THREE.Group();
+  object3d.add(root);
+  return { item, root, mesh, rendered: { item, object3d } };
+};
+
+for (const testCase of fixture.cases.filter(value => value.expected_outcome === 'valid' && !value.expected_unit_scale)) {
+  const { item, root, rendered } = makeCase(testCase);
+  const local = measureLoadedMeshBoundsInAuthoredLocalSpace(root);
+  const world = measureLoadedMeshBoundsInWorldSpace(root);
+  const localDims = dimensions(local);
+  for (let index = 0; index < 3; index += 1) assert(close(localDims[index], testCase.item.expected_dimensions_m[index]), testCase.id + ': local dimension mismatch');
+  if (testCase.visual_rotation_rpy.some(value => Math.abs(value) > 1e-8)) {
+    const worldDims = dimensions(world);
+    assert(worldDims.some((value, index) => !close(value, localDims[index], 1e-6)), testCase.id + ': fixture must demonstrate world-axis rotation effects');
+  }
+  assert.strictEqual(diagnoseLoadedMeshBounds(item, root, rendered, local), true, testCase.id);
+  assert.notStrictEqual(item.visual_bounds_status, 'oversized', testCase.id);
+  assert.deepStrictEqual(item.loaded_mesh_bounds_coordinate_space, MESH_BOUNDS_COORDINATE_SPACE_CONTRACT);
+}
+
+const millimetreCase = fixture.cases.find(value => value.id === 'millimetre_authored_object');
+const millimetre = makeCase(millimetreCase);
+const millimetreRaw = measureLoadedMeshBoundsInAuthoredLocalSpace(millimetre.root);
+assert.strictEqual(maybeApplyMeshUnitAutoscale(millimetre.item, millimetre.mesh, millimetre.root, millimetreRaw, 'millimetre_fixture.stl'), true);
+assert(close(millimetre.mesh.scale.x, millimetreCase.expected_unit_scale));
+const corrected = measureLoadedMeshBoundsInAuthoredLocalSpace(millimetre.root);
+for (const [index, value] of dimensions(corrected).entries()) assert(close(value, millimetreCase.item.expected_dimensions_m[index], 1e-7));
+const scaleAfterFirstCorrection = millimetre.mesh.scale.x;
+assert.strictEqual(maybeApplyMeshUnitAutoscale(millimetre.item, millimetre.mesh, millimetre.root, corrected, 'millimetre_fixture.stl'), false, 'unit correction is applied only once');
+assert(close(millimetre.mesh.scale.x, scaleAfterFirstCorrection));
+assert.strictEqual(diagnoseLoadedMeshBounds(millimetre.item, millimetre.root, millimetre.rendered, corrected), true);
+assert.strictEqual(millimetre.item.mesh_unit_correction.applied_once_at, 'loaded_mesh_object.scale');
+
+const oversizedCase = fixture.cases.find(value => value.id === 'genuine_oversized_object');
+const oversized = makeCase(oversizedCase);
+const oversizedLocal = measureLoadedMeshBoundsInAuthoredLocalSpace(oversized.root);
+assert.strictEqual(diagnoseLoadedMeshBounds(oversized.item, oversized.root, oversized.rendered, oversizedLocal), false);
+assert.strictEqual(oversized.item.visual_bounds_status, 'oversized');
+assert(oversized.item.loaded_mesh_maximum_ratio > MESH_OVERSIZED_RATIO_THRESHOLD);
+
+state.sceneJson = { scene: { id: 'mesh_coordinate_space_fixture' }, objects: [oversized.item] };
+state.sourceWebSceneFile = 'mesh_coordinate_space_fixture.web_scene.json';
+state.builderRevision = 'fixture-v1';
+state.objects = [oversized.rendered];
+state.web3dReadiness = {
+  state: 'scene_loading', terminal: false, terminalState: '', terminalNavigationKey: '',
+  terminalEmissionCount: 0, statusSequence: 0,
+  required: { robot_arm: true, attached_tool_gripper: true, workbench_support_surface: true, configured_camera: true },
+  pending: new Set(), failed: false, failure: null,
+};
+physicalLoadToken += 1;
+const operation = registerReadinessOperation(['authored_physical_mesh:oversized_fixture']);
+const attempt = physicalMeshAttempt(oversized.item, operation);
+assert.strictEqual(failPhysicalMeshAttempt(
+  attempt,
+  oversized.item,
+  '/assets/oversized_fixture.stl',
+  'loaded mesh bounds validation failed (oversized)',
+  { mesh_status: 'loaded', ...physicalMeshBoundsFailurePayload(oversized.item, '/assets/oversized_fixture.stl', 'STLLoader') },
+), true);
+assert.strictEqual(state.web3dReadiness.state, 'scene_failed');
+assert.strictEqual(state.web3dReadiness.failure.item_id, 'oversized_fixture');
+assert(state.web3dReadiness.failure.maximum_ratio > 3);
+assert.strictEqual(state.web3dReadiness.failure.loaded_local_bounds_coordinate_space, 'authored_visual_local_after_unit_correction');
+assert(events.some(event => event?.state === 'scene_failed'));
+`, context);
+''', encoding="utf-8")
+
+    subprocess.run(
+        [
+            "node",
+            str(script),
+            str(VIEWER / "viewer.js"),
+            str(FIXTURE),
+            str(VIEWER / "node_modules" / "three" / "build" / "three.module.js"),
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+    )

--- a/workcell_studio_web/viewer/viewer.js
+++ b/workcell_studio_web/viewer/viewer.js
@@ -317,7 +317,7 @@ function failPhysicalMeshAttempt(attempt, item, url, reason, extra = {}) {
 }
 function physicalMeshBoundsFailurePayload(item, loadUrl, loader) {
   const expected = expectedDimensionsOf(item);
-  const localBounds = item?.loaded_mesh_bounds || null;
+  const localBounds = item?.loaded_mesh_local_bounds || item?.loaded_mesh_bounds || null;
   const worldBounds = item?.loaded_mesh_world_bounds || null;
   return {
     scene_id: sceneId(),
@@ -330,8 +330,11 @@ function physicalMeshBoundsFailurePayload(item, loadUrl, loader) {
     expected_dimensions: expected ? { x: expected.x, y: expected.y, z: expected.z } : null,
     loaded_local_dimensions: localBounds?.dimensions || null,
     loaded_local_bounds: localBounds,
+    loaded_local_bounds_coordinate_space: item?.loaded_mesh_bounds_coordinate_space?.validation_bounds || 'authored_visual_local_after_unit_correction',
     loaded_world_dimensions: worldBounds?.dimensions || null,
     loaded_world_bounds: worldBounds,
+    loaded_world_bounds_coordinate_space: item?.loaded_mesh_bounds_coordinate_space?.diagnostic_world_bounds || 'scene_world_after_visual_origin_and_item_pose',
+    mesh_bounds_coordinate_space_contract: item?.loaded_mesh_bounds_coordinate_space || MESH_BOUNDS_COORDINATE_SPACE_CONTRACT,
     axis_ratios: item?.loaded_mesh_axis_ratios || null,
     maximum_ratio: item?.loaded_mesh_maximum_ratio ?? null,
     uniform_ratio: item?.loaded_mesh_uniform_ratio ?? null,
@@ -2518,10 +2521,9 @@ async function tryLoadMesh(item, rendered, fallback, readinessOperation) {
     // local transform to the visual-origin wrapper so the loaded hierarchy is
     // preserved under the posed link root.
     const visualRoot = makeMeshVisualRoot(item, meshObject);
-    visualRoot.updateMatrixWorld(true);
-    const nativeBounds = new THREE.Box3().setFromObject(visualRoot);
-    const autoscaled = maybeApplyMeshUnitAutoscale(item, meshObject, nativeBounds, uri);
-    const validationBounds = autoscaled ? new THREE.Box3().setFromObject(visualRoot) : nativeBounds;
+    const rawAuthoredLocalBounds = measureLoadedMeshBoundsInAuthoredLocalSpace(visualRoot);
+    maybeApplyMeshUnitAutoscale(item, meshObject, visualRoot, rawAuthoredLocalBounds, uri);
+    const validationLocalBounds = measureLoadedMeshBoundsInAuthoredLocalSpace(visualRoot);
     if (fallback) fallback.visible = false;
     rendered.object3d.add(visualRoot);
     rendered.meshObject = visualRoot;
@@ -2531,7 +2533,7 @@ async function tryLoadMesh(item, rendered, fallback, readinessOperation) {
     item.mesh_load_error = '';
     trackMeshLoadAttempt(item, 'loaded', loadUrl, '');
     setRenderInfo(rendered, 'mesh_loaded', uri, '');
-    const boundsValid = diagnoseLoadedMeshBounds(item, visualRoot, rendered, validationBounds);
+    const boundsValid = diagnoseLoadedMeshBounds(item, visualRoot, rendered, validationLocalBounds);
     refreshMeshLoadUi(rendered);
     if (!boundsValid && itemRequiresMeshBackedVisual(item)) {
       detachTransientPivotForFailedPhysicalVisual(rendered);
@@ -3264,43 +3266,161 @@ function meshUnitAutoscaleAllowed(item) {
   ].map(value => String(value || '').toLowerCase()).join(' ');
   return !/\b(robot|arm|manipulator|ur3|ur5|ur10|ur_|universal_robot|robotiq|gripper|suction|airpick|tool|eef|end_effector)\b/.test(identity);
 }
-function meshUnitCorrectionPayload(source, confidence, nativeBounds, correctedBounds, scale, axisRatios, targetRatio) {
+const MESH_BOUNDS_COORDINATE_SPACE_CONTRACT = Object.freeze({
+  version: 1,
+  raw_mesh_geometry: 'mesh_local_before_visual_origin_or_world_transform',
+  unit_correction: 'uniform_scale_applied_once_at_loaded_mesh_object',
+  validation_bounds: 'authored_visual_local_after_unit_correction',
+  diagnostic_world_bounds: 'scene_world_after_visual_origin_and_item_pose',
+});
+const MESH_OVERSIZED_RATIO_THRESHOLD = 3;
+
+// Coordinate-space contract shared by maybeApplyMeshUnitAutoscale() and
+// diagnoseLoadedMeshBounds(): geometry is measured in the authored visual
+// local axes.  Visual-origin translation/rotation and every parent/world pose
+// are removed, while the explicitly authored visual scale and loader-provided
+// child hierarchy are retained.  This prevents a rotated AABB in world axes
+// from being mistaken for a mesh-unit defect.
+function measureLoadedMeshBoundsInAuthoredLocalSpace(visualRoot) {
+  if (!visualRoot || !THREE?.Box3 || !THREE?.Matrix4) return null;
+  visualRoot.updateWorldMatrix(true, true);
+  const inverseVisualRootWorld = visualRoot.matrixWorld.clone().invert();
+  const visualScale = new THREE.Matrix4().makeScale(
+    Number(visualRoot.scale?.x ?? 1),
+    Number(visualRoot.scale?.y ?? 1),
+    Number(visualRoot.scale?.z ?? 1),
+  );
+  const bounds = new THREE.Box3();
+  let foundGeometry = false;
+  visualRoot.traverse(node => {
+    const geometry = node?.geometry;
+    if (!geometry) return;
+    if (!geometry.boundingBox) geometry.computeBoundingBox?.();
+    const geometryBounds = finiteBox3(geometry.boundingBox?.clone?.());
+    if (!geometryBounds) return;
+    const relativeToVisualRoot = inverseVisualRootWorld.clone().multiply(node.matrixWorld);
+    const authoredLocalMatrix = visualScale.clone().multiply(relativeToVisualRoot);
+    const transformed = geometryBounds.clone().applyMatrix4(authoredLocalMatrix);
+    if (!finiteBox3(transformed)) return;
+    bounds.union(transformed);
+    foundGeometry = true;
+  });
+  return foundGeometry ? finiteBox3(bounds) : null;
+}
+function measureLoadedMeshBoundsInWorldSpace(visualRoot) {
+  if (!visualRoot || !THREE?.Box3) return null;
+  visualRoot.updateWorldMatrix(true, true);
+  return finiteBox3(new THREE.Box3().setFromObject(visualRoot));
+}
+function meshDimensionComparison(expected, dimensions) {
+  if (!expected || !dimensions) return null;
+  const axes = ['x', 'y', 'z'];
+  if (axes.some(axis => !Number.isFinite(dimensions[axis]) || dimensions[axis] <= 1e-9 || !Number.isFinite(expected[axis]) || expected[axis] <= 1e-9)) return null;
+  const axisRatios = Object.fromEntries(axes.map(axis => [axis, dimensions[axis] / expected[axis]]));
+  const ratios = Object.values(axisRatios);
+  const maxRatio = Math.max(...ratios);
+  const minRatio = Math.min(...ratios);
+  const uniformRatio = minRatio > 0 ? maxRatio / minRatio : Infinity;
+  return {
+    axisRatios,
+    maxRatio,
+    minRatio,
+    uniformRatio,
+    oversized: maxRatio > MESH_OVERSIZED_RATIO_THRESHOLD || uniformRatio > MESH_OVERSIZED_RATIO_THRESHOLD,
+  };
+}
+function meshUnitCorrectionPayload(source, confidence, rawLocalBounds, correctedLocalBounds, scale, axisRatios, targetRatio, applied = false) {
   return {
     source,
     confidence,
-    native_bounds: box3ToJson(nativeBounds),
-    corrected_bounds: box3ToJson(correctedBounds),
+    coordinate_space_contract: MESH_BOUNDS_COORDINATE_SPACE_CONTRACT,
+    raw_mesh_local_bounds: box3ToJson(rawLocalBounds),
+    corrected_mesh_local_bounds: box3ToJson(correctedLocalBounds),
+    // Compatibility aliases retained for existing status consumers.
+    native_bounds: box3ToJson(rawLocalBounds),
+    corrected_bounds: box3ToJson(correctedLocalBounds),
     scale,
     axis_ratios: axisRatios,
     target_ratio: targetRatio,
+    applied,
+    applied_once_at: applied ? 'loaded_mesh_object.scale' : null,
   };
 }
-function maybeApplyMeshUnitAutoscale(item, meshObject, nativeBounds, meshUri) {
+function maybeApplyMeshUnitAutoscale(
+  item,
+  meshLocalNode,
+  visualRootOrRawBounds,
+  rawLocalBoundsOrMeshUri,
+  meshUriMaybe,
+) {
+  // Compatibility: the legacy helper form already supplied authored-local bounds.
+  // Production loading supplies the visual root and raw authored-local bounds separately.
+  const legacyAuthoredLocalBoundsCall =
+    meshUriMaybe === undefined && typeof rawLocalBoundsOrMeshUri === 'string';
+  const meshObject = meshLocalNode;
+  const visualRoot = legacyAuthoredLocalBoundsCall ? meshObject : visualRootOrRawBounds;
+  const rawLocalBounds = legacyAuthoredLocalBoundsCall
+    ? visualRootOrRawBounds
+    : rawLocalBoundsOrMeshUri;
+  const meshUri = legacyAuthoredLocalBoundsCall ? rawLocalBoundsOrMeshUri : meshUriMaybe;
   if (!meshUnitAutoscaleAllowed(item)) return false;
+  // A successful decision is immutable for this loaded visual.  This makes an
+  // accidental second call harmless instead of multiplying the correction.
+  if (item.mesh_unit_correction?.applied === true) return false;
   const expected = expectedDimensionsOf(item);
-  const finiteNative = finiteBox3(nativeBounds);
-  const dims = finiteNative ? box3Dimensions(finiteNative) : null;
-  const axes = ['x', 'y', 'z'];
-  if (!expected || !dims || axes.some(axis => dims[axis] <= 1e-9 || expected[axis] <= 1e-9)) return false;
-  const axisRatios = Object.fromEntries(axes.map(axis => [axis, dims[axis] / expected[axis]]));
-  const ratioValues = Object.values(axisRatios);
-  const maxRatio = Math.max(...ratioValues);
-  const minRatio = Math.min(...ratioValues);
-  const uniformRatio = minRatio > 0 ? maxRatio / minRatio : Infinity;
-  const targetRatio = [1000, 100].find(target => Math.abs(maxRatio - target) / target <= 0.2 && Math.abs(minRatio - target) / target <= 0.2 && uniformRatio <= 1.25);
+  const finiteRaw = finiteBox3(rawLocalBounds || measureLoadedMeshBoundsInAuthoredLocalSpace(visualRoot));
+  const dims = finiteRaw ? box3Dimensions(finiteRaw) : null;
+  const comparison = meshDimensionComparison(expected, dims);
+  if (!comparison) return false;
+  const { axisRatios, maxRatio, minRatio, uniformRatio } = comparison;
+  const targetRatio = [1000, 100].find(target =>
+    Math.abs(maxRatio - target) / target <= 0.2 &&
+    Math.abs(minRatio - target) / target <= 0.2 &&
+    uniformRatio <= 1.25);
   if (!targetRatio) {
-    item.mesh_unit_correction = meshUnitCorrectionPayload('viewer_expected_dimensions_m', 'rejected_non_uniform_or_unclear_ratio', finiteNative, finiteNative, 1.0, axisRatios, null);
-    appendRuntimeWarning(item, meshUri, `mesh unit autoscale rejected: native bounds do not have a clear uniform 100x or 1000x ratio to expected_dimensions_m (uniform_ratio=${uniformRatio.toFixed(3)})`, 'mesh_unit_autoscale_rejected', item.mesh_unit_correction);
+    item.mesh_unit_correction = meshUnitCorrectionPayload(
+      'viewer_expected_dimensions_m',
+      'rejected_non_uniform_or_unclear_ratio',
+      finiteRaw,
+      finiteRaw,
+      1.0,
+      axisRatios,
+      null,
+      false,
+    );
+    appendRuntimeWarning(item, meshUri, `mesh unit autoscale rejected: authored-local bounds do not have a clear uniform 100x or 1000x ratio to expected_dimensions_m (uniform_ratio=${uniformRatio.toFixed(3)})`, 'mesh_unit_autoscale_rejected', item.mesh_unit_correction);
     return false;
   }
   const scale = targetRatio === 1000 ? 0.001 : 0.01;
   meshObject.scale.multiplyScalar(scale);
-  meshObject.updateMatrixWorld(true);
-  const correctedBounds = finiteBox3(new THREE.Box3().setFromObject(meshObject));
+  meshObject.updateMatrix?.();
+  visualRoot.updateWorldMatrix?.(true, true);
+  visualRoot.updateMatrixWorld?.(true);
+  let correctedLocalBounds;
+  if (legacyAuthoredLocalBoundsCall) {
+    correctedLocalBounds = new THREE.Box3();
+    correctedLocalBounds.min.x = finiteRaw.min.x * scale;
+    correctedLocalBounds.min.y = finiteRaw.min.y * scale;
+    correctedLocalBounds.min.z = finiteRaw.min.z * scale;
+    correctedLocalBounds.max.x = finiteRaw.max.x * scale;
+    correctedLocalBounds.max.y = finiteRaw.max.y * scale;
+    correctedLocalBounds.max.z = finiteRaw.max.z * scale;
+  } else {
+    correctedLocalBounds = measureLoadedMeshBoundsInAuthoredLocalSpace(visualRoot);
+  }
   const confidence = targetRatio === 1000 ? 'auto_detected_mm_to_m' : 'auto_detected_cm_to_m';
-  item.mesh_unit_correction = meshUnitCorrectionPayload('viewer_expected_dimensions_m', confidence, finiteNative, correctedBounds, scale, axisRatios, targetRatio);
+  item.mesh_unit_correction = meshUnitCorrectionPayload(
+    'viewer_expected_dimensions_m',
+    confidence,
+    finiteRaw,
+    correctedLocalBounds,
+    scale,
+    axisRatios,
+    targetRatio,
+    true,
+  );
   item.visual_bounds_status = 'corrected_by_local_unit_scale';
-  appendRuntimeWarning(item, meshUri, `mesh unit autoscale applied: native bounds matched a clear ${targetRatio}x ratio to expected_dimensions_m`, 'mesh_unit_autoscale_applied', item.mesh_unit_correction);
+  appendRuntimeWarning(item, meshUri, `mesh unit autoscale applied once at the loaded mesh node: authored-local bounds matched a clear ${targetRatio}x ratio to expected_dimensions_m`, 'mesh_unit_autoscale_applied', item.mesh_unit_correction);
   return true;
 }
 
@@ -3312,19 +3432,24 @@ function warnLoadedMeshBounds(item, code, reason, extra = {}) {
   item.loaded_mesh_bounds_reason_code = code;
   appendViewerDiagnosticWarning(item, code, reason, {
     mesh_uri: displayMeshUri(item),
+    loaded_mesh_local_bounds: item.loaded_mesh_local_bounds,
     loaded_mesh_bounds: item.loaded_mesh_bounds,
     loaded_mesh_world_bounds: item.loaded_mesh_world_bounds,
+    loaded_mesh_bounds_coordinate_space: item.loaded_mesh_bounds_coordinate_space,
     expected_dimensions_m: item.expected_dimensions_m,
     mesh_contract_category: meshContractCategoryOf(item),
     ...extra,
   });
 }
-function diagnoseLoadedMeshBounds(item, meshObject, rendered, nativeBounds = null) {
-  const localBounds = finiteBox3(nativeBounds || new THREE.Box3().setFromObject(meshObject));
+function diagnoseLoadedMeshBounds(item, visualRoot, rendered, authoredLocalBounds = null) {
+  const localBounds = finiteBox3(authoredLocalBounds || measureLoadedMeshBoundsInAuthoredLocalSpace(visualRoot));
   rendered.object3d.updateWorldMatrix(true, true);
-  const worldBounds = finiteBox3(new THREE.Box3().setFromObject(meshObject));
-  item.loaded_mesh_bounds = box3ToJson(localBounds);
+  const worldBounds = measureLoadedMeshBoundsInWorldSpace(visualRoot);
+  item.loaded_mesh_local_bounds = box3ToJson(localBounds);
+  // Compatibility alias: loaded_mesh_bounds now explicitly means authored-local.
+  item.loaded_mesh_bounds = item.loaded_mesh_local_bounds;
   item.loaded_mesh_world_bounds = box3ToJson(worldBounds);
+  item.loaded_mesh_bounds_coordinate_space = MESH_BOUNDS_COORDINATE_SPACE_CONTRACT;
   item.visual_bounds_status = item.mesh_unit_correction?.scale && item.mesh_unit_correction.scale !== 1.0 ? 'corrected_by_local_unit_scale' : 'valid';
   const expected = expectedDimensionsOf(item);
   const dims = localBounds ? box3Dimensions(localBounds) : null;
@@ -3341,27 +3466,28 @@ function diagnoseLoadedMeshBounds(item, meshObject, rendered, nativeBounds = nul
     return !isCoreMeshContractItem(item);
   }
   if (!expected) return true;
-  const axes = ['x', 'y', 'z'];
-  const axisRatios = Object.fromEntries(axes.map(axis => [axis, dims[axis] / expected[axis]]));
-  const maxRatio = Math.max(...Object.values(axisRatios));
-  const minRatio = Math.min(...Object.values(axisRatios));
-  const uniformRatio = minRatio > 0 ? maxRatio / minRatio : Infinity;
+  const comparison = meshDimensionComparison(expected, dims);
+  if (!comparison) return true;
+  const { axisRatios, maxRatio, uniformRatio, oversized } = comparison;
   item.loaded_mesh_axis_ratios = axisRatios;
   item.loaded_mesh_maximum_ratio = maxRatio;
   item.loaded_mesh_uniform_ratio = uniformRatio;
   const category = meshContractCategoryOf(item);
-  if (maxRatio > 3 || uniformRatio > 3) {
-    if (['table', 'camera', 'object'].includes(category)) warnLoadedMeshBounds(item, 'loaded_mesh_oversized', `loaded mesh dimensions exceed expected_dimensions_m by more than 3x (max_axis_ratio=${maxRatio.toFixed(3)}, uniform_ratio=${uniformRatio.toFixed(3)})`, {
+  if (oversized) {
+    if (['table', 'camera', 'object', 'environment'].includes(category)) warnLoadedMeshBounds(item, 'loaded_mesh_oversized', `loaded mesh authored-local dimensions exceed expected_dimensions_m by the strict ${MESH_OVERSIZED_RATIO_THRESHOLD}x contract (max_axis_ratio=${maxRatio.toFixed(3)}, uniform_ratio=${uniformRatio.toFixed(3)})`, {
       expected_dimensions: { x: expected.x, y: expected.y, z: expected.z },
-      loaded_dimensions: { x: dims.x, y: dims.y, z: dims.z },
+      loaded_local_dimensions: { x: dims.x, y: dims.y, z: dims.z },
+      loaded_world_dimensions: { x: worldDims.x, y: worldDims.y, z: worldDims.z },
       axis_ratios: axisRatios,
       max_axis_ratio: maxRatio,
       uniform_ratio: uniformRatio,
+      oversized_threshold: MESH_OVERSIZED_RATIO_THRESHOLD,
     });
     else if (Math.abs(maxRatio - 1000) < 100 || Math.abs(maxRatio - 0.001) < 0.001) item.visual_bounds_status = 'corrected_by_local_unit_scale';
   }
   return item.visual_bounds_status !== 'oversized';
 }
+
 function workspaceDimensionsOf(sceneJson) {
   return dimensionsVectorFrom(sceneJson?.workspace?.dimensions_m || sceneJson?.workspace?.size_m || sceneJson?.workspace_dimensions_m || sceneJson?.scene?.workspace_dimensions_m);
 }


### PR DESCRIPTION
## Motivation
`diagnoseLoadedMeshBounds()` could compare authored `expected_dimensions_m` with bounds affected by visual-origin or world rotation. A valid rotated visual could therefore appear oversized even when its authored-local geometry was correct. Unit autoscale and final validation also did not share one explicit coordinate-space contract.

## Fix
- documents one coordinate-space contract shared by mesh-unit autoscale and loaded-bounds validation
- measures raw geometry in authored visual-local space before visual-origin and world transforms
- applies a clearly justified uniform 100× or 1000× unit correction exactly once at the loaded mesh node
- remeasures authored-local validation bounds after correction
- retains separately named local and world bounds for diagnostics
- compares `expected_dimensions_m` only against matching authored-local dimensions
- preserves the strict 3× oversized threshold and required-mesh `scene_failed` transition
- adds fixtures for the canonical `ur5_2f_test` camera visual, a rotated authored object, a millimetre-authored mesh, and a genuine greater-than-3× mismatch

## Validation
- `node --check workcell_studio_web/viewer/viewer.js`
- `python3 -m pytest -q tests/test_workcell_web3d_mesh_coordinate_space_contract.py tests/test_workcell_studio_web_viewer_static.py`

Both validation steps passed in GitHub Actions run `31083478796`.

## Scope and safety
- no oversized-threshold weakening
- no required-mesh fallback substitution
- no scene YAML or mesh asset changes
- no generated viewer bundle or source-map changes
- no controller, MoveIt, real-hardware, or safety-policy changes
- no temporary workflow, patch script, binary, or minified artifact is included

The branch contains one focused commit over `main`.