### PR TITLE
Fail Web3D acceptance when scene is not ready

### DIFF
--- a/scripts/run_workcell_web3d_visual_acceptance.py
+++ b/scripts/run_workcell_web3d_visual_acceptance.py
@@ -1356,6 +1356,7 @@ def run_one_scene(scene_dir: Path, *, output_path: Path | None, scene_id: str | 
     if any(step["returncode"] != 0 for step in steps): rc = 1
     if require_browser and require_browser_artifact_errors(browser, server_status, screenshot_path, browser_status_path): rc = 1
     status = browser.get("status") if isinstance(browser, Mapping) else None
+    if require_browser and isinstance(status, Mapping) and str(_status_value(status, "web3d_readiness_state", "web3dReadinessState", "viewer_boot_state", "viewerBootState") or "") != "scene_ready": rc = 1
     legacy_strict_scene = not expected or (expected.get("robot") == "ur5" and expected.get("tool") == "robotiq_2f")
     if isinstance(status, Mapping) and legacy_strict_scene and validate_browser_status(status): rc = 1
     elif require_browser and not isinstance(status, Mapping): rc = 1

--- a/tests/test_workcell_web3d_visual_acceptance.py
+++ b/tests/test_workcell_web3d_visual_acceptance.py
@@ -251,6 +251,7 @@ def test_acceptance_script_supports_playwright_browser_status_path():
     assert "window.__WORKCELL_ROBOT_PREVIEW_READY__" in text
     assert "robot_preview_lifecycle_state" in text
     assert "validate_browser_status(status)" in text
+    assert '!= "scene_ready": rc = 1' in text
     assert "EXPECTED_MESH_LOADED_COUNT = 18" in text
     assert "EXPECTED_REQUIRED_MESH_FAILED_COUNT = 0" in text
     assert "viewer_url:" in text


### PR DESCRIPTION
## Summary
Fixes the single-scene Web3D visual acceptance harness so `--require-browser` cannot return success when the browser terminal lifecycle is anything other than `scene_ready`.

Previously, strict browser-status validation was gated by a legacy robot/tool combination, which allowed the canonical `ur5_2f_test` scene to return exit code 0 even when the viewer reported `scene_failed`.

This change:
- adds a generic required-browser terminal-state gate for `web3d_readiness_state` / `viewer_boot_state`
- preserves the existing legacy deep validator for its additional checks
- adds a source-contract regression assertion

## Validation
- `python3 -m pytest -q tests/test_workcell_web3d_visual_acceptance.py` -> 60 passed
- `git diff --check` -> clean

This is intentionally a narrow acceptance-harness fix only; no viewer runtime or scene content changes are included.