### PR TITLE
Fix scene-load diagnostic context build

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -720,6 +720,7 @@ if(BUILD_TESTING)
     scene3d_render_role_classifier_test.cpp
     scene3d_ur5_baked_transform_test.cpp
     scene3d_product_view_layer_defaults_test.cpp
+    scene_load_diagnostic_context_test.cpp
     command_builders_test.cpp
     scene_preview_widget_ui_test.cpp
     workcell_studio_canvas_model_mesh_test.cpp

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -1961,7 +1961,7 @@ void Scene3DViewportWidget::ingest_preview_items(const QVector<ScenePreviewWidge
       {QStringLiteral("warnings"), QJsonArray::fromStringList(scene_load_warning_tokens)}};
     const auto report = scene_load_diagnostics_->observe(
       scene_load_identity_, QStringLiteral("canvas_ingestion"), content);
-    if (report.emit) qInfo().noquote() << report.summary
+    if (report.should_emit) qInfo().noquote() << report.summary
       << QStringLiteral("content=%1").arg(QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Compact)));
   }
   const bool should_emit_scene_load_summary =

--- a/workcell_builder/workcell_builder/gui/scene_load_diagnostic_context.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_load_diagnostic_context.cpp
@@ -49,11 +49,11 @@ SceneLoadDiagnosticContext::Result SceneLoadDiagnosticContext::observe(
   QString terminal_state;
   if (terminal && content.isObject()) terminal_state = content.toObject().value(QStringLiteral("state")).toString();
   const bool terminal_transition = terminal && last_terminal_state_by_load_.value(load_key) != terminal_state;
-  const bool emit = debug_enabled_ || changed || terminal_transition;
+  const bool should_emit = debug_enabled_ || changed || terminal_transition;
   last_hash_by_report_.insert(report_key, hash);
   if (terminal) last_terminal_state_by_load_.insert(load_key, terminal_state);
 
-  return {emit,
+  return {should_emit,
     QStringLiteral("Scene load: scene=%1 source=%2 navigation=%3 type=%4 hash=%5")
       .arg(scene, source).arg(identity.navigation_token).arg(type, hash.left(12)),
     hash};

--- a/workcell_builder/workcell_builder/gui/scene_load_diagnostic_context.h
+++ b/workcell_builder/workcell_builder/gui/scene_load_diagnostic_context.h
@@ -19,7 +19,7 @@ public:
 
   struct Result
   {
-    bool emit{false};
+    bool should_emit{false};
     QString summary;
     QString content_hash;
   };

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -1328,7 +1328,7 @@ void ScenePreviewWidget::handle_embedded_web_runtime_failure(
     {QStringLiteral("detail"), detail}};
   const auto failure_report = scene_load_diagnostics_.observe(
     diagnostic_identity, QStringLiteral("terminal_readiness"), failure_content, true);
-  if (!failure_report.emit) return;
+  if (!failure_report.should_emit) return;
   emit studio_log_requested(failure_report.summary + QStringLiteral(" content=%1")
     .arg(QString::fromUtf8(QJsonDocument(failure_content).toJson(QJsonDocument::Compact))));
   if (finish_post_save_product_view_refresh(identity, navigation_token, false, detail)) return;
@@ -2286,7 +2286,7 @@ void ScenePreviewWidget::poll_embedded_web_readiness(const EmbeddedWebRequestIde
     if (boot_state != QStringLiteral("scene_failed") && boot_state != QStringLiteral("failed")) {
       const auto readiness_report = scene_load_diagnostics_.observe(
         diagnostic_identity, QStringLiteral("terminal_readiness"), readiness_content, terminal_report);
-      if (readiness_report.emit) emit studio_log_requested(readiness_report.summary + QStringLiteral(" content=%1")
+      if (readiness_report.should_emit) emit studio_log_requested(readiness_report.summary + QStringLiteral(" content=%1")
         .arg(QString::fromUtf8(QJsonDocument(readiness_content).toJson(QJsonDocument::Compact))));
     }
 
@@ -2878,7 +2878,7 @@ void ScenePreviewWidget::set_preview_items(const QVector<PreviewItem> & items)
   }
   const auto report = [this, &diagnostic_identity](const QString & type, const QJsonObject & content) {
     const auto result = scene_load_diagnostics_.observe(diagnostic_identity, type, content);
-    if (result.emit) emit studio_log_requested(result.summary + QStringLiteral(" content=%1")
+    if (result.should_emit) emit studio_log_requested(result.summary + QStringLiteral(" content=%1")
       .arg(QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Compact))));
   };
   report(QStringLiteral("asset_discovery"), QJsonObject{{QStringLiteral("items"), preview_items_.size()}});

--- a/workcell_builder/workcell_builder/test/scene_load_diagnostic_context_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene_load_diagnostic_context_test.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <QJsonObject>
+
 #include "scene_load_diagnostic_context.h"
 
 TEST(SceneLoadDiagnosticContext, RepeatedPollingAndRefreshCallbacksEmitOnce)
@@ -7,9 +9,9 @@ TEST(SceneLoadDiagnosticContext, RepeatedPollingAndRefreshCallbacksEmitOnce)
   SceneLoadDiagnosticContext context;
   const SceneLoadDiagnosticContext::Identity load{"ur5_2f_test", "builder_revision:41", 7};
   const QJsonObject ready{{"state", "scene_ready"}, {"rendered", 9}};
-  EXPECT_TRUE(context.observe(load, "terminal_readiness", ready, true).emit);
-  EXPECT_FALSE(context.observe(load, "terminal_readiness", ready, true).emit);
-  EXPECT_FALSE(context.observe(load, "terminal_readiness", QJsonObject{{"rendered", 9}, {"state", "scene_ready"}}, true).emit);
+  EXPECT_TRUE(context.observe(load, "terminal_readiness", ready, true).should_emit);
+  EXPECT_FALSE(context.observe(load, "terminal_readiness", ready, true).should_emit);
+  EXPECT_FALSE(context.observe(load, "terminal_readiness", QJsonObject{{"rendered", 9}, {"state", "scene_ready"}}, true).should_emit);
 }
 
 TEST(SceneLoadDiagnosticContext, RevisionAndMaterialFailureChangesEmit)
@@ -17,12 +19,12 @@ TEST(SceneLoadDiagnosticContext, RevisionAndMaterialFailureChangesEmit)
   SceneLoadDiagnosticContext context;
   const QJsonObject failure{{"state", "scene_failed"}, {"reason", "mesh missing"}};
   const SceneLoadDiagnosticContext::Identity rev1{"ur5_2f_test", "builder_revision:41", 7};
-  EXPECT_TRUE(context.observe(rev1, "terminal_readiness", failure, true).emit);
-  EXPECT_FALSE(context.observe(rev1, "terminal_readiness", failure, true).emit);
+  EXPECT_TRUE(context.observe(rev1, "terminal_readiness", failure, true).should_emit);
+  EXPECT_FALSE(context.observe(rev1, "terminal_readiness", failure, true).should_emit);
   EXPECT_TRUE(context.observe(rev1, "terminal_readiness",
-    QJsonObject{{"state", "scene_failed"}, {"reason", "package unresolved"}}, true).emit);
+    QJsonObject{{"state", "scene_failed"}, {"reason", "package unresolved"}}, true).should_emit);
   const SceneLoadDiagnosticContext::Identity rev2{"ur5_2f_test", "builder_revision:42", 8};
-  EXPECT_TRUE(context.observe(rev2, "terminal_readiness", failure, true).emit);
+  EXPECT_TRUE(context.observe(rev2, "terminal_readiness", failure, true).should_emit);
 }
 
 TEST(SceneLoadDiagnosticContext, DebugModeEmitsIdenticalObservations)
@@ -30,6 +32,6 @@ TEST(SceneLoadDiagnosticContext, DebugModeEmitsIdenticalObservations)
   SceneLoadDiagnosticContext context;
   context.set_debug_enabled(true);
   const SceneLoadDiagnosticContext::Identity load{"ur5_2f_test", "scene.json", 3};
-  EXPECT_TRUE(context.observe(load, "asset_discovery", QJsonObject{{"assets", 4}}).emit);
-  EXPECT_TRUE(context.observe(load, "asset_discovery", QJsonObject{{"assets", 4}}).emit);
+  EXPECT_TRUE(context.observe(load, "asset_discovery", QJsonObject{{"assets", 4}}).should_emit);
+  EXPECT_TRUE(context.observe(load, "asset_discovery", QJsonObject{{"assets", 4}}).should_emit);
 }


### PR DESCRIPTION
Repairs the merged scene-load diagnostic context so Workcell Builder builds on ROS 2 Humble with Qt5.

Changes:
- register scene_load_diagnostic_context_test.cpp in the mandatory test-source inventory
- rename Result::emit and related local identifiers to should_emit because emit is a Qt macro
- update all call sites and tests
- include QJsonObject directly in the focused test

Validation:
- clean workcell_builder build passed
- focused scene-load diagnostic test compiled and is run separately before merge

No scene YAML, Web3D bundle, mesh assets, controller settings, MoveIt behavior, or hardware configuration are changed.