### PR TITLE
Add shared scene-load diagnostic context and wire into preview, viewport, and embedded viewer

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -69,6 +69,7 @@ add_executable(workcell_builder
     gui/mainwindow.ui
     gui/scene_preview_widget.cpp
     gui/scene_preview_widget.h
+    gui/scene_load_diagnostic_context.cpp
     gui/robot_home_yaml_io.cpp
     gui/robot_home_yaml_io.hpp
     gui/scene3d_viewport_widget.cpp
@@ -382,16 +383,19 @@ if(BUILD_TESTING)
 
   ament_add_gtest(workcell_scene3d_stl_parser_test
     test/scene3d_stl_parser_test.cpp
+    gui/scene_load_diagnostic_context.cpp
     gui/scene3d_viewport_widget.cpp
     gui/scene3d_visual_classification.cpp)
   ament_add_gtest(workcell_scene3d_render_role_classifier_test
     test/scene3d_render_role_classifier_test.cpp
+    gui/scene_load_diagnostic_context.cpp
     gui/scene3d_viewport_widget.cpp
     gui/scene3d_visual_classification.cpp
     gui/object_placement_yaml_io.cpp
     src_object_placement_model.cpp)
   ament_add_gtest(workcell_scene3d_ur5_baked_transform_test
     test/scene3d_ur5_baked_transform_test.cpp
+    gui/scene_load_diagnostic_context.cpp
     gui/scene3d_viewport_widget.cpp
     gui/scene3d_visual_classification.cpp)
 
@@ -408,12 +412,19 @@ if(BUILD_TESTING)
 
   ament_add_gtest(workcell_scene_preview_widget_ui_test
     test/scene_preview_widget_ui_test.cpp
+    gui/scene_load_diagnostic_context.cpp
     gui/scene_preview_widget.cpp
     gui/robot_home_yaml_io.cpp
     gui/scene3d_viewport_widget.cpp
     gui/scene3d_visual_classification.cpp
     gui/object_placement_yaml_io.cpp
     src_object_placement_model.cpp)
+  ament_add_gtest(workcell_scene_load_diagnostic_context_test
+    test/scene_load_diagnostic_context_test.cpp
+    gui/scene_load_diagnostic_context.cpp)
+  if(TARGET workcell_scene_load_diagnostic_context_test)
+    target_link_libraries(workcell_scene_load_diagnostic_context_test Qt5::Core)
+  endif()
   ament_add_gtest(workcell_studio_canvas_model_mesh_test
     test/workcell_studio_canvas_model_mesh_test.cpp
     src_workcell_studio_canvas_model.cpp

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -1953,6 +1953,17 @@ void Scene3DViewportWidget::ingest_preview_items(const QVector<ScenePreviewWidge
   scene_load_warning_tokens.removeDuplicates();
   scene_load_warning_tokens.sort();
   const QString warning_signature = scene_load_warning_tokens.join(QLatin1Char('|'));
+  if (scene_load_diagnostics_) {
+    const QJsonObject content{
+      {QStringLiteral("received"), static_cast<int>(items.size())},
+      {QStringLiteral("visible"), visible_item_count},
+      {QStringLiteral("mesh_sources"), mesh_source_count},
+      {QStringLiteral("warnings"), QJsonArray::fromStringList(scene_load_warning_tokens)}};
+    const auto report = scene_load_diagnostics_->observe(
+      scene_load_identity_, QStringLiteral("canvas_ingestion"), content);
+    if (report.emit) qInfo().noquote() << report.summary
+      << QStringLiteral("content=%1").arg(QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Compact)));
+  }
   const bool should_emit_scene_load_summary =
     debug_logs ||
     last_scene_load_summary_item_count_ != items.size() ||

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "scene_preview_widget.h"
+#include "scene_load_diagnostic_context.h"
 
 #include <QOpenGLFunctions>
 #include <QOpenGLWidget>
@@ -81,6 +82,9 @@ public:
   void set_isometric_view();
   void invalidate_mesh_cache();
   void ingest_preview_items(const QVector<ScenePreviewWidget::PreviewItem> & preview_items);
+  void set_scene_load_diagnostic_context(SceneLoadDiagnosticContext * context,
+    const SceneLoadDiagnosticContext::Identity & identity)
+  { scene_load_diagnostics_ = context; scene_load_identity_ = identity; }
 
   struct RenderDebugCounters
   {
@@ -188,6 +192,8 @@ protected:
   void dropEvent(QDropEvent * event) override;
 
 private:
+  SceneLoadDiagnosticContext * scene_load_diagnostics_{nullptr};
+  SceneLoadDiagnosticContext::Identity scene_load_identity_;
   struct ItemBounds { double x, y, z, sx, sy, sz; };
   QPointF project_to_screen(double x, double y, double z) const;
   bool pick_item_at_screen(const QPoint & pos, QString & out_id, QString & out_role, QString * out_tooltip = nullptr) const;

--- a/workcell_builder/workcell_builder/gui/scene_load_diagnostic_context.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_load_diagnostic_context.cpp
@@ -1,0 +1,60 @@
+#include "scene_load_diagnostic_context.h"
+
+#include <QCryptographicHash>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+namespace {
+QJsonValue normalized_json(const QJsonValue & value)
+{
+  if (value.isObject()) {
+    const QJsonObject input = value.toObject();
+    QStringList keys = input.keys();
+    keys.sort();
+    QJsonObject output;
+    for (const QString & key : keys) output.insert(key, normalized_json(input.value(key)));
+    return output;
+  }
+  if (value.isArray()) {
+    QJsonArray output;
+    for (const QJsonValue & item : value.toArray()) output.append(normalized_json(item));
+    return output;
+  }
+  return value;
+}
+}
+
+QString SceneLoadDiagnosticContext::normalized_content_hash(const QJsonValue & content)
+{
+  QJsonArray wrapper;
+  wrapper.append(normalized_json(content));
+  const QByteArray bytes = QJsonDocument(wrapper).toJson(QJsonDocument::Compact);
+  return QString::fromLatin1(QCryptographicHash::hash(bytes, QCryptographicHash::Sha256).toHex());
+}
+
+SceneLoadDiagnosticContext::Result SceneLoadDiagnosticContext::observe(
+  const Identity & identity, const QString & report_type, const QJsonValue & content, bool terminal)
+{
+  const QString scene = identity.scene_id.trimmed().isEmpty() ? QStringLiteral("unknown") : identity.scene_id.trimmed();
+  const QString source = identity.source_identity.trimmed().isEmpty() ? QStringLiteral("unknown") : identity.source_identity.trimmed();
+  const QString type = report_type.trimmed().isEmpty() ? QStringLiteral("unknown") : report_type.trimmed();
+  const QString load_key = QStringLiteral("%1\x1f%2\x1f%3").arg(scene, source).arg(identity.navigation_token);
+  const QString report_key = load_key + QLatin1Char('\x1f') + type;
+  const QString hash = normalized_content_hash(content);
+  const bool changed = last_hash_by_report_.value(report_key) != hash;
+
+  // A terminal transition is always visible. Polling the same terminal state
+  // is still an identical observation and remains quiet outside diagnostics.
+  QString terminal_state;
+  if (terminal && content.isObject()) terminal_state = content.toObject().value(QStringLiteral("state")).toString();
+  const bool terminal_transition = terminal && last_terminal_state_by_load_.value(load_key) != terminal_state;
+  const bool emit = debug_enabled_ || changed || terminal_transition;
+  last_hash_by_report_.insert(report_key, hash);
+  if (terminal) last_terminal_state_by_load_.insert(load_key, terminal_state);
+
+  return {emit,
+    QStringLiteral("Scene load: scene=%1 source=%2 navigation=%3 type=%4 hash=%5")
+      .arg(scene, source).arg(identity.navigation_token).arg(type, hash.left(12)),
+    hash};
+}

--- a/workcell_builder/workcell_builder/gui/scene_load_diagnostic_context.h
+++ b/workcell_builder/workcell_builder/gui/scene_load_diagnostic_context.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <QHash>
+#include <QJsonValue>
+#include <QString>
+
+// One lifecycle-scoped gate for Product View load diagnostics.  Producers in
+// the builder, native canvas, and embedded viewer bridge use the same identity
+// and hash rules rather than maintaining independent "last message" caches.
+class SceneLoadDiagnosticContext
+{
+public:
+  struct Identity
+  {
+    QString scene_id;
+    QString source_identity;
+    quint64 navigation_token{0};
+  };
+
+  struct Result
+  {
+    bool emit{false};
+    QString summary;
+    QString content_hash;
+  };
+
+  void set_debug_enabled(bool enabled) { debug_enabled_ = enabled; }
+  bool debug_enabled() const { return debug_enabled_; }
+  Result observe(const Identity & identity, const QString & report_type,
+                 const QJsonValue & content, bool terminal = false);
+  static QString normalized_content_hash(const QJsonValue & content);
+
+private:
+  QHash<QString, QString> last_hash_by_report_;
+  QHash<QString, QString> last_terminal_state_by_load_;
+  bool debug_enabled_{false};
+};

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -1320,13 +1320,17 @@ void ScenePreviewWidget::handle_embedded_web_runtime_failure(
       .arg(identity.scene_id).arg(identity.generation).arg(navigation_token).arg(detail));
     return;
   }
-  const QString terminal_key = QStringLiteral("%1|%2|%3|%4").arg(identity.scene_id).arg(identity.generated_web_scene_path).arg(identity.payload_revision).arg(navigation_token);
-  if (embedded_web_terminal_runtime_failures_.contains(terminal_key)) {
-    emit studio_log_requested(QStringLiteral("Suppressed duplicate Embedded Product View terminal failure for scene %1 revision %2 navigation %3: %4")
-      .arg(identity.scene_id).arg(identity.generation).arg(navigation_token).arg(detail));
-    return;
-  }
-  embedded_web_terminal_runtime_failures_.insert(terminal_key);
+  scene_load_diagnostics_.set_debug_enabled(diagnostic_debug_logging_enabled());
+  const SceneLoadDiagnosticContext::Identity diagnostic_identity{
+    identity.scene_id, QStringLiteral("builder_revision:%1").arg(identity.payload_revision), navigation_token};
+  const QJsonObject failure_content{
+    {QStringLiteral("state"), QStringLiteral("scene_failed")},
+    {QStringLiteral("detail"), detail}};
+  const auto failure_report = scene_load_diagnostics_.observe(
+    diagnostic_identity, QStringLiteral("terminal_readiness"), failure_content, true);
+  if (!failure_report.emit) return;
+  emit studio_log_requested(failure_report.summary + QStringLiteral(" content=%1")
+    .arg(QString::fromUtf8(QJsonDocument(failure_content).toJson(QJsonDocument::Compact))));
   if (finish_post_save_product_view_refresh(identity, navigation_token, false, detail)) return;
   native_compatibility_fallback_active_ = false;
   embedded_web_last_error_ = detail;
@@ -1341,7 +1345,8 @@ void ScenePreviewWidget::handle_embedded_web_runtime_failure(
   refresh_mode_and_state();
 
   ++embedded_web_terminal_results_accepted_;
-  emit studio_log_requested(QStringLiteral("Embedded Product View terminal failure accepted; leaving Web3D selected with Retry available. %1").arg(detail));
+  if (diagnostic_debug_logging_enabled()) emit studio_log_requested(
+    QStringLiteral("Embedded Product View terminal failure accepted; leaving Web3D selected with Retry available. %1").arg(detail));
 #endif
 }
 
@@ -2262,17 +2267,35 @@ void ScenePreviewWidget::poll_embedded_web_readiness(const EmbeddedWebRequestIde
       .arg(builder_revision.isEmpty() ? QStringLiteral("unknown") : builder_revision)
       .arg(QStringLiteral("[%1]").arg(pending_required_loads.join(QStringLiteral(", "))));
 
+    scene_load_diagnostics_.set_debug_enabled(diagnostic_debug_logging_enabled());
+    const SceneLoadDiagnosticContext::Identity diagnostic_identity{
+      identity.scene_id,
+      !builder_revision.isEmpty() ? QStringLiteral("builder_revision:%1").arg(builder_revision) : source_json,
+      navigation_token};
+    const QJsonObject readiness_content{
+      {QStringLiteral("state"), boot_state == QStringLiteral("scene_failed") ? boot_state :
+        (lifecycle_state.isEmpty() ? boot_state : lifecycle_state)},
+      {QStringLiteral("terminal"), terminal},
+      {QStringLiteral("failed_stage"), failed_stage},
+      {QStringLiteral("fatal_error"), fatal_error},
+      {QStringLiteral("failed_required_item_count"), failed_required_count},
+      {QStringLiteral("rendered_physical_item_count"), rendered_physical_count},
+      {QStringLiteral("pending_required_loads"), QJsonArray::fromStringList(pending_required_loads)}};
+    const bool terminal_report = terminal || lifecycle_state == QStringLiteral("scene_ready") ||
+      lifecycle_state == QStringLiteral("scene_failed") || boot_state == QStringLiteral("scene_failed");
+    if (boot_state != QStringLiteral("scene_failed") && boot_state != QStringLiteral("failed")) {
+      const auto readiness_report = scene_load_diagnostics_.observe(
+        diagnostic_identity, QStringLiteral("terminal_readiness"), readiness_content, terminal_report);
+      if (readiness_report.emit) emit studio_log_requested(readiness_report.summary + QStringLiteral(" content=%1")
+        .arg(QString::fromUtf8(QJsonDocument(readiness_content).toJson(QJsonDocument::Compact))));
+    }
+
     if (boot_state == QStringLiteral("scene_failed") || boot_state == QStringLiteral("failed")) {
       const QString detail = QStringLiteral("viewer JavaScript failed at %1: %2%3")
         .arg(failed_stage.isEmpty() ? QStringLiteral("unknown_stage") : failed_stage,
              fatal_error.isEmpty() ? QStringLiteral("unknown error") : fatal_error,
              fatal_stack.isEmpty() ? QString() : QStringLiteral("; stack: %1").arg(fatal_stack.left(500)));
       handle_embedded_web_runtime_failure(identity, navigation_token, detail);
-      emit studio_log_requested(QStringLiteral("Embedded Product View JavaScript failure for scene %1.\nStage: %2\nFatal error: %3\nStack excerpt:\n%4")
-        .arg(identity.scene_id,
-             failed_stage.isEmpty() ? QStringLiteral("unknown_stage") : failed_stage,
-             fatal_error.isEmpty() ? QStringLiteral("unknown error") : fatal_error,
-             fatal_stack.left(500)));
       return;
     }
 
@@ -2297,8 +2320,9 @@ void ScenePreviewWidget::poll_embedded_web_readiness(const EmbeddedWebRequestIde
       set_embedded_product_view_state(EmbeddedProductViewState::Ready, QStringLiteral("viewer ready"));
       show_embedded_web_product_view();
       poll_embedded_editor_events();
-      emit studio_log_requested(QStringLiteral("Embedded Product View ready after terminal scene_ready: scene=%1 json=%2 builder_revision=%3 robot_preview_lifecycle_state=%4 failed_required_item_count=0")
-        .arg(identity.scene_id, expected_json_path, expected_builder_revision, robot_state.isEmpty() ? QStringLiteral("not_required") : robot_state));
+      if (diagnostic_debug_logging_enabled()) emit studio_log_requested(
+        QStringLiteral("Embedded Product View ready after terminal scene_ready: scene=%1 json=%2 builder_revision=%3 robot_preview_lifecycle_state=%4 failed_required_item_count=0")
+          .arg(identity.scene_id, expected_json_path, expected_builder_revision, robot_state.isEmpty() ? QStringLiteral("not_required") : robot_state));
       finish_post_save_product_view_refresh(identity, navigation_token, true, QStringLiteral("matching terminal scene_ready accepted"));
       return;
     }
@@ -2840,8 +2864,31 @@ void ScenePreviewWidget::set_preview_items(const QVector<PreviewItem> & items)
     ++preview_payload_revision_;
     ++preview_payload_generation_;
   }
+  scene_load_diagnostics_.set_debug_enabled(diagnostic_debug_logging_enabled());
+  SceneLoadDiagnosticContext::Identity diagnostic_identity{
+    preview_scene_name_, QStringLiteral("builder_revision:%1").arg(preview_payload_revision_),
+    embedded_web_navigation_token_};
+  int mesh_items = 0;
+  int unresolved_packages = 0;
+  int warning_count = 0;
+  for (const PreviewItem & item : preview_items_) {
+    if (item.mesh_available || !item.mesh_path.trimmed().isEmpty()) ++mesh_items;
+    if (!item.package_uri.trimmed().isEmpty() && item.source_path_resolution_outcome.contains(QStringLiteral("unresolved"), Qt::CaseInsensitive)) ++unresolved_packages;
+    warning_count += item.warnings.size() + (!item.mesh_load_warning.trimmed().isEmpty() ? 1 : 0);
+  }
+  const auto report = [this, &diagnostic_identity](const QString & type, const QJsonObject & content) {
+    const auto result = scene_load_diagnostics_.observe(diagnostic_identity, type, content);
+    if (result.emit) emit studio_log_requested(result.summary + QStringLiteral(" content=%1")
+      .arg(QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Compact))));
+  };
+  report(QStringLiteral("asset_discovery"), QJsonObject{{QStringLiteral("items"), preview_items_.size()}});
+  report(QStringLiteral("visual_mesh_index"), QJsonObject{{QStringLiteral("mesh_items"), mesh_items}, {QStringLiteral("warnings"), warning_count}});
+  report(QStringLiteral("package_resolution"), QJsonObject{{QStringLiteral("unresolved_packages"), unresolved_packages}});
   auto * viewport = active_native_viewport();
-  if (viewport) viewport->ingest_preview_items(preview_items_);
+  if (viewport) {
+    viewport->set_scene_load_diagnostic_context(&scene_load_diagnostics_, diagnostic_identity);
+    viewport->ingest_preview_items(preview_items_);
+  }
   const bool has_selected = std::any_of(preview_items_.cbegin(), preview_items_.cend(), [this](const PreviewItem & it){ return it.id == selected_preview_item_id_; });
   if (!selected_preview_item_id_.isEmpty() && !has_selected) {
     const QString missing_id = selected_preview_item_id_;

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QWidget>
+#include "scene_load_diagnostic_context.h"
 #include <QByteArray>
 #include <QVector>
 #include <QStringList>
@@ -618,5 +619,6 @@ private:
   int post_save_refresh_payload_revision_{ 0 };
   QByteArray preview_payload_fingerprint_;
   int last_visual_quality_revision_logged_{ -1 };
+  SceneLoadDiagnosticContext scene_load_diagnostics_;
   QSet<QString> emitted_scene_diagnostic_keys_;
 };

--- a/workcell_builder/workcell_builder/test/scene_load_diagnostic_context_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene_load_diagnostic_context_test.cpp
@@ -1,0 +1,35 @@
+#include <gtest/gtest.h>
+
+#include "scene_load_diagnostic_context.h"
+
+TEST(SceneLoadDiagnosticContext, RepeatedPollingAndRefreshCallbacksEmitOnce)
+{
+  SceneLoadDiagnosticContext context;
+  const SceneLoadDiagnosticContext::Identity load{"ur5_2f_test", "builder_revision:41", 7};
+  const QJsonObject ready{{"state", "scene_ready"}, {"rendered", 9}};
+  EXPECT_TRUE(context.observe(load, "terminal_readiness", ready, true).emit);
+  EXPECT_FALSE(context.observe(load, "terminal_readiness", ready, true).emit);
+  EXPECT_FALSE(context.observe(load, "terminal_readiness", QJsonObject{{"rendered", 9}, {"state", "scene_ready"}}, true).emit);
+}
+
+TEST(SceneLoadDiagnosticContext, RevisionAndMaterialFailureChangesEmit)
+{
+  SceneLoadDiagnosticContext context;
+  const QJsonObject failure{{"state", "scene_failed"}, {"reason", "mesh missing"}};
+  const SceneLoadDiagnosticContext::Identity rev1{"ur5_2f_test", "builder_revision:41", 7};
+  EXPECT_TRUE(context.observe(rev1, "terminal_readiness", failure, true).emit);
+  EXPECT_FALSE(context.observe(rev1, "terminal_readiness", failure, true).emit);
+  EXPECT_TRUE(context.observe(rev1, "terminal_readiness",
+    QJsonObject{{"state", "scene_failed"}, {"reason", "package unresolved"}}, true).emit);
+  const SceneLoadDiagnosticContext::Identity rev2{"ur5_2f_test", "builder_revision:42", 8};
+  EXPECT_TRUE(context.observe(rev2, "terminal_readiness", failure, true).emit);
+}
+
+TEST(SceneLoadDiagnosticContext, DebugModeEmitsIdenticalObservations)
+{
+  SceneLoadDiagnosticContext context;
+  context.set_debug_enabled(true);
+  const SceneLoadDiagnosticContext::Identity load{"ur5_2f_test", "scene.json", 3};
+  EXPECT_TRUE(context.observe(load, "asset_discovery", QJsonObject{{"assets", 4}}).emit);
+  EXPECT_TRUE(context.observe(load, "asset_discovery", QJsonObject{{"assets", 4}}).emit);
+}


### PR DESCRIPTION
### Motivation
- Provide a single lifecycle-scoped diagnostic gate for Product View scene loads so the native canvas, preview widget, and embedded Web3D viewer emit consistent, de-duplicated reports keyed by scene ID, source identity/builder revision, navigation token, report type, and normalized content hash.
- Ensure the key logical reports for asset discovery, visual mesh index, package resolution, canvas ingestion, and terminal readiness are always visible when materially changed while suppressing repeated identical polling noise unless explicit debug/advanced diagnostics is enabled.
- Keep `scene_ready` / `scene_failed` terminal transitions visible and make diagnostic output actionable and compact for operator logs and automated validation.

### Description
- Added a new diagnostics helper `SceneLoadDiagnosticContext` (`gui/scene_load_diagnostic_context.h` and `gui/scene_load_diagnostic_context.cpp`) that normalizes JSON, computes a SHA-256 content hash, and gates emission by report key and terminal transitions.
- Wired the shared context into `ScenePreviewWidget` to emit `asset_discovery`, `visual_mesh_index`, and `package_resolution` summaries before ingestion, and to increment the diagnostic identity on payload commits via the existing payload revision/generation.
- Integrated the same context with embedded viewer readiness/failure polling in `ScenePreviewWidget::poll_embedded_web_readiness` and `handle_embedded_web_runtime_failure` so `terminal_readiness` reports flow through the same de-duplication logic while always showing material changes.
- Connected native canvas ingestion by calling `Scene3DViewportWidget::set_scene_load_diagnostic_context` and emitting a `canvas_ingestion` report in `Scene3DViewportWidget::ingest_preview_items` with the shared identity.
- Added focused unit tests `test/scene_load_diagnostic_context_test.cpp` exercising repeated polling suppression, JSON-order-insensitive equality, builder-revision changes, failure-content changes, and debug-mode repetition, and updated `CMakeLists.txt` to include the new test and source where appropriate.

### Testing
- Ran repository checks and static validation (`git diff --check` and a small Python source presence check) which passed and confirmed the new files and report types are present. (passed)
- Attempted to configure the project with `cmake -S workcell_builder/workcell_builder -B /tmp/wb-build -DBUILD_TESTING=ON -DWORKCELL_BUILDER_ALLOW_NATIVE_3D_FALLBACK=ON` but configuration failed due to the environment missing ROS2/`ament_cmake` which prevented a full CMake configure/build. (blocked)
- Attempted to compile and run the new test manually with `g++` but the container lacked Qt (`Qt5Core.pc`) and GoogleTest development headers, so direct compilation/execution of the unit binary could not be completed. (blocked)
- Performed targeted runtime-source checks by running a quick script asserting new report strings (`asset_discovery`, `visual_mesh_index`, `package_resolution`, `canvas_ingestion`, `terminal_readiness`) are present across the modified sources, which succeeded. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7443188aa48331ace96507e137de3e)